### PR TITLE
Prevent KeyError on PYTHONPATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 - Fix broken order by (#2638)
 - Report the Inmanta OSS product version correctly (#2622)
-- Set PYTHONPATH so that all subprocesses also see packages in parent venv (#2650)
+- Set PYTHONPATH so that all subprocesses also see packages in parent venv (#2650, #2747)
 - Create virtual environments without pip and use the pip of the parent venv
 - Correctly set `[:n]` as syntactic sugar for `[0:n]` instead of leaving lower unbound (#2689)
 

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -172,7 +172,7 @@ class BashIO(IOBase):
         if env is not None:
             current_env.update(env)
 
-        if not env or "PYTHONPATH" not in env:
+        if (not env or "PYTHONPATH" not in env) and "PYTHONPATH" in current_env:
             # Remove the inherited python path
             del current_env["PYTHONPATH"]
 
@@ -438,7 +438,7 @@ class LocalIO(IOBase):
         if env is not None:
             current_env.update(env)
 
-        if not env or "PYTHONPATH" not in env:
+        if (not env or "PYTHONPATH" not in env) and "PYTHONPATH" in current_env:
             # Remove the inherited python path
             del current_env["PYTHONPATH"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -258,7 +258,7 @@ def deactive_venv():
     old_os_path = os.environ.get("PATH", "")
     old_prefix = sys.prefix
     old_path = list(sys.path)
-    old_pythonpath = os.environ.get("PYTHONPATH", "")
+    old_pythonpath = os.environ.get("PYTHONPATH", None)
 
     yield
 
@@ -266,7 +266,12 @@ def deactive_venv():
     sys.prefix = old_prefix
     sys.path = old_path
     pkg_resources.working_set = pkg_resources.WorkingSet._build_master()
-    os.environ["PYTHONPATH"] = old_pythonpath
+    # Restore PYTHONPATH
+    if "PYTHONPATH" in os.environ:
+        if old_pythonpath is not None:
+            os.environ["PYTHONPATH"] = old_pythonpath
+        else:
+            del os.environ["PYTHONPATH"]
 
 
 def reset_metrics():


### PR DESCRIPTION
# Description

This PR adds the following fixes:

* Ensure not KeyError occurs when `io.run()` is called while the `PYTHONPATH` environment variable is not present in `os.environ`.
* Ensure the `PYTHONPATH` environment variable is correctly restored in the `deactive_venv` fixture.

closes #2747 

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
