### PR TITLE
deprecated yaml dictionary syntax for module requires

### DIFF
--- a/changelogs/unreleased/module-requires-legacy-warning.yml
+++ b/changelogs/unreleased/module-requires-legacy-warning.yml
@@ -1,0 +1,7 @@
+description: Deprecated yaml dictionary syntax for module requires
+change-type: patch
+destination-branches:
+  - iso4
+  - master
+sections:
+  deprecation-note: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -37,6 +37,7 @@ import yaml
 from pkg_resources import parse_requirements, parse_version
 from pydantic import BaseModel, Field, NameEmail, ValidationError, validator
 
+import inmanta.warnings
 from inmanta import env, loader, plugins
 from inmanta.ast import CompilerException, LocatableString, Location, ModuleNotFoundException, Namespace, Range
 from inmanta.ast.blocks import BasicBlock
@@ -100,6 +101,10 @@ class InvalidMetadata(CompilerException):
             error_type = error["type"]
             msg += f"\n{error['loc']}\n\t{mgs} ({error_type})"
         return msg
+
+
+class MetadataDeprecationWarning(inmanta.warnings.InmantaWarning):
+    pass
 
 
 class ProjectNotFoundException(CompilerException):
@@ -347,6 +352,12 @@ class Metadata(BaseModel):
     def requires_to_list(cls, v: object) -> object:
         if isinstance(v, dict):
             # transform legacy format for backwards compatibility
+            inmanta.warnings.warn(
+                MetadataDeprecationWarning(
+                    "The yaml dictionary syntax for specifying module requirements has been deprecated. Please use the"
+                    " documented list syntax instead."
+                )
+            )
             result: List[str] = []
             for key, value in v.items():
                 if not (isinstance(key, str) and isinstance(value, str) and value.startswith(key)):

--- a/src/inmanta/warnings.py
+++ b/src/inmanta/warnings.py
@@ -27,8 +27,8 @@ class InmantaWarning(Warning):
     Base class for Inmanta Warnings.
     """
 
-    def __init__(self):
-        Warning.__init__(self)
+    def __init__(self, *args):
+        Warning.__init__(self, *args)
 
 
 class WarningBehaviour(Enum):


### PR DESCRIPTION
# Description

deprecated yaml dictionary syntax for module requires


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
