### PR TITLE
Fix test on python38

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cookiecutter==1.7.2
 cryptography==3.4.4
 docstring-parser==0.7.3
 execnet==1.8.0
-importlib_metadata==3.4.0
+importlib_metadata==2.1.0
 jinja2==2.11.3
 more-itertools==8.7.0
 netifaces==0.10.9
@@ -14,7 +14,7 @@ pip==21.0.1
 ply==3.11
 pydantic==1.7.3
 pyformance==0.4
-PyJWT==2.0.1
+PyJWT==1.7.1
 python-dateutil==2.8.1
 pyyaml==5.4.1
 setuptools==53.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cookiecutter==1.7.2
 cryptography==3.4.4
 docstring-parser==0.7.3
 execnet==1.8.0
-importlib_metadata==2.1.0
+importlib_metadata==3.4.0
 jinja2==2.11.3
 more-itertools==8.7.0
 netifaces==0.10.9
@@ -14,7 +14,7 @@ pip==21.0.1
 ply==3.11
 pydantic==1.7.3
 pyformance==0.4
-PyJWT==1.7.1
+PyJWT==2.0.1
 python-dateutil==2.8.1
 pyyaml==5.4.1
 setuptools==53.0.0

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -15,6 +15,7 @@
 
     Contact: bart@inmanta.com
 """
+import glob
 import logging
 import os
 import subprocess
@@ -96,7 +97,11 @@ def test_install_package_already_installed_in_parent_env(tmpdir):
     assert not set(parent_installed) - set(installed_packages)
 
     # site dir should be empty
-    site_dir = os.path.join(venv.env_path, "lib/python3.6/site-packages")
+    site_dir = os.path.join(venv.env_path, "lib/python*/site-packages")
+    dirs = glob.glob(site_dir)
+    assert len(dirs) == 1
+    site_dir = dirs[0]
+
     assert not os.listdir(site_dir)
 
     # test installing a package that is already present in the parent venv


### PR DESCRIPTION
# Description

The env tests did not support python3.8 yet. This fixes this.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
