### PR TITLE
Fix importerror stable api

### DIFF
--- a/changelogs/unreleased/fix-importerror-stable-api.yml
+++ b/changelogs/unreleased/fix-importerror-stable-api.yml
@@ -1,0 +1,4 @@
+description: Fix ImportError for stable_api decorator in local.py
+issue-nr: 2414
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -22,7 +22,12 @@ import shutil
 import subprocess
 import sys
 
-from inmanta.stable_api import stable_api
+try:
+    from inmanta.stable_api import stable_api
+except ImportError:
+    # Use dummy decorator
+    def stable_api(cls):
+        return cls
 
 try:
     import grp  # @UnresolvedImport

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -29,6 +29,7 @@ except ImportError:
     def stable_api(cls):
         return cls
 
+
 try:
     import grp  # @UnresolvedImport
     import pwd

--- a/src/inmanta/agent/io/local.py
+++ b/src/inmanta/agent/io/local.py
@@ -23,14 +23,6 @@ import subprocess
 import sys
 
 try:
-    from inmanta.stable_api import stable_api
-except ImportError:
-    # Use dummy decorator
-    def stable_api(cls):
-        return cls
-
-
-try:
     import grp  # @UnresolvedImport
     import pwd
 except ImportError:
@@ -374,10 +366,11 @@ class BashIO(IOBase):
         return repr(self)
 
 
-@stable_api
 class LocalIO(IOBase):
     """
     This class provides handler IO methods
+
+    This class is part of the stable API.
     """
 
     def is_remote(self):


### PR DESCRIPTION
# Description

Fix ImportError for stable_api decorator in local.py.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
