### PR TITLE
Updated dependabot to update importlib-metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
   ignore:
-      # Conflict with tox
-    - dependency-name: "importlib-metadata"
-      versions: [">=3"]
       # Breaking change
     - dependency-name: "pyjwt"
       versions: [">=2"]

--- a/changelogs/unreleased/dependabot-config.yml
+++ b/changelogs/unreleased/dependabot-config.yml
@@ -1,0 +1,5 @@
+change-type: patch
+description: Update dependabot to update import_metadata
+destination-branches:
+- master
+sections: {}


### PR DESCRIPTION
# Description

Allow dependabot to update importlib-metadata
to fix failed build on update of inmanta-dev-depenencies==1.32.0
and because https://github.com/tox-dev/tox/pull/1764

Does this need to go through mergebot?

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Changelog entry
