### PR TITLE
Fix broken test case test_resource_evolution

### DIFF
--- a/changelogs/unreleased/fix-test-case-resource-evolution.yml
+++ b/changelogs/unreleased/fix-test-case-resource-evolution.yml
@@ -1,4 +1,4 @@
 ---
 description: Fix broken test case `test_resource_evolution`
 change-type: patch
-destination-branches: [master, iso3, iso4]
+destination-branches: [master]

--- a/changelogs/unreleased/fix-test-case-resource-evolution.yml
+++ b/changelogs/unreleased/fix-test-case-resource-evolution.yml
@@ -1,0 +1,4 @@
+---
+description: Fix broken test case `test_resource_evolution`
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/tests/agent_server/test_evolution.py
+++ b/tests/agent_server/test_evolution.py
@@ -191,7 +191,7 @@ async def test_resource_evolution(server, client, environment, no_agent_backoff,
 
     implement Resource using std::none
 
-    Resource(key="a", value="b", agent="agent1")
+    Resource(key="a", value="b", agent="agent1", purge_on_delete=true)
     """
     )
 
@@ -222,7 +222,7 @@ async def test_resource_evolution(server, client, environment, no_agent_backoff,
 
     implement Resource using std::none
 
-    Resource(key="a", value="b", agent="agent1", uid="alpha")
+    Resource(key="a", value="b", agent="agent1", uid="alpha", purge_on_delete=true)
     """
     )
 


### PR DESCRIPTION
# Description

The `test_resource_evolution` test case broke due to the update to the std module that sets the `purge_on_delete` flag to false by default. The branches `merge-tool/2959/iso4` and `issue/2958-set-purge-on-delete-to-false-iso3` which should merge #2959 into the ISO4 and ISO3 respectively are also stuck on this issue. I will apply this change on those branches as well. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [ ] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
