### PR TITLE
make sure module metadata parsing is compatible with legacy format

### DIFF
--- a/changelogs/unreleased/fix-legacy-module-loading.yml
+++ b/changelogs/unreleased/fix-legacy-module-loading.yml
@@ -1,0 +1,5 @@
+description: Make sure module metadata parsing is compatible with legacy format
+change-type: patch
+destination-branches:
+  - master
+  - iso4


### PR DESCRIPTION
# Description

Fixes two issues:
- `module.yml` files like the one in `ip` would fail to be parsed because `requires` is specified as a dict.
- The error reporting code assumes `ValidationError.errors()[i]["loc"]` is an iterable of strings. This is not the case at least when the invalid field is en element of the list (in that case it's `("the_list", i)` where `i` is the element index). I opted to just report that field as is because I couldn't find any API documentation on the field so we would have no guarantee we'd handle all cases.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
