### PR TITLE
bumped docstring-parser dependency

### DIFF
--- a/changelogs/unreleased/bump-docstring-parser.yml
+++ b/changelogs/unreleased/bump-docstring-parser.yml
@@ -1,0 +1,5 @@
+description: Bump docstring-parser dependency and account for non-backwards compatible changes.
+change-type: patch
+destination-branches:
+  - iso4
+  - master

--- a/changelogs/unreleased/bump-docstring-parser.yml
+++ b/changelogs/unreleased/bump-docstring-parser.yml
@@ -1,4 +1,6 @@
-description: Bump docstring-parser dependency and account for non-backwards compatible changes.
+description: Fixed docstring-parser compatibility after non-backwards compatible changes and constrained dependency to semi-safe range.
 change-type: patch
+sections:
+  bugfix: "{{description}}"
 destination-branches:
   - master

--- a/changelogs/unreleased/bump-docstring-parser.yml
+++ b/changelogs/unreleased/bump-docstring-parser.yml
@@ -1,5 +1,4 @@
 description: Bump docstring-parser dependency and account for non-backwards compatible changes.
 change-type: patch
 destination-branches:
-  - iso4
   - master

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==8.0.1
 colorlog==5.0.1
 cookiecutter==1.7.3
 cryptography==3.4.7
-docstring-parser==0.9.1
+docstring-parser==0.10
 email-validator==1.1.3
 execnet==1.9.0
 importlib_metadata==4.6.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ requires = [
     "colorlog",
     "cookiecutter",
     "cryptography",
-    "docstring-parser>=0.10",
+    # docstring-parser has been known to publish non-backwards compatible minors in the past
+    "docstring-parser~=0.10.0",
     "email-validator",
     "execnet",
     "importlib_metadata",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requires = [
     "colorlog",
     "cookiecutter",
     "cryptography",
-    "docstring-parser>=0.8",
+    "docstring-parser>=0.10",
     "email-validator",
     "execnet",
     "importlib_metadata",

--- a/src/inmanta/docstring_parser.py
+++ b/src/inmanta/docstring_parser.py
@@ -68,5 +68,5 @@ def parse_docstring(doc_string: str) -> DocString:
     """
     Parse the docstring of an entity.
     """
-    doc_string = docstring_parser.parse(doc_string, style=docstring_parser.DocstringStyle.rest)
+    doc_string = docstring_parser.parse(doc_string, style=docstring_parser.DocstringStyle.REST)
     return DocString(doc_string)

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -426,7 +426,7 @@ class MethodProperties(object):
         self._strict_typing = strict_typing
         self.function = function
 
-        self._parsed_docstring = docstring_parser.parse(text=function.__doc__, style=docstring_parser.DocstringStyle.rest)
+        self._parsed_docstring = docstring_parser.parse(text=function.__doc__, style=docstring_parser.DocstringStyle.REST)
         self._docstring_parameter_map = {p.arg_name: p.description for p in self._parsed_docstring.params}
 
         # validate client types


### PR DESCRIPTION
# Description

The `docstring-parser` package had non-backwards compatible changes in its newest release. This caused most of our tests to fail (all tests that use `inmanta-core` without using its constraints file.
Two questions:
- Does this mean we need to do a patch release? Running `pip install inmanta-core` now will produce this same issue since our `setup.py` does not constrain `docstring-parser`.
- Should we use `~=0.10.0` instead of `>=0.10` to reduce the likelihood of this happening again? We could add a comment stating that `docstring-parser` has been known to publish non-backwards compatible minors, leading us to constrain it in `setup.py`. I'm not sure how dependabot would interact with this.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] ~~Correct, in line with design~~
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
