### PR TITLE
Ensure that an error at agent startup time is properly logged

### DIFF
--- a/changelogs/unreleased/2777-fix-error-handling-agent-startup.yml
+++ b/changelogs/unreleased/2777-fix-error-handling-agent-startup.yml
@@ -6,3 +6,4 @@ sections:
 destination-branches:
   - master
   - iso4
+  - iso3

--- a/changelogs/unreleased/2777-fix-error-handling-agent-startup.yml
+++ b/changelogs/unreleased/2777-fix-error-handling-agent-startup.yml
@@ -1,0 +1,8 @@
+description: Ensure that an error at agent startup time is properly logged.
+issue-nr: 2777
+change-type: patch
+sections:
+  bugfix: "{{description}}"
+destination-branches:
+  - master
+  - iso4

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -964,6 +964,7 @@ class AutostartedAgentManager(ServerSlice):
 
         agent_log = os.path.join(self._server_storage["logs"], "agent-%s.log" % env.id)
 
+        proc: Optional[subprocess.Process] = None
         try:
             proc = await self._fork_inmanta(
                 ["-vvvv", "--timed-logs", "--config", config_path, "--log-file", agent_log, "agent"], out, err
@@ -978,7 +979,7 @@ class AutostartedAgentManager(ServerSlice):
             self._agent_procs[env.id] = proc
         except Exception as e:
             # Prevent dangling processes
-            if proc.returncode is None:
+            if proc is not None and proc.returncode is None:
                 proc.kill()
             raise e
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -19,6 +19,7 @@ import asyncio
 import datetime
 import logging
 import typing
+from asyncio import subprocess
 from typing import Dict, List, Optional, Set, Tuple
 from unittest.mock import Mock
 from uuid import UUID, uuid4
@@ -31,7 +32,7 @@ from inmanta.agent import config as agent_config
 from inmanta.const import AgentAction, AgentStatus
 from inmanta.protocol import Result
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
-from inmanta.server.agentmanager import AgentManager, SessionAction, SessionManager
+from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager, SessionAction, SessionManager
 from inmanta.server.protocol import Session
 from utils import UNKWN, assert_equal_ish, retry_limited
 
@@ -1072,3 +1073,26 @@ async def test_add_internal_agent_when_missing_in_agent_map(server, environment,
     env = await data.Environment.get_by_id(UUID(environment))
     autostart_agent_map = await env.get(data.AUTOSTART_AGENT_MAP)
     assert "internal" in autostart_agent_map
+
+
+@pytest.mark.asyncio
+async def test_error_handling_agent_fork(server, environment, monkeypatch):
+    """
+    Verifies resolution of issue: inmanta/inmanta-core#2777
+    """
+    exception_message = "The start of the agent failed"
+
+    async def _dummy_fork_inmanta(
+        self, args: List[str], outfile: Optional[str], errfile: Optional[str], cwd: Optional[str] = None
+    ) -> subprocess.Process:
+        raise Exception(exception_message)
+
+    # Make the _fork_inmanta method raise an Exception
+    monkeypatch.setattr(AutostartedAgentManager, "_fork_inmanta", _dummy_fork_inmanta)
+
+    env = await data.Environment.get_by_id(UUID(environment))
+    autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
+    with pytest.raises(Exception) as excinfo:
+        await autostarted_agent_manager._ensure_agents(env=env, agents=["internal"], restart=True)
+
+    assert exception_message in str(excinfo.value)


### PR DESCRIPTION
# Description

Ensure that an error at agent startup time is properly logged.

closes #2777 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
