### PR TITLE
Fix race condition in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,7 +932,7 @@ async def async_finalizer():
 
 class CompileRunnerMock(object):
     def __init__(
-        self, request: data.Compile, make_compile_fail: bool = False, runner_queue: Optional[asyncio.Queue] = None
+        self, request: data.Compile, make_compile_fail: bool = False, runner_queue: Optional[queue.Queue] = None
     ) -> None:
         self.request = request
         self.version: Optional[int] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,7 +932,7 @@ async def async_finalizer():
 
 class CompileRunnerMock(object):
     def __init__(
-        self, request: data.Compile, make_compile_fail: bool = False, runner_queue: Optional[queue.Queue] = None
+        self, request: data.Compile, make_compile_fail: bool = False, runner_queue: Optional[asyncio.Queue] = None
     ) -> None:
         self.request = request
         self.version: Optional[int] = None
@@ -959,7 +959,7 @@ class CompileRunnerMock(object):
         return success, None
 
 
-def monkey_patch_compiler_service(monkeypatch, server, make_compile_fail, runner_queue=None):
+def monkey_patch_compiler_service(monkeypatch, server, make_compile_fail, runner_queue: Optional[queue.Queue] = None):
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
 
     def patch(compile: data.Compile, project_dir: str) -> CompileRun:

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -19,6 +19,7 @@ import asyncio
 import datetime
 import logging
 import os
+import queue
 import shutil
 import subprocess
 import uuid
@@ -597,8 +598,29 @@ async def test_server_recompile(server, client, environment, monkeypatch):
     assert not os.path.exists(project_dir)
 
 
+async def run_compile_and_wait_until_compile_is_done(
+    compiler_service: CompilerService, mocked_compiler_service_block: queue.Queue, env_id: uuid.UUID
+) -> None:
+
+    current_task = compiler_service._recompiles[env_id]
+
+    # prevent race conditions where compile is not yet in queue
+    await retry_limited(lambda: not mocked_compiler_service_block.empty(), timeout=10)
+    run = mocked_compiler_service_block.get(block=True)
+    run.block = False
+
+    def _is_compile_finished() -> bool:
+        if env_id not in compiler_service._recompiles:
+            return True
+        if current_task is not compiler_service._recompiles[env_id]:
+            return True
+        return False
+
+    await retry_limited(_is_compile_finished, timeout=10)
+
+
 @pytest.mark.asyncio(timeout=90)
-async def test_compileservice_queue(mocked_compiler_service_block, server, client, environment):
+async def test_compileservice_queue(mocked_compiler_service_block: asyncio.Queue, server, client, environment):
     """
     Test the inspection of the compile queue. The compile runner is mocked out so the "started" field does not have the
     correct value in this test.
@@ -664,13 +686,7 @@ async def test_compileservice_queue(mocked_compiler_service_block, server, clien
     assert result.code == 200
 
     # finish a compile and wait for service to take on next
-    current_task = compilerslice._recompiles[env.id]
-
-    run = mocked_compiler_service_block.get()
-    run.block = False
-
-    while current_task is compilerslice._recompiles[env.id]:
-        await asyncio.sleep(0.01)
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
     # api should return five when ready
     result = await client.get_compile_queue(environment)
@@ -679,18 +695,14 @@ async def test_compileservice_queue(mocked_compiler_service_block, server, clien
     assert result.code == 200
 
     # finish second compile
-    current_task = compilerslice._recompiles[env.id]
-    run = mocked_compiler_service_block.get(block=True, timeout=2)
-    run.block = False
-
-    while current_task is compilerslice._recompiles[env.id]:
-        await asyncio.sleep(0.2)
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
     assert await compilerslice.get_report(compile_id2) == await compilerslice.get_report(compile_id4)
 
     # finish third compile
-    current_task = compilerslice._recompiles[env.id]
-    run = mocked_compiler_service_block.get(block=True, timeout=2)
+    # prevent race conditions where compile is not yet in queue
+    await retry_limited(lambda: not mocked_compiler_service_block.empty(), timeout=10)
+    run = mocked_compiler_service_block.get(block=True)
     result = await client.get_compile_queue(environment)
     assert len(result.result["queue"]) == 3
     assert result.result["queue"][0]["remote_id"] == str(remote_id3)
@@ -956,26 +968,8 @@ async def test_compileservice_auto_recompile_wait(mocked_compiler_service_block,
         assert result.code == 200
 
         # Start working through it
-        current_task = compilerslice._recompiles[env.id]
-        run = mocked_compiler_service_block.get(block=True, timeout=2)
-        run.block = False
-        while current_task is compilerslice._recompiles[env.id]:
-            await asyncio.sleep(0.2)
-
-        # Make sure that when enough time passes, waiting is not necessary
-        await asyncio.sleep(2)
-
-        current_task = compilerslice._recompiles[env.id]
-        run = mocked_compiler_service_block.get(block=True, timeout=2)
-        run.block = False
-        while current_task is compilerslice._recompiles[env.id]:
-            await asyncio.sleep(0.2)
-
-        current_task = compilerslice._recompiles[env.id]
-        run = mocked_compiler_service_block.get(block=True, timeout=2)
-        run.block = False
-        while current_task is compilerslice._recompiles.get(env.id):
-            await asyncio.sleep(0.2)
+        for i in range(3):
+            await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
         LogSequence(caplog, allow_errors=False).contains(
             "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -620,7 +620,7 @@ async def run_compile_and_wait_until_compile_is_done(
 
 
 @pytest.mark.asyncio(timeout=90)
-async def test_compileservice_queue(mocked_compiler_service_block: asyncio.Queue, server, client, environment):
+async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, server, client, environment):
     """
     Test the inspection of the compile queue. The compile runner is mocked out so the "started" field does not have the
     correct value in this test.

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=
     -rrequirements.txt
 extras=
     dataflow_graphic
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/db/test_db_schema.py::test_dbschema_update_db_downgrade
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=
     -rrequirements.txt
 extras=
     dataflow_graphic
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv tests/db/test_db_schema.py::test_dbschema_update_db_downgrade
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME


### PR DESCRIPTION
# Description

* Fix a race condition in the tests where a compile request is retrieved from the queue, while it's not yet added to the compile queue.
* Remove code duplication.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [ ] ~~Changelog entry~~
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
