### PR TITLE
Issue/2603 unknown in collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Bug fixes
 - Fix broken links in the documentation (#2495)
+- Fixed bug in serialization of Resource with Unknowns in collections (#2603)
 - Fixed documentation of `install_mode`
 - Ensure all running compilations are stopped when the server is stopped (#2508)
 - Cleanup old entries in the agentprocess and agentinstance database tables (#2499)

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -299,6 +299,9 @@ class Resource(metaclass=ResourceMeta):
                     value = cls.map[field_name](exporter, model_object)
                 else:
                     value = getattr(model_object, field_name)
+                # serialize to weed out all unknowns
+                # not very efficient, but the tree has to be traversed anyways
+                # passing along the serialized version would break the resource apis
                 json.dumps(value, default=inmanta.util.custom_json_encoder)
                 return value
             except proxy.UnknownException as e:

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -39,7 +39,6 @@ from typing import (
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.execute import proxy, runtime, util
 from inmanta.types import JsonType
-from inmanta.util import custom_json_encoder
 
 if TYPE_CHECKING:
     from inmanta import export
@@ -290,6 +289,7 @@ class Resource(metaclass=ResourceMeta):
     def map_field(
         cls, exporter: Optional["export.Exporter"], entity_name: str, field_name: str, model_object: "proxy.DynamicProxy"
     ) -> str:
+        from inmanta.data import json_encode
         try:
             try:
                 if hasattr(cls, "get_" + field_name):
@@ -299,7 +299,7 @@ class Resource(metaclass=ResourceMeta):
                     value = cls.map[field_name](exporter, model_object)
                 else:
                     value = getattr(model_object, field_name)
-                json.dumps(value, default=custom_json_encoder)
+                json_encode(value)
                 return value
             except proxy.UnknownException as e:
                 return e.unknown

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -15,7 +15,7 @@
 
     Contact: code@inmanta.com
 """
-
+import json
 import logging
 import re
 from typing import (
@@ -35,6 +35,8 @@ from typing import (
     Union,
     cast,
 )
+
+from inmanta.util import custom_json_encoder
 
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.execute import proxy, runtime, util
@@ -298,7 +300,7 @@ class Resource(metaclass=ResourceMeta):
                     value = cls.map[field_name](exporter, model_object)
                 else:
                     value = getattr(model_object, field_name)
-
+                json.dumps(value, default=custom_json_encoder)
                 return value
             except proxy.UnknownException as e:
                 return e.unknown

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -36,11 +36,10 @@ from typing import (
     cast,
 )
 
-from inmanta.util import custom_json_encoder
-
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.execute import proxy, runtime, util
 from inmanta.types import JsonType
+from inmanta.util import custom_json_encoder
 
 if TYPE_CHECKING:
     from inmanta import export

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -36,6 +36,7 @@ from typing import (
     cast,
 )
 
+import inmanta.util
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.execute import proxy, runtime, util
 from inmanta.types import JsonType
@@ -289,7 +290,6 @@ class Resource(metaclass=ResourceMeta):
     def map_field(
         cls, exporter: Optional["export.Exporter"], entity_name: str, field_name: str, model_object: "proxy.DynamicProxy"
     ) -> str:
-        from inmanta.data import json_encode
         try:
             try:
                 if hasattr(cls, "get_" + field_name):
@@ -299,7 +299,7 @@ class Resource(metaclass=ResourceMeta):
                     value = cls.map[field_name](exporter, model_object)
                 else:
                     value = getattr(model_object, field_name)
-                json_encode(value)
+                json.dumps(value, default=inmanta.util.custom_json_encoder)
                 return value
             except proxy.UnknownException as e:
                 return e.unknown

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -19,6 +19,7 @@ import json
 import os
 
 import pytest
+from inmanta.const import ResourceState
 
 from inmanta import config, const
 from inmanta.export import DependencyCycleException
@@ -260,6 +261,21 @@ a = exp::Test2(mydict={"a": null}, mylist=["a",null])
     assert resource["mylist"] == ["a", None]
     assert resource["mydict"] == {"a": None}
 
+def test_export_unknown_in_collection(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import exp
+import tests
+
+a = exp::Test2(mydict={"a": tests::unknown()}, mylist=["a"])
+b = exp::Test2(name="idb", mydict={"a": "b"}, mylist=["a", tests::unknown()])
+"""
+    )
+    _version, json_value, status, model = snippetcompiler.do_export(include_status=True)
+
+    assert len(json_value) == 2
+    assert status['exp::Test2[agenta,name=ida]'] == ResourceState.undefined
+    assert status['exp::Test2[agenta,name=idb]'] == ResourceState.undefined
 
 def test_1934_cycle_in_dep_mgmr(snippetcompiler):
     snippetcompiler.setup_for_snippet(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -19,9 +19,9 @@ import json
 import os
 
 import pytest
-from inmanta.const import ResourceState
 
 from inmanta import config, const
+from inmanta.const import ResourceState
 from inmanta.export import DependencyCycleException
 
 
@@ -261,6 +261,7 @@ a = exp::Test2(mydict={"a": null}, mylist=["a",null])
     assert resource["mylist"] == ["a", None]
     assert resource["mydict"] == {"a": None}
 
+
 def test_export_unknown_in_collection(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
@@ -274,8 +275,9 @@ b = exp::Test2(name="idb", mydict={"a": "b"}, mylist=["a", tests::unknown()])
     _version, json_value, status, model = snippetcompiler.do_export(include_status=True)
 
     assert len(json_value) == 2
-    assert status['exp::Test2[agenta,name=ida]'] == ResourceState.undefined
-    assert status['exp::Test2[agenta,name=idb]'] == ResourceState.undefined
+    assert status["exp::Test2[agenta,name=ida]"] == ResourceState.undefined
+    assert status["exp::Test2[agenta,name=idb]"] == ResourceState.undefined
+
 
 def test_1934_cycle_in_dep_mgmr(snippetcompiler):
     snippetcompiler.setup_for_snippet(


### PR DESCRIPTION
# Description

Pre-serialize the resource attributes to catch the UnknownException early. 

Not a very nice approach, but best I could do without risking major backward compatibility issues .
Suggestion welcome

closes #2603

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

