### PR TITLE
re-enable pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
   ignore:
-      # Breaking change, see #2729 
+      # Breaking change, see #2729
     - dependency-name: "openapi-spec-validator"
       versions: [">=0.3.0"]
-      # version 21.1 contains a bug: https://github.com/pypa/pip/issues/9878
-    - dependency-name: "pip"
-      versions: [">=21.1"]


### PR DESCRIPTION
# Description

Re-enable pip updates 

closes #2894

:warning: I didn't add a changelog entry as this only goes into master, is that OK? 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
