### PR TITLE
modified behavior of inmanta module install to be consistent with build behavior

### DIFF
--- a/changelogs/unreleased/inmanta-module-install-consistency-fix.yml
+++ b/changelogs/unreleased/inmanta-module-install-consistency-fix.yml
@@ -1,0 +1,4 @@
+description: Modified behavior of inmanta module install to be consistent with build behavior
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -370,7 +370,7 @@ class ModuleTool(ModuleLikeTool):
         """
         module = self.get_module(module)
         if not isinstance(module, ModuleV1):
-            raise ModuleVersionException(f"Expected a v1 module, but found v{module.ModuleGeneration.value} module")
+            raise ModuleVersionException(f"Expected a v1 module, but found v{module.GENERATION.value} module")
         ModuleConverter(module).convert_in_place()
 
     def build(self, path: Optional[str] = None, output_dir: Optional[str] = None) -> str:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -594,7 +594,7 @@ version: 0.0.1dev0"""
         if editable:
             if module.GENERATION == ModuleGeneration.V1:
                 raise ModuleVersionException(
-                    "Can not install v1 modules in-place. You can upgrade your module with `inmanta module v1tov2`."
+                    "Can not install v1 modules in editable mode. You can upgrade your module with `inmanta module v1tov2`."
                 )
             install(module_path)
         else:


### PR DESCRIPTION
# Description

In addition to adding consistency this will also allow `inmanta module install` on v1 modules. `inmanta module install -e` will of course be rejected because v1 requires conversion, which we can't do for editable mode.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
