### PR TITLE
Fix rendering issue in the Developer Getting Started Guide

### DIFF
--- a/changelogs/unreleased/fix-rendering-issue-in-docs.yml
+++ b/changelogs/unreleased/fix-rendering-issue-in-docs.yml
@@ -1,0 +1,4 @@
+---
+description: Fix rendering issue in the Developer Getting Started Guide
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/docs/model_developers/developer_getting_started.rst
+++ b/docs/model_developers/developer_getting_started.rst
@@ -12,7 +12,7 @@ Other development setups are possible, but this one provides a good starting poi
 * Module developers guide
 * Required environment variables
 
-**The examples below are using ``pip`` your system might require you to use ``pip3``**.
+**The examples below are using** ``pip`` **your system might require you to use** ``pip3``.
 
 
 Install VS Code and Inmanta extension
@@ -30,7 +30,7 @@ Further information about Inmanta VS Code extension is available on `this <https
 Setting up Python virtual environments
 ########################################
 
-For every project that you work on, we recommend using a new virtual environment using ``venv``s. If you need a refresher, you can check out `this <https://docs.python.org/3/tutorial/venv.html>`_ page.
+For every project that you work on, we recommend using a new virtual environment using ``venv``. If you need a refresher, you can check out `this <https://docs.python.org/3/tutorial/venv.html>`_ page.
 
 To create a virtual environment:
 
@@ -44,7 +44,7 @@ Then activate it by running:
     
     source ~/.virtualenvs/my_project/bin/activate
 
-**Upgrading your ``pip`` will save you a lot of time and troubleshooting (due to changes in the pip resolver in version 20 and 21).** 
+**Upgrading your** ``pip`` **will save you a lot of time and troubleshooting (due to changes in the pip resolver in version 20 and 21).**
 
 You can do so by running:
 
@@ -147,9 +147,9 @@ Becomes:
     repo:
         - git@code.inmanta.com:example/{}.git
 
-* Now, in your ``main.cf`` file, if you import a module like, ``import <my_module>`` and save the file, you can get code completion. If you are working on an exisitng project with a populated ``main.``cf file, code completion will work as expected.
+* Now, in your ``main.cf`` file, if you import a module like, ``import <my_module>`` and save the file, you can get code completion. If you are working on an existing project with a populated ``main.cf`` file, code completion will work as expected.
 
-**Please note, code completion and navigation work on modules that are imported in the ``main.cf`` file**.
+**Please note, code completion and navigation work on modules that are imported in the** ``main.cf`` **file**.
 
 
 Module developers guide
@@ -179,12 +179,13 @@ There are also guides `here <https://docs.inmanta.com/community/latest/model_dev
 Working on an Existing Module
 =============================
 
-Modules that you want to work on, have to be ``import``ed in the ``main.cf`` file that is located in your main project directory. For instance:
+Modules that you want to work on, have to be imported in the ``main.cf`` file that is located in your main project directory. For instance:
 
-::
+.. code-block:: inmanta
+
     import vyos
 
-To download the ``import``ed modules in your ``main.cf`` file run:
+To download the imported modules in your ``main.cf`` file run:
 
 .. code-block:: bash
 


### PR DESCRIPTION
# Description

This PR fixes the following issues in the `Developer Getting Started Guide`:

* In some placed the double backticks were not interpreted correctly. Double backticks have the limitation that they cannot be nested within `**` for example and should be separated from surrounding text by a white space. 
* The `import vyos` statement was not part of a code block.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
