### PR TITLE
Added install option inmanta-core[pytest-inmanta-extension]

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,8 +2,8 @@
 current_version = 5.0.1
 
 [bumpversion:file:setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
+search = version = "{current_version}"
+replace = version = "{new_version}"
 
 [bumpversion:file:tests_common/setup.py]
 search = version = "{current_version}"

--- a/changelogs/unreleased/pytest-inmanta-extension-option.yml
+++ b/changelogs/unreleased/pytest-inmanta-extension-option.yml
@@ -1,0 +1,5 @@
+description: Added ability to do `pip install inmanta-core[pytest-inmanta-extension]`
+change-type: patch
+destination-branches: [master, iso4, iso3]
+sections:
+    feature: "{{description}}"

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "debug": ["rpdb"],
         # option to install a matched pair of inmanta-core and pytest-inmanta-extensions
         "pytest-inmanta-extensions": [f"pytest-inmanta-extensions~={version}.0.dev"],
+        "datatrace": ["graphviz"],
     },
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -32,17 +32,19 @@ namespace_packages = ["inmanta_ext.core"]
 
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
+version = "5.0.1"
+
 setup(
-    version="5.0.1",
+    version=version,
     python_requires=">=3.6",  # also update classifiers
     # Meta data
     name="inmanta-core",
     description="Inmanta deployment tool",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author="Inmanta",
     author_email="code@inmanta.com",
     url="https://github.com/inmanta/inmanta-core",
@@ -72,7 +74,9 @@ setup(
     include_package_data=True,
     install_requires=requires,
     extras_require={
-      "debug": ["rpdb"]
+        "debug": ["rpdb"],
+        # option to install a matched pair of inmanta-core and pytest-inmanta-extensions
+        "pytest-inmanta-extensions": [f"pytest-inmanta-extensions~={version}.0.dev"],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
# Description

Added install option inmanta-core[pytest-inmanta-extension]
also ran black on setup.py

- I think this will fail to merge in the other branches. 
- I don't exactly know how to test this before merging it in?

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [X] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

