### PR TITLE
Upgrade pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix broken order by (#2638)
 - Report the Inmanta OSS product version correctly (#2622)
 - Set PYTHONPATH so that all subprocesses also see packages in parent venv (#2650)
+- Create virtual environments without pip and use the pip of the parent venv
 
 # Release 4.0.0 (2020-12-23)
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -154,9 +154,9 @@ class VirtualEnv(object):
         # write out a "stub" pip so that pip list works in the virtual env
         bin_path = os.path.join(self.env_path, "bin", "pip")
         with open(bin_path, "w") as fd:
-            fd.write("""#!/bin/sh
+            fd.write(f"""#!/bin/sh
 source activate
-export PYTHONPATH=/home/bart/.virtualenvs/inmanta/lib/python3.6/site-packages:$PYTHONPATH
+export PYTHONPATH="{self.env_path}/lib/python3.6/site-packages:$PYTHONPATH"
 python -m pip $@
             """)
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -152,8 +152,8 @@ class VirtualEnv(object):
         os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
 
         # write out a "stub" pip so that pip list works in the virtual env
-        bin_path = os.path.join(self.env_path, "bin", "pip")
-        with open(bin_path, "w") as fd:
+        pip_path = os.path.join(self.env_path, "bin", "pip")
+        with open(pip_path, "w") as fd:
             fd.write(
                 f"""#!/bin/sh
 source activate
@@ -162,7 +162,7 @@ python -m pip $@
             """
             )
 
-        os.chmod(bin_path, 0o755)
+        os.chmod(pip_path, 0o755)
 
     def _parse_line(self, req_line: str) -> Tuple[Optional[str], str]:
         """

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -16,7 +16,6 @@
     Contact: code@inmanta.com
 """
 
-import glob
 import hashlib
 import json
 import logging

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -107,9 +107,9 @@ class VirtualEnv(object):
         LOGGER.debug("Ensuring latest pip and wheel versions available")
         cmd: List["str"] = [self.virtual_python, "-m", "pip", "install", "-U", "pip", "wheel"]
         try:
-            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        except CalledProcessError:
-            LOGGER.exception("Failed to upgrade pip")
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except CalledProcessError as e:
+            LOGGER.exception("Failed to upgrade pip: %s", e.output.decode())
 
         return True
 
@@ -251,6 +251,7 @@ class VirtualEnv(object):
 
             assert self.virtual_python is not None
             cmd: List["str"] = [self.virtual_python, "-m", "pip", "install", "-r", path]
+            output: bytes = b""  # Make sure the var is always defined in the except bodies
             try:
                 output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
             except CalledProcessError as e:

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 
+import glob
 import hashlib
 import json
 import logging
@@ -153,11 +154,12 @@ class VirtualEnv(object):
 
         # write out a "stub" pip so that pip list works in the virtual env
         pip_path = os.path.join(self.env_path, "bin", "pip")
+
         with open(pip_path, "w") as fd:
             fd.write(
                 f"""#!/bin/sh
 source activate
-export PYTHONPATH="{self.env_path}/lib/python3.6/site-packages:$PYTHONPATH"
+export PYTHONPATH="{os.pathsep.join(sys.path)}"
 python -m pip $@
             """
             )

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -151,6 +151,18 @@ class VirtualEnv(object):
         # Also set the python path environment variable for any subprocess
         os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
 
+        # write out a "stub" pip so that pip list works in the virtual env
+        bin_path = os.path.join(self.env_path, "bin", "pip")
+        with open(bin_path, "w") as fd:
+            fd.write("""#!/bin/sh
+source activate
+export PYTHONPATH=/home/bart/.virtualenvs/inmanta/lib/python3.6/site-packages:$PYTHONPATH
+python -m pip $@
+            """)
+
+        os.chmod(bin_path, 0o755)
+
+
     def _parse_line(self, req_line: str) -> Tuple[Optional[str], str]:
         """
         Parse the requirement line

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -102,6 +102,15 @@ class VirtualEnv(object):
 
         # set the path to the python and the pip executables
         self.virtual_python = python_bin
+
+        # update pip to the latest version and install wheel
+        LOGGER.debug("Ensuring latest pip and wheel versions available")
+        cmd: List["str"] = [self.virtual_python, "-m", "pip", "install", "-U", "pip", "wheel"]
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except CalledProcessError:
+            LOGGER.exception("Failed to upgrade pip")
+
         return True
 
     def use_virtual_env(self) -> None:

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -247,6 +247,7 @@ python -m pip $@
         """
         requirements_file = self._gen_requirements_file(requirements_list)
 
+        path = ""
         try:
             fdnum, path = tempfile.mkstemp()
             fd = os.fdopen(fdnum, "w+", encoding="utf-8")
@@ -327,6 +328,7 @@ python -m pip $@
         :return: A dict with package names as keys and versions as values
         """
         cmd = [python_interpreter, "-m", "pip", "list", "--format", "json"]
+        output = b""
         try:
             environment = os.environ.copy()
             output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL, env=environment)

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -154,14 +154,15 @@ class VirtualEnv(object):
         # write out a "stub" pip so that pip list works in the virtual env
         bin_path = os.path.join(self.env_path, "bin", "pip")
         with open(bin_path, "w") as fd:
-            fd.write(f"""#!/bin/sh
+            fd.write(
+                f"""#!/bin/sh
 source activate
 export PYTHONPATH="{self.env_path}/lib/python3.6/site-packages:$PYTHONPATH"
 python -m pip $@
-            """)
+            """
+            )
 
         os.chmod(bin_path, 0o755)
-
 
     def _parse_line(self, req_line: str) -> Tuple[Optional[str], str]:
         """

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -27,13 +27,7 @@ from inmanta import env
 from utils import LogSequence
 
 
-@pytest.mark.fixture
-def lorem():
-    # make sure lorem is not installed
-    subprocess.check_output(["pip", "uninstall", "lorem"], stderr=subprocess.PIPE)
-
-
-def test_basic_install(tmpdir, lorem):
+def test_basic_install(tmpdir):
     """If this test fails, try running "pip uninstall lorem dummy-yummy iplib" before running it."""
 
     env_dir1 = tmpdir.mkdir("env1").strpath
@@ -111,11 +105,6 @@ def test_install_package_already_installed_in_parent_env(tmpdir, lorem):
 
     # Assert nothing installed in the virtual env
     assert not os.listdir(site_dir)
-
-    # Install a package and verify that it is in the site dir
-    assert "lorem" not in installed_packages
-    venv.install_from_list(["lorem"])
-    assert "lorem" in os.listdir(site_dir)
 
     # report json
     output = subprocess.check_output([os.path.join(venv.env_path, "bin/pip"), "list"])

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -81,7 +81,7 @@ def test_install_fails(tmpdir, caplog):
     log_sequence.contains("inmanta.env", logging.ERROR, f"requirements: {package_name}")
 
 
-def test_install_package_already_installed_in_parent_env(tmpdir, lorem):
+def test_install_package_already_installed_in_parent_env(tmpdir):
     """Test using and installing a package that is already present in the parent virtual environment."""
     # get all packages in the parent
     parent_installed = list(env.VirtualEnv._get_installed_packages(sys.executable).keys())
@@ -107,8 +107,7 @@ def test_install_package_already_installed_in_parent_env(tmpdir, lorem):
     assert not os.listdir(site_dir)
 
     # report json
-    output = subprocess.check_output([os.path.join(venv.env_path, "bin/pip"), "list"])
-    assert "lorem" in output.decode()
+    subprocess.check_output([os.path.join(venv.env_path, "bin/pip"), "list"])
 
 
 def test_req_parser(tmpdir):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -27,7 +27,13 @@ from inmanta import env
 from utils import LogSequence
 
 
-def test_basic_install(tmpdir):
+@pytest.mark.fixture
+def lorem():
+    # make sure lorem is not installed
+    subprocess.check_output(["pip", "uninstall", "lorem"], stderr=subprocess.PIPE)
+
+
+def test_basic_install(tmpdir, lorem):
     """If this test fails, try running "pip uninstall lorem dummy-yummy iplib" before running it."""
 
     env_dir1 = tmpdir.mkdir("env1").strpath
@@ -81,11 +87,8 @@ def test_install_fails(tmpdir, caplog):
     log_sequence.contains("inmanta.env", logging.ERROR, f"requirements: {package_name}")
 
 
-def test_install_package_already_installed_in_parent_env(tmpdir):
+def test_install_package_already_installed_in_parent_env(tmpdir, lorem):
     """Test using and installing a package that is already present in the parent virtual environment."""
-    # make sure lorem is not installed
-    subprocess.check_output(["pip", "uninstall", "lorem"], stderr=subprocess.PIPE)
-
     # get all packages in the parent
     parent_installed = list(env.VirtualEnv._get_installed_packages(sys.executable).keys())
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -17,6 +17,7 @@
 """
 import logging
 import os
+import subprocess
 import sys
 from subprocess import CalledProcessError
 
@@ -104,6 +105,15 @@ def test_install_package_already_installed_in_parent_env(tmpdir):
 
     # Assert nothing installed in the virtual env
     assert not os.listdir(site_dir)
+
+    # Install a package and verify that it is in the site dir
+    assert "lorem" not in installed_packages
+    venv.install_from_list(["lorem"])
+    assert "lorem" in os.listdir(site_dir)
+
+    # report json
+    output = subprocess.check_output([os.path.join(venv.env_path, "bin/pip"), "list"])
+    assert "lorem" in output.decode()
 
 
 def test_req_parser(tmpdir):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -83,6 +83,9 @@ def test_install_fails(tmpdir, caplog):
 
 def test_install_package_already_installed_in_parent_env(tmpdir):
     """Test using and installing a package that is already present in the parent virtual environment."""
+    # make sure lorem is not installed
+    subprocess.check_output(["pip", "uninstall", "lorem"], stderr=subprocess.PIPE)
+
     # get all packages in the parent
     parent_installed = list(env.VirtualEnv._get_installed_packages(sys.executable).keys())
 


### PR DESCRIPTION
# Description

- Upgrade pip when venv is created
- Fix a potential error in pip install

Should we add pip >= 21.0.1 to the requirements file?

The tests run fine on my machine but seem to be unstable on jenkins. The tests also become a lot slower. So what do we do about it? The current irt moduleset issues seem to be related to not having a pip that can install cryptography (which might be fixable with doing correct PYTHONPATH inheritance)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
