### PR TITLE
Issue/2729 openapi spec validator bump

### DIFF
--- a/changelogs/unreleased/2729-openapi-spec-validator-version-bump.yml
+++ b/changelogs/unreleased/2729-openapi-spec-validator-version-bump.yml
@@ -1,0 +1,5 @@
+---
+description: Bumping version of openapi_spec_validator to 0.3.1 and fixing api definition.
+issue-nr: 2729
+change-type: patch
+destination-branches: [master, iso4]

--- a/changelogs/unreleased/2729-openapi-spec-validator-version-bump.yml
+++ b/changelogs/unreleased/2729-openapi-spec-validator-version-bump.yml
@@ -2,4 +2,4 @@
 description: Bumping version of openapi_spec_validator to 0.3.1 and fixing api definition.
 issue-nr: 2729
 change-type: patch
-destination-branches: [master, iso4]
+destination-branches: [iso4]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 inmanta-dev-dependencies[pytest,async,core,sphinx]==1.33.0
 bumpversion==0.6.0
-openapi_spec_validator==0.2.9
-types-PyYAML==5.4.6
-types-python-dateutil==0.1.6
+openapi_spec_validator==0.3.1
+types-PyYAML==5.4.10
+types-python-dateutil==2.8.0
 types-setuptools==57.0.2
 types-toml==0.1.5

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 inmanta-dev-dependencies[pytest,async,core,sphinx]==1.33.0
 bumpversion==0.6.0
 openapi_spec_validator==0.3.1
-types-PyYAML==5.4.10
-types-python-dateutil==2.8.0
+types-PyYAML==5.4.6
+types-python-dateutil==0.1.6
 types-setuptools==57.0.2
 types-toml==0.1.5


### PR DESCRIPTION
# Description

Bumping version of openapi_spec_validator to 0.3.1 and fixing api definition. (Issue #2729, PR #3219)

 - Bumped openapi_spec_validator version to `0.3.1`.
 - Fixed api generation for routes returning ReturnValue objects

closes #2729

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
