### PR TITLE
Update build_tag from dev to .dev0

### DIFF
--- a/changelogs/unreleased/update-build-tag.yml
+++ b/changelogs/unreleased/update-build-tag.yml
@@ -1,3 +1,3 @@
 description: Update build_tag from dev to .dev0
 change-type: patch
-destination-branches: [master, iso3, iso4]
+destination-branches: [iso3]

--- a/changelogs/unreleased/update-build-tag.yml
+++ b/changelogs/unreleased/update-build-tag.yml
@@ -1,0 +1,3 @@
+description: Update build_tag from dev to .dev0
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [egg_info]
-tag_build = rc
+# Append a zero at the end as a workaround for setuptools bug (pypa/pip#9446)
+# see https://github.com/pypa/pip/issues/9446
+tag_build = .dev0
 tag_date = 0
 tag_svn_revision = 0
 

--- a/tests_common/setup.cfg
+++ b/tests_common/setup.cfg
@@ -1,4 +1,6 @@
 [egg_info]
-tag_build =
+# Append a zero at the end as a workaround for setuptools bug (pypa/pip#9446)
+# see https://github.com/pypa/pip/issues/9446
+tag_build = .dev0
 tag_date = 0
 tag_svn_revision = 0


### PR DESCRIPTION
# Description

Update build_tag from dev to .dev0

closes inmanta/infra-tickets#104

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
