### PR TITLE
Issue/2723 module version constraints iso3

### DIFF
--- a/changelogs/unreleased/2723-documentation-module-version-constraints.yml
+++ b/changelogs/unreleased/2723-documentation-module-version-constraints.yml
@@ -1,6 +1,6 @@
 description: "Correctly describe in the documentation how version constraints can be set on module dependencies in the module.yml file"
 issue-nr: 2723
 change-type: patch
-destination-branches: [master, iso3, iso4]
+destination-branches: [iso3]
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/2723-documentation-module-version-constraints.yml
+++ b/changelogs/unreleased/2723-documentation-module-version-constraints.yml
@@ -1,0 +1,6 @@
+description: "Correctly describe in the documentation how version constraints can be set on module dependencies in the module.yml file"
+issue-nr: 2723
+change-type: patch
+destination-branches: [master, iso3, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -17,9 +17,9 @@ The source is organized in modules. Each module is a git repository with the fol
     |  +-- _init.cf
     +-- plugins/
     +-- templates/
-    +-- module.yaml
+    +-- module.yml
 
-The ``module.yaml`` file, the ``model`` directory and the ``model/_init.cf`` are required.
+The ``module.yml`` file, the ``model`` directory and the ``model/_init.cf`` are required.
 
 For example::
 
@@ -33,7 +33,7 @@ For example::
     |  |  +-- other.cf
     +-- plugins/
     +-- templates/
-    +-- module.yaml
+    +-- module.yml
 
 The model code is in the ``.cf`` files. Each file forms a namespace. The namespaces for the files are the following.
 

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -63,7 +63,7 @@ three keys mandatory:
 * *version*: The version of this module. For a new module a start version could be 0.1dev0 These
   versions are parsed using the same version parser as python setuptools.
 
-For example the following module.yaml from the :doc:`../quickstart`
+For example the following module.yml from the :doc:`../quickstart`
 
 .. code-block:: yaml
 
@@ -71,9 +71,9 @@ For example the following module.yaml from the :doc:`../quickstart`
     license: Apache 2.0
     version: 0.1
 
-Module depdencies are indicated by importing a module in a model file. However, these import do not
-have a specifc version identifier. The version of a module import can be constrained in the
-module.yml file. The *requires* key excepts a list of version specs. These version specs use `PEP440
+Module dependencies are indicated by importing a module in a model file. However, these imports do not
+have a specific version identifier. The version of a module import can be constrained in the
+module.yml file. The *requires* key expects a list of version specs. These version specs use `PEP440
 syntax <https://www.python.org/dev/peps/pep-0440/#version-specifiers>`_.
 
 To specify specific version are required, constraints can be added to the requires list::
@@ -83,8 +83,8 @@ To specify specific version are required, constraints can be added to the requir
     source: git@github.com:inmanta/ip
     version: 0.1.15
     requires:
-        net: net ~= 0.2.4
-        std: std >1.0 <2.5
+        - net ~= 0.2.4
+        - std >1.0 <2.5
 
 A module can also indicate a minimal compiler version with the *compiler_version* key.
 


### PR DESCRIPTION
# Description

Correctly describe in the documentation how version constraints can be set on module dependencies in the module.yml file.

**Changes: I created the previous PR on the master branch instead of the iso3 branch**

closes #2723

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
