### PR TITLE
Disable the autouse flag on the postgres_db fixture

### DIFF
--- a/changelogs/unreleased/remove-autouse-postgres-db-fixture.yml
+++ b/changelogs/unreleased/remove-autouse-postgres-db-fixture.yml
@@ -1,0 +1,4 @@
+---
+description: Disable autouse flag on the postgres_db fixture.
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def postgres_proc(unused_tcp_port_factory):
     proc.stop()
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def postgres_db(postgresql_proc):
     yield postgresql_proc
 


### PR DESCRIPTION
# Description

Disable the `autouse` flag on the `postgres_db` fixture.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
