### PR TITLE
Cleanup changes to os.curdir (ISO3)

### DIFF
--- a/changelogs/unreleased/cleanup-os-curdir.yml
+++ b/changelogs/unreleased/cleanup-os-curdir.yml
@@ -1,0 +1,4 @@
+---
+description: Make sure that test cases don't change `os.curdir`
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/changelogs/unreleased/cleanup-os-curdir.yml
+++ b/changelogs/unreleased/cleanup-os-curdir.yml
@@ -1,4 +1,4 @@
 ---
 description: Make sure that test cases don't change `os.curdir`
 change-type: patch
-destination-branches: [master, iso3, iso4]
+destination-branches: [iso3]

--- a/tests/moduletool/common.py
+++ b/tests/moduletool/common.py
@@ -91,11 +91,11 @@ def add_file(modpath, file, content, msg, version=None, dev=False, tag=True):
     if version is None:
         return commitmodule(modpath, msg)
     else:
-        ocd = os.curdir
-        os.curdir = modpath
+        old_cwd = os.getcwd()
+        os.chdir(modpath)
         subprocess.check_output(["git", "add", "*"], cwd=modpath, stderr=subprocess.STDOUT)
         ModuleTool().commit(msg, version=version, dev=dev, commit_all=True, tag=tag)
-        os.curdir = ocd
+        os.chdir(old_cwd)
 
 
 def add_file_and_compiler_constraint(modpath, file, content, msg, version, compiler_version):
@@ -143,7 +143,6 @@ def install_project(modules_dir, name, config=True):
     coroot = os.path.join(subroot, name)
     subprocess.check_output(["git", "clone", os.path.join(modules_dir, "repos", name)], cwd=subroot, stderr=subprocess.STDOUT)
     os.chdir(coroot)
-    os.curdir = coroot
     if config:
         Config.load_config()
     return coroot

--- a/tests/moduletool/test_freeze.py
+++ b/tests/moduletool/test_freeze.py
@@ -274,6 +274,5 @@ requires:
     modp = os.path.join(coroot, "libs/modC")
     app(["module", "install"])
     os.chdir(modp)
-    os.curdir = modp
     app(["module", "freeze"])
     verify()

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -33,7 +33,6 @@ def test_bad_checkout(modules_dir, modules_repo):
         ["git", "clone", os.path.join(modules_dir, "repos", "badproject")], cwd=modules_dir, stderr=subprocess.STDOUT
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     with pytest.raises(ModuleNotFoundException):
@@ -46,7 +45,6 @@ def test_bad_setup(modules_dir, modules_repo):
         ["git", "clone", os.path.join(modules_dir, "repos", "badproject"), coroot], cwd=modules_dir, stderr=subprocess.STDOUT
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     mod1 = os.path.join(coroot, "libs", "mod1")
@@ -65,7 +63,6 @@ def test_complex_checkout(modules_dir, modules_repo):
         ["git", "clone", os.path.join(modules_dir, "repos", "testproject")], cwd=modules_dir, stderr=subprocess.STDOUT
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     ModuleTool().execute("install", [])
@@ -92,7 +89,6 @@ def test_for_git_failures(modules_dir, modules_repo):
         stderr=subprocess.STDOUT,
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     ModuleTool().execute("install", [])
@@ -118,7 +114,6 @@ def test_install_for_git_failures(modules_dir, modules_repo):
         stderr=subprocess.STDOUT,
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     gp = module.gitprovider
@@ -136,7 +131,6 @@ def test_for_repo_without_versions(modules_dir, modules_repo):
         ["git", "clone", os.path.join(modules_dir, "repos", "noverproject")], cwd=modules_dir, stderr=subprocess.STDOUT
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     ModuleTool().execute("install", [])
@@ -148,7 +142,6 @@ def test_bad_dep_checkout(modules_dir, modules_repo):
         ["git", "clone", os.path.join(modules_dir, "repos", "baddep")], cwd=modules_dir, stderr=subprocess.STDOUT
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     with pytest.raises(CompilerException):
@@ -171,7 +164,6 @@ def test_dev_checkout(modules_dir, modules_repo):
         ["git", "clone", os.path.join(modules_dir, "repos", "devproject")], cwd=modules_dir, stderr=subprocess.STDOUT
     )
     os.chdir(coroot)
-    os.curdir = coroot
     Config.load_config()
 
     ModuleTool().execute("install", [])

--- a/tests/moduletool/test_update.py
+++ b/tests/moduletool/test_update.py
@@ -39,7 +39,6 @@ def test_module_update_with_install_mode_master(
 
     # Set masterproject_multi_mod as current project
     os.chdir(masterproject_multi_mod)
-    os.curdir = masterproject_multi_mod
     Config.load_config()
 
     # Dependencies masterproject_multi_mod


### PR DESCRIPTION
# Description

`os.curdir` is a built-in constant and should not be changed by any code. Changing it breaks the standard Python library. 

```
>>> import os
>>> d = "/tmp/test/."
>>> os.curdir = "/tmp/"
>>> os.path.exists(d)
False
>>> os.makedirs(d)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/tmp/test/.'
```

This PR cleans up the code that changes `os.curdir`. `os.chdir()` should be used to change the current working directory.

Apply change from #3141 on ISO3 branch.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
