### PR TITLE
Issue/3106 modules v2 metadata parsing

### DIFF
--- a/changelogs/unreleased/3106-modules-v2-parsing.yml
+++ b/changelogs/unreleased/3106-modules-v2-parsing.yml
@@ -1,0 +1,5 @@
+description: Added parsing and internal representation of modules v2 metadata
+change-type: major
+issue-nr: 3106
+destination-branches:
+  - master

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -393,7 +393,7 @@ class CfgParser(RawParser):
             if isinstance(source, TextIOBase):
                 raise InvalidMetadata(msg=f"Metadata defined in {source.name} doesn't have a metadata section.") from e
             else:
-                raise InvalidMetadata(msg=f"Metadata doesn't have a metadata section.") from e
+                raise InvalidMetadata(msg="Metadata doesn't have a metadata section.") from e
 
 
 T = TypeVar("T", bound="Metadata")
@@ -483,12 +483,10 @@ class ModuleMetadata(ABC, Metadata):
         try:
             new_metadata = cls.parse(result)
         except Exception:
-            raise Exception(f"Unable to rewrite module definition.")
+            raise Exception("Unable to rewrite module definition.")
 
         if new_metadata.version != new_version:
-            raise Exception(
-                f"Unable to write module definition, should be {new_version} got {new_metadata.version} instead."
-            )
+            raise Exception(f"Unable to write module definition, should be {new_version} got {new_metadata.version} instead.")
 
         return result, new_metadata
 
@@ -529,9 +527,7 @@ class ModuleV1Metadata(ModuleMetadata, MetadataFieldRequires):
 
     @classmethod
     def _substitute_version(cls: Type[TModuleMetadata], source: str, new_version: str) -> str:
-        return re.sub(
-            r"([\s]version\s*:\s*['\"\s]?)[^\"'}\s]+(['\"]?)", r"\g<1>" + new_version + r"\g<2>", source
-        )
+        return re.sub(r"([\s]version\s*:\s*['\"\s]?)[^\"'}\s]+(['\"]?)", r"\g<1>" + new_version + r"\g<2>", source)
 
 
 @stable_api
@@ -553,9 +549,7 @@ class ModuleV2Metadata(ModuleMetadata):
 
     @classmethod
     def _substitute_version(cls: Type[TModuleMetadata], source: str, new_version: str) -> str:
-        return re.sub(
-            r"(\[metadata\][^\[]*\s*version\s*=\s*)[^\"'}\s\[]+", r"\g<1>" + new_version, source
-        )
+        return re.sub(r"(\[metadata\][^\[]*\s*version\s*=\s*)[^\"'}\s\[]+", r"\g<1>" + new_version, source)
 
 
 @stable_api
@@ -1126,6 +1120,7 @@ class ModuleGeneration(enum.Enum):
     """
     The generation of a module. This might affect the on-disk structure of a module as well as how it's distributed.
     """
+
     V1: int = 1
     V2: int = 2
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -342,6 +342,7 @@ List of possible module install modes, kept for backwards compatibility. New cod
 """
 
 
+@stable_api
 class FreezeOperator(str, enum.Enum):
     eq = "=="
     compatible = "~="
@@ -356,6 +357,7 @@ class FreezeOperator(str, enum.Enum):
 T = TypeVar("T", bound="Metadata")
 
 
+@stable_api
 class Metadata(BaseModel):
     name: str
     description: Optional[str] = None
@@ -448,6 +450,7 @@ class CfgParser(RawParser):
 TModuleMetadata = TypeVar("TModuleMetadata", bound="ModuleMetadata")
 
 
+@stable_api
 class ModuleMetadata(ABC, Metadata):
     version: str
     license: str
@@ -491,6 +494,7 @@ class ModuleMetadata(ABC, Metadata):
         raise NotImplementedError()
 
 
+@stable_api
 class ModuleV1Metadata(ModuleMetadata, MetadataFieldRequires):
     """
     :param name: The name of the module.
@@ -526,6 +530,7 @@ class ModuleV1Metadata(ModuleMetadata, MetadataFieldRequires):
         )
 
 
+@stable_api
 class ModuleV2Metadata(ModuleMetadata):
     """
     :param name: The name of the module.
@@ -549,11 +554,13 @@ class ModuleV2Metadata(ModuleMetadata):
         )
 
 
+@stable_api
 class ModuleRepoType(enum.Enum):
     git = "git"
     package = "package"
 
 
+@stable_api
 class ModuleRepoInfo(BaseModel):
 
     url: str
@@ -567,6 +574,7 @@ class ModuleRepoInfo(BaseModel):
         return v
 
 
+@stable_api
 class ProjectMetadata(Metadata, MetadataFieldRequires):
     """
     :param name: The name of the project.
