### PR TITLE
Remove redundant request_timeout on compiler_rest_transport from tests (#3170)

### DIFF
--- a/changelogs/unreleased/remove-request-timeout-from-tests.yml
+++ b/changelogs/unreleased/remove-request-timeout-from-tests.yml
@@ -1,0 +1,4 @@
+---
+description: Remove redundant `request_timeout` on `compiler_rest_transport` from tests
+change-type: patch
+destination-branches: [master, iso3, iso4]

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -22,7 +22,7 @@ from datetime import datetime
 
 import pytest
 
-from inmanta import config, const, data
+from inmanta import const, data
 from inmanta.agent.agent import Agent
 from inmanta.export import unknown_parameters
 from inmanta.util import get_compiler_version
@@ -140,8 +140,6 @@ async def test_purge_on_delete_requires(client, server, environment, clienthelpe
 
 @pytest.mark.asyncio(timeout=20)
 async def test_purge_on_delete_compile_failed_with_compile(event_loop, client, server, environment, snippetcompiler):
-    config.Config.set("compiler_rest_transport", "request_timeout", "1")
-
     snippetcompiler.setup_for_snippet(
         """
     h = std::Host(name="test", os=std::linux)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,7 +27,7 @@ import pytest
 from dateutil import parser
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
-from inmanta import config, const, data, loader, resources
+from inmanta import const, data, loader, resources
 from inmanta.agent import handler
 from inmanta.agent.agent import Agent
 from inmanta.const import ParameterSource
@@ -600,8 +600,6 @@ async def test_batched_code_upload(
     server_multi, client_multi, sync_client_multi, environment_multi, agent_multi, snippetcompiler
 ):
     """Test uploading all code definitions at once"""
-    config.Config.set("compiler_rest_transport", "request_timeout", "1")
-
     snippetcompiler.setup_for_snippet(
         """
     h = std::Host(name="test", os=std::linux)


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3170