### PR TITLE
Issue/master version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.0
+current_version = 5.0.1
 
 [bumpversion:file:setup.py]
 search = version="{current_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 5.0.0 (?)
+# Release 5.0.0 (2021-02-25)
 
 ## Bug fixes
 - Fix broken order by (#2638)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    version="5.0.0",
+    version="5.0.1",
     python_requires=">=3.6",  # also update classifiers
     # Meta data
     name="inmanta-core",

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -36,7 +36,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    version="5.0.0",
+    version="5.0.1",
     python_requires=">=3.6",  # also update classifiers
     # Meta data
     name="pytest-inmanta-extensions",


### PR DESCRIPTION
part of inmanta/irt#520

I've branched off `iso5-next` and `iso5-stable` (the latter mainly so we don't forget to set the build tag correctly when we do the actual release).