### PR TITLE
fixed change entries

### DIFF
--- a/changelogs/4.2.0/2787-compiler-memory-leak.yml
+++ b/changelogs/4.2.0/2787-compiler-memory-leak.yml
@@ -1,3 +1,3 @@
 description: "Fixed memory leak introduced by #2787"
 change-type: patch
-destination-branches: [master, iso3, iso4]
+destination-branches: [master, iso4]


### PR DESCRIPTION
Start from a clean slate for some change entries that were forgotten and merged at a later point. This messes with the timestamp-reasoning of the change entry check.