### PR TITLE
Added resource_deploy_done API endpoint

### DIFF
--- a/changelogs/unreleased/2931-add-deploy-done-endpoint.yml
+++ b/changelogs/unreleased/2931-add-deploy-done-endpoint.yml
@@ -1,0 +1,7 @@
+---
+description: Added `resource_deploy_done` endpoint
+issue-nr: 2931
+change-type: minor
+destination-branches: [master]
+sections:
+  feature: "{{description}}"

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -17,7 +17,7 @@
 """
 import datetime
 import uuid
-from typing import Any, Dict, List, NewType, Optional, Union
+from typing import Any, ClassVar, Dict, List, NewType, Optional, Union
 
 import pydantic
 
@@ -44,7 +44,9 @@ class BaseModel(pydantic.BaseModel):
     Base class for all data objects in Inmanta
     """
 
-    _normalize_timestamps = pydantic.validator("*", allow_reuse=True)(validator_timezone_aware_timestamps)
+    _normalize_timestamps: ClassVar[classmethod] = pydantic.validator("*", allow_reuse=True)(
+        validator_timezone_aware_timestamps
+    )
 
     class Config:
         """

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -276,6 +276,30 @@ class ResourceAction(BaseModel):
 
 
 class LogLine(BaseModel):
+    class Config:
+        """
+        Pydantic config.
+        """
+        # Override the setting from the BaseModel class as such that the level field is
+        # serialises using the name of the enum instead of its value. This is required
+        # to make sure that data sent to the API endpoints resource_action_update
+        # and resource_deploy_done are serialized consistently using the name of the enum.
+        use_enum_values = False
+
+    @pydantic.validator('level', pre=True)
+    def level_from_enum_attribute(cls, v):
+        """
+        Ensure that a LogLine object can be instantiated using pydantic when the level field
+        is represented using the name of the enum instead of its value. This is required to
+        make sure that a serialized version of this object passes pydantic validation.
+        """
+        if isinstance(v, str):
+            try:
+                return const.LogLevel[v]
+            except KeyError:
+                raise ValueError(f"Invalid enum value {v}. Valid values: { ','.join([x.name for x in const.LogLevel]) }")
+        return v
+
     level: const.LogLevel
     msg: str
     args: List[ArgumentTypes] = []

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -288,7 +288,7 @@ class LogLine(BaseModel):
         use_enum_values = False
 
     @pydantic.validator("level", pre=True)
-    def level_from_enum_attribute(cls, v):
+    def level_from_enum_attribute(cls, v: object) -> object:
         """
         Ensure that a LogLine object can be instantiated using pydantic when the level field
         is represented using the name of the enum instead of its value. This is required to

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -28,11 +28,23 @@ from inmanta.stable_api import stable_api
 from inmanta.types import ArgumentTypes, JsonType, SimpleTypes, StrictNonIntBool
 
 
+def validator_timezone_aware_timestamps(value: object) -> object:
+    """
+    A Pydantic validator to ensure that all datetime times are timezone aware.
+    """
+    if isinstance(value, datetime.datetime) and value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    else:
+        return value
+
+
 @stable_api
 class BaseModel(pydantic.BaseModel):
     """
     Base class for all data objects in Inmanta
     """
+
+    _normalize_timestamps = pydantic.validator('*', allow_reuse=True)(validator_timezone_aware_timestamps)
 
     class Config:
         """

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -298,7 +298,7 @@ class LogLine(BaseModel):
             try:
                 return const.LogLevel[v]
             except KeyError:
-                return v
+                raise ValueError(f"Invalid enum value {v}. Valid values: { ','.join([x.name for x in const.LogLevel]) }")
         return v
 
     level: const.LogLevel

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -44,7 +44,7 @@ class BaseModel(pydantic.BaseModel):
     Base class for all data objects in Inmanta
     """
 
