### PR TITLE
Issue/compiler cycle breaking on functions

### DIFF
--- a/changelogs/unreleased/2787-compiler-bug-on-plugins-with-cyclebreakig.yml
+++ b/changelogs/unreleased/2787-compiler-bug-on-plugins-with-cyclebreakig.yml
@@ -1,0 +1,6 @@
+description: Fixed compiler issue on rescheduling of plugins breaking the cycle breaking
+issue-nr: 2787
+change-type: patch
+destination-branches: [master, iso3, iso4]
+sections:
+    bugfix: "{{description}}"

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -253,6 +253,7 @@ class FunctionUnit(Waiter):
         self.result = result
         result.set_provider(self)
         self.requires = requires
+        self.base_requires = requires
         self.function = function
         self.resolver = resolver
         self.queue_scheduler = queue_scheduler
@@ -261,13 +262,14 @@ class FunctionUnit(Waiter):
         self.ready(self)
 
     def execute(self):
-        requires = {k: v.get_value() for (k, v) in self.requires.items()}
+        requires = {k: v.get_value() for (k, v) in self.base_requires.items()}
         try:
             self.function.resume(requires, self.resolver, self.queue_scheduler, self.result)
             self.done = True
         except UnsetException as e:
             LOGGER.debug("Unset value in python code in plugin %s %s.%s.", self.function.function, e.instance, e.attribute)
-            self.waitfor(e.get_result_variable())
+            # Don't handle it here!
+            raise
         except RuntimeException as e:
             e.set_statement(self.function)
             raise e

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -269,6 +269,9 @@ class FunctionUnit(Waiter):
         except UnsetException as e:
             LOGGER.debug("Unset value in python code in plugin %s %s.%s.", self.function.function, e.instance, e.attribute)
             # Don't handle it here!
+            # This exception is used by the scheduler to re-queue the unit
+            # If it is handled here, the re-queueing can not be done,
+            # leading to very subtle errors such as #2787
             raise
         except RuntimeException as e:
             e.set_statement(self.function)

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -253,7 +253,7 @@ class FunctionUnit(Waiter):
         self.result = result
         result.set_provider(self)
         self.requires = requires
-        self.base_requires = requires
+        self.base_requires = dict(requires)
         self.function = function
         self.resolver = resolver
         self.queue_scheduler = queue_scheduler

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -252,7 +252,10 @@ class FunctionUnit(Waiter):
         Waiter.__init__(self, queue_scheduler)
         self.result = result
         result.set_provider(self)
+        # requires is used to track all required RV's
+        # It can grow larger as new requires are discovered
         self.requires = requires
+        # base_requires are the original requires for this function call
         self.base_requires = dict(requires)
         self.function = function
         self.resolver = resolver

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -652,7 +652,7 @@ class Waiter(object):
 
     def _requeue_with_additional_requires(self, key: object, waitable: ResultVariable) -> None:
         """
-            Re-queue with an additional requirement
+        Re-queue with an additional requirement
         """
         self.requires[key] = waitable
         self.waitfor(waitable)

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -382,7 +382,8 @@ class BaseListVariable(DelayedResultVariable[ListValue]):
     def listener(self, resultcollector: ResultCollector, location: Location) -> None:
         for value in self.value:
             resultcollector.receive_result(value, location)
-        self.listeners.append(resultcollector)
+        if not self.hasValue:
+            self.listeners.append(resultcollector)
 
     def is_multi(self) -> bool:
         return True
@@ -648,6 +649,13 @@ class Waiter(object):
         self.queue = queue
         self.queue.add_to_all(self)
         self.done = False
+
+    def _requeue_with_additional_requires(self, key: object, waitable: ResultVariable) -> None:
+        """
+            Re-queue with an additional requirement
+        """
+        self.requires[key] = waitable
+        self.waitfor(waitable)
 
     def waitfor(self, waitable: ResultVariable) -> None:
         self.waitcount = self.waitcount + 1

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -17,7 +17,7 @@
 """
 
 from abc import abstractmethod
-from typing import Deque, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
+from typing import Deque, Dict, Generic, List, Optional, Set, TypeVar, Union, cast, Hashable
 
 import inmanta.warnings as inmanta_warnings
 from inmanta.ast import (
@@ -650,7 +650,7 @@ class Waiter(object):
         self.queue.add_to_all(self)
         self.done = False
 
-    def _requeue_with_additional_requires(self, key: object, waitable: ResultVariable) -> None:
+    def _requeue_with_additional_requires(self, key: Hashable, waitable: ResultVariable) -> None:
         """
         Re-queue with an additional requirement
         """

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -17,7 +17,7 @@
 """
 
 from abc import abstractmethod
