### PR TITLE
Use core instead of extension feature in inmanta-dev-dependencies

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-inmanta-dev-dependencies[pytest,async,extension,sphinx]==1.23.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==1.23.0
 bumpversion==0.6.0
 openapi_spec_validator==0.2.9

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-inmanta-dev-dependencies[pytest,async,extension,sphinx]==1.22.0
+inmanta-dev-dependencies[pytest,async,extension,sphinx]==1.23.0
 bumpversion==0.6.0
 openapi_spec_validator==0.2.9


### PR DESCRIPTION
# Description

Use core instead of extension feature in inmanta-dev-dependencies.