### PR TITLE
Fix flake8 formatting

### DIFF
--- a/changelogs/unreleased/fix-flake8.yml
+++ b/changelogs/unreleased/fix-flake8.yml
@@ -1,0 +1,4 @@
+---
+description: Fix flake8 formatting
+change-type: patch
+destination-branches: [master]

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -817,7 +817,6 @@ async def test_agent_actions(server, client, async_finalizer):
     await asyncio.gather(start_agent(env1_id, ["agent1", "agent2"]), start_agent(env2_id, ["agent1"]))
 
     async def assert_agents_paused(expected_statuses: Dict[Tuple[UUID, str], bool]) -> None:
-
         async def _does_expected_status_match_actual_status() -> bool:
             for (env_id, agent_name), paused in expected_statuses.items():
                 # Check in-memory session state
@@ -855,9 +854,7 @@ async def test_agent_actions(server, client, async_finalizer):
                     live_session = agent_manager.tid_endpoint_to_session[(env_id, agent_name)]
                     agent_instance: Optional[data.AgentInstance] = await data.AgentInstance.get_by_id(agent_from_db.primary)
                     if agent_instance is None:
-                        LOGGER.info(
-                            "Agent %s in environment %s is not paused, but no AgentInstance exists", agent_name, env_id
-                        )
+                        LOGGER.info("Agent %s in environment %s is not paused, but no AgentInstance exists", agent_name, env_id)
                         return False
                     if agent_instance.process != live_session.id:
                         LOGGER.info(


### PR DESCRIPTION
# Description

Fix flake8 formatting. I think this issue is caused by the merge of 1505141e90666ee88c912e468311c36eff30e7ba via dependabot.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
