### PR TITLE
Fix doller sign escaping issue

### DIFF
--- a/changelogs/unreleased/fix-escaping-issue-in-install-docs.yml
+++ b/changelogs/unreleased/fix-escaping-issue-in-install-docs.yml
@@ -1,0 +1,5 @@
+description: Fix dollar sign escaping issue in installation documentation
+change-type: patch
+destination-branches: [master]
+sections:
+  bugfix: "{{description}}"

--- a/docs/install/install-server/install-server.inc
+++ b/docs/install/install-server/install-server.inc
@@ -12,7 +12,7 @@ Install the software
           sudo tee /etc/yum.repos.d/inmanta_oss_stable.repo <<EOF
           [inmanta-oss-stable]
           name=inmanta-oss-stable
-          baseurl=https://packages.inmanta.com/public/oss-stable/rpm/el/$releasever/$basearch
+          baseurl=https://packages.inmanta.com/public/oss-stable/rpm/el/\$releasever/\$basearch
           repo_gpgcheck=1
           enabled=1
           gpgkey=https://packages.inmanta.com/public/oss-stable/gpg.A34DD0A274F07713.key

--- a/docs/install/install-server/install-server.inc
+++ b/docs/install/install-server/install-server.inc
@@ -40,7 +40,7 @@ Install the software
           sudo tee /etc/yum.repos.d/inmanta_oss_stable.repo <<EOF
           [inmanta-oss-stable]
           name=inmanta-oss-stable
-          baseurl=https://packages.inmanta.com/public/oss-stable/rpm/el/$releasever/$basearch
+          baseurl=https://packages.inmanta.com/public/oss-stable/rpm/el/\$releasever/\$basearch
           repo_gpgcheck=1
           enabled=1
           gpgkey=https://packages.inmanta.com/public/oss-stable/gpg.A34DD0A274F07713.key


### PR DESCRIPTION
# Description

Fix doller sign escaping issue in installation documentation.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
