### PR TITLE
Disable version bumps for the openapi-spec-validator dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,6 @@ updates:
       # Breaking change
     - dependency-name: "pyjwt"
       versions: [">=2"]
-      # Breaking change
+      # Breaking change, see #2729 
     - dependency-name: "openapi-spec-validator"
       versions: [">=0.3.0"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
       # Breaking change
     - dependency-name: "pyjwt"
       versions: [">=2"]
+      # Breaking change
+    - dependency-name: "openapi-spec-validator"
+      versions: [">=0.3.0"]


### PR DESCRIPTION
# Description

Disable version bumps larger or equal than `0.3.0` for the `openapi-spec-validator` dependency until #2729 is resolved.