### PR TITLE
fix tcp_port range and String interpolation typo

### DIFF
--- a/changelogs/unreleased/0000000001-typo_fix.yml
+++ b/changelogs/unreleased/0000000001-typo_fix.yml
@@ -1,0 +1,13 @@
+---
+description: Fixed two typos in language.rst file of core docs
+issue-nr: N/A
+change-type: patch
+destination-branches: [master]
+sections:
+  bugfix: "Fixed typos in language.rst file"
+  known-issue: "4 byte unicode character are not supported"
+  upgrade-note: "None"
+  deprecation-note: "None"
+  other-note: |
+    * TCP port ranges from 65565 to 65535
+    * Changed "include" to "included" on string interpolation section

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -139,7 +139,7 @@ For example
 
 .. code-block:: inmanta
 
-    typedef tcp_port as int matching self > 0 and self < 65565
+    typedef tcp_port as int matching self > 0 and self < 65535
     typedef mac_addr as string matching /([0-9a-fA-F]{2})(:[0-9a-fA-F]{2}){5}$/
 
 
@@ -550,7 +550,7 @@ configuration files. To construct configuration files, templates and string inte
 String interpolation
 --------------------
 
-String interpolation allows variables to be include as parameters inside a string.
+String interpolation allows variables to be included as parameters inside a string.
 
 The included variables are resolved in the lexical scope of the string they are included in.
 


### PR DESCRIPTION
# Description

Fixed two typos in language.rst file of core docs:

* TCP port ranges from 65565 to 65535
* Changed "include" to "included" on string interpolation section