-from typing import Deque, Dict, Generic, List, Optional, Set, TypeVar, Union, cast, Hashable
+from typing import Deque, Dict, Generic, Hashable, List, Optional, Set, TypeVar, Union, cast
 
 import inmanta.warnings as inmanta_warnings
 from inmanta.ast import (
@@ -650,7 +650,7 @@ class Waiter(object):
         self.queue.add_to_all(self)
         self.done = False
 
-    def _requeue_with_additional_requires(self, key: Hashable, waitable: ResultVariable) -> None:
+    def requeue_with_additional_requires(self, key: Hashable, waitable: ResultVariable) -> None:
         """
         Re-queue with an additional requirement
         """

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -331,7 +331,7 @@ class Scheduler(object):
                     count = count + 1
                 except UnsetException as e:
                     # some statements don't know all their dependencies up front,...
-                    next._requeue_with_additional_requires(e, e.get_result_variable())
+                    next.requeue_with_additional_requires(e, e.get_result_variable())
 
             # all safe stmts are done
             progress = False

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -331,7 +331,7 @@ class Scheduler(object):
                     count = count + 1
                 except UnsetException as e:
                     # some statements don't know all their dependencies up front,...
-                    next.waitfor(e.get_result_variable())
+                    next._requeue_with_additional_requires(e, e.get_result_variable())
 
             # all safe stmts are done
             progress = False

--- a/tests/compiler/test_scheduling.py
+++ b/tests/compiler/test_scheduling.py
@@ -67,4 +67,3 @@ def test_function_rescheduling(snippetcompiler):
     )
 
     compiler.do_compile()
-

--- a/tests/compiler/test_scheduling.py
+++ b/tests/compiler/test_scheduling.py
@@ -19,7 +19,7 @@
 from inmanta import compiler
 
 
-def test_function_rescheduling(snippetcompiler):
+def test_2787_function_rescheduling(snippetcompiler):
     """
     Particular case where a bug in handling of plugin calls causes cycle breaking to fail
     """

--- a/tests/compiler/test_scheduling.py
+++ b/tests/compiler/test_scheduling.py
@@ -1,0 +1,70 @@
+"""
+    Copyright 2021 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from inmanta import compiler
+
+
+def test_function_rescheduling(snippetcompiler):
+    """
+    Particular case where a bug in handling of plugin calls causes cycle breaking to fail
+    """
+    snippetcompiler.setup_for_snippet(
+        """
+
+   import tests
+
+   entity Rule:
+     bool purged
+   end
+
+   entity Service:
+     string name
+   end
+
+   Rule.services [0:] -- Service
+
+   Service.effective_services [0:] -- Service
+   Service.subservice [0:] -- Service
+   implementation effective_members for Service:
+        for service in subservice:
+            self.effective_services += service.effective_services
+        end
+   end
+
+   a = Rule(
+        services = Service( name="top",
+            subservice=Service(name="inner")
+        ),
+        purged = tests::resolve_rule_purged_status(a.services)
+  )
+
+  implementation rq for Rule:
+    if self.purged:
+       self.requires = services
+    else:
+       self.provides = services
+    end
+  end
+
+  implement Rule using rq
+  implement Service using effective_members
+    """
+    )
+
+    compiler.do_compile()
+

--- a/tests/data/modules/tests/plugins/__init__.py
+++ b/tests/data/modules/tests/plugins/__init__.py
@@ -31,6 +31,15 @@ def do_uknown(inp: "any") -> "string":
 
 counter = defaultdict(lambda: 0)
 
+@plugin
+def resolve_rule_purged_status(
+    sources: "list",
+) -> "bool":
+    for source in sources:
+        if len(source.effective_services) == 0:
+            return True
+
+    return False
 
 @plugin
 def once(string: "string") -> "number":

--- a/tests/data/modules/tests/plugins/__init__.py
+++ b/tests/data/modules/tests/plugins/__init__.py
@@ -31,6 +31,7 @@ def do_uknown(inp: "any") -> "string":
 
 counter = defaultdict(lambda: 0)
 
+
 @plugin
 def resolve_rule_purged_status(
     sources: "list",
@@ -40,6 +41,7 @@ def resolve_rule_purged_status(
             return True
 
     return False
+
 
 @plugin
 def once(string: "string") -> "number":


### PR DESCRIPTION
# Description

Fixes a very particular bug on the compiler, where cycle breaking fails, because plugins calls (FunctionUnit) are inadvertently dropped from the all_waiters set when being re-scheduled. 

closes #2787 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [X] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~


