### PR TITLE
pytest-inmanta-extensions: constrain core to rc version

### DIFF
--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -22,7 +22,7 @@ from setuptools import find_packages, setup
 requires = [
     "asyncpg",
     "click",
-    "inmanta-core~=4.0.dev",
+    "inmanta-core~=4.1.0.0rc",
     "pyformance",
     "pytest-asyncio",
     "pytest-env",


### PR DESCRIPTION
Pin to rc version, as discussed on slack. If approved I'll apply similar changes on extension repositories and on the `iso{3,5}-next` branches.

part of inmanta/irt#520