### PR TITLE
Fix bug in v1tov2 command

### DIFF
--- a/changelogs/unreleased/3159-v1tov2-adds-dependency-on-std.yml
+++ b/changelogs/unreleased/3159-v1tov2-adds-dependency-on-std.yml
@@ -1,0 +1,7 @@
+---
+description: Fix bug where the std module gets a dependency to itself when it is converted to a v2 module using the `inmanta module v1tov2` command.
+issue-nr: 3159
+change-type: patch
+destination-branches: [master]
+sections:
+  bugfix: "Fixed encoding bug #2362"

--- a/changelogs/unreleased/3159-v1tov2-adds-dependency-on-std.yml
+++ b/changelogs/unreleased/3159-v1tov2-adds-dependency-on-std.yml
@@ -4,4 +4,4 @@ issue-nr: 3159
 change-type: patch
 destination-branches: [master]
 sections:
-  bugfix: "Fixed encoding bug #2362"
+  bugfix: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1315,7 +1315,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
 
         (statements, block) = self.get_ast(name)
         imports = [x for x in statements if isinstance(x, DefineImport)]
-        if self._project.autostd:
+        if self.name != "std" and self._project.autostd:
             std_locatable = LocatableString("std", Range("internal", 0, 0, 0, 0), 0, block.namespace)
             imports.insert(0, DefineImport(std_locatable, std_locatable))
         return imports


### PR DESCRIPTION
# Description

Fixed bug where the std module gets a dependency to itself in the `setup.cfg` file when the v1 std module it is converted to a v2 module using the `inmanta module v1tov2` command.

closes #3159

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
