### PR TITLE
Re-enable version bumps cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click-plugins==1.1.1
 click==7.1.2
 colorlog==4.7.2
 cookiecutter==1.7.2
-cryptography==3.4.4
+cryptography==3.4.5
 docstring-parser==0.7.3
 execnet==1.8.0
 importlib_metadata==2.1.0


### PR DESCRIPTION
# Description

The version bumps for cryptography were disabled in the past due to failing tests. By bumping it manually, dependabot will start bumping it again. 