### PR TITLE
Fix order by that does not support parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Release 4.1.0 (?)
+## Bug fixes
+- Fix broken order by (#2638)
 
 # Release 4.0.0 (2020-12-23)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Shortcuts for various dev tasks. Based on makefile from pydantic
 .DEFAULT_GOAL := all
-isort = isort -rc src tests tests_common
+isort = isort src tests tests_common
 black = black src tests tests_common
 
 .PHONY: install

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2455,7 +2455,7 @@ class ConfigurationModel(BaseDocument):
         if limit is not None:
             limit = int(limit)
         if offset is not None:
-            offset = int(limit)
+            offset = int(offset)
 
         transient_states = ",".join(["$" + str(i) for i in range(1, len(const.TRANSIENT_STATES) + 1)])
         transient_states_values = [cls._get_value(s) for s in const.TRANSIENT_STATES]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2064,7 +2064,7 @@ class Resource(BaseDocument):
         values = values + cls._get_value(resource_version_ids)
         query = (
             f"SELECT * FROM {cls.table_name()} "
-            "WHERE {filter_statement} AND resource_version_id IN ({ resource_version_ids_statement})"
+            f"WHERE {filter_statement} AND resource_version_id IN ({resource_version_ids_statement})"
         )
         resources = await cls.select_query(query, values, connection=connection)
         return resources

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -460,7 +460,6 @@ class BaseDocument(object, metaclass=DocumentMeta):
             if o not in possible:
                 raise RuntimeError(f"The following order can not be applied: {order}, {o} should be one of {possible}")
 
-        print(cls._fields, order_by_column)
         if order_by_column is not None and order_by_column not in cls._fields:
             raise RuntimeError(f"{order_by_column} is not a valid field name.")
 
@@ -2449,6 +2448,15 @@ class ConfigurationModel(BaseDocument):
         connection: Optional[asyncpg.connection.Connection] = None,
         **query: Any,
     ) -> List["ConfigurationModel"]:
+        # sanitize and validate order parameters
+        cls._validate_order(order_by_column, order)
+
+        # ensure limit and offset is an integer
+        if limit is not None:
+            limit = int(limit)
+        if offset is not None:
+            offset = int(limit)
+
         transient_states = ",".join(["$" + str(i) for i in range(1, len(const.TRANSIENT_STATES) + 1)])
         transient_states_values = [cls._get_value(s) for s in const.TRANSIENT_STATES]
         (filterstr, values) = cls._get_composed_filter(col_name_prefix="c", offset=len(transient_states_values) + 1, **query)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1210,7 +1210,7 @@ async def test_issue_422(init_dataclasses_and_load_schema):
 
 
 @pytest.mark.asyncio
-async def test_get_latest_resource(init_dataclasses_and_load_schema):
+async def test_get_latest_resource(init_dataclasses_and_load_schema, postgresql_client):
     project = data.Project(name="test")
     await project.insert()
 
@@ -1260,6 +1260,18 @@ async def test_get_latest_resource(init_dataclasses_and_load_schema):
 
     res = await data.Resource.get_latest_version(env.id, key)
     assert res.model == 2
+
+
+@pytest.mark.asyncio
+async def test_order_by_validation(init_dataclasses_and_load_schema):
+    """Test the validation of the order by column names and the sort order value. This test case checks that wrong values
+    are rejected. Other test cases validate that the parameters work.
+    """
+    with pytest.raises(RuntimeError):
+        await data.Resource.get_list(order_by_column="; DROP DATABASE")
+
+    with pytest.raises(RuntimeError):
+        await data.Resource.get_list(order="BAD")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

- It is not supported to use parameters in order by. This patch fixes this.
- Add some typing in related methods while reading code
- Use string formatters to improve code readbility
- Fix a warning in make format
- Added a test case for input validation

I did not add an extra test case to validate the order because test_data.py::test_get_latest_resource
was broken. This patch fixes it.

closes #2638 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
