### PR TITLE
fix for compiler crash

### DIFF
--- a/changelogs/unreleased/2811-compiler-bug.yml
+++ b/changelogs/unreleased/2811-compiler-bug.yml
@@ -2,6 +2,6 @@
 description: Fixed compiler issue on cycle breaking
 change-type: patch
 destination-branches: [master, iso3, iso4]
-issue: 2811
+issue-nr: 2811
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/2811-compiler-bug.yml
+++ b/changelogs/unreleased/2811-compiler-bug.yml
@@ -1,0 +1,7 @@
+---
+description: Fixed compiler issue on cycle breaking
+change-type: patch
+destination-branches: [master, iso3, iso4]
+issue: 2811
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -254,6 +254,9 @@ class Scheduler(object):
         for waiter in allwaiters:
             for rv in waiter.requires.values():
                 if isinstance(rv, DelayedResultVariable):
+                    if rv.hasValue:
+                        # get_progress_potential fails when there is a value already
+                        continue
                     if rv.get_waiting_providers() > 0 and rv.get_progress_potential() > 0:
                         LOGGER.debug("Waiting blocked on %s", rv)
                         rv.freeze()


### PR DESCRIPTION
# Description

fixes a call in an unexpected context.

Unfortunately, this is so hard to reproduce I couldn't come up with a testcase. 

closes #2811 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [X] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
