### PR TITLE
Fix race condition in incremental deploy

### DIFF
--- a/changelogs/unreleased/fix-race-condition-incremental-deploy.yml
+++ b/changelogs/unreleased/fix-race-condition-incremental-deploy.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition where the resource state of resources, which are not part of the incremental deploy, are not yet set + Check explicitly of unexpected states in the deploy handler method
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -641,6 +641,7 @@ class ResourceHandler(object):
 
         resources_in_unexpected_state = filter_resources_in_unexpected_state(requires)
         if resources_in_unexpected_state:
+            ctx.set_status(const.ResourceState.skipped)
             ctx.warning(
                 "Resource %(resource)s skipped because a dependency is in an unexpected state: %(unexpected_states)s",
                 resource=resource.id.resource_version_str(),

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -321,22 +321,20 @@ class ResourceService(protocol.ServerSlice):
             "timestamp": util.datetime_utc_isoformat(now),
             "args": [],
         }
-        self.add_background_task(
-            self.resource_action_update(
-                env,
-                neg_increment,
-                action_id=uuid.uuid4(),
-                started=now,
-                finished=now,
-                status=const.ResourceState.deployed,
-                # does this require a different ResourceAction?
-                action=const.ResourceAction.deploy,
-                changes={},
-                messages=[logline],
-                change=const.Change.nochange,
-                send_events=False,
-                keep_increment_cache=True,
-            )
+        await self.resource_action_update(
+            env,
+            neg_increment,
+            action_id=uuid.uuid4(),
+            started=now,
+            finished=now,
+            status=const.ResourceState.deployed,
+            # does this require a different ResourceAction?
+            action=const.ResourceAction.deploy,
+            changes={},
+            messages=[logline],
+            change=const.Change.nochange,
+            send_events=False,
+            keep_increment_cache=True,
         )
 
         resources = await data.Resource.get_resources_for_version(env.id, version, agent)


### PR DESCRIPTION
# Description

* Fix race condition where the resource state of resources, which are not part of the incremental deploy, are not yet set
* Explicitly check whether the `requires` argument of the `deploy()` contains unexpected states. If it has, log a warning and skip the resource.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
