### PR TITLE
Fix bugs in handling of the deploy method in the agent

### DIFF
--- a/changelogs/unreleased/fix-bug-in-deploy-method.yml
+++ b/changelogs/unreleased/fix-bug-in-deploy-method.yml
@@ -1,4 +1,4 @@
 ---
-description: Fix bug in deploy() handler method: Pass ResourceIdStr type instead of ResourceVersionIdStr
+description: Fix bug in the way that the agent handles the deploy() handler method.
 change-type: patch
 destination-branches: [master]

--- a/changelogs/unreleased/fix-bug-in-deploy-method.yml
+++ b/changelogs/unreleased/fix-bug-in-deploy-method.yml
@@ -1,0 +1,4 @@
+---
+description: Fix bug in deploy() handler method: Pass ResourceIdStr type instead of ResourceVersionIdStr
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -142,6 +142,8 @@ class ResourceAction(object):
                     self.resource,
                     requires,
                 )
+                if ctx.status is None:
+                    ctx.set_status(const.ResourceState.deployed)
             except ChannelClosedException as e:
                 ctx.set_status(const.ResourceState.failed)
                 ctx.exception(str(e))

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -113,7 +113,7 @@ class ResourceAction(object):
             raise Exception("Failed to report the start of the deployment to the server")
         return {Id.parse_id(key).resource_str(): const.ResourceState[value] for key, value in result.result["data"].items()}
 
-    async def _execute(self, ctx: handler.HandlerContext, requires: Dict[ResourceVersionIdStr, const.ResourceState]) -> None:
+    async def _execute(self, ctx: handler.HandlerContext, requires: Dict[ResourceIdStr, const.ResourceState]) -> None:
         """
         :param ctx: The context to use during execution of this deploy
         :param requires: A dictionary that maps each dependency of the resource to be deployed, to its resource state.

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -22,13 +22,13 @@ import uuid
 from collections import defaultdict, namedtuple
 from threading import Condition
 from typing import Dict
-from inmanta.data.model import ResourceIdStr
 
 from pytest import fixture
 
 from inmanta import const, data
 from inmanta.agent.agent import Agent
 from inmanta.agent.handler import CRUDHandler, HandlerContext, ResourceHandler, ResourcePurged, SkipResource, provider
+from inmanta.data.model import ResourceIdStr
 from inmanta.resources import IgnoreResourceException, PurgeableResource, Resource, resource
 from inmanta.server import SLICE_AGENT_MANAGER
 from inmanta.util import get_compiler_version
@@ -181,7 +181,7 @@ def resource_container():
         fields = ("key", "value", "purged")
 
     @resource("test::Deploy", agent="agent", id_attribute="key")
-    class Deploy(Resource):
+    class DeployR(Resource):
         """
         Raise a SkipResource exception in the deploy() handler method.
         """
@@ -540,7 +540,6 @@ def resource_container():
 
     @provider("test::Deploy", name="test_wait")
     class Deploy(Provider):
-
         def deploy(
             self,
             ctx: HandlerContext,
@@ -553,7 +552,6 @@ def resource_container():
                 raise Exception()
             elif resource.set_state_to_deployed:
                 ctx.set_status(const.ResourceState.deployed)
-
 
     yield ResourceContainer(
         Provider=Provider,

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -21,6 +21,8 @@ import time
 import uuid
 from collections import defaultdict, namedtuple
 from threading import Condition
+from typing import Dict
+from inmanta.data.model import ResourceIdStr
 
 from pytest import fixture
 
@@ -177,6 +179,14 @@ def resource_container():
         """
 
         fields = ("key", "value", "purged")
+
+    @resource("test::Deploy", agent="agent", id_attribute="key")
+    class Deploy(Resource):
+        """
+        Raise a SkipResource exception in the deploy() handler method.
+        """
+
+        fields = ("key", "value", "set_state_to_deployed", "purged")
 
     @provider("test::Resource", name="test_resource")
     class Provider(ResourceHandler):
