### PR TITLE
Issue/2676 fix pythonpath

### DIFF
--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -172,6 +172,10 @@ class BashIO(IOBase):
         if env is not None:
             current_env.update(env)
 
+        if "PYTHONPATH" not in env:
+            # Remove the inherited python path
+            del current_env["PYTHONPATH"]
+
         cmds = [command] + arguments
         result = subprocess.Popen(
             self._run_as_args(*cmds), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=current_env, cwd=cwd
@@ -433,6 +437,11 @@ class LocalIO(IOBase):
         current_env = os.environ.copy()
         if env is not None:
             current_env.update(env)
+
+        if "PYTHONPATH" not in env:
+            # Remove the inherited python path
+            del current_env["PYTHONPATH"]
+
         if sys.version_info < (3, 0, 0):
             # python < 2.7 does not support dict comprehensions
             new_env = {}

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -172,7 +172,7 @@ class BashIO(IOBase):
         if env is not None:
             current_env.update(env)
 
-        if "PYTHONPATH" not in env:
+        if not env or "PYTHONPATH" not in env:
             # Remove the inherited python path
             del current_env["PYTHONPATH"]
 
@@ -438,7 +438,7 @@ class LocalIO(IOBase):
         if env is not None:
             current_env.update(env)
 
-        if "PYTHONPATH" not in env:
+        if not env or "PYTHONPATH" not in env:
             # Remove the inherited python path
             del current_env["PYTHONPATH"]
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -33,7 +33,7 @@ io_list = [LocalIO("local:", {}), BashIO("local:", {}), BashIO("local:", {}, run
 io_names = ["local", "bash", "bash_root"]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def testdir():
     testdir = tempfile.mkdtemp()
     yield testdir
@@ -290,10 +290,13 @@ def test_run_pythonpath(io, tmpdir):
     """ Test to see if the python path of the venv is removed for the subprocess
         See issue #2676
     """
-    print(os.environ.get("PYTHONPATH"))
     venv = env.VirtualEnv(tmpdir)
     venv.use_virtual_env()
-    print(os.environ.get("PYTHONPATH"))
-    result = io.run("env")
 
+    result = io.run("env")
     assert "PYTHONPATH" not in result[0]
+
+    if not hasattr(io, "run_as") or not io.run_as:
+        # This does not work as expected when using the run_as root feature with bash and sudo
+        result = io.run("env", env={"PYTHONPATH": "test"})
+        assert "PYTHONPATH" in result[0]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -299,6 +299,6 @@ def test_run_pythonpath(io, tmpdir):
 
     if not hasattr(io, "run_as") or not io.run_as:
         # This does not work as expected when using the run_as root feature with bash and sudo because by default
-        # PYTHONPATH is a "bad" variable
+        # PYTHONPATH is a "bad" variable in sudo https://fossies.org/linux/sudo/plugins/sudoers/env.c#l_190
         result = io.run("env", env={"PYTHONPATH": "test"})
         assert "PYTHONPATH" in result[0]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -285,10 +285,11 @@ def test_uri_parse():
     assert config["host"] == "1.2.3.4"
     assert config["python"] == "/usr/bin/python2"
 
+
 @pytest.mark.parametrize("io", io_list)
 def test_run_pythonpath(io, tmpdir):
-    """ Test to see if the python path of the venv is removed for the subprocess
-        See issue #2676
+    """Test to see if the python path of the venv is removed for the subprocess
+    See issue #2676
     """
     venv = env.VirtualEnv(tmpdir)
     venv.use_virtual_env()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -298,6 +298,7 @@ def test_run_pythonpath(io, tmpdir):
     assert "PYTHONPATH" not in result[0]
 
     if not hasattr(io, "run_as") or not io.run_as:
-        # This does not work as expected when using the run_as root feature with bash and sudo
+        # This does not work as expected when using the run_as root feature with bash and sudo because by default
+        # PYTHONPATH is a "bad" variable
         result = io.run("env", env={"PYTHONPATH": "test"})
         assert "PYTHONPATH" in result[0]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -25,6 +25,7 @@ import tempfile
 
 import pytest
 
+from inmanta import env
 from inmanta.agent.io import parse_agent_uri
 from inmanta.agent.io.local import BashIO, LocalIO
 
@@ -75,7 +76,6 @@ def test_check_read_binary(io, testdir):
 def test_check_run_pipe_actual(io, testdir):
     filename = os.path.join(testdir, "testfile")
     result = io.run("sh", ["-c", "export PATH=$PATH:/usr/lib/jvm/jre-1.7.0-openjdk/bin; env >" + filename + " 2>&1"])
-    print(result)
     assert "/usr/lib/jvm/jre-1.7.0-openjdk/bin" not in result[0]
     assert result[2] == 0
     assert os.path.exists(filename)
@@ -284,3 +284,16 @@ def test_uri_parse():
     assert config["port"] == "22"
     assert config["host"] == "1.2.3.4"
     assert config["python"] == "/usr/bin/python2"
+
+@pytest.mark.parametrize("io", io_list)
+def test_run_pythonpath(io, tmpdir):
+    """ Test to see if the python path of the venv is removed for the subprocess
+        See issue #2676
+    """
+    print(os.environ.get("PYTHONPATH"))
+    venv = env.VirtualEnv(tmpdir)
+    venv.use_virtual_env()
+    print(os.environ.get("PYTHONPATH"))
+    result = io.run("env")
+
+    assert "PYTHONPATH" not in result[0]


### PR DESCRIPTION
# Description

Remove the PYTHONPATH from IO. This does not work as expected when using sudo bashio but I am unable to find the root cause.

There are test cases that verify that setting env variables works with sudo bashio, but this test case does not.

closes #2676 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
