### PR TITLE
pin core dependency with ~= instead of >= for pytest-inmanta-extensions

### DIFF
--- a/changelogs/unreleased/pytest-inmanta-pin-core.yml
+++ b/changelogs/unreleased/pytest-inmanta-pin-core.yml
@@ -1,0 +1,4 @@
+description: pin core dependency with ~= instead of >= for pytest-inmanta-extensions
+change-type: patch
+destination-branches:
+  - master

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -24,7 +24,7 @@ version = "5.1.1"
 requires = [
     "asyncpg",
     "click",
-    f"inmanta-core>={version}.dev",
+    f"inmanta-core~={version}.dev",
     "pyformance",
     "pytest-asyncio",
     "pytest-env",


### PR DESCRIPTION
Not 100% sure about this one but I believe this should pin with ~=, same as iso4.

I'll cherry-pick to iso5-next if approved. After cherry-picking I'll rebuild `pytest-inmanta-extensions` and retrigger the specific module sets build to make sure it still works with this new constraint.