### PR TITLE
Install openapi dependencies from constraint file

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -169,7 +169,7 @@ doctest:
 
 .PHONY: openapi
 openapi:
-	pip install pytest-inmanta-extensions
+	pip install -r ../requirements.dev.txt
 	pytest ./extract_openapi_json.py
 	mv openapi.json reference/openapi.json
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -169,8 +169,7 @@ doctest:
 
 .PHONY: openapi
 openapi:
-	pip install -r ../requirements.dev.txt
-	pytest ./extract_openapi_json.py
+	pytest --rootdir=../tests ./extract_openapi_json.py
 	mv openapi.json reference/openapi.json
 
 # Pattern rule for converting SVG to PDF


### PR DESCRIPTION
# Description

Install the `pytest-inmanta-extensions` via the `requirements.dev.txt` file as such that version constraints are taken into account.