@@ -527,6 +537,23 @@ def resource_container():
             elif "value" in changes:
                 Provider.set(resource.id.get_agent_name(), resource.key, resource.value)
                 ctx.set_updated()
+
+    @provider("test::Deploy", name="test_wait")
+    class Deploy(Provider):
+
+        def deploy(
+            self,
+            ctx: HandlerContext,
+            resource: Resource,
+            requires: Dict[ResourceIdStr, const.ResourceState],
+        ) -> None:
+            if self.skip(resource.id.agent_name, resource.key):
+                raise SkipResource()
+            elif self.fail(resource.id.agent_name, resource.key):
+                raise Exception()
+            elif resource.set_state_to_deployed:
+                ctx.set_status(const.ResourceState.deployed)
+
 
     yield ResourceContainer(
         Provider=Provider,

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -3373,3 +3373,51 @@ async def test_set_fact_in_handler(server, client, environment, agent, clienthel
 
     params = await data.Parameter.get_list()
     compare_params(params, [param1, param2, param3, param4])
+
+
+@pytest.mark.asyncio
+async def test_deploy_handler_method(
+    server, client, environment, agent, clienthelper, resource_container, no_agent_backoff
+):
+    """
+    Test whether the resource states are set correctly when the deploy() method is overridden.
+    """
+    async def deploy_resource(set_state_to_deployed_in_handler: bool = False) -> const.ResourceState:
+        version = await clienthelper.get_version()
+        rvid = f"test::Deploy[agent1,key=key1],v={version}"
+        resources = [
+            {
+                "key": "key1",
+                "value": "value1",
+                "set_state_to_deployed": set_state_to_deployed_in_handler,
+                "id": rvid,
+                "send_event": False,
+                "purged": False,
+                "requires": [],
+            },
+        ]
+
+        await _deploy_resources(client, environment, resources, version, push=True)
+        await _wait_until_deployment_finishes(client, environment, version=version)
+
+        result = await client.get_resource(
+            tid=environment,
+            id=rvid,
+            status=True,
+        )
+        assert result.code == 200
+        return result.result["status"]
+
+    # No exception raise + no state set explicitly via Handler Context -> deployed state
+    assert const.ResourceState.deployed == await deploy_resource(set_state_to_deployed_in_handler=False)
+
+    # State is set explicitly via HandlerContext to deployed
+    assert const.ResourceState.deployed == await deploy_resource(set_state_to_deployed_in_handler=True)
+
+    # SkipResource exception is raised by handler
+    resource_container.Provider.set_skip("agent1", "key1", 1)
+    assert const.ResourceState.skipped == await deploy_resource()
+
+    # Exception is raised by handler
+    resource_container.Provider.set_fail("agent1", "key1", 1)
+    assert const.ResourceState.failed == await deploy_resource()

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -3376,12 +3376,11 @@ async def test_set_fact_in_handler(server, client, environment, agent, clienthel
 
 
 @pytest.mark.asyncio
-async def test_deploy_handler_method(
-    server, client, environment, agent, clienthelper, resource_container, no_agent_backoff
-):
+async def test_deploy_handler_method(server, client, environment, agent, clienthelper, resource_container, no_agent_backoff):
     """
     Test whether the resource states are set correctly when the deploy() method is overridden.
     """
+
     async def deploy_resource(set_state_to_deployed_in_handler: bool = False) -> const.ResourceState:
         version = await clienthelper.get_version()
         rvid = f"test::Deploy[agent1,key=key1],v={version}"


### PR DESCRIPTION
# Description

This PR fixes the following bugs in the wat that the agent handles the deploy method:

* Ensure that the `requires` dictionary passed as an argument to the `deploy()` method contains keys of type `ResourceIdStr` instead of `ResourceVersionIdStr`
* Ensure that the resource is skipped when the `deploy()` method raises a `SkipResource` exception.
* Ensure that the resource state of a resource is set to `deployed` when the `deploy()` method doesn't set the state explicitly and doesn't raise an exception either.

# Self Check:

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
