### PR TITLE
Add version constraint on inmanta-dev-dependencies (master)

### DIFF
--- a/changelogs/unreleased/add-inmanta-dev-dependencies-to-lock-file.yml
+++ b/changelogs/unreleased/add-inmanta-dev-dependencies-to-lock-file.yml
@@ -1,4 +1,4 @@
 ---
 description: Constrain the version of inmanta-dev-dependencies in the requirements.txt file
 change-type: patch
-destination-branches: [master, iso3, iso4]
+destination-branches: [master]

--- a/changelogs/unreleased/add-inmanta-dev-dependencies-to-lock-file.yml
+++ b/changelogs/unreleased/add-inmanta-dev-dependencies-to-lock-file.yml
@@ -1,0 +1,4 @@
+---
+description: Constrain the version of inmanta-dev-dependencies in the requirements.txt file
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,3 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==1.42.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]
 bumpversion==0.6.0
 openapi_spec_validator==0.2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ tornado==6.1
 typing_inspect==0.7.1
 
 # The module set tests install the pytest-inmanta-extensions package.
-# This version constraint ensure that the dependencies of the
+# This version constraint ensures that the dependencies of the
 # pytest-inmanta-extensions package remain compatible with inmanta-core.
 inmanta-dev-dependencies==1.42.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,11 @@ texttable==1.6.3
 tornado==6.1
 typing_inspect==0.7.1
 
+# The module set tests install the pytest-inmanta-extensions package.
+# This version constraint ensure that the dependencies of the
+# pytest-inmanta-extensions package remain compatible with inmanta-core.
+inmanta-dev-dependencies==1.42.0
+
 # Optional import in code
 graphviz==0.16
 rpdb==0.1.6


### PR DESCRIPTION
# Description

Constrain the version of inmanta-dev-dependencies in the requirements.txt file.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
