### PR TITLE
Fix broken link to openapi.json file

### DIFF
--- a/changelogs/unreleased/fix-broken-link-to-openapi-json.yml
+++ b/changelogs/unreleased/fix-broken-link-to-openapi-json.yml
@@ -1,0 +1,3 @@
+description: Fix broken link to openapi.json file
+change-type: patch
+destination-branches: [master, iso4]

--- a/docs/administrators/metering.rst
+++ b/docs/administrators/metering.rst
@@ -74,7 +74,7 @@ Each API method is reported with a `key=rpc.{endpoint_name}`.
 The `endpoint_name` is the server's internal name for the endpoint.
 
 To know which url corresponds to which method, please consult either
- * the `operationId` field of the `OpenAPI spec </_specs/openapi.json>`_ or
+ * the `operationId` field of the `OpenAPI spec <../_specs/openapi.json>`_ or
  * the method names in :mod:`inmanta.protocol.methods` and :mod:`inmanta.protocol.methods_v2`
 
 

--- a/docs/check_sphinx.py
+++ b/docs/check_sphinx.py
@@ -30,4 +30,6 @@ def test_linkcheck(build_docs):
     # This check verifies that the reference/openapi.html file is created.
     openapi_html_file = htmldir.join("reference/openapi.html")
     assert os.path.exists(openapi_html_file)
+    openapi_json_file = htmldir.join("_specs/openapi.json")
+    assert os.path.exists(openapi_json_file)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -284,7 +284,7 @@ texinfo_documents = [
 
 # Ingnore link check of openapi.html because it's used in a toctree.
 # A trick was required to include a non-sphinx document in a toctee.
-linkcheck_ignore = [r'http(s)?://localhost:\d+/', r'http://127.0.0.1:\d+', r'openapi.html', r'https://twitter.com/inmanta_com']
+linkcheck_ignore = [r'http(s)?://localhost:\d+/', r'http://127.0.0.1:\d+', r'openapi.html', r'https://twitter.com/inmanta_com', '../_specs/openapi.json']
 
 # Do not print the warning that tabs only work in html
 # https://github.com/djungelorm/sphinx-tabs/issues/39


### PR DESCRIPTION
# Description

Fix broken link to `openapi.json` file.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
