### PR TITLE
Fix python path inheritance for virtual envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 - Fix broken order by (#2638)
 - Report the Inmanta OSS product version correctly (#2622)
-
+- Set PYTHONPATH so that all subprocesses also see packages in parent venv (#2650)
 
 # Release 4.0.0 (2020-12-23)
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -136,6 +136,8 @@ class VirtualEnv(object):
         os.environ["PATH"] = binpath + os.pathsep + old_os_path
         prev_sys_path = list(sys.path)
 
+        os.environ["PYTHONPATH"] = site_packages + os.pathsep + os.environ.get("PYTHONPATH", "")
+
         site.addsitedir(site_packages)
         sys.real_prefix = sys.prefix
         sys.prefix = base
@@ -267,7 +269,7 @@ class VirtualEnv(object):
 
     def _set_current_requirements_hash(self, new_hash):
         """
-        Set the current requirements hahs
+        Set the current requirements hash
         """
         path = os.path.join(self.env_path, "requirements.sha1sum")
         with open(path, "w+", encoding="utf-8") as fd:
@@ -300,6 +302,12 @@ class VirtualEnv(object):
             self.__cache_done.add(x)
 
     def _remove_requirements_present_in_parent_env(self, requirements_list: List[str]) -> List[str]:
+        """ Given an existing list of requirements, remove all the requirements that are already present in the parent
+        virtual environment.
+
+        :param requirements_list: The full list of requirements.
+        :return: A list of requirements with the packages installed in the parent filtered from it.
+        """
         reqs_to_remove = []
         packages_installed_in_parent = self.get_package_installed_in_parent_env()
         for r in requirements_list:
@@ -317,6 +325,10 @@ class VirtualEnv(object):
 
     @classmethod
     def _get_installed_packages(cls, python_interpreter: str) -> Dict[str, str]:
+        """Return a list of all installed packages in the site-packages of a python interpreter.
+        :param python_interpreter: The python interpreter to get the packages for
+        :return: A dict with package names as keys and versions as values
+        """
         cmd = [python_interpreter, "-m", "pip", "list", "--format", "json"]
         try:
             output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -243,7 +243,6 @@ class VirtualEnv(object):
             assert self.virtual_python is not None
             cmd: List["str"] = [self.virtual_python, "-m", "pip", "install", "-r", path]
             try:
-                print(subprocess.check_output([self.virtual_python, "-m", "pip", "list"]))
                 output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
             except CalledProcessError as e:
                 LOGGER.error("%s: %s", cmd, e.output.decode())

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -166,6 +166,10 @@ class VirtualEnv(object):
         return None, req_line
 
     def _gen_requirements_file(self, requirements_list: List[str]) -> str:
+        """ Generate a new requirements file based on the requirements list that was built from all the different modules.
+        :param requirements_list:  A list of requirements from all the requirements files in all modules.
+        :return: A string that can be written to a requirements file that pip understands.
+        """
         modules: Dict[str, Any] = {}
         for req in requirements_list:
             parsed_name, req_spec = self._parse_line(req)
@@ -284,7 +288,7 @@ class VirtualEnv(object):
             if len(requirements_list) == 0:
                 return
 
-        requirements_list = sorted(self._remove_requirements_present_in_parent_env(requirements_list))
+        requirements_list = sorted(requirements_list)
 
         # hash it
         sha1sum = hashlib.sha1()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -16,7 +16,6 @@
     Contact: bart@inmanta.com
 """
 import logging
-import os
 import sys
 from subprocess import CalledProcessError
 
@@ -72,13 +71,10 @@ def test_install_fails(tmpdir, caplog):
     venv.use_virtual_env()
     caplog.clear()
     package_name = "non-existing-pkg-inmanta"
-    exception_raised = False
-    try:
-        venv.install_from_list([package_name])
-    except Exception:
-        exception_raised = True
 
-    assert exception_raised
+    with pytest.raises(Exception):
+        venv.install_from_list([package_name])
+
     log_sequence = LogSequence(caplog)
     log_sequence.contains("inmanta.env", logging.ERROR, f"requirements: {package_name}")
 
@@ -99,6 +95,7 @@ def test_install_package_already_installed_in_parent_env(tmpdir):
     ]
 
     # verify that the venv sees all parent packages
+    assert not set(parent_installed) - set(installed_packages)
 
     # test installing a package that is already present in the parent venv
     random_package = parent_installed[0]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2016 Inmanta
+    Copyright 2021 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
 
     Contact: bart@inmanta.com
 """
-
 import logging
+import os
+import sys
 from subprocess import CalledProcessError
 
 import pytest
@@ -83,16 +84,29 @@ def test_install_fails(tmpdir, caplog):
 
 
 def test_install_package_already_installed_in_parent_env(tmpdir):
+    """Test using and installing a package that is already present in the parent virtual environment."""
+    # get all packages in the parent
+    parent_installed = [
+        p for p in env.VirtualEnv._get_installed_packages(sys.executable).keys() if p not in ["pip", "setuptools"]
+    ]
+
+    # create a venv and list all packages available in the venv
     venv = env.VirtualEnv(tmpdir)
     venv.use_virtual_env()
+
     installed_packages = [
-        p for p in env.VirtualEnv._get_installed_packages(venv._parent_python).keys() if p != "pip" and p != "setuptools"
+        p for p in env.VirtualEnv._get_installed_packages(venv._parent_python).keys() if p not in ["pip", "setuptools"]
     ]
-    random_package = installed_packages[0]
+
+    # verify that the venv sees all parent packages
+
+    # test installing a package that is already present in the parent venv
+    random_package = parent_installed[0]
     venv.install_from_list([random_package])
 
-    # Assert not installed in virtual_python venv
-    assert random_package not in env.VirtualEnv._get_installed_packages(venv.virtual_python).keys()
+    # Assert not installed in virtual_python venv by doing a pip list in the virtual env without inheriting PYTHONPATH
+    venv_installed = env.VirtualEnv._get_installed_packages(venv.virtual_python, inherit_python_path=False).keys()
+    assert random_package not in venv_installed
 
 
 def test_req_parser(tmpdir):
@@ -133,41 +147,3 @@ def test_gen_req_file(tmpdir):
         'lorem == 0.1.1, > 0.1 ; python_version < "3.7" and platform_machine == "x86_64" and platform_system == "Linux"'
         in req_lines
     )
-
-
-def test_remove_requirements_present_in_parent_env(tmpdir):
-    v = env.VirtualEnv(tmpdir)
-    v.use_virtual_env()
-
-    # Verify parsing works
-    reqs = [
-        "lorem == 0.1.1",
-        "lorem > 0.1",
-        "lorem >= 1.1,<1.5",
-        "dummy-yummy",
-        "iplib@git+https://github.com/bartv/python3-iplib",
-    ]
-    assert v._remove_requirements_present_in_parent_env(reqs) == reqs
-
-    installed_packages = {
-        k: v for k, v in env.VirtualEnv._get_installed_packages(v._parent_python).items() if k != "pip" and k != "setuptools"
-    }
-    package = next(iter(installed_packages.keys()))
-    package_version = installed_packages[package]
-    splitted_package_version = package_version.split(".", maxsplit=1)
-    newer_package_version = f"{int(splitted_package_version[0]) + 1}.{splitted_package_version[1]}"
-
-    # Package is present in parent venv and constraint is met
-    reqs = [f"{package}=={package_version}", "non_existing_package==1.1.1"]
-    reqs_after_removal = ["non_existing_package==1.1.1"]
-    assert v._remove_requirements_present_in_parent_env(reqs) == reqs_after_removal
-
-    reqs = [f"{package}>={package_version},<{newer_package_version}", "non_existing_package==1.1.1"]
-    assert v._remove_requirements_present_in_parent_env(reqs) == reqs_after_removal
-
-    # Package is present in parent venv, but constraint isn't met
-    reqs = [f"{package}=={newer_package_version}", "non_existing_package==1.1.1"]
-    assert v._remove_requirements_present_in_parent_env(reqs) == reqs
-
-    reqs = [f"{package}>{package_version}", "non_existing_package==1.1.1"]
-    assert v._remove_requirements_present_in_parent_env(reqs) == reqs


### PR DESCRIPTION
# Description

Improve handling of python path for processes that are forked by the server/compiler/agent. This should fix issues where the compiler or agents needs to install python packages that are already present in the server python path / venv.

closes #2650 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
