### PR TITLE
Extend parameter type support for GET methods

### DIFF
--- a/changelogs/unreleased/2775-extended-param-support-get.yml
+++ b/changelogs/unreleased/2775-extended-param-support-get.yml
@@ -1,0 +1,6 @@
+description: Add partial support for collection type parameters for GET methods
+issue-nr: 2775
+change-type: minor
+destination-branches: [master, iso4]
+sections:
+    feature: "{{description}}"

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -779,14 +779,12 @@ class MethodProperties(object):
                     # param = { "key1": "val1", "key2": "val2" } to param.key1=val1 and param.key2=val2
                     params_to_add = {**params_to_add, **self._encode_dict_for_get(query_param_name, query_param_value)}
                     already_processed_params.append(query_param_name)
-                if isinstance(query_param_value, list):
-                    params_to_add[query_param_name] = self._encode_list_for_get(query_param_value)
             for param in already_processed_params:
                 del qs_map[param]
             qs_map.update(params_to_add)
             # encode arguments in url
             if len(qs_map) > 0:
-                url += "?" + parse.urlencode(qs_map)
+                url += "?" + parse.urlencode(qs_map, True)
 
             body = None
         else:
@@ -798,17 +796,8 @@ class MethodProperties(object):
         self, query_param_name: str, query_param_value: Dict[str, Union[Any, List[Any]]]
     ) -> Dict[str, str]:
         """ Dicts are encoded in the following manner: param = {'ab': 1, 'cd': 2} to param.abc=1&param.cd=2 """
-        sub_dict = {}
-        for key, value in query_param_value.items():
-            if isinstance(value, list):
-                sub_dict[f"{query_param_name}.{key}"] = self._encode_list_for_get(value)
-            else:
-                sub_dict[f"{query_param_name}.{key}"] = value
+        sub_dict = {f"{query_param_name}.{key}": value for key, value in query_param_value.items()}
         return sub_dict
-
-    def _encode_list_for_get(self, query_param_value: List[Any]) -> str:
-        """ Lists are encoded in the following manner: param = [1, 2] to param=1,2 """
-        return ",".join([str(param_element).replace(",", "%2C") for param_element in query_param_value])
 
 
 class UrlMethod(object):

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -807,7 +807,7 @@ class MethodProperties(object):
 
     def _encode_list_for_get(self, query_param_value: List[Any]) -> str:
         """ Lists are encoded in the following manner: param = [1, 2] to param=1,2 """
-        return ",".join([str(param_element) for param_element in query_param_value])
+        return ",".join([str(param_element).replace(",", "%2C") for param_element in query_param_value])
 
 
 class UrlMethod(object):

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -775,14 +775,15 @@ class MethodProperties(object):
             already_processed_params = []
             for query_param_name, query_param_value in qs_map.items():
                 if isinstance(query_param_value, dict):
+                    # Add parameters from the dict as separate parameters for example
+                    # param = { "key1": "val1", "key2": "val2" } to param.key1=val1 and param.key2=val2
                     params_to_add = {**params_to_add, **self._encode_dict_for_get(query_param_name, query_param_value)}
                     already_processed_params.append(query_param_name)
                 if isinstance(query_param_value, list):
                     params_to_add[query_param_name] = self._encode_list_for_get(query_param_value)
-                    already_processed_params.append(query_param_name)
             for param in already_processed_params:
                 del qs_map[param]
-            qs_map = {**qs_map, **params_to_add}
+            qs_map.update(params_to_add)
             # encode arguments in url
             if len(qs_map) > 0:
                 url += "?" + parse.urlencode(qs_map)

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -549,11 +549,6 @@ class MethodProperties(object):
                     raise InvalidMethodDefinition(f"Union of argument {arg} can contain only one generic {name}")
 
         elif typing_inspect.is_generic_type(arg_type):
-            if in_url:
-                raise InvalidMethodDefinition(
-                    f"Type {arg_type} of argument {arg} is not allowed for {self.operation}, as it can not be part of the URL"
-                )
-
             orig = typing_inspect.get_origin(arg_type)
             if not issubclass(orig, (list, dict)):
                 raise InvalidMethodDefinition(f"Type {arg_type} of argument {arg} can only be generic List or Dict")
