### PR TITLE
Add changelog section to the documentation

### DIFF
--- a/changelogs/unreleased/417-add-changelog-to-docs.yml
+++ b/changelogs/unreleased/417-add-changelog-to-docs.yml
@@ -1,0 +1,7 @@
+description: Add changelog section to the documentation
+issue-nr: 417
+issue-repo: irt
+change-type: patch
+destination-branches: [iso4]
+sections:
+  feature: "{{description}}"

--- a/docs/changelogs.rst
+++ b/docs/changelogs.rst
@@ -1,0 +1,9 @@
+Changelog
+=========
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    CHANGELOG.md
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ import sys, os, pkg_resources, datetime
 extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode',
     'sphinxarg.ext', 'sphinxcontrib.inmanta.config', 'sphinxcontrib.inmanta.dsl', 'sphinx_tabs.tabs',
-    'sphinxcontrib.inmanta.environmentsettings', 'sphinx_click.ext'
+    'sphinxcontrib.inmanta.environmentsettings', 'sphinx_click.ext', 'recommonmark'
 ]
 
 def setup(app):
@@ -63,7 +63,10 @@ redoc = [
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ Currently, the Inmanta project is mainly developed and maintained by `Inmanta nv
     glossary
     reference/index
     troubleshooting
+    changelogs
 
 Additional resources
 --------------------

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==1.31.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==1.33.0
 bumpversion==0.6.0
 openapi_spec_validator==0.2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cryptography==3.4.6
 docstring-parser==0.7.3
 email-validator==1.1.2
 execnet==1.8.0
-importlib_metadata==2.1.1
+importlib_metadata==4.0.1
 jinja2==2.11.3
 more-itertools==8.7.0
 netifaces==0.10.9


### PR DESCRIPTION
# Description

* Add changelog section to the documentation pages
* Enable markdown on the documentation

Note: I had to bump the version of the `importlib_metadata` package in order to resolve a version conflict with the `pytest-randomly` package.

This PR applies the change of #2877 on the ISO4 branch.

Part of inmanta/irt#417

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
