### PR TITLE
backport 2359 from iso4 to iso3

### DIFF
--- a/changelogs/unreleased/2420-backport-pep-marker-fix-to-iso3.yml
+++ b/changelogs/unreleased/2420-backport-pep-marker-fix-to-iso3.yml
@@ -1,0 +1,7 @@
+---
+description: Added support for environment markers as described in PEP 508 to module requirements parsing
+issue-nr: 2359
+change-type: patch
+destination-branches: [iso3]
+sections:
+    bugfix: "{{description}} (backport from iso4)"

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -203,6 +203,7 @@ python -m pip $@
 
             url = None
             version = None
+            marker = None
             try:
                 # this will fail is an url is supplied
                 parsed_req = list(pkg_resources.parse_requirements(req_spec))
@@ -213,16 +214,20 @@ python -m pip $@
                     elif hasattr(item, "unsafe_name"):
                         name = item.unsafe_name
                     version = item.specs
+                    marker = item.marker
                     if hasattr(item, "url"):
                         url = item.url
             except InvalidRequirement:
                 url = req_spec
 
             if name not in modules:
-                modules[name] = {"name": name, "version": []}
+                modules[name] = {"name": name, "version": [], "markers": []}
 
             if version is not None:
                 modules[name]["version"].extend(version)
+
+            if marker is not None:
+                modules[name]["markers"].append(marker)
 
             if url is not None:
                 modules[name]["url"] = url
@@ -230,13 +235,17 @@ python -m pip $@
         requirements_file = ""
         for module, info in modules.items():
             version_spec = ""
+            markers: str = ""
             if len(info["version"]) > 0:
                 version_spec = " " + (", ".join(["%s %s" % (a, b) for a, b in info["version"]]))
+
+            if len(info["markers"]) > 0:
+                markers = " ; " + (" and ".join(map(str, info["markers"])))
 
             if "url" in info:
                 module = info["url"]
 
-            requirements_file += module + version_spec + "\n"
+            requirements_file += module + version_spec + markers + "\n"
 
         return requirements_file
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -135,7 +135,20 @@ def test_req_parser(tmpdir):
 
 def test_gen_req_file(tmpdir):
     e = env.VirtualEnv(tmpdir)
-    req = ["lorem == 0.1.1", "lorem > 0.1", "dummy-yummy", "iplib@git+https://github.com/bartv/python3-iplib", "lorem"]
+    req = [
+        "lorem == 0.1.1",
+        "lorem > 0.1",
+        "dummy-yummy",
+        "iplib@git+https://github.com/bartv/python3-iplib",
+        "lorem",
+        # verify support for environment markers as described in PEP 508
+        "lorem;python_version<'3.7'",
+        "lorem;platform_machine == 'x86_64' and platform_system == 'Linux'",
+    ]
 
     req_lines = [x for x in e._gen_requirements_file(req).split("\n") if len(x) > 0]
     assert len(req_lines) == 3
+    assert (
+        'lorem == 0.1.1, > 0.1 ; python_version < "3.7" and platform_machine == "x86_64" and platform_system == "Linux"'
+        in req_lines
+    )


### PR DESCRIPTION
# Description

Added support for environment markers as described in PEP 508 to module requirements parsing
backport from iso4

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
