### PR TITLE
fixed change entries

### DIFF
--- a/changelogs/5.1.0/2787-compiler-memory-leak.yml
+++ b/changelogs/5.1.0/2787-compiler-memory-leak.yml
@@ -1,3 +1,3 @@
 description: "Fixed memory leak introduced by #2787"
 change-type: patch
-destination-branches: [master, iso3, iso4]
+destination-branches: [master, iso4]

--- a/changelogs/unreleased/2683-port-pyjwt2.yml
+++ b/changelogs/unreleased/2683-port-pyjwt2.yml
@@ -1,4 +1,4 @@
 description: Port jwt usage to PyJWT 2
 issue-nr: 2683
 change-type: patch
-destination-branches: [master, iso4]
+destination-branches: [master]

--- a/changelogs/unreleased/fix-change-entries.yml
+++ b/changelogs/unreleased/fix-change-entries.yml
@@ -1,0 +1,5 @@
+description: Fixed old change entries
+change-type: patch
+destination-branches:
+  - iso4
+  - master

--- a/changelogs/unreleased/fix-change-entries.yml
+++ b/changelogs/unreleased/fix-change-entries.yml
@@ -1,5 +1,0 @@
-description: Fixed old change entries
-change-type: patch
-destination-branches:
-  - iso4
-  - master


### PR DESCRIPTION
Start from a clean slate for some change entries that were forgotten and merged at a later point. This messes with the timestamp-reasoning of the change entry check.