### PR TITLE
simplified .bumpversion.cfg now that we're doing semantic versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,2 @@
 [bumpversion]
 current_version = 4.0.0
-parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
-serialize = 
-	{major}.{minor}.{patch}
-	{major}.{minor}
-
-[bumpversion:part:minor]
-first_value = 1


### PR DESCRIPTION
I don't think it makes sense to continue having such a complicated `.bumpversion.cfg` file