### PR TITLE
Bump pydantic dependency to 1.7.3

### DIFF
--- a/changelogs/unreleased/bump-version-pydantic.yml
+++ b/changelogs/unreleased/bump-version-pydantic.yml
@@ -1,0 +1,4 @@
+---
+description: Bump pydantic dependency to 1.7.3
+change-type: patch
+destination-branches: [iso3]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ more-itertools==8.5.0
 netifaces==0.10.9
 pip==21.0.1
 ply==3.11
-pydantic==1.6.1
+pydantic==1.7.3
 pyformance==0.4
 PyJWT==1.7.1
 python-dateutil==2.8.1


### PR DESCRIPTION
# Description

pytest-docker fails for the combination (os=fedora-latest, branch=iso3), because it uses Python3.9. The problem is situated in the pydantic dependency. Pydantic only support Python3.9 from version `1.7.0`, while inmanta-core still uses version `1.6.1`. 

Next to that, there is an inconsistency between inmanta-core and the inmanta-lsm extension with respect to the pydantic dependency. Inmanta-core pins pydantic to version `1.6.1`, while inmanta-lsm pins it to version `1.7.3`. For that reason I decided bump the pydantic version to `1.7.3` on inmanta-core as well. This fixes the inconsistency and the failure on pytest-docker.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
