### PR TITLE
Prevent checkout of std module in tests directory

### DIFF
--- a/changelogs/unreleased/prevent-std-checkout-in-test-directory.yml
+++ b/changelogs/unreleased/prevent-std-checkout-in-test-directory.yml
@@ -1,0 +1,4 @@
+---
+description: Prevent that the tests checkout the std module in the test/data/plugins_project/libs directory.
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -31,9 +31,11 @@ from inmanta.loader import ModuleSource, SourceInfo
 from inmanta.module import Project
 
 
-def test_code_manager():
+def test_code_manager(tmpdir: py.path.local):
     """Verify the code manager"""
-    project_dir: str = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "plugins_project")
+    original_project_dir: str = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "plugins_project")
+    project_dir = os.path.join(tmpdir, "plugins_project")
+    shutil.copytree(original_project_dir, project_dir)
     project: Project = Project(project_dir)
     Project.set(project)
     project.load()


### PR DESCRIPTION
# Description

The `test_code_manager` test case, executed `project.load()` in the `test/data/plugins_project` directory of the inmanta-core project. This way the std module got checked out into the `test/data/plugins_project/libs` directory. When the std module is present in the `test/data/plugins_project/libs` directory, the following error occurs when the test suite is ran:

```
import file mismatch:
imported module 'test_agent' has this __file__ attribute:
  /tmp/inmanta-core/tests/test_agent.py
which is not the same as the test file we want to collect:
  /tmp/inmanta-core/tests/data/plugins_project/libs/std/tests/test_agent.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules

```

This PR makes sure that the `test_code_manager` test case executes `project.load()` in a temporary directory to prevent the above-mentioned issues.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
