### PR TITLE
re-added inmanta.module.INSTALL_OPTS and added documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,9 @@ src/*/parser/parsetab.py
 # Inmanta Release Tool
 docs/reference/modules
 docs/moduleguides
+docs/inmanta.pdf
 docs/_static/*.pdf
+docs/_static/*.png
 
 # Mypy
 .mypy

--- a/changelogs/unreleased/fix-api-breaking-pytest-inmanta.yml
+++ b/changelogs/unreleased/fix-api-breaking-pytest-inmanta.yml
@@ -1,5 +1,5 @@
 description: Re-added inmanta.module.INSTALL_OPTS and added documentation to fix API used by pytest-inmanta.
 change-type: patch
-destination-repos:
+destination-branches:
   - master
   - iso4

--- a/changelogs/unreleased/fix-api-breaking-pytest-inmanta.yml
+++ b/changelogs/unreleased/fix-api-breaking-pytest-inmanta.yml
@@ -1,0 +1,5 @@
+description: Re-added inmanta.module.INSTALL_OPTS and added documentation to fix API used by pytest-inmanta.
+change-type: patch
+destination-repos:
+  - master
+  - iso4

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -92,6 +92,18 @@ Attributes
     :undoc-members:
 
 
+Modules
+-------
+
+.. autoclass:: inmanta.module.InstallMode
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autodata:: inmanta.module.INSTALL_OPTS
+
+
 Typing
 ------
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -289,6 +289,7 @@ class InstallMode(str, enum.Enum):
     """
     Enumeration of all possible module install modes.
     """
+
     release = "release"
     prerelease = "prerelease"
     master = "master"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -310,7 +310,6 @@ class FreezeOperator(str, enum.Enum):
         all_values = [re.escape(o.value) for o in cls]
         return f"^({'|'.join(all_values)})$"
 
-print("loading")
 
 class Metadata(BaseModel):
     name: str

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -286,9 +286,18 @@ def merge_specs(mainspec: "Dict[str, List[Requirement]]", new: "List[Requirement
 
 
 class InstallMode(str, enum.Enum):
+    """
+    Enumeration of all possible module install modes.
+    """
     release = "release"
     prerelease = "prerelease"
     master = "master"
+
+
+INSTALL_OPTS: List[str] = [mode.value for mode in InstallMode]
+"""
+List of possible module install modes, kept for backwards compatibility. New code should use :class:`InstallMode` instead.
+"""
 
 
 class FreezeOperator(str, enum.Enum):
@@ -301,6 +310,7 @@ class FreezeOperator(str, enum.Enum):
         all_values = [re.escape(o.value) for o in cls]
         return f"^({'|'.join(all_values)})$"
 
+print("loading")
 
 class Metadata(BaseModel):
     name: str

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -287,12 +287,28 @@ def merge_specs(mainspec: "Dict[str, List[Requirement]]", new: "List[Requirement
 
 class InstallMode(str, enum.Enum):
     """
-    Enumeration of all possible module install modes.
+    The module install mode determines what version of a module should be selected when a module is downloaded.
     """
 
     release = "release"
+    """
+    Only use a released version that is compatible with the current compiler and any version constraints defined in the
+    ``requires`` lists for the project or any other modules (see :class:`ProjectMetadata` and :class:`ModuleMetadata`).
+
+    A version is released when there is a tag on a commit. This tag should be a valid version identifier (PEP440) and should
+    not be a prerelease version. Inmanta selects the latest available version (version sort based on PEP440) that is compatible
+    with all constraints.
+    """
+
     prerelease = "prerelease"
+    """
+    Similar to :attr:`InstallMode.release` but prerelease versions are allowed as well.
+    """
+
     master = "master"
+    """
+    Use the module's master branch.
+    """
 
 
 INSTALL_OPTS: List[str] = [mode.value for mode in InstallMode]
@@ -379,16 +395,7 @@ class ProjectMetadata(Metadata):
     :param downloadpath: (Optional) This value determines the path where Inmanta should download modules from
       repositories. This path is not automatically included in in modulepath!
     :param install_mode: (Optional) This key determines what version of a module should be selected when a module
-      is downloaded. The available values are:
-
-        * **release (default):** Only use a released version, that is compatible with the current
-          compiler and the version constraints defined in the ``requires`` list.
-          A version is released when there is a tag on a commit. This tag should be a
-          valid version identifier (PEP440) and should not be a prerelease version. Inmanta selects
-          the latest available version (version sort based on PEP440).
-        * **prerelease:** Similar to release, but also prerelease versions are allowed.
-        * **master:** Use the master branch.
-
+      is downloaded. For more information see :class:`InstallMode`.
     :param repo: (Optional) This key requires a list (a yaml list) of repositories where Inmanta can find
       modules. Inmanta creates the git repo url by formatting {} or {0} with the name of the repo. If no formatter is present it
       appends the name of the module. Inmanta tries to clone a module in the order in which it is defined in this value.

--- a/tests/test_import_entry_points.py
+++ b/tests/test_import_entry_points.py
@@ -81,3 +81,7 @@ def test_import_proxy(import_entry_point) -> None:
 def test_import_compile_data(import_entry_point) -> None:
     assert import_entry_point("inmanta.data.model") == 0
     assert import_entry_point("inmanta.ast.export") == 0
+
+
+def test_import_module(import_entry_point) -> None:
+    assert import_entry_point("inmanta.module") == 0


### PR DESCRIPTION
# Description

This fixes the breaking of the API used by pytest-inmanta introduced by d0959ab1.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
