### PR TITLE
Rename environment variable INMANTA_RUNNING_TESTS

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,13 @@ copyright = f'{datetime.datetime.now().year} Inmanta NV'
 # built documents.
 #
 # The short X.Y version.
-if "INMANTA_RUNNING_TESTS" in os.environ:
+if "INMANTA_DONT_DISCOVER_VERSION" in os.environ:
+    # Used to:
+    # 1) Decouple the inmanta-core package from the inmanta
+    #    package when running the tests.
+    # 2) Build the ISO documentation, which is built on top
+    #    of the inmanta-core documentation. During the ISO docs build,
+    #    this value will be overwritten with the ISO product version.
     version = "1.0.0"
 else:
     version = pkg_resources.get_distribution("inmanta").version

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ basepython = python3
 basepython=python3
 changedir=docs
 setenv   =
-    INMANTA_RUNNING_TESTS = ""
+    INMANTA_DONT_DISCOVER_VERSION = ""
 deps=
     -rrequirements.dev.txt
     -rrequirements.txt
@@ -48,7 +48,7 @@ commands=py.test -v check_sphinx.py -m "not link_check"
 basepython=python3
 changedir=docs
 setenv   =
-    INMANTA_RUNNING_TESTS = ""
+    INMANTA_DONT_DISCOVER_VERSION = ""
 deps=
     -rrequirements.dev.txt
     -rrequirements.txt


### PR DESCRIPTION
# Description

Change environment variable `INMANTA_RUNNING_TESTS` to `INMANTA_DONT_DISCOVER_VERSION`. This was done, because the use of this environment variable is not limited to running test cases.