### PR TITLE
explicitly added files to bumpversion file (#2635)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,13 @@
 [bumpversion]
 current_version = 2020.4.5
 parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 	{major}.{minor}
 
 [bumpversion:part:minor]
 first_value = 1
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:tests_common/setup.py]

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -35,7 +35,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    version="2020.4.4",
+    version="2020.4.5",
     python_requires=">=3.6",  # also update classifiers
     # Meta data
     name="pytest-inmanta-extensions",


### PR DESCRIPTION
Part of inmanta/irt#393.

I think `tests_common/setup.py` was forgotten in #2607.