@@ -565,12 +560,22 @@ class MethodProperties(object):
                 )
 
             elif len(args) == 1:  # A generic list
+                if in_url and (issubclass(args[0], dict) or issubclass(args[0], list)):
+                    raise InvalidMethodDefinition(
+                        f"Type {arg_type} of argument {arg} is not allowed for {self.operation}, "
+                        f"lists of dictionaries and lists of lists are not supported for GET requests"
+                    )
                 self._validate_type_arg(arg, args[0], strict=strict, allow_none_type=allow_none_type, in_url=in_url)
 
             elif len(args) == 2:  # Generic Dict
                 if not issubclass(args[0], str):
                     raise InvalidMethodDefinition(
                         f"Type {arg_type} of argument {arg} must be a Dict with str keys and not {args[0].__name__}"
+                    )
+                if in_url and (typing_inspect.is_union_type(args[1]) or issubclass(args[1], dict)):
+                    raise InvalidMethodDefinition(
+                        f"Type {arg_type} of argument {arg} is not allowed for {self.operation}, "
+                        f"nested dictionaries and union types for dictionary values are not supported for GET requests"
                     )
 
                 self._validate_type_arg(arg, args[1], strict=strict, allow_none_type=True, in_url=in_url)
@@ -765,7 +770,19 @@ class MethodProperties(object):
 
         if self.operation not in ("POST", "PUT", "PATCH"):
             qs_map = {k: v for k, v in msg.items() if v is not None and k not in path_params}
-
+            # Preprocess dict and list parameters for GET
+            params_to_add = {}
+            already_processed_params = []
+            for query_param_name, query_param_value in qs_map.items():
+                if isinstance(query_param_value, dict):
+                    params_to_add = {**params_to_add, **self._encode_dict_for_get(query_param_name, query_param_value)}
+                    already_processed_params.append(query_param_name)
+                if isinstance(query_param_value, list):
+                    params_to_add[query_param_name] = self._encode_list_for_get(query_param_value)
+                    already_processed_params.append(query_param_name)
+            for param in already_processed_params:
+                del qs_map[param]
+            qs_map = {**qs_map, **params_to_add}
             # encode arguments in url
             if len(qs_map) > 0:
                 url += "?" + parse.urlencode(qs_map)
@@ -775,6 +792,22 @@ class MethodProperties(object):
             body = msg
 
         return Request(url=url, method=self.operation, headers=headers, body=body)
+
+    def _encode_dict_for_get(
+        self, query_param_name: str, query_param_value: Dict[str, Union[Any, List[Any]]]
+    ) -> Dict[str, str]:
+        """ Dicts are encoded in the following manner: param = {'ab': 1, 'cd': 2} to param.abc=1&param.cd=2 """
+        sub_dict = {}
+        for key, value in query_param_value.items():
+            if isinstance(value, list):
+                sub_dict[f"{query_param_name}.{key}"] = self._encode_list_for_get(value)
+            else:
+                sub_dict[f"{query_param_name}.{key}"] = value
+        return sub_dict
+
+    def _encode_list_for_get(self, query_param_value: List[Any]) -> str:
+        """ Lists are encoded in the following manner: param = [1, 2] to param=1,2 """
+        return ",".join([str(param_element) for param_element in query_param_value])
 
 
 class UrlMethod(object):

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -202,7 +202,11 @@ class CallArguments(object):
                             for param_name, param_value in self._message.items()
                             if param_name.startswith(dict_prefix) and len(param_name) > len(dict_prefix)
                         }
-                        value = await self._get_dict_value_from_message(arg, dict_prefix, dict_with_prefixed_names)
+                        value = (
+                            await self._get_dict_value_from_message(arg, dict_prefix, dict_with_prefixed_names)
+                            if dict_with_prefixed_names
+                            else None
+                        )
 
                         for key in dict_with_prefixed_names.keys():
                             all_fields.remove(key)

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -243,8 +243,13 @@ class CallArguments(object):
     ) -> Dict[str, Any]:
         value = {k[len(dict_prefix) :]: v for k, v in dict_with_prefixed_names.items()}
         # Check if the values should be converted to lists
