### PR TITLE
Remove redundant request_timeout on compiler_rest_transport from tests

### DIFF
--- a/changelogs/unreleased/remove-request-timeout-from-tests.yml
+++ b/changelogs/unreleased/remove-request-timeout-from-tests.yml
@@ -1,0 +1,4 @@
+---
+description: Remove redundant `request_timeout` on `compiler_rest_transport` from tests
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -140,8 +140,6 @@ async def test_purge_on_delete_requires(client, server, environment, clienthelpe
 
 @pytest.mark.asyncio(timeout=20)
 async def test_purge_on_delete_compile_failed_with_compile(event_loop, client, server, environment, snippetcompiler):
-    config.Config.set("compiler_rest_transport", "request_timeout", "1")
-
     snippetcompiler.setup_for_snippet(
         """
     h = std::Host(name="test", os=std::linux)

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -22,7 +22,7 @@ from datetime import datetime
 
 import pytest
 
-from inmanta import config, const, data
+from inmanta import const, data
 from inmanta.agent.agent import Agent
 from inmanta.export import unknown_parameters
 from inmanta.util import get_compiler_version

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -601,8 +601,6 @@ async def test_batched_code_upload(
     server_multi, client_multi, sync_client_multi, environment_multi, agent_multi, snippetcompiler
 ):
     """Test uploading all code definitions at once"""
-    config.Config.set("compiler_rest_transport", "request_timeout", "1")
-
     snippetcompiler.setup_for_snippet(
         """
     h = std::Host(name="test", os=std::linux)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,7 +27,7 @@ import pytest
 from dateutil import parser
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
-from inmanta import config, const, data, loader, resources
+from inmanta import const, data, loader, resources
 from inmanta.agent import handler
 from inmanta.agent.agent import Agent
 from inmanta.const import ParameterSource


### PR DESCRIPTION
# Description

Remove redundant request_timeout on compiler_rest_transport from tests, because there seems to be no reason why it should be there. This timeout failed to tests on the CI pipeline.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