@@ -1412,6 +1420,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
 
 
 # TODO: port usage of Module's class methods to ModuleV1
+@stable_api
 class ModuleV1(Module[ModuleV1Metadata]):
     MODULE_FILE = "module.yml"
     GENERATION = ModuleGeneration.V1
@@ -1560,6 +1569,7 @@ class ModuleV1(Module[ModuleV1Metadata]):
         return ModuleV1Metadata
 
 
+@stable_api
 class ModuleV2(Module[ModuleV2Metadata]):
     MODULE_FILE = "setup.cfg"
     GENERATION = ModuleGeneration.V2

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -103,6 +103,10 @@ class InvalidModuleException(CompilerException):
         return out
 
 
+class ModuleMetadataFileNotFound(InvalidModuleException):
+    pass
+
+
 @stable_api
 class InvalidMetadata(CompilerException):
     """
@@ -368,7 +372,7 @@ class YamlParser(RawParser):
             return yaml.safe_load(source)
         except yaml.YAMLError as e:
             if isinstance(source, TextIOBase):
-                raise InvalidMetadata(msg=f"Metadata defined in {source.name} is invalid") from e
+                raise InvalidMetadata(msg=f"Invalid yaml syntax in {source.name}:\n{str(e)}") from e
             else:
                 raise InvalidMetadata(msg=str(e)) from e
 
@@ -382,7 +386,7 @@ class CfgParser(RawParser):
             return config["metadata"]
         except configparser.Error as e:
             if isinstance(source, TextIOBase):
-                raise InvalidMetadata(msg=f"Metadata defined in {source.name} is invalid") from e
+                raise InvalidMetadata(msg=f"Invalid syntax in {source.name}:\n{str(e)}") from e
             else:
                 raise InvalidMetadata(msg=str(e)) from e
         except KeyError as e:
@@ -660,7 +664,7 @@ class ModuleLike(ABC, Generic[T]):
         metadata_file_path = self.get_metadata_file_path()
 
         if not os.path.exists(metadata_file_path):
-            raise InvalidModuleException(f"Metadata file {metadata_file_path} does not exist")
+            raise ModuleMetadataFileNotFound(f"Metadata file {metadata_file_path} does not exist")
 
         with open(metadata_file_path, "r", encoding="utf-8") as fd:
             return self.get_metadata_from_source(source=fd)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -321,7 +321,7 @@ class ModuleTool(ModuleLikeTool):
     def get_module(self, module: str = None, project=None) -> Module:
         """Finds and loads a module, either based on the CWD or based on the name passed in as an argument and the project"""
         if module is None:
-            project: Optional[Project] = self.get_project_for_module(module)
+            project = self.get_project_for_module(module)
             path: str = os.path.realpath(os.curdir)
             try:
                 return ModuleV2(project, path)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -33,7 +33,7 @@ from pkg_resources import parse_version
 from inmanta.ast import CompilerException
 from inmanta.command import CLIException, ShowUsageException
 from inmanta.const import MAX_UPDATE_ATTEMPT
-from inmanta.module import FreezeOperator, InstallMode, Module, Project, gitprovider
+from inmanta.module import FreezeOperator, InstallMode, InvalidModuleException, Module, ModuleMetadataFileNotFound, ModuleV1, ModuleV2, Project, gitprovider
 
 if TYPE_CHECKING:
     from pkg_resources import Requirement  # noqa: F401
@@ -321,7 +321,17 @@ class ModuleTool(ModuleLikeTool):
     def get_module(self, module: str = None, project=None) -> Module:
         """Finds and loads a module, either based on the CWD or based on the name passed in as an argument and the project"""
         if module is None:
-            return Module(self.get_project_for_module(module), os.path.realpath(os.curdir))
+            project: Optional[Project] = self.get_project_for_module(module)
+            path: str = os.path.realpath(os.curdir)
+            try:
+                return ModuleV2(project, path)
+            except ModuleMetadataFileNotFound as e:
+                try:
+                    return ModuleV1(project, path)
+                except ModuleMetadataFileNotFound:
+                    # ignore this exception in favor of the v2 one
+                    pass
+                raise e
         else:
             project = self.get_project(load=True)
             return project.get_module(module)
@@ -403,7 +413,7 @@ version: 0.0.1dev0"""
                     reqv = "master"
                 else:
                     release_only = project._install_mode == InstallMode.release
-                    versions = Module.get_suitable_version_for(name, specs[name], mod._path, release_only=release_only)
+                    versions = ModuleV1.get_suitable_version_for(name, specs[name], mod._path, release_only=release_only)
                     if versions is None:
                         reqv = "None"
                     else:
