### PR TITLE
explicitly added files to bumpversion file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,2 +1,6 @@
 [bumpversion]
 current_version = 4.1.0
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:tests_common/setup.py]


### PR DESCRIPTION
# Description

Explicitly added files to bumpversion file. This will need to be cherry-picked to `iso3` and `iso4`.

part of inmanta/irt#393

# Self Check:

- [ ] Attached issue to pull request
- [ ] Changelog entry