-        type_args = typing_inspect.get_args(self._argspec.annotations.get(arg), evaluate=True)
-        if issubclass(type_args[1], list):
+        type_args = self._argspec.annotations.get(arg)
+        if typing_inspect.is_optional_type(type_args):
+            # If optional, get the type args from the not None type argument
+            dict_args = typing_inspect.get_args(typing_inspect.get_args(type_args, evaluate=True)[0], evaluate=True)
+        else:
+            dict_args = typing_inspect.get_args(self._argspec.annotations.get(arg), evaluate=True)
+        if issubclass(dict_args[1], list):
             value = {key: [val] if not isinstance(val, list) else val for key, val in value.items()}
         return value
 

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -258,13 +258,7 @@ class CallArguments(object):
     def _get_list_value_from_url(self, value: str) -> List[str]:
         # Split by the delimiter
         split_parts = value.split(",")
-        empty_strings = [part for part in split_parts if len(part) == 0]
-        if len(empty_strings):
-            raise exceptions.BadRequest(
-                "Empty strings are not allowed in list parameters for GET requests. "
-                f"This exception may have been caused by using the list delimiter (',') "
-                f"in a list value: {value}"
-            )
+        split_parts = [part.replace("%2C", ",") for part in split_parts]
         return split_parts
 
     async def _get_param_value_from_message(self, arg: str, arg_type: Type) -> Any:

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -241,7 +241,9 @@ class CallArguments(object):
         # Check if the values should be converted to lists
         type_args = typing_inspect.get_args(self._argspec.annotations.get(arg), evaluate=True)
         if issubclass(type_args[1], list):
-            value = {key: val.split(",") if not isinstance(val, list) else val for key, val in value.items()}
+            value = {
+                key: self._get_list_value_from_url(val) if not isinstance(val, list) else val for key, val in value.items()
+            }
         return value
 
     def _is_dict_or_optional_dict(self, arg_type: Type) -> bool:
@@ -249,13 +251,25 @@ class CallArguments(object):
             arg_type = typing_inspect.get_args(arg_type, evaluate=True)[0]
         return issubclass(arg_type, dict)
 
+    def _get_list_value_from_url(self, value: str) -> List[str]:
+        # Split by the delimiter
+        split_parts = value.split(",")
+        empty_strings = [part for part in split_parts if len(part) == 0]
+        if len(empty_strings):
+            raise exceptions.BadRequest(
+                "Empty strings are not allowed in list parameters for GET requests. "
+                f"This exception may have been caused by using the list delimiter (',') "
+                f"in a list value: {value}"
+            )
+        return split_parts
+
     async def _get_param_value_from_message(self, arg: str, arg_type: Type) -> Any:
         value = self._message[arg]
         if self._properties.operation == "GET":
             if typing_inspect.is_optional_type(arg_type):
                 arg_type = typing_inspect.get_args(arg_type, evaluate=True)[0]
             if not typing_inspect.is_union_type(arg_type) and issubclass(arg_type, list) and not isinstance(value, list):
-                value = value.split(",")
+                value = self._get_list_value_from_url(value)
         return value
 
     def _validate_union_return(self, arg_type: Type, value: Any) -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2013,3 +2013,10 @@ async def test_dict_list_get_by_url(unused_tcp_port, postgres_db, database_name,
         raise_error=False,
     )
     assert response.code == 400
+    filter_with_comma = {"filter.a": "b", "filter.c": "e", "filter.,&?=%": ",&?=%"}
+    url = url_concat(f"http://localhost:{server_bind_port.get()}/api/v1/test/1/monty", filter_with_comma)
+    response = await client.fetch(
+        url,
+        raise_error=False,
+    )
+    assert response.code == 200

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1794,7 +1794,7 @@ async def test_dict_get_optional(unused_tcp_port, postgres_db, database_name, as
 
         @protocol.handle(test_method)
         async def test_method(self, id: str, name: str, filter: Optional[Dict[str, str]] = None) -> str:  # NOQA
-            return ",".join(filter.keys()) if filter else ""
+            return ",".join(filter.keys()) if filter is not None else ""
 
     rs = Server()
     server = ProjectServer(name="projectserver")


### PR DESCRIPTION
# Description

To do the filtering in the service instance api (inmanta/inmanta-lsm#463), in the way discussed in the design inmanta/inmanta-telco#81, the api has to (partially) support collection types, this PR is about adding that support.

closes #2775 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