@@ -443,7 +453,7 @@ version: 0.0.1dev0"""
             for module in modules:
                 spec = specs.get(module, [])
                 try:
-                    Module.update(my_project, module, spec, install_mode=my_project._install_mode)
+                    ModuleV1.update(my_project, module, spec, install_mode=my_project._install_mode)
                 except Exception:
                     LOGGER.exception("Failed to update module %s", module)
 
@@ -516,11 +526,6 @@ version: 0.0.1dev0"""
         Verify dependencies and frozen module versions
         """
         Project.get().verify()
-
-    def _find_module(self):
-        module = Module(None, os.path.realpath(os.curdir))
-        LOGGER.info("Successfully loaded module %s with version %s" % (module.name, module.version))
-        return module
 
     def commit(
         self,

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -33,7 +33,16 @@ from pkg_resources import parse_version
 from inmanta.ast import CompilerException
 from inmanta.command import CLIException, ShowUsageException
 from inmanta.const import MAX_UPDATE_ATTEMPT
-from inmanta.module import FreezeOperator, InstallMode, InvalidModuleException, Module, ModuleMetadataFileNotFound, ModuleV1, ModuleV2, Project, gitprovider
+from inmanta.module import (
+    FreezeOperator,
+    InstallMode,
+    Module,
+    ModuleMetadataFileNotFound,
+    ModuleV1,
+    ModuleV2,
+    Project,
+    gitprovider,
+)
 
 if TYPE_CHECKING:
     from pkg_resources import Requirement  # noqa: F401

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -64,7 +64,7 @@ def test_module_error(snippetcompiler):
 caused by:
   Could not load module badmodule
   caused by:
-    inmanta.module.InvalidModuleException: Metadata file {path_modules_yml_file} does not exist
+    inmanta.module.ModuleMetadataFileNotFound: Metadata file {path_modules_yml_file} does not exist
 """,
     )
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -23,12 +23,12 @@ import subprocess
 import sys
 import warnings
 from typing import Iterator, Type
+from unittest.mock import patch
 
 import py
 import pytest
 import yaml
 from pkg_resources import Requirement, parse_version
-from unittest.mock import patch
 
 from inmanta import module
 from inmanta.module import InvalidMetadata, MetadataDeprecationWarning, Project

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -88,7 +88,7 @@ compiler_version: 2017.2
     """
     )
 
-    mod = module.Module(None, module_path.strpath)
+    mod = module.ModuleV1(None, module_path.strpath)
 
     assert mod.version == "1.2"
     assert mod.compiler_version == "2017.2"
@@ -198,7 +198,7 @@ async def test_version_argument(modules_repo):
     make_module_simple(modules_repo, "mod-version", [], "1.2")
     module_path = os.path.join(modules_repo, "mod-version")
 
-    mod = module.Module(None, module_path)
+    mod = module.ModuleV1(None, module_path)
     assert mod.version == "1.2"
 
     args = [sys.executable, "-m", "inmanta.app", "module", "commit", "-m", "msg", "-v", "1.3.1", "-r"]
@@ -251,7 +251,7 @@ compiler_version: 2017.2
     """
     )
     with pytest.raises(InvalidMetadata, match="Version non_pep440_value is not PEP440 compliant"):
-        module.Module(None, inmanta_module.get_root_dir_of_module())
+        module.ModuleV1(None, inmanta_module.get_root_dir_of_module())
 
 
 @pytest.mark.asyncio
@@ -264,7 +264,7 @@ test:
 """
     )
     with pytest.raises(InvalidMetadata, match=f"Invalid yaml syntax in {inmanta_module.get_path_module_yml_file()}"):
-        module.Module(None, inmanta_module.get_root_dir_of_module())
+        module.ModuleV1(None, inmanta_module.get_root_dir_of_module())
 
 
 @pytest.mark.asyncio
@@ -279,7 +279,7 @@ requires:
     - ip > 1.0.0
         """
     )
-    mod: module.Module = module.Module(None, inmanta_module.get_root_dir_of_module())
+    mod: module.Module = module.ModuleV1(None, inmanta_module.get_root_dir_of_module())
     assert mod.requires() == [Requirement.parse("std"), Requirement.parse("ip > 1.0.0")]
 
 
@@ -293,7 +293,7 @@ version: 1.0.0
 requires: std > 1.0.0
         """
     )
-    mod: module.Module = module.Module(None, inmanta_module.get_root_dir_of_module())
+    mod: module.Module = module.ModuleV1(None, inmanta_module.get_root_dir_of_module())
     assert mod.requires() == [Requirement.parse("std > 1.0.0")]
 
 
@@ -311,7 +311,7 @@ requires:
     )
     mod: module.Module
     with warnings.catch_warnings(record=True) as w:
-        mod = module.Module(None, inmanta_module.get_root_dir_of_module())
+        mod = module.ModuleV1(None, inmanta_module.get_root_dir_of_module())
         assert len(w) == 1
         warning = w[0]
         assert issubclass(warning.category, MetadataDeprecationWarning)
@@ -331,4 +331,4 @@ requires:
         """
     )
     with pytest.raises(InvalidMetadata, match="Invalid legacy requires"):