-    _normalize_timestamps = pydantic.validator('*', allow_reuse=True)(validator_timezone_aware_timestamps)
+    _normalize_timestamps = pydantic.validator("*", allow_reuse=True)(validator_timezone_aware_timestamps)
 
     class Config:
         """

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -298,7 +298,7 @@ class LogLine(BaseModel):
             try:
                 return const.LogLevel[v]
             except KeyError:
-                raise ValueError(f"Invalid enum value {v}. Valid values: { ','.join([x.name for x in const.LogLevel]) }")
+                return v
         return v
 
     level: const.LogLevel

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -280,13 +280,14 @@ class LogLine(BaseModel):
         """
         Pydantic config.
         """
+
         # Override the setting from the BaseModel class as such that the level field is
         # serialises using the name of the enum instead of its value. This is required
         # to make sure that data sent to the API endpoints resource_action_update
         # and resource_deploy_done are serialized consistently using the name of the enum.
         use_enum_values = False
 
-    @pydantic.validator('level', pre=True)
+    @pydantic.validator("level", pre=True)
     def level_from_enum_attribute(cls, v):
         """
         Ensure that a LogLine object can be instantiated using pydantic when the level field

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -259,3 +259,11 @@ class ResourceAction(BaseModel):
     changes: Optional[JsonType]
     change: Optional[const.Change]
     send_event: Optional[bool]
