### PR TITLE
Fix link to keycloak documentation

### DIFF
--- a/changelogs/unreleased/fix-docs-keycloak-link.yml
+++ b/changelogs/unreleased/fix-docs-keycloak-link.yml
@@ -1,0 +1,4 @@
+---
+description: Fix link to keycloak documentation
+change-type: patch
+destination-branches: [iso3]

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -291,7 +291,7 @@ able to access this url).
 
 Both the correct url for the issuer and the jwks_uri is also defined in the openid-configuration endpoint of keycloack. For
 the examples above this url is http://localhost:8080/auth/realms/master/.well-known/openid-configuration
-(https://www.keycloak.org/docs/latest/securing_apps/index.html#endpoints-2)
+(https://www.keycloak.org/docs/latest/securing_apps/index.html#endpoints)
 
 .. warning:: When the certificate of keycloak is not trusted by the system on which inmanta is installed, set ``validate_cert``
     to false in the ``auth_jwt_keycloak`` block for keycloak.


### PR DESCRIPTION
# Description

This issue was already fixed on the master and the ISO4 branch using cf64664c3e961dc63f958a91f6d8cc430c2c36a0. This PR doesn't touch the `docs/platform_developers/exceptions.rst` file, because ISO3 still has the `InvalidSchemaVersion` exception.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors~~
- [ ] ~~Sufficient test cases~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
