### PR TITLE
old release pipeline cleanup: removed dashboard constraint from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,6 @@ exclude = '''
 )/
 '''
 
-
-[tool.irt]
-dashboard = 'master'
-
 [tool.irt.build.python]
 hooks = { 'pre' = 'pre-build.sh' }
 


### PR DESCRIPTION
I'll cherry-pick this to `iso4` and `iso5-next`.