### PR TITLE
Set environment setting purge_on_delete to false by default

### DIFF
--- a/changelogs/unreleased/2958-set-purge-on-delete-to-false.yml
+++ b/changelogs/unreleased/2958-set-purge-on-delete-to-false.yml
@@ -4,4 +4,4 @@ issue-nr: 2958
 change-type: patch
 destination-branches: [master, iso3, iso4]
 sections:
-  upgrade-note: "On newly created environments, the environment setting `purge_on_delete` will be set to false by default instead of true"
+  upgrade-note: "On newly created environments, the environment setting `purge_on_delete` will be set to false by default instead of true. This overrides any purge_on_delete settings on individual resources. You need to explicitly set it to true to enable the old behavior again."

--- a/changelogs/unreleased/2958-set-purge-on-delete-to-false.yml
+++ b/changelogs/unreleased/2958-set-purge-on-delete-to-false.yml
@@ -1,0 +1,7 @@
+---
+description: Set `purge_on_delete` to false on every environment by default
+issue-nr: 2958
+change-type: patch
+destination-branches: [master, iso3, iso4]
+sections:
+  upgrade-note: "On newly created environments, the environment setting `purge_on_delete` will be set to false by default instead of true"

--- a/changelogs/unreleased/set-purge-on-delete-to-false.yml
+++ b/changelogs/unreleased/set-purge-on-delete-to-false.yml
@@ -1,7 +1,0 @@
----
-description: Set purge\_on\_delete to false on every environment by default
-issue-nr: 2958
-change-type: patch
-destination-branches: [master, iso3, iso4]
-sections:
-  upgrade-note: "On newly created environments, the environment setting purge\_on\_delete will be set to false by default instead of true"

--- a/changelogs/unreleased/set-purge-on-delete-to-false.yml
+++ b/changelogs/unreleased/set-purge-on-delete-to-false.yml
@@ -1,0 +1,7 @@
+---
+description: Set purge\_on\_delete to false on every environment by default
+issue-nr: 2958
+change-type: patch
+destination-branches: [master, iso3, iso4]
+sections:
+  upgrade-note: "On newly created environments, the environment setting purge\_on\_delete will be set to false by default instead of true"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -960,7 +960,7 @@ class Environment(BaseDocument):
         ),
         PURGE_ON_DELETE: Setting(
             name=PURGE_ON_DELETE,
-            default=True,
+            default=False,
             typ="bool",
             validator=convert_boolean,
             doc="Enable purge on delete. When set to true, the server will detect the absence of resources with purge_on_delete"

--- a/tests/agent_server/test_evolution.py
+++ b/tests/agent_server/test_evolution.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 import pytest
 
 from agent_server.conftest import get_agent, stop_agent
-from inmanta import const, resources, data
+from inmanta import const, data, resources
 from inmanta.agent import handler
 from inmanta.agent.handler import CRUDHandler, HandlerContext, provider
 from inmanta.export import unknown_parameters

--- a/tests/agent_server/test_evolution.py
+++ b/tests/agent_server/test_evolution.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 import pytest
 
 from agent_server.conftest import get_agent, stop_agent
-from inmanta import const, resources
+from inmanta import const, resources, data
 from inmanta.agent import handler
 from inmanta.agent.handler import CRUDHandler, HandlerContext, provider
 from inmanta.export import unknown_parameters
@@ -172,6 +172,10 @@ async def test_resource_evolution(server, client, environment, no_agent_backoff,
     agent = await get_agent(server, environment, "agent1")
     async_finalizer(agent.stop)
 
+    # Enable purge_on_delete at the environment level
+    result = await client.set_setting(tid=environment, id=data.PURGE_ON_DELETE, value=True)
+    assert result.code == 200
+
     # override origin check
     monkeypatch.setattr(SourceInfo, "_get_module_name", lambda s: s.module_name)
     monkeypatch.setattr(SourceInfo, "get_siblings", lambda s: iter([s]))
@@ -225,7 +229,7 @@ async def test_resource_evolution(server, client, environment, no_agent_backoff,
     version, _ = await snippetcompiler.do_export_and_deploy()
     result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
     assert result.code == 200
-    assert result.result["model"]["total"] == 2
+    assert result.result["model"]["total"] == 2  # purge_on_delete
 
     await _wait_until_deployment_finishes(client, environment, version)
     assert provider.isset("agent1", "a")

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -279,3 +279,21 @@ async def test_decommission_protected_environment(server, client):
     result = await client.environment_settings_set(env_id, data.PROTECTED_ENVIRONMENT, False)
     assert result.code == 200
     await assert_decomission_env(env_id, decommission_succeeds=True)
+
+
+@pytest.mark.asyncio
+async def test_default_value_purge_on_delete_setting(server, client):
+    """
+    Ensure that the purge_on_delete setting of an environment is set to false by default.
+    """
+    result = await client.create_project("env-test")
+    assert result.code == 200
+    project_id = result.result["project"]["id"]
+
+    result = await client.create_environment(project_id=project_id, name="dev")
+    assert result.code == 200
+    env_id = result.result["environment"]["id"]
+
+    result = await client.get_setting(tid=env_id, id=data.PURGE_ON_DELETE)
+    assert result.code == 200
+    assert result.result["value"] is False

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -30,6 +30,18 @@ from inmanta.util import get_compiler_version
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="function")
+async def environment(environment, client):
+    """
+    Override the environment fixture, defined in conftest.py, to make sure that the
+    purge_on_delete environment setting is enabled for all tests defined in this file.
+    """
+    result = await client.set_setting(tid=environment, id=data.PURGE_ON_DELETE, value=True)
+    assert result.code == 200
+
+    yield environment
+
+
 @pytest.mark.asyncio
 async def test_purge_on_delete_requires(client, server, environment, clienthelper):
     """


### PR DESCRIPTION
# Description

Set environment setting `purge_on_delete` to false by default.

closes #2958

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
