### PR TITLE
Issue/2729 openapi spec validator bump

### DIFF
--- a/changelogs/unreleased/2729-openapi-spec-validator-version-bump.yml
+++ b/changelogs/unreleased/2729-openapi-spec-validator-version-bump.yml
@@ -1,0 +1,5 @@
+---
+description: Bumping version of openapi_spec_validator to 0.3.1 and fixing api definition.
+issue-nr: 2729
+change-type: patch
+destination-branches: [master, iso4]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 inmanta-dev-dependencies[pytest,async,core,sphinx]==1.53.0
 bumpversion==0.6.0
-openapi_spec_validator==0.2.10
+openapi_spec_validator==0.3.1
 pip2pi==0.8.2
 types-PyYAML==5.4.8
 types-python-dateutil==0.1.6

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -256,7 +256,7 @@ def environment_settings_list(tid: uuid.UUID) -> model.EnvironmentSettingsRepons
     client_types=[ClientType.api, ClientType.agent, ClientType.compiler],
     api_version=2,
 )
-def environment_settings_set(tid: uuid.UUID, id: str, value: model.EnvSettingType) -> None:
+def environment_settings_set(tid: uuid.UUID, id: str, value: model.EnvSettingType) -> ReturnValue[None]:
     """
     Set a value
     """
@@ -286,7 +286,7 @@ def environment_setting_get(tid: uuid.UUID, id: str) -> model.EnvironmentSetting
     client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
-def environment_setting_delete(tid: uuid.UUID, id: str) -> None:
+def environment_setting_delete(tid: uuid.UUID, id: str) -> ReturnValue[None]:
     """
     Delete a value
     """

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -256,7 +256,7 @@ def environment_settings_list(tid: uuid.UUID) -> model.EnvironmentSettingsRepons
     client_types=[ClientType.api, ClientType.agent, ClientType.compiler],
     api_version=2,
 )
-def environment_settings_set(tid: uuid.UUID, id: str, value: model.EnvSettingType) -> ReturnValue[None]:
+def environment_settings_set(tid: uuid.UUID, id: str, value: model.EnvSettingType) -> None:
     """
     Set a value
     """
@@ -286,7 +286,7 @@ def environment_setting_get(tid: uuid.UUID, id: str) -> model.EnvironmentSetting
     client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
-def environment_setting_delete(tid: uuid.UUID, id: str) -> ReturnValue[None]:
+def environment_setting_delete(tid: uuid.UUID, id: str) -> None:
     """
     Delete a value
     """

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -418,7 +418,7 @@ class OperationHandler:
 
         return_properties: Optional[Dict[str, Schema]] = None
 
-        if is_generic_type(return_type) and get_origin(return_type) == ReturnValue:
+        if return_type == ReturnValue or is_generic_type(return_type) and get_origin(return_type) == ReturnValue:
             # Dealing with the special case of ReturnValue[...]
             links_type = self.type_converter.get_openapi_type(Dict[str, str])
             links_type.title = "Links"


### PR DESCRIPTION
# Description

 - Bumped openapi_spec_validator version to `0.3.1`.
 - Fixed api generation for routes returning ReturnValue objects

closes #2729 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
