### PR TITLE
Issue/2689 bugfix relation lower unbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Report the Inmanta OSS product version correctly (#2622)
 - Set PYTHONPATH so that all subprocesses also see packages in parent venv (#2650)
 - Create virtual environments without pip and use the pip of the parent venv
+- Correctly set `[:n]` as syntactic sugar for `[0:n]` instead of leaving lower unbound (#2689)
 
 # Release 4.0.0 (2020-12-23)
 

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -65,7 +65,9 @@ class Attribute(Locatable):
         if nullable:
             self.__type = NullableType(self.__type)
 
-        self.low = 0 if nullable else 1
+        self.low: int = 0 if nullable else 1
+        # This attribute is only used for the DeprecatedOptionVariable
+        self.high: Optional[int] = None
         self.comment = None  # type: Optional[str]
         self.end: Optional[RelationAttribute] = None
 
@@ -154,7 +156,7 @@ class RelationAttribute(Attribute):
         Attribute.__init__(self, entity, value_type, name, location)
         self.end: Optional[RelationAttribute] = None
         self.low = 1
-        self.high = 1
+        self.high: Optional[int] = 1
         self.depends = False
         self.source_annotations = []
         self.target_annotations = []
@@ -165,7 +167,7 @@ class RelationAttribute(Attribute):
     def __repr__(self) -> str:
         return "[%d:%s] %s" % (self.low, self.high if self.high is not None else "", self.name)
 
-    def set_multiplicity(self, values: "Tuple[int, int]") -> None:
+    def set_multiplicity(self, values: "Tuple[int, Optional[int]]") -> None:
         """
         Set the multiplicity of this end
         """
@@ -173,12 +175,13 @@ class RelationAttribute(Attribute):
         self.high = values[1]
 
     def get_new_result_variable(self, instance: "Instance", queue: QueueScheduler) -> ResultVariable:
+        out: ResultVariable
         if self.low == 1 and self.high == 1:
-            out = AttributeVariable(self, instance)  # type: ResultVariable
+            out = AttributeVariable(self, instance)
         elif self.low == 0 and self.high == 1:
-            out = OptionVariable(self, instance, queue)  # type: ResultVariable
+            out = OptionVariable(self, instance, queue)
         else:
-            out = ListVariable(self, instance, queue)  # type: ResultVariable
+            out = ListVariable(self, instance, queue)
         out.set_type(self.type)
         return out
 

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -156,7 +156,7 @@ class RelationAttribute(Attribute):
         Attribute.__init__(self, entity, value_type, name, location)
         self.end: Optional[RelationAttribute] = None
         self.low = 1
-        self.high: Optional[int] = 1
+        self.high = 1
         self.depends = False
         self.source_annotations = []
         self.target_annotations = []

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -523,7 +523,7 @@ class DefineTypeDefault(TypeDefinitionStatement):
             default.add_default(name, value)
 
 
-Relationside = Tuple[LocatableString, LocatableString, Tuple[Optional[int], Optional[int]]]
+Relationside = Tuple[LocatableString, Optional[LocatableString], Optional[Tuple[int, Optional[int]]]]
 
 
 class DefineRelation(BiStatement):
@@ -544,8 +544,8 @@ class DefineRelation(BiStatement):
         self.anchors.append(TypeReferenceAnchor(left[0].namespace, left[0]))
         self.anchors.append(TypeReferenceAnchor(right[0].namespace, right[0]))
 
-        self.left = left
-        self.right = right
+        self.left: Relationside = left
+        self.right: Relationside = right
 
         self.comment = None
 
@@ -603,6 +603,7 @@ class DefineRelation(BiStatement):
                 ("Attribute name %s is already defined in %s, unable to define relationship") % (str(self.left[1]), right.name),
             )
 
+        left_end: Optional[RelationAttribute]
         if self.left[1] is not None:
             left_end = RelationAttribute(right, left, str(self.left[1]), self.left[1].get_location())
             left_end.target_annotations = self.annotations
@@ -611,6 +612,7 @@ class DefineRelation(BiStatement):
         else:
             left_end = None
 
+        right_end: Optional[RelationAttribute]
         if self.right[1] is not None:
             if right == left and str(self.left[1]) == str(self.right[1]):
                 # relation is its own inverse

--- a/src/inmanta/model.py
+++ b/src/inmanta/model.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 from builtins import str
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 """
     Objects defining the serialization format for type information.
@@ -194,7 +194,7 @@ class Relation(object):
     def __init__(
         self,
         mytype: str,
-        multi: Tuple[int, int],
+        multi: Tuple[int, Optional[int]],
         reverse: str,
         comment: str,
         location: Location,
@@ -203,8 +203,6 @@ class Relation(object):
     ) -> None:
         self.type = mytype
         lower = multi[0]
-        if lower is None:
-            lower = -1
         upper = multi[1]
         if upper is None:
             upper = -1

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -523,7 +523,7 @@ def p_multi_3(p: YaccProduction) -> None:
 
 def p_multi_4(p: YaccProduction) -> None:
     "multi : '['  ':' INT ']' "
-    p[0] = (None, p[3])
+    p[0] = (0, p[3])
 
 
 # typedef

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -122,7 +122,8 @@ end
 A.opt [%s:1] -- A
 
 index A(name,opt)
-""" % ("0" if explicit else "")
+"""
+            % ("0" if explicit else "")
         )
         compiler.do_compile()
 

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -110,7 +110,8 @@ index A(name,opt)
         compiler.do_compile()
 
 
-def test_issue_745_index_on_optional(snippetcompiler):
+@pytest.mark.parametrize("explicit", [True, False])
+def test_issue_745_2689_index_on_optional(snippetcompiler, explicit: bool):
     with pytest.raises(IndexException):
         snippetcompiler.setup_for_snippet(
             """
@@ -118,10 +119,10 @@ entity A:
     string name
 end
 
-A.opt [0:1] -- A
+A.opt [%s:1] -- A
 
 index A(name,opt)
-"""
+""" % ("0" if explicit else "")
         )
         compiler.do_compile()
 

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -683,3 +683,21 @@ a = A()
     else:
         with pytest.raises(CompilerException):
             compiler.do_compile()
+
+
+def test_2689_relation_unset_lower(snippetcompiler) -> None:
+    snippetcompiler.setup_for_snippet(
+        """
+entity A:
+end
+
+entity B:
+end
+B.a [:1] -- A
+B(a=A())
+
+implement A using std::none
+implement B using std::none
+        """
+    )
+    compiler.do_compile()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -220,7 +220,7 @@ Test tests [3] -- [:10] Foo bars
     assert str(rel.right[1]) == "bars"
 
     assert rel.left[2] == (3, 3)
-    assert rel.right[2] == (None, 10)
+    assert rel.right[2] == (0, 10)
 
 
 def test_new_relation():


### PR DESCRIPTION
# Description

Correctly set `[:n]` as syntactic sugar for `[0:]` instead of handling this in the AST. Also fixed some type annotations related to this to make sure the annotations match the actual types. This should resolve all issues of AST code reasoning on incorrect type information for relation upper and lower fields and should prevent similar issues in the future.

closes #2689

mypy diff (red is good):
```diff
- src/inmanta/ast/attribute.py:179: error: Name 'out' already defined on line 177
- src/inmanta/ast/attribute.py:181: error: Name 'out' already defined on line 177
- src/inmanta/ast/statements/define.py:609: error: Argument 1 to "set_multiplicity" of "RelationAttribute" has incompatible type "Tuple[Optional[int], Optional[int]]"; expected "Tuple[int, int]"
- src/inmanta/ast/statements/define.py:621: error: Argument 1 to "set_multiplicity" of "RelationAttribute" has incompatible type "Tuple[Optional[int], Optional[int]]"; expected "Tuple[int, int]"
+ src/inmanta/ast/statements/define.py:610: error: Argument 1 to "set_multiplicity" of "RelationAttribute" has incompatible type "Optional[Tuple[int, Optional[int]]]"; expected "Tuple[int, Optional[int]]"
+ src/inmanta/ast/statements/define.py:623: error: Argument 1 to "set_multiplicity" of "RelationAttribute" has incompatible type "Optional[Tuple[int, Optional[int]]]"; expected "Tuple[int, Optional[int]]"
- src/inmanta/parser/plyInmantaParser.py:493: error: Argument 1 to "DefineRelation" has incompatible type "Tuple[Any, None, None]"; expected "Tuple[LocatableString, LocatableString, Tuple[Optional[int], Optional[int]]]"
- src/inmanta/parser/plyInmantaParser.py:505: error: Argument 1 to "DefineRelation" has incompatible type "Tuple[Any, None, None]"; expected "Tuple[LocatableString, LocatableString, Tuple[Optional[int], Optional[int]]]"
```

I'll cherry-pick this onto iso4 and iso3.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
