### PR TITLE
Add ci file for integration tests

### DIFF
--- a/.ci-integration-tests.yml
+++ b/.ci-integration-tests.yml
@@ -1,0 +1,2 @@
+pipeline_template: ci/inmanta-extensions/Jenkinsfile-integration-tests
+repo_name: inmanta-core

--- a/changelogs/unreleased/add-ci-file-integration-tests.yml
+++ b/changelogs/unreleased/add-ci-file-integration-tests.yml
@@ -1,0 +1,6 @@
+---
+description: Added .ci file to run integration tests.
+issue-nr: 133
+issue-repo: infra-tickets
+change-type: patch
+destination-branches: [master, iso3, iso4]


### PR DESCRIPTION
# Description

Add `.ci` file for integration test.

Part of inmanta/infra-tickets#133

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
