### PR TITLE
Make sure that pydantic objects are timezone aware

### DIFF
--- a/changelogs/unreleased/make-pydantic-object-timezone-aware.yml
+++ b/changelogs/unreleased/make-pydantic-object-timezone-aware.yml
@@ -1,0 +1,4 @@
+---
+description: Make sure that Pydantic objects are timezone ware
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -17,7 +17,7 @@
 """
 import datetime
 import uuid
-from typing import Any, Dict, List, NewType, Optional, Union
+from typing import Any, ClassVar, Dict, List, NewType, Optional, Union
 
 import pydantic
 
@@ -28,11 +28,25 @@ from inmanta.stable_api import stable_api
 from inmanta.types import ArgumentTypes, JsonType, SimpleTypes, StrictNonIntBool
 
 
+def validator_timezone_aware_timestamps(value: object) -> object:
+    """
+    A Pydantic validator to ensure that all datetime times are timezone aware.
+    """
+    if isinstance(value, datetime.datetime) and value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    else:
+        return value
+
+
 @stable_api
 class BaseModel(pydantic.BaseModel):
     """
     Base class for all data objects in Inmanta
     """
+
+    _normalize_timestamps: ClassVar[classmethod] = pydantic.validator("*", allow_reuse=True)(
+        validator_timezone_aware_timestamps
+    )
 
     class Config:
         """

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -26,13 +26,14 @@ import re
 import time
 import uuid
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from inspect import Parameter
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Coroutine,
     Dict,
     Generic,
@@ -60,7 +61,7 @@ from tornado import web
 
 from inmanta import config as inmanta_config
 from inmanta import const, execute, util
-from inmanta.data.model import BaseModel
+from inmanta.data.model import BaseModel, validator_timezone_aware_timestamps
 from inmanta.protocol.exceptions import BadRequest, BaseHttpException
 from inmanta.stable_api import stable_api
 from inmanta.types import ArgumentTypes, HandlerType, JsonType, MethodType, ReturnTypes, StrictNonIntBool
@@ -336,16 +337,10 @@ VALID_SIMPLE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, StrictNon
 
 
 class MethodArgumentsBaseModel(pydantic.BaseModel):
-    @pydantic.root_validator
-    @classmethod
-    def datetime_timezone_aware(cls, values: Dict[str, object]) -> Dict[str, object]:
-        """
-        Make sure all instances of datetime are timezone-aware. Any naive inputs are interpreted as UTC.
-        """
-        return {
-            key: (value.replace(tzinfo=timezone.utc) if isinstance(value, datetime) and value.tzinfo is None else value)
-            for key, value in values.items()
-        }
+
+    _normalize_timestamps: ClassVar[classmethod] = pydantic.validator("*", allow_reuse=True)(
+        validator_timezone_aware_timestamps
+    )
 
 
 class MethodProperties(object):

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import datetime
 import sys
 import typing
 from enum import Enum
@@ -65,3 +66,18 @@ def test_union_bool_json():
     assert x.attr2 is True
     assert x.attr3 is True
     assert x.attr4 is True
+
+
+def test_timezone_aware_fields_in_pydantic_object():
+    """
+    Verify that timestamp fields in pydantic object that extends from the inmanta
+    BaseModel class, are made timezone aware.
+    """
+
+    class Test(BaseModel):
+        timestamp: datetime.datetime
+
+    timestamp = datetime.datetime.now()
+    assert timestamp.tzinfo is None
+    test = Test(timestamp=timestamp)
+    assert test.timestamp.tzinfo is not None


### PR DESCRIPTION
# Description

This PR extracts the change in #3008 to make pydantic object timezone aware, to a separate pull request.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