+
+
+class LogLine(BaseModel):
+    level: const.LogLevel
+    msg: str
+    args: List[ArgumentTypes] = []
+    kwargs: Dict[str, ArgumentTypes] = {}
+    timestamp: datetime.datetime

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -26,7 +26,7 @@ import re
 import time
 import uuid
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from inspect import Parameter
 from typing import (
@@ -60,7 +60,7 @@ from tornado import web
 
 from inmanta import config as inmanta_config
 from inmanta import const, execute, util
-from inmanta.data.model import BaseModel
+from inmanta.data.model import BaseModel, validator_timezone_aware_timestamps
 from inmanta.protocol.exceptions import BadRequest, BaseHttpException
 from inmanta.stable_api import stable_api
 from inmanta.types import ArgumentTypes, HandlerType, JsonType, MethodType, ReturnTypes, StrictNonIntBool
@@ -336,16 +336,8 @@ VALID_SIMPLE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, StrictNon
 
 
 class MethodArgumentsBaseModel(pydantic.BaseModel):
-    @pydantic.root_validator
-    @classmethod
-    def datetime_timezone_aware(cls, values: Dict[str, object]) -> Dict[str, object]:
-        """
-        Make sure all instances of datetime are timezone-aware. Any naive inputs are interpreted as UTC.
-        """
-        return {
-            key: (value.replace(tzinfo=timezone.utc) if isinstance(value, datetime) and value.tzinfo is None else value)
-            for key, value in values.items()
-        }
+
+    _normalize_timestamps = pydantic.validator('*', allow_reuse=True)(validator_timezone_aware_timestamps)
 
 
 class MethodProperties(object):

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -337,7 +337,7 @@ VALID_SIMPLE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, StrictNon
 
 class MethodArgumentsBaseModel(pydantic.BaseModel):
 
-    _normalize_timestamps = pydantic.validator('*', allow_reuse=True)(validator_timezone_aware_timestamps)
+    _normalize_timestamps = pydantic.validator("*", allow_reuse=True)(validator_timezone_aware_timestamps)
 
 
 class MethodProperties(object):

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -33,6 +33,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Coroutine,
     Dict,
     Generic,
@@ -337,7 +338,9 @@ VALID_SIMPLE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, StrictNon
 
 class MethodArgumentsBaseModel(pydantic.BaseModel):
 
-    _normalize_timestamps = pydantic.validator("*", allow_reuse=True)(validator_timezone_aware_timestamps)
+    _normalize_timestamps: ClassVar[classmethod] = pydantic.validator("*", allow_reuse=True)(
+        validator_timezone_aware_timestamps
+    )
 
 
 class MethodProperties(object):

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -424,7 +424,6 @@ def resource_deploy_done(
     changes: Dict[str, model.AttributeStateChange] = {},
     change: Optional[Change] = None,
     send_events: bool = False,
-    keep_increment_cache: bool = False,
 ) -> None:
     """
     Report to the server that an agent has finished the deployment of a certain resource.
@@ -439,7 +438,6 @@ def resource_deploy_done(
                    have been changed. The value contains the new value and/or the original value.
     :param change: The type of change that was done the given resource.
     :param send_events: Send events to the dependents of this resource.
-    :param keep_increment_cache: The increment cache will be cleared iff this value is set to false.
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -21,8 +21,8 @@ import datetime
 import uuid
 from typing import Dict, List, Optional, Union
 
-from inmanta.const import AgentAction, ApiDocsFormat, ClientType, Change, ResourceState, ResourceAction
-from inmanta.data import model, LogLine
+from inmanta.const import AgentAction, ApiDocsFormat, Change, ClientType, ResourceAction, ResourceState
+from inmanta.data import LogLine, model
 from inmanta.protocol.common import ReturnValue
 
 from . import methods
@@ -412,7 +412,8 @@ def get_resource_actions(
     operation="POST",
     agent_server=True,
     arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.agent], api_version=2
+    client_types=[ClientType.agent],
+    api_version=2,
 )
 def resource_deploy_done(
     tid: uuid.UUID,
@@ -426,19 +427,19 @@ def resource_deploy_done(
     keep_increment_cache: bool = False,
 ) -> None:
     """
-        Report to the server that an agent has finished the deployment of a certain resource.
+    Report to the server that an agent has finished the deployment of a certain resource.
 
-        :param tid: The id of the environment the resource belongs to
-        :param resource_id: The resource version id of the resource for which the deployment is finished.
-        :param action_id: A unique ID associated with this resource deployment action. This should be the same ID that was
-                          passed to the `/resource/<resource_id>/deploy/start` API call.
-        :param status: The current status of the resource (if known)
-        :param messages: A list of log entries produced by the deployment action.
-        :param changes: A dict of changes to this resource. The key of this dict indicates the attributes/fields that
-                       have been changed. The value contains the new value and/or the original value.
-        :param change: The type of change that was done the given resource.
-        :param send_events: Send events to the dependents of this resource.
-        :param keep_increment_cache: The increment cache will be cleared iff this value is set to false.
+    :param tid: The id of the environment the resource belongs to
+    :param resource_id: The resource version id of the resource for which the deployment is finished.
+    :param action_id: A unique ID associated with this resource deployment action. This should be the same ID that was
+                      passed to the `/resource/<resource_id>/deploy/start` API call.
+    :param status: The current status of the resource (if known)
+    :param messages: A list of log entries produced by the deployment action.
+    :param changes: A dict of changes to this resource. The key of this dict indicates the attributes/fields that
+                   have been changed. The value contains the new value and/or the original value.
+    :param change: The type of change that was done the given resource.
+    :param send_events: Send events to the dependents of this resource.
+    :param keep_increment_cache: The increment cache will be cleared iff this value is set to false.
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -21,8 +21,8 @@ import datetime
 import uuid
 from typing import Dict, List, Optional, Union
 
-from inmanta.const import AgentAction, ApiDocsFormat, ClientType
-from inmanta.data import model
+from inmanta.const import AgentAction, ApiDocsFormat, ClientType, Change, ResourceState, ResourceAction
+from inmanta.data import model, LogLine
 from inmanta.protocol.common import ReturnValue
 
 from . import methods
@@ -404,4 +404,39 @@ def get_resource_actions(
 
     :raises BadRequest: When the supplied parameters are not valid.
 
+    """
+
+
+@typedmethod(
+    path="/resource/<resource_id>/deploy/done",
+    operation="POST",
+    agent_server=True,
+    arg_options=methods.ENV_OPTS,
+    client_types=[ClientType.agent], api_version=2
+)
+def resource_deploy_done(
+    tid: uuid.UUID,
+    resource_id: str,
+    action_id: uuid.UUID,
+    status: ResourceState,
+    messages: List[model.LogLine] = [],
+    changes: Dict[str, model.AttributeStateChange] = {},
+    change: Optional[Change] = None,
+    send_events: bool = False,
+    keep_increment_cache: bool = False,
+) -> None:
+    """
+        Report to the server that an agent has finished the deployment of a certain resource.
+
+        :param tid: The id of the environment the resource belongs to
+        :param resource_id: The resource version id of the resource for which the deployment is finished.
+        :param action_id: A unique ID associated with this resource deployment action. This should be the same ID that was
+                          passed to the `/resource/<resource_id>/deploy/start` API call.
+        :param status: The current status of the resource (if known)
+        :param messages: A list of log entries produced by the deployment action.
+        :param changes: A dict of changes to this resource. The key of this dict indicates the attributes/fields that
+                       have been changed. The value contains the new value and/or the original value.
+        :param change: The type of change that was done the given resource.
+        :param send_events: Send events to the dependents of this resource.
+        :param keep_increment_cache: The increment cache will be cleared iff this value is set to false.
     """

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -21,8 +21,8 @@ import datetime
 import uuid
 from typing import Dict, List, Optional, Union
 
-from inmanta.const import AgentAction, ApiDocsFormat, Change, ClientType, ResourceAction, ResourceState
-from inmanta.data import LogLine, model
+from inmanta.const import AgentAction, ApiDocsFormat, Change, ClientType, ResourceState
+from inmanta.data import model
 from inmanta.protocol.common import ReturnValue
 
 from . import methods

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -438,7 +438,7 @@ class ResourceService(protocol.ServerSlice):
                     self.log_resource_action(
                         env.id,
                         [resource_id],
-                        log.level,
+                        log.level.value,
                         log.timestamp,
                         log.msg,
                     )

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -415,7 +415,7 @@ class ResourceService(protocol.ServerSlice):
                     connection=connection, environment=env.id, resource_version_id=resource_id
                 )
                 if resource is None:
-                    raise NotFound(f"The resource with the given id does not exist in the given environment.")
+                    raise NotFound("The resource with the given id does not exist in the given environment.")
 
                 # no escape from terminal
                 if resource.status != status and resource.status in TERMINAL_STATES:

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -16,17 +16,17 @@
     Contact: code@inmanta.com
 """
 import datetime
+import json
 import sys
 import typing
-import pytest
 from enum import Enum
-import json
 
 import pydantic
+import pytest
 
-from inmanta import types, const
-from inmanta.protocol.common import json_encode
+from inmanta import const, types
 from inmanta.data.model import BaseModel, LogLine
+from inmanta.protocol.common import json_encode
 
 
 def test_model_inheritance():
@@ -76,13 +76,7 @@ def test_log_line_serialization():
     Ensure that the level field of a LogLine serializes and deserializes correctly
     using the name of the enum instead of the value.
     """
-    log_line = LogLine(
-        level=const.LogLevel.DEBUG,
-        msg="test",
-        args=[],
-        kwargs={},
-        timestamp=datetime.datetime.now()
-    )
+    log_line = LogLine(level=const.LogLevel.DEBUG, msg="test", args=[], kwargs={}, timestamp=datetime.datetime.now())
     serializes_log_line = json_encode(log_line)
     deserialized_log_line_dct = json.loads(serializes_log_line)
     assert deserialized_log_line_dct["level"] == const.LogLevel.DEBUG.name
@@ -98,11 +92,5 @@ def test_log_line_deserialization():
     Ensure that a proper error is raised when an invalid log level is used.
     """
     with pytest.raises(ValueError) as excinfo:
-        LogLine(
-            level=11,
-            msg="test",
-            args=[],
-            kwargs={},
-            timestamp=datetime.datetime.now()
-        )
+        LogLine(level=11, msg="test", args=[], kwargs={}, timestamp=datetime.datetime.now())
     assert "value is not a valid enumeration member" in str(excinfo.value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1073,6 +1073,10 @@ async def test_resource_deploy_start_action_id_conflict(server, client, environm
 @pytest.mark.parametrize("endpoint_to_use", ["resource_deploy_done", "resource_action_update"])
 @pytest.mark.asyncio
 async def test_resource_deploy_done(server, client, environment, agent, caplog, endpoint_to_use):
+    """
+    Ensure that the `resource_deploy_done` endpoint behaves in the same way as the `resource_action_update` endpoint
+    when the finished field is not None.
+    """
     env_id = uuid.UUID(environment)
 
     model_version = 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,7 +21,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from dateutil import parser
@@ -1071,7 +1071,7 @@ async def test_resource_deploy_start_action_id_conflict(server, client, environm
 
 
 @pytest.mark.asyncio
-async def test_resource_deploy_done(server, client, environment, agent):
+async def test_resource_deploy_done(server, client, environment, agent, caplog):
     env_id = uuid.UUID(environment)
 
     model_version = 1
@@ -1084,29 +1084,212 @@ async def test_resource_deploy_done(server, client, environment, agent):
     )
     await cm.insert()
 
-    model_version = 1
     rvid_r1_v1 = f"std::File[agent1,path=/etc/file1],v={model_version}"
     await data.Resource.new(
         environment=env_id,
-        status=const.ResourceState.skipped,
+        status=const.ResourceState.available,
         resource_version_id=rvid_r1_v1,
         attributes={"purge_on_delete": False, "requires": []},
     ).insert()
 
     action_id = uuid.uuid4()
     result = await agent._client.resource_deploy_start(tid=env_id, resource_id=rvid_r1_v1, action_id=action_id)
-    assert result.code == 200
+    assert result.code == 200, result.result
 
+    # Assert initial state
+    result = await client.get_resource_actions(tid=env_id)
+    assert result.code == 200, result.result
+    assert len(result.result["data"]) == 1
+    resource_action = result.result["data"][0]
+    assert resource_action["environment"] == str(env_id)
+    assert resource_action["version"] == model_version
+    assert resource_action["resource_version_ids"] == [rvid_r1_v1]
+    assert resource_action["action_id"] == str(action_id)
+    assert resource_action["action"] == const.ResourceAction.deploy
+    assert resource_action["started"] is not None
+    assert resource_action["finished"] is None
+    assert resource_action["messages"] is None
+    assert resource_action["status"] == const.ResourceState.deploying
+    assert resource_action["changes"] is None
+    assert resource_action["change"] is None
+    assert resource_action["send_event"] is False
+
+    result = await client.get_resource(tid=env_id, id=rvid_r1_v1)
+    assert result.code == 200, result.result
+    assert "last_deploy" not in result.result["resource"]
+    assert result.result["resource"]["status"] == const.ResourceState.available
+
+    result = await client.get_version(tid=env_id, id=1)
+    assert result.code == 200, result.result
+    assert not result.result["model"]["deployed"]
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        # Mark deployment as done
+        now = datetime.now()
+        result = await agent._client.resource_deploy_done(
+            tid=env_id,
+            resource_id=rvid_r1_v1,
+            action_id=action_id,
+            status=const.ResourceState.deployed,
+            messages=[
+                LogLine(level=const.LogLevel.DEBUG, msg="message", kwargs={"keyword": 123}, timestamp=now),
+                LogLine(level=const.LogLevel.INFO, msg="test", kwargs={}, timestamp=now),
+            ],
+            changes={"attr1": AttributeStateChange(current=None, desired="test")},
+            change=const.Change.created,
+            send_events=True,
+        )
+        assert result.code == 200, result.result
+
+    # Assert effect of resource_deploy_done call
+    assert f"{rvid_r1_v1}: message" in caplog.messages
+    assert f"{rvid_r1_v1}: test" in caplog.messages
+
+    result = await client.get_resource_actions(tid=env_id)
+    assert result.code == 200, result.result
+    assert len(result.result["data"]) == 1
+    resource_action = result.result["data"][0]
+    assert resource_action["environment"] == str(env_id)
+    assert resource_action["version"] == model_version
+    assert resource_action["resource_version_ids"] == [rvid_r1_v1]
+    assert resource_action["action_id"] == str(action_id)
+    assert resource_action["action"] == const.ResourceAction.deploy
+    assert resource_action["started"] is not None
+    assert resource_action["finished"] is not None
+    assert resource_action["messages"] == [
+        {
+            "level": const.LogLevel.DEBUG.value,
+            "msg": "message",
+            "args": [],
+            "kwargs": {"keyword": 123},
+            "timestamp": now.isoformat(timespec="microseconds"),
+        },
+        {
+            "level": const.LogLevel.INFO.value,
+            "msg": "test",
+            "args": [],
+            "kwargs": {},
+            "timestamp": now.isoformat(timespec="microseconds"),
+        },
+    ]
+    assert resource_action["status"] == const.ResourceState.deployed
+    assert resource_action["changes"] == {rvid_r1_v1: {"attr1": AttributeStateChange(current=None, desired="test").dict()}}
+    assert resource_action["change"] == const.Change.created.value
+    assert resource_action["send_event"] is True
+
+    result = await client.get_resource(tid=env_id, id=rvid_r1_v1)
+    assert result.code == 200, result.result
+    assert result.result["resource"]["last_deploy"] is not None
+    assert result.result["resource"]["status"] == const.ResourceState.deployed
+
+    result = await client.get_version(tid=env_id, id=1)
+    assert result.code == 200, result.result
+    assert result.result["model"]["deployed"]
+
+    # A new resource_deploy_done call for the same action_id should result in a Conflict
     result = await agent._client.resource_deploy_done(
         tid=env_id,
         resource_id=rvid_r1_v1,
         action_id=action_id,
         status=const.ResourceState.deployed,
-        messages=[
-            LogLine(level=const.LogLevel.DEBUG, msg="A message", kwargs={"keyword": 123}, timestamp=datetime.now().astimezone())
-        ],
+        messages=[],
+        changes={"attr1": AttributeStateChange(current="test", desired="test2")},
+        change=const.Change.updated,
+        send_events=True,
+    )
+    assert result.code == 409, result.result
+
+
+@pytest.mark.asyncio
+async def test_resource_deploy_done_invalid_state(server, client, environment, agent, caplog):
+    """
+    Ensure proper error handling when a transient state is passed to the `resource_deploy_done` endpoint.
+    """
+    env_id = uuid.UUID(environment)
+
+    model_version = 1
+    cm = data.ConfigurationModel(
+        environment=env_id,
+        version=model_version,
+        date=datetime.now().astimezone(),
+        total=1,
+        version_info={},
+    )
+    await cm.insert()
+
+    rvid_r1_v1 = f"std::File[agent1,path=/etc/file1],v={model_version}"
+    await data.Resource.new(
+        environment=env_id,
+        status=const.ResourceState.available,
+        resource_version_id=rvid_r1_v1,
+        attributes={"purge_on_delete": False, "requires": []},
+    ).insert()
+
+    action_id = uuid.uuid4()
+    result = await agent._client.resource_deploy_start(tid=env_id, resource_id=rvid_r1_v1, action_id=action_id)
+    assert result.code == 200, result.result
+
+    result = await agent._client.resource_deploy_done(
+        tid=env_id,
+        resource_id=rvid_r1_v1,
+        action_id=action_id,
+        status=const.ResourceState.deploying,
+        messages=[],
         changes={"attr1": AttributeStateChange(current=None, desired="test")},
         change=const.Change.created,
+        send_events=True,
+    )
+    assert result.code == 400, result.result
+    assert "No transient state can be used to mark a deployment as done" in result.result["message"]
+
+
+@pytest.mark.asyncio
+async def test_resource_deploy_done_error_handling(server, client, environment, agent):
+    env_id = uuid.UUID(environment)
+
+    model_version = 1
+    cm = data.ConfigurationModel(
+        environment=env_id,
+        version=model_version,
+        date=datetime.now().astimezone(),
+        total=1,
+        version_info={},
+    )
+    await cm.insert()
+
+    rvid_r1_v1 = f"std::File[agent1,path=/etc/file1],v={model_version}"
+
+    # Resource doesn't exist
+    result = await agent._client.resource_deploy_done(
+        tid=env_id,
+        resource_id=rvid_r1_v1,
+        action_id=uuid.uuid4(),
+        status=const.ResourceState.deployed,
+        messages=[],
+        changes={},
+        change=const.Change.nochange,
         send_events=False,
     )
-    assert result.code == 200
+    assert result.code == 404, result.result
+
+    # Create resource
+    await data.Resource.new(
+        environment=env_id,
+        status=const.ResourceState.available,
+        resource_version_id=rvid_r1_v1,
+        attributes={"purge_on_delete": False, "requires": []},
+    ).insert()
+
+    # Resource action doesn't exist
+    result = await agent._client.resource_deploy_done(
+        tid=env_id,
+        resource_id=rvid_r1_v1,
+        action_id=uuid.uuid4(),
+        status=const.ResourceState.deployed,
+        messages=[],
+        changes={},
+        change=const.Change.nochange,
+        send_events=False,
+    )
+    assert result.code == 404, result.result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1157,7 +1157,7 @@ async def test_resource_deploy_done(server, client, environment, agent, caplog, 
                 change=const.Change.purged,
                 send_events=True,
             )
-            assert result.code == 200, result.result
+            assert result.code == 200, result.resul
         else:
             result = await agent._client.resource_action_update(
                 tid=env_id,
@@ -1194,14 +1194,14 @@ async def test_resource_deploy_done(server, client, environment, agent, caplog, 
     assert resource_action["finished"] is not None
     assert resource_action["messages"] == [
         {
-            "level": const.LogLevel.DEBUG.value if endpoint_to_use == "resource_deploy_done" else const.LogLevel.DEBUG.name,
+            "level": const.LogLevel.DEBUG.name,
             "msg": "message",
             "args": [],
             "kwargs": {"keyword": 123},
             "timestamp": now.isoformat(timespec="microseconds"),
         },
         {
-            "level": const.LogLevel.INFO.value if endpoint_to_use == "resource_deploy_done" else const.LogLevel.INFO.name,
+            "level": const.LogLevel.INFO.name,
             "msg": "test",
             "args": [],
             "kwargs": {},

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1157,7 +1157,7 @@ async def test_resource_deploy_done(server, client, environment, agent, caplog, 
                 change=const.Change.purged,
                 send_events=True,
             )
-            assert result.code == 200, result.resul
+            assert result.code == 200, result.result
         else:
             result = await agent._client.resource_action_update(
                 tid=env_id,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,10 +28,10 @@ from dateutil import parser
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 from inmanta import config, const, data, loader, resources
-from inmanta.data.model import LogLine, AttributeStateChange
 from inmanta.agent import handler
 from inmanta.agent.agent import Agent
 from inmanta.const import ParameterSource
+from inmanta.data.model import AttributeStateChange, LogLine
 from inmanta.export import upload_code
 from inmanta.protocol import Client
 from inmanta.server import (
@@ -1102,13 +1102,8 @@ async def test_resource_deploy_done(server, client, environment, agent):
         resource_id=rvid_r1_v1,
         action_id=action_id,
         status=const.ResourceState.deployed,
-        messages = [
-            LogLine(
-                level=const.LogLevel.DEBUG,
-                msg="A message",
-                kwargs={"keyword": 123},
-                timestamp=datetime.now().astimezone()
-            )
+        messages=[
+            LogLine(level=const.LogLevel.DEBUG, msg="A message", kwargs={"keyword": 123}, timestamp=datetime.now().astimezone())
         ],
         changes={"attr1": AttributeStateChange(current=None, desired="test")},
         change=const.Change.created,


### PR DESCRIPTION
# Description

* Added the resource_deploy_done endpoint
* Make sure that timestamp on pydantic objects are also made timezone aware.

closes #2931

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
