### PR TITLE
Extend programmatic api docs

### DIFF
--- a/changelogs/unreleased/extend-programmatic-api-docs-sphinx.yml
+++ b/changelogs/unreleased/extend-programmatic-api-docs-sphinx.yml
@@ -1,0 +1,5 @@
+description: Extend programmatic API documentation for parts used by inmanta-sphinx
+change-type: patch
+destination-branches:
+  - master
+  - iso4

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -108,6 +108,9 @@ Attributes
     :members: validate, get_type, type
     :undoc-members:
 
+.. autoclass:: inmanta.ast.attribute.RelationAttribute
+    :show-inheritance:
+
 
 Modules
 -------
@@ -119,7 +122,22 @@ Modules
 
 .. autodata:: inmanta.module.INSTALL_OPTS
 
+.. autoclass:: inmanta.module.InvalidMetadata
+
+.. autoclass:: inmanta.module.ModuleLike
+    :members: metadata, name
+    :undoc-members:
+
 .. autoclass:: inmanta.module.Module
+    :show-inheritance:
+
+
+Project
+-------
+
+.. autoclass:: inmanta.module.Project
+    :members: get, load, set
+    :undoc-members:
 
 
 Typing

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -122,6 +122,8 @@ Modules
 
 .. autodata:: inmanta.module.INSTALL_OPTS
 
+.. autoclass:: inmanta.module.InvalidModuleException
+
 .. autoclass:: inmanta.module.InvalidMetadata
 
 .. autoclass:: inmanta.module.ModuleLike

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -138,6 +138,7 @@ Project
 .. autoclass:: inmanta.module.Project
     :members: get, load, set
     :undoc-members:
+    :show-inheritance:
 
 
 Typing

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -481,6 +481,10 @@ class ModuleLike(ABC, Generic[T]):
     name = property(get_name)
 
     @property
+    def metadata(self) -> T:
+        return self._metadata
+
+    @property
     def freeze_recursive(self) -> bool:
         return self._metadata.freeze_recursive
 


### PR DESCRIPTION
# Description

Extend modules API and documentation to provide inmanta-sphinx with a stable API (see inmanta/inmanta-sphinx#43). This pull request doesn't add full documentation for all parts used by inmanta-sphinx. It mainly contains documentation for the parts that caused the docs builds to fail with a few others thrown in. I've created #2853 for the rest since it turned out to be a lot more than initially expected.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
