### PR TITLE
Enhance documentation 'inmanta module build' command

### DIFF
--- a/changelogs/unreleased/enhance-build-command-documentation.yml
+++ b/changelogs/unreleased/enhance-build-command-documentation.yml
@@ -1,0 +1,4 @@
+---
+description: Enhance the documentation of the `inmanta module build` command.
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -340,11 +340,16 @@ class ModuleTool(ModuleLikeTool):
         build = subparser.add_parser("build", help="Build a Python package from a V2 module.")
         build.add_argument(
             "path",
-            help="The path to the module that should be built",
+            help="The path to the module that should be built. By default, the current working directory is used.",
             nargs="?",
         )
         build.add_argument(
-            "-o", "--output-dir", help="The directory where the Python package will be stored.", default=None, dest="output_dir"
+            "-o",
+            "--output-dir",
+            help="The directory where the Python package will be stored. By default, the ./dist directory "
+            "in the root of the module is used.",
+            default=None,
+            dest="output_dir",
         )
 
     def build(self, path: Optional[str] = None, output_dir: Optional[str] = None) -> str:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -346,8 +346,7 @@ class ModuleTool(ModuleLikeTool):
         build.add_argument(
             "-o",
             "--output-dir",
-            help="The directory where the Python package will be stored. By default, the ./dist directory "
-            "in the root of the module is used.",
+            help="The directory where the Python package will be stored. Default: <module_root>/dist",
             default=None,
             dest="output_dir",
         )


### PR DESCRIPTION
# Description

I noticed that the documentation of the `inmanta module build` command could be improved, by adding the default values. This PR fixes that.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
