### PR TITLE
Fix issues with dict parameters of GET methods on python 3.8

### DIFF
--- a/changelogs/unreleased/fix-get-dict-param-py38.yml
+++ b/changelogs/unreleased/fix-get-dict-param-py38.yml
@@ -1,0 +1,3 @@
+description: Fix issues with dict parameters of GET methods on python 3.8
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -560,7 +560,8 @@ class MethodProperties(object):
                 )
 
             elif len(args) == 1:  # A generic list
-                if in_url and (issubclass(args[0], dict) or issubclass(args[0], list)):
+                unsubscripted_arg = typing_inspect.get_origin(args[0]) if typing_inspect.get_origin(args[0]) else args[0]
+                if in_url and (issubclass(unsubscripted_arg, dict) or issubclass(unsubscripted_arg, list)):
                     raise InvalidMethodDefinition(
                         f"Type {arg_type} of argument {arg} is not allowed for {self.operation}, "
                         f"lists of dictionaries and lists of lists are not supported for GET requests"
@@ -572,7 +573,8 @@ class MethodProperties(object):
                     raise InvalidMethodDefinition(
                         f"Type {arg_type} of argument {arg} must be a Dict with str keys and not {args[0].__name__}"
                     )
-                if in_url and (typing_inspect.is_union_type(args[1]) or issubclass(args[1], dict)):
+                unsubscripted_dict_value_arg = typing_inspect.get_origin(args[1]) if typing_inspect.get_origin(args[1]) else args[1]
+                if in_url and (typing_inspect.is_union_type(args[1]) or issubclass(unsubscripted_dict_value_arg, dict)):
                     raise InvalidMethodDefinition(
                         f"Type {arg_type} of argument {arg} is not allowed for {self.operation}, "
                         f"nested dictionaries and union types for dictionary values are not supported for GET requests"

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -573,7 +573,9 @@ class MethodProperties(object):
                     raise InvalidMethodDefinition(
                         f"Type {arg_type} of argument {arg} must be a Dict with str keys and not {args[0].__name__}"
                     )
-                unsubscripted_dict_value_arg = typing_inspect.get_origin(args[1]) if typing_inspect.get_origin(args[1]) else args[1]
+                unsubscripted_dict_value_arg = (
+                    typing_inspect.get_origin(args[1]) if typing_inspect.get_origin(args[1]) else args[1]
+                )
                 if in_url and (typing_inspect.is_union_type(args[1]) or issubclass(unsubscripted_dict_value_arg, dict)):
                     raise InvalidMethodDefinition(
                         f"Type {arg_type} of argument {arg} is not allowed for {self.operation}, "

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -249,13 +249,17 @@ class CallArguments(object):
             dict_args = typing_inspect.get_args(typing_inspect.get_args(type_args, evaluate=True)[0], evaluate=True)
         else:
             dict_args = typing_inspect.get_args(self._argspec.annotations.get(arg), evaluate=True)
-        if issubclass(dict_args[1], list):
+        dict_value_arg_type = (
+            typing_inspect.get_origin(dict_args[1]) if typing_inspect.get_origin(dict_args[1]) else dict_args[1]
+        )
+        if issubclass(dict_value_arg_type, list):
             value = {key: [val] if not isinstance(val, list) else val for key, val in value.items()}
         return value
 
     def _is_dict_or_optional_dict(self, arg_type: Type) -> bool:
         if typing_inspect.is_optional_type(arg_type):
             arg_type = typing_inspect.get_args(arg_type, evaluate=True)[0]
+        arg_type = typing_inspect.get_origin(arg_type) if typing_inspect.get_origin(arg_type) else arg_type
         return issubclass(arg_type, dict)
 
     def _validate_union_return(self, arg_type: Type, value: Any) -> None:


### PR DESCRIPTION
# Description

Some tests failed on python 3.8 because of the typing differences, this PR provides a fix.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
