### PR TITLE
added custom json encoders to stable API definition

### DIFF
--- a/changelogs/unreleased/stable-api-custom-json-encoder.yml
+++ b/changelogs/unreleased/stable-api-custom-json-encoder.yml
@@ -1,0 +1,5 @@
+description: Added custom json encoders to stable API definition.
+change-type: patch
+destination-branches:
+  - iso4
+  - master

--- a/changelogs/unreleased/stable-api-custom-json-encoder.yml
+++ b/changelogs/unreleased/stable-api-custom-json-encoder.yml
@@ -1,5 +1,4 @@
 description: Added custom json encoders to stable API definition.
 change-type: patch
 destination-branches:
-  - iso4
   - master

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -38,7 +38,6 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 
 from inmanta import COMPILER_VERSION
-from inmanta.data.model import BaseModel
 from inmanta.stable_api import stable_api
 from inmanta.types import JsonType, PrimitiveTypes, ReturnTypes
 
@@ -278,7 +277,8 @@ def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
         # Logs can push exceptions through RPC. Return a string representation.
         return str(o)
 
-    if isinstance(o, BaseModel):
+    from inmanta.data.model import BaseModel
+    if isinstance(o, model.BaseModel):
         return o.dict(by_alias=True)
 
     LOGGER.error("Unable to serialize %s", o)

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -278,7 +278,8 @@ def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
         return str(o)
 
     from inmanta.data.model import BaseModel
-    if isinstance(o, model.BaseModel):
+
+    if isinstance(o, BaseModel):
         return o.dict(by_alias=True)
 
     LOGGER.error("Unable to serialize %s", o)

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -39,6 +39,7 @@ from tornado.ioloop import IOLoop
 
 from inmanta import COMPILER_VERSION
 from inmanta.data.model import BaseModel
+from inmanta.stable_api import stable_api
 from inmanta.types import JsonType, PrimitiveTypes, ReturnTypes
 
 LOGGER = logging.getLogger(__name__)
@@ -228,6 +229,7 @@ class JSONSerializable(ABC):
         raise NotImplementedError()
 
 
+@stable_api
 def internal_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
     """
     A custom json encoder that knows how to encode other types commonly used by Inmanta from standard python libraries. This
@@ -240,6 +242,7 @@ def internal_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
     return _custom_json_encoder(o)
 
 
+@stable_api
 def api_boundary_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
     """
     A custom json encoder that knows how to encode other types commonly used by Inmanta from standard python libraries. This

--- a/tests/test_import_entry_points.py
+++ b/tests/test_import_entry_points.py
@@ -98,3 +98,7 @@ def test_import_protocol(import_entry_point) -> None:
 
 def test_import_const(import_entry_point) -> None:
     assert import_entry_point("inmanta.const") == 0
+
+
+def test_import_util(import_entry_point: Callable[[str], Optional[int]]) -> None:
+    assert import_entry_point("inmanta.util") == 0


### PR DESCRIPTION
Should I add this to the docs as well? It doesn't necessarily need to be there I think unless we still want the docs to collect all stable API elements to better keep track of them.