### PR TITLE
Bump dep on latest branch to fix pytest docker builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ tornado==6.0.4
 tox==3.20.1
 tox-venv==0.4.0
 asyncpg==0.21.0
-pytest-postgresql==2.5.1
+pytest-postgresql==2.5.2
 pytest-env==0.6.2
 jinja2==2.11.2
 pep8-naming==0.11.1


### PR DESCRIPTION
# Description

We released with a broken pytest-postgresql for centos7. This bump seems to fix it when I run the tests locally in docker on my machine. It does not affect customer code, so should not be released. Just on sitting on the latest branch is enough.

closes #2629 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
