### PR TITLE
Bump Jinja2 dependency to 3.0.1

### DIFF
--- a/changelogs/unreleased/bump-jinja2-to-3.0.1.yml
+++ b/changelogs/unreleased/bump-jinja2-to-3.0.1.yml
@@ -1,0 +1,6 @@
+---
+description: Bump the Jinja3 dependency to version 3.0.1
+issue-nr: 143
+issue-repo: infra-tickets
+change-type: patch
+destination-branches: [master, iso4]

--- a/changelogs/unreleased/bump-jinja2-to-3.0.1.yml
+++ b/changelogs/unreleased/bump-jinja2-to-3.0.1.yml
@@ -3,4 +3,4 @@ description: Bump the Jinja3 dependency to version 3.0.1
 issue-nr: 143
 issue-repo: infra-tickets
 change-type: patch
-destination-branches: [master, iso4]
+destination-branches: [iso4]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ docstring-parser==0.7.3
 email-validator==1.1.2
 execnet==1.8.0
 importlib_metadata==4.0.1
-jinja2==2.11.3
+jinja2==3.0.1
 more-itertools==8.7.0
 netifaces==0.10.9
 packaging==20.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asyncpg==0.22.0
 click-plugins==1.1.1
 click==7.1.2
 colorlog==4.7.2
-cookiecutter==1.7.2
+cookiecutter==1.7.3
 cryptography==3.4.6
 docstring-parser==0.7.3
 email-validator==1.1.2

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -880,7 +880,7 @@ async def test_dict_with_optional_values(unused_tcp_port, postgres_db, database_
     """Test dict which may have None as a value"""
     configure(unused_tcp_port, database_name, postgres_db.port)
 
-    types = Union[int, str]
+    types = Union[pydantic.StrictInt, pydantic.StrictStr]
 
     class Result(BaseModel):
         val: Optional[types]


### PR DESCRIPTION
# Description

Bumps jinja2 to 3.0.1.

Part of inmanta/infra-tickets#143

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
