### PR TITLE
Make sure that the server_config and the server_pre_start fixture execute in the right order

### DIFF
--- a/changelogs/unreleased/set-dependency-server-pre-start-fixture.yml
+++ b/changelogs/unreleased/set-dependency-server-pre-start-fixture.yml
@@ -1,0 +1,6 @@
+description: Make sure that the server_config and the server_pre_start fixture execute in the right order.
+change-type: patch
+destination-branches:
+  - master
+  - iso4
+  - iso3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,7 +350,7 @@ def inmanta_config():
 
 
 @pytest.fixture
-def server_pre_start():
+def server_pre_start(server_config):
     """This fixture is called by the server. Override this fixture to influence server config"""
 
 
@@ -500,7 +500,7 @@ async def server_config(event_loop, inmanta_config, postgres_db, database_name, 
 
 
 @pytest.fixture(scope="function")
-async def server(server_pre_start, server_config):
+async def server(server_pre_start):
     """
     :param event_loop: explicitly include event_loop to make sure event loop started before and closed after this fixture.
     May not be required


### PR DESCRIPTION
# Description

Make sure that the server_config and the server_pre_start fixture execute in the right order.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
