### PR TITLE
bump inmanta-dev-dependencies to 1.31.0

### DIFF
--- a/changelogs/unreleased/bump-inmanta-dev-dependencies.yml
+++ b/changelogs/unreleased/bump-inmanta-dev-dependencies.yml
@@ -1,0 +1,4 @@
+description: bump inmanta-dev-dependencies constraint
+change-type: patch
+destination-branches:
+  - iso4

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==1.23.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==1.31.0
 bumpversion==0.6.0
 openapi_spec_validator==0.2.9


### PR DESCRIPTION
This is required to bump the dependency on `inmanta-sphinx`. This should get the docs builds to succeed again.