### PR TITLE
Add ci file docs test

### DIFF
--- a/.ci-docs-test.yml
+++ b/.ci-docs-test.yml
@@ -1,0 +1,1 @@
+pipeline_template: ci/inmanta-core/Jenkinsfile-docs-test

--- a/changelogs/unreleased/add-ci-file-docs-test.yml
+++ b/changelogs/unreleased/add-ci-file-docs-test.yml
@@ -1,0 +1,6 @@
+---
+description: Added .ci file to run docs tests.
+issue-nr: 133
+issue-repo: infra-tickets
+change-type: patch
+destination-branches: [master, iso3, iso4]


### PR DESCRIPTION
# Description

Added `.ci` file to run documentation tests.

Part of inmanta/infra-tickets#133

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