-        module.Module(None, inmanta_module.get_root_dir_of_module())
+        module.ModuleV1(None, inmanta_module.get_root_dir_of_module())

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -106,7 +106,7 @@ def test_get_module_v2(tmp_working_dir: py.path.local):
     metadata_file.write(
         """
 [metadata]
-name = mod
+name = inmanta-modules-mod
 version = 1.2.3
 license = ASL
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -28,6 +28,7 @@ import py
 import pytest
 import yaml
 from pkg_resources import Requirement, parse_version
+from unittest.mock import patch
 
 from inmanta import module
 from inmanta.module import InvalidMetadata, MetadataDeprecationWarning, Project
@@ -41,7 +42,8 @@ from test_app_cli import app
 def tmp_working_dir(tmpdir: py.path.local) -> Iterator[py.path.local]:
     cwd = os.getcwd()
     os.chdir(str(tmpdir))
-    yield tmpdir
+    with patch("os.curdir", new=str(tmpdir)):
+        yield tmpdir
     os.chdir(cwd)
 
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -17,7 +17,6 @@
 """
 import asyncio
 import os
-import py
 import re
 import shutil
 import subprocess
@@ -25,6 +24,7 @@ import sys
 import warnings
 from typing import Type
 
+import py
 import pytest
 import yaml
 from pkg_resources import Requirement, parse_version
@@ -82,23 +82,18 @@ def test_rewrite(tmpdir, module_type: Type[module.Module]):
     model = module_path.join("model").mkdir()
     model.join("_init.cf").write("\n")
 
-    metadata_file: str = module_path.join(
-        "module.yml" if v1 else "setup.cfg"
-    )
+    metadata_file: str = module_path.join("module.yml" if v1 else "setup.cfg")
 
     def metadata_contents(version: str) -> str:
         if v1:
-            return (
-                f"""
+            return f"""
 name: mod
 license: ASL
 version: {version}
 compiler_version: 2017.2
-                """.strip()
-            )
+            """.strip()
         else:
-            return (
-                f"""
+            return f"""
 [metadata]
 name = mod
 version = {version}
@@ -111,8 +106,7 @@ install_requires =
 
   cookiecutter~=1.7.0
   cryptography>1.0,<3.5
-                """.strip()
-            )
+            """.strip()
 
     metadata_file.write(metadata_contents("1.2"))
     mod = module_type(None, module_path.strpath)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -34,7 +34,7 @@ def test_module():
 
 def test_bad_module():
     bad_mod_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "modules", "mod2")
-    with pytest.raises(module.InvalidModuleException):
+    with pytest.raises(module.ModuleMetadataFileNotFound):
         module.ModuleV1(project=mock.Mock(), path=bad_mod_dir)
 
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -29,13 +29,13 @@ from inmanta import module
 
 def test_module():
     good_mod_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "modules", "mod1")
-    module.Module(project=mock.Mock(), path=good_mod_dir)
+    module.ModuleV1(project=mock.Mock(), path=good_mod_dir)
 
 
 def test_bad_module():
     bad_mod_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "modules", "mod2")
     with pytest.raises(module.InvalidModuleException):
-        module.Module(project=mock.Mock(), path=bad_mod_dir)
+        module.ModuleV1(project=mock.Mock(), path=bad_mod_dir)
 
 
 class TestModuleName(unittest.TestCase):
@@ -58,7 +58,7 @@ class TestModuleName(unittest.TestCase):
 
     def test_wrong_name(self):
         mod_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "modules", "mod3")
-        module.Module(project=mock.Mock(), path=mod_dir)
+        module.ModuleV1(project=mock.Mock(), path=mod_dir)
 
         self.handler.flush()
         assert "The name in the module file (mod1) does not match the directory name (mod3)" in self.stream.getvalue().strip()


### PR DESCRIPTION
# Description

Adds parsing and internal representation of modules v2 metadata. Some changes to the `Module` class were required to fit this in the existing implementation. I tried to keep this as minimal as possible, which means this pull request leaves core in the state where it has entry points to parse V2 modules, but they are never used outside testing. `ModuleTool` and `Project` always work on `ModuleV1`. Further changes to `Project`, `Module` and its subclasses will have to be implemented by follow-up tickets.

I've created #3114 as a follow-up to make sure the documentation and usage of `Module` is updated.

(opened in a bit of a rush, I hope I haven't missed anything)

closes #3106

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: #3114)

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
