### PR TITLE
set correct version for tests_common

### DIFF
--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -22,7 +22,7 @@ from setuptools import find_packages, setup
 requires = [
     "asyncpg",
     "click",
-    "inmanta",
+    "inmanta-core",
     "pyformance",
     "pytest-asyncio",
     "pytest-env",
@@ -35,7 +35,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    version="2020.6",
+    version="4.0.0",
     python_requires=">=3.6",  # also update classifiers
     # Meta data
     name="pytest-inmanta-extensions",
@@ -58,7 +58,7 @@ setup(
         "Framework :: Pytest",
     ],
     keywords="pytest inmanta tests",
-    project_urls={"Bug Tracker": "https://github.com/inmanta/inmanta/issues"},
+    project_urls={"Bug Tracker": "https://github.com/inmanta/inmanta-core/issues"},
     # Packaging
     package_dir={"": "src"},
     packages=find_packages("src"),


### PR DESCRIPTION
This file appears to have been forgotten when renaming and switching to semantic versioning. This is blocking the release.
