### PR TITLE
Iso3 dashboard pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
 
 
 [tool.irt]
-dashboard = '3.5.3'
+dashboard = '3.5.2'
 
 [tool.irt.build.python]
 hooks = { 'pre' = 'pre-build.sh' }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
 
 
 [tool.irt]
-dashboard = '3.5.1'
+dashboard = '3.5.3'
 
 [tool.irt.build.python]
 hooks = { 'pre' = 'pre-build.sh' }


### PR DESCRIPTION
I'm not 100% sure of this but I think this needs to be bumped. This PR bumps it to the last stable version (the current dev version doesn't have any changes except for the `pyproject.toml` file).

I'm planning to cherry-pick this to `iso3-next`.