### PR TITLE
Issue/3204 project install tests

### DIFF
--- a/changelogs/unreleased/3024-modules-v2-project-install-tests.yml
+++ b/changelogs/unreleased/3024-modules-v2-project-install-tests.yml
@@ -1,0 +1,5 @@
+description: Expanded modules v2 project install tests
+issue-nr: 3204
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1764,7 +1764,8 @@ class Module(ModuleLike[TModuleMetadata], ABC):
 
     def get_version(self) -> version.Version:
         """
-        Return the version of this module
+        Return the version of this module. This is the actually installed version, which might differ from the version declared
+        in its metadata (e.g. by a .dev0 tag).
         """
         return version.Version(self._metadata.version)
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -56,8 +56,9 @@ from typing import (
 )
 
 import more_itertools
+import pkg_resources
 import yaml
-from pkg_resources import Requirement, parse_requirements, parse_version
+from pkg_resources import Distribution, DistributionNotFound, Requirement, parse_requirements, parse_version
 from pydantic import BaseModel, Field, NameEmail, ValidationError, validator
 
 import inmanta.warnings
@@ -330,8 +331,11 @@ gitprovider = CLIGitProvider()
 
 class ModuleSource(Generic[TModule]):
     def get_installed_module(self, project: "Project", module_name: str) -> Optional[TModule]:
+        """
+        Returns a module object for a module if it is installed.
+        """
         path: Optional[str] = self.path_for(module_name)
-        return self.from_path(project, path) if path is not None else None
+        return self.from_path(project, module_name, path) if path is not None else None
 
     def get_module(
         self, project: "Project", module_spec: List[InmantaModuleRequirement], install: bool = False
@@ -371,7 +375,10 @@ class ModuleSource(Generic[TModule]):
 
     @classmethod
     @abstractmethod
-    def from_path(cls, project: Optional["Project"], path: str) -> TModule:
+    def from_path(cls, project: Optional["Project"], module_name: str, path: str) -> TModule:
+        """
+        Returns a module instance given a path to it.
+        """
         raise NotImplementedError("Abstract method")
 
     def _get_module_name(self, module_spec: List[InmantaModuleRequirement]) -> str:
@@ -388,6 +395,21 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
     def __init__(self, urls: List[str]) -> None:
         self.urls: List[str] = [url if not os.path.exists(url) else os.path.abspath(url) for url in urls]
         env.process_env.init_namespace(const.PLUGINS_PACKAGE)
+
+    @classmethod
+    def get_installed_version(cls, module_name: str) -> Optional[version.Version]:
+        """
+        Returns the version for a module if it is installed.
+        """
+        if module_name.startswith(ModuleV2.PKG_NAME_PREFIX):
+            raise ValueError("PythonRepo instances work with inmanta module names, not Python package names.")
+        try:
+            dist: Distribution = pkg_resources.get_distribution(cls.get_python_package_name(module_name))
+            return version.Version(dist.version)
+        except DistributionNotFound:
+            return None
+        except version.InvalidVersion:
+            raise InvalidModuleException(f"Package {package} was installed but it has no valid version.")
 
     @classmethod
     def get_python_package_name(cls, module_name: str) -> str:
@@ -424,14 +446,14 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
             python_package: str = self.get_python_package_name(module_name)
             namespace_package: str = self.get_namespace_package_name(module_name)
             raise InvalidModuleException(f"{python_package} does not contain a {namespace_package} module.")
-        return self.from_path(project, path)
+        return self.from_path(project, module_name, path)
 
     def path_for(self, name: str) -> Optional[str]:
         """
         Returns the path to the module root directory. Should be called prior to configuring the module finder for v1 modules.
         """
         if name.startswith(ModuleV2.PKG_NAME_PREFIX):
-            raise Exception("PythonRepo instances work with inmanta module names, not Python package names.")
+            raise ValueError("PythonRepo instances work with inmanta module names, not Python package names.")
         package: str = self.get_namespace_package_name(name)
         mod_spec: Optional[Tuple[Optional[str], Loader]] = env.ActiveEnv.get_module_file(package)
         if mod_spec is None:
@@ -456,13 +478,18 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
         raise Exception(f"Invalid module: found plugins package but the module has no {ModuleV2.MODULE_FILE}.")
 
     @classmethod
-    def from_path(cls, project: Optional["Project"], path: str) -> "ModuleV2":
-        return ModuleV2(project, path, is_editable_install=os.path.exists(os.path.join(path, const.PLUGINS_PACKAGE)))
+    def from_path(cls, project: Optional["Project"], module_name: str, path: str) -> "ModuleV2":
+        return ModuleV2(
+            project,
+            path,
+            is_editable_install=os.path.exists(os.path.join(path, const.PLUGINS_PACKAGE)),
+            version=cls.get_installed_version(module_name),
+        )
 
     def _get_module_name(self, module_spec: List[InmantaModuleRequirement]) -> str:
         module_name: str = super()._get_module_name(module_spec)
         if module_name.startswith(ModuleV2.PKG_NAME_PREFIX.replace("-", "_")):
-            raise Exception("PythonRepo instances work with inmanta module names, not Python package names.")
+            raise ValueError("PythonRepo instances work with inmanta module names, not Python package names.")
         return module_name
 
 
@@ -475,7 +502,7 @@ class ModuleV1Source(ModuleSource["ModuleV1"]):
         module_name: str = self._get_module_name(module_spec)
         path: Optional[str] = self.path_for(module_name)
         if path is not None:
-            return self.from_path(project, path)
+            return self.from_path(project, module_name, path)
         else:
             if project.downloadpath is None:
                 raise CompilerException(
@@ -494,7 +521,7 @@ class ModuleV1Source(ModuleSource["ModuleV1"]):
         return self.local_repo.path_for(name)
 
     @classmethod
-    def from_path(cls, project: Optional["Project"], path: str) -> "ModuleV1":
+    def from_path(cls, project: Optional["Project"], module_name: str, path: str) -> "ModuleV1":
         return ModuleV1(project, path)
 
 
@@ -1459,7 +1486,7 @@ class Project(ModuleLike[ProjectMetadata]):
                 - Python downgrades transient dependency a to a<2
             2.
                 - latest v2 mod a is installed
-                - some v1 mod depends on a<2
+                - some v1 (or even v2 when in install mode) mod depends on a<2
                 - after loading, during plugin requirements install, `pip install a<2` is run
                 - Python downgrades direct dependency a to a<2
         In both cases, a<2 might be a valid version, but since it was installed transiently after the compiler has loaded module
@@ -1483,11 +1510,11 @@ class Project(ModuleLike[ProjectMetadata]):
                     result = False
                 elif installed.version != module.version:
                     LOGGER.warning(
-                        "Compiler has loaded module %(name)s==%(loaded_version)s but"
-                        " %(name)s==%(installed_version)s has later been installed as a side effect.",
-                        name=name,
-                        loaded_version=module.version,
-                        installed_version=installed.version,
+                        "Compiler has loaded module %s==%s but %s==%s has later been installed as a side effect.",
+                        name,
+                        module.version,
+                        name,
+                        installed.version,
                     )
                     result = False
         return result
@@ -1690,11 +1717,11 @@ class Module(ModuleLike[TModuleMetadata], ABC):
             fd.write(new_module_def)
         self._metadata = new_metadata
 
-    def get_version(self) -> str:
+    def get_version(self) -> version.Version:
         """
         Return the version of this module
         """
-        return str(self._metadata.version)
+        return version.Version(self._metadata.version)
 
     version = property(get_version)
 
@@ -2099,12 +2126,24 @@ class ModuleV2(Module[ModuleV2Metadata]):
     GENERATION = ModuleGeneration.V2
     PKG_NAME_PREFIX = "inmanta-module-"
 
-    def __init__(self, project: Optional[Project], path: str, is_editable_install: bool = False) -> None:
+    def __init__(
+        self,
+        project: Optional[Project],
+        path: str,
+        is_editable_install: bool = False,
+        version: Optional[version.Version] = None,
+    ) -> None:
         self._is_editable_install = is_editable_install
+        self._version: Optional[version.Version] = version
         try:
             super(ModuleV2, self).__init__(project, path)
         except InvalidMetadata as e:
             raise InvalidModuleException(f"The module found at {path} is not a valid V2 module") from e
+
+    def get_version(self) -> version.Version:
+        return self._version if self._version is not None else super().get_version()
+
+    version = property(get_version)
 
     def ensure_versioned(self) -> None:
         if self._is_editable_install:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -452,7 +452,7 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
         except DistributionNotFound:
             return None
         except version.InvalidVersion:
-            raise InvalidModuleException(f"Package {package} was installed but it has no valid version.")
+            raise InvalidModuleException(f"Package {dist.project_name} was installed but it has no valid version.")
 
     @classmethod
     def get_python_package_name(cls, module_name: str) -> str:
@@ -526,7 +526,7 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
             project,
             path,
             is_editable_install=os.path.exists(os.path.join(path, const.PLUGINS_PACKAGE)),
-            version=cls.get_installed_version(module_name),
+            installed_version=cls.get_installed_version(module_name),
         )
 
     def _get_module_name(self, module_spec: List[InmantaModuleRequirement]) -> str:
@@ -2177,10 +2177,10 @@ class ModuleV2(Module[ModuleV2Metadata]):
         project: Optional[Project],
         path: str,
         is_editable_install: bool = False,
-        version: Optional[version.Version] = None,
+        installed_version: Optional[version.Version] = None,
     ) -> None:
         self._is_editable_install = is_editable_install
-        self._version: Optional[version.Version] = version
+        self._version: Optional[version.Version] = installed_version
         try:
             super(ModuleV2, self).__init__(project, path)
         except InvalidMetadata as e:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1815,9 +1815,9 @@ class Module(ModuleLike[TModuleMetadata], ABC):
             if impor not in out:
                 v1_mode: bool = self.GENERATION == ModuleGeneration.V1
                 mainmod = self._project.get_module(impor, install=v1_mode, allow_v1=v1_mode)
-                version = mainmod.version
+                vers: version.Version = mainmod.version
                 # track submodules for cycle avoidance
-                out[impor] = mode + " " + version
+                out[impor] = mode + " " + str(vers)
                 if recursive:
                     todo.extend([statement.name for statement in mainmod.get_imports(impor)])
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -593,7 +593,7 @@ version: 0.0.1dev0"""
         if last_failure is not None and not done:
             raise last_failure
 
-    def install(self, editable: bool = False, path: Optional[str] = None):
+    def install(self, editable: bool = False, path: Optional[str] = None) -> None:
         """
         Install a module in the active Python environment. Only works for v2 modules: v1 modules can only be installed in the
         context of a project.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -789,11 +789,14 @@ class SnippetCompilationTest(KeepOnFail):
         self,
         snippet: str,
         autostd: bool = True,
-        install_v2_modules: List[LocalPackagePath] = None,
-        add_to_module_path: List[str] = None,
+        install_v2_modules: Optional[List[LocalPackagePath]] = None,
+        add_to_module_path: Optional[List[str]] = None,
         python_package_source: Optional[List[str]] = None,
     ) -> Project:
         """
+        Sets up the project to compile a snippet of inmanta DSL. Activates the compiler environment (and patches
+        env.process_env).
+
         :param install_v2_modules: Indicates which V2 modules should be installed in the compiler venv
         :param add_to_module_path: Additional directories that should be added to the module path.
         :param python_package_source: The python package repository that should be configured on the Inmanta project in order to

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -791,7 +791,7 @@ class SnippetCompilationTest(KeepOnFail):
         autostd: bool = True,
         install_v2_modules: Optional[List[LocalPackagePath]] = None,
         add_to_module_path: Optional[List[str]] = None,
-        python_package_source: Optional[List[str]] = None,
+        python_package_sources: Optional[List[str]] = None,
     ) -> Project:
         """
         Sets up the project to compile a snippet of inmanta DSL. Activates the compiler environment (and patches
@@ -799,10 +799,10 @@ class SnippetCompilationTest(KeepOnFail):
 
         :param install_v2_modules: Indicates which V2 modules should be installed in the compiler venv
         :param add_to_module_path: Additional directories that should be added to the module path.
-        :param python_package_source: The python package repository that should be configured on the Inmanta project in order to
+        :param python_package_sources: The python package repository that should be configured on the Inmanta project in order to
                                       discover V2 modules.
         """
-        self.setup_for_snippet_external(snippet, add_to_module_path, python_package_source)
+        self.setup_for_snippet_external(snippet, add_to_module_path, python_package_sources)
         loader.PluginModuleFinder.reset()
         project = Project(self.project_dir, autostd=autostd)
         Project.set(project)
@@ -838,10 +838,10 @@ class SnippetCompilationTest(KeepOnFail):
         loader.PluginModuleFinder.reset()
 
     def setup_for_snippet_external(
-        self, snippet: str, add_to_module_path: Optional[List[str]] = None, python_package_source: Optional[List[str]] = None
+        self, snippet: str, add_to_module_path: Optional[List[str]] = None, python_package_sources: Optional[List[str]] = None
     ) -> None:
         add_to_module_path = add_to_module_path if add_to_module_path is not None else []
-        python_package_source = python_package_source if python_package_source is not None else []
+        python_package_sources = python_package_sources if python_package_sources is not None else []
         with open(os.path.join(self.project_dir, "project.yml"), "w", encoding="utf-8") as cfg:
             cfg.write(
                 f"""
@@ -853,13 +853,13 @@ class SnippetCompilationTest(KeepOnFail):
                 - {{type: git, url: {self.repo} }}
             """.rstrip()
             )
-            if python_package_source:
+            if python_package_sources:
                 cfg.write(
                     "".join(
                         f"""
                 - {{type: package, url: {source} }}
                         """.rstrip()
-                        for source in python_package_source
+                        for source in python_package_sources
                     )
                 )
         self.main = os.path.join(self.project_dir, "main.cf")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -821,7 +821,7 @@ class SnippetCompilationTest(KeepOnFail):
         env.process_env.notify_change()
         os.makedirs(path, exist_ok=True)
 
-    def _install_v2_modules(self, project: Project, install_v2_modules: List[LocalPackagePath] = None) -> None:
+    def _install_v2_modules(self, project: Project, install_v2_modules: Optional[List[LocalPackagePath]] = None) -> None:
         install_v2_modules = install_v2_modules if install_v2_modules is not None else []
         module_tool = ModuleTool()
         for mod in install_v2_modules:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1118,7 +1118,7 @@ def tmpvenv_active(deactive_venv, tmpvenv: py.path.local) -> Iterator[Tuple[py.p
     sys.prefix = base
 
     # patch env.process_env to recognize this environment as the active one, deactive_venv restores it
-    env.process_env.__init__(python_path=python_path)
+    env.process_env.__init__(python_path=str(python_path))
     # patch inmanta_plugins namespace path so importlib.util.find_spec("inmanta_plugins") includes the venv path
     env.process_env.init_namespace(const.PLUGINS_PACKAGE)
     env.process_env.notify_change()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -799,8 +799,8 @@ class SnippetCompilationTest(KeepOnFail):
 
         :param install_v2_modules: Indicates which V2 modules should be installed in the compiler venv
         :param add_to_module_path: Additional directories that should be added to the module path.
-        :param python_package_sources: The python package repository that should be configured on the Inmanta project in order to
-                                      discover V2 modules.
+        :param python_package_sources: The python package repository that should be configured on the Inmanta project in order
+            to discover V2 modules.
         """
         self.setup_for_snippet_external(snippet, add_to_module_path, python_package_sources)
         loader.PluginModuleFinder.reset()

--- a/tests/data/modules_v2/minimalv2module/setup.cfg
+++ b/tests/data/modules_v2/minimalv2module/setup.cfg
@@ -11,4 +11,4 @@ include_package_data=True
 packages=find_namespace:
 
 [options.package_data]
-inmanta_plugins.minimalv2module=model/*, setup.cfg
+*=model/*, setup.cfg

--- a/tests/moduletool/test_build.py
+++ b/tests/moduletool/test_build.py
@@ -147,7 +147,7 @@ def test_build_v2_module_incomplete_package_data(tmpdir, modules_v2_dir: str, ca
     setup_cfg_file = os.path.join(module_copy_dir, "setup.cfg")
     config_parser = configparser.ConfigParser()
     config_parser.read(setup_cfg_file)
-    config_parser.set("options.package_data", "inmanta_plugins.minimalv2module", "setup.cfg")
+    config_parser.set("options.package_data", "*", "setup.cfg")
     with open(setup_cfg_file, "w") as fd:
         config_parser.write(fd)
 

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -132,7 +132,6 @@ def module_from_template(
         return module.ModuleV2Metadata.parse(fh)
 
 
-# TODO: replace all usages with snippetcompiler_clean
 def setup_simple_project(
     projects_dir: str, path: str, imports: List[str], *, index_urls: Optional[List[str]] = None, github_source: bool = True
 ) -> module.ProjectMetadata:
@@ -531,6 +530,10 @@ def test_project_install_modules_cache_invalid(
         python_package_source=[index.url, local_module_package_index],
     )
 
+    if not preinstall_v2:
+        # populate project.modules[module_name]
+        module.Project.get().get_module(module_name, install=False, allow_v1=True)
+
     os.chdir(module.Project.get().path)
     with pytest.raises(CompilerException):
         ProjectTool().execute("install", [])
@@ -539,7 +542,7 @@ def test_project_install_modules_cache_invalid(
         f"Compiler has loaded module {module_name}=={v2_version}.dev0 but {module_name}=={v2_version} has"
         " later been installed as a side effect."
         if preinstall_v2
-        else f""
+        else f"Compiler has loaded module {module_name} as v1 but it has later been installed as v2 as a side effect."
     )
 
     assert (

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -537,7 +537,7 @@ def test_project_install_modules_cache_invalid(
         import {module_name}
         """,
         autostd=False,
-        python_package_source=[index.url, local_module_package_index],
+        python_package_sources=[index.url, local_module_package_index],
     )
 
     if not preinstall_v2:
@@ -617,7 +617,7 @@ def test_project_install_incompatible_versions(
         """,
         autostd=False,
         add_to_module_path=[v1_modules_path],
-        python_package_source=[index.url],
+        python_package_sources=[index.url],
     )
 
     # install project
@@ -672,7 +672,7 @@ def test_project_install_incompatible_dependencies(
         import {module.ModuleV2.get_name_from_metadata(v2mod2)}
         """,
         autostd=False,
-        python_package_source=[index.url, "https://pypi.org/simple"],
+        python_package_sources=[index.url, "https://pypi.org/simple"],
     )
 
     # install project

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -47,7 +47,7 @@ def build_venv_active(tmpvenv_active: Tuple[py.path.local, py.path.local]) -> It
     """
     Yields an active virtual environment that is suitable to build modules with.
     """
-    env.process_env.install_from_index([Requirement.parse("virtualenv")])
+    env.process_env.install_from_index([Requirement.parse("build")])
     yield tmpvenv_active
 
 

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -68,6 +68,9 @@ def run_module_install(module_path: str, editable: bool, set_path_argument: bool
 
 @dataclass
 class PipIndex:
+    """
+    Local pip index that makes use of dir2pi to publish its artifacts.
+    """
     artifact_dir: str
 
     @property

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import warnings
+from packaging import version
 from typing import Iterator, Type
 
 import py
@@ -171,12 +172,12 @@ install_requires =
     metadata_file.write(metadata_contents("1.2"))
     mod = module_type(None, module_path.strpath)
 
-    assert mod.version == "1.2"
+    assert mod.version == version.Version("1.2")
     if v1:
         assert mod.compiler_version == "2017.2"
 
     mod.rewrite_version("1.3.1")
-    assert mod.version == "1.3.1"
+    assert mod.version == version.Version("1.3.1")
     if v1:
         assert mod.compiler_version == "2017.2"
     assert metadata_file.read().strip() == metadata_contents("1.3.1")
@@ -283,7 +284,7 @@ async def test_version_argument(modules_repo):
     module_path = os.path.join(modules_repo, "mod-version")
 
     mod = module.ModuleV1(None, module_path)
-    assert mod.version == "1.2"
+    assert mod.version == version.Version("1.2")
 
     args = [sys.executable, "-m", "inmanta.app", "module", "commit", "-m", "msg", "-v", "1.3.1", "-r"]
     process = await asyncio.subprocess.create_subprocess_exec(
@@ -449,7 +450,7 @@ install_requires =
     )
     mod: module.ModuleV2 = module.ModuleV2(None, inmanta_module_v2.get_root_dir_of_module())
     assert mod.metadata.name == "inmanta-module-mod1"
-    assert mod.metadata.version == "1.2.3"
+    assert mod.metadata.version == version.Version("1.2.3")
     assert mod.metadata.license == "Apache 2.0"
 
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -450,7 +450,7 @@ install_requires =
     )
     mod: module.ModuleV2 = module.ModuleV2(None, inmanta_module_v2.get_root_dir_of_module())
     assert mod.metadata.name == "inmanta-module-mod1"
-    assert mod.metadata.version == version.Version("1.2.3")
+    assert mod.metadata.version == "1.2.3"
     assert mod.metadata.license == "Apache 2.0"
 
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -22,7 +22,6 @@ import shutil
 import subprocess
 import sys
 import warnings
-from packaging import version
 from typing import Iterator, Type
 
 import py
@@ -41,6 +40,7 @@ from inmanta.module import (
 from inmanta.moduletool import ModuleTool
 from inmanta.parser import ParserException
 from moduletool.common import add_file, commitmodule, install_project, make_module_simple, makeproject
+from packaging import version
 from test_app_cli import app
 
 

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -201,7 +201,7 @@ def test_load_module_v2_module_using_install(
     """
     module_name = "minimalv2module"
     project: Project = snippetcompiler_clean.setup_for_snippet(
-        snippet=f"import {module_name}", python_package_source=[local_module_package_index]
+        snippet=f"import {module_name}", python_package_sources=[local_module_package_index]
     )
     assert module_name not in project.modules
     assert module_name not in os.listdir(project.downloadpath)
@@ -271,7 +271,7 @@ def test_load_module_recursive_v2_module_depends_on_v1(
     Dependency graph:  v2_depends_on_v1 (V2)  --->  mod1 (V1)
     """
     project = snippetcompiler.setup_for_snippet(
-        snippet="import v2_depends_on_v1", python_package_source=local_module_package_index
+        snippet="import v2_depends_on_v1", python_package_sources=[local_module_package_index]
     )
     if preload_v1_module:
         project.get_module("mod1", allow_v1=True)
@@ -294,7 +294,7 @@ def test_load_module_recursive_complex_module_dependencies(local_module_package_
     complex_module_dependencies_mod1::submod                  complex_module_dependencies_mod2::submod
     """
     project = snippetcompiler.setup_for_snippet(
-        snippet="import complex_module_dependencies_mod1", autostd=False, python_package_source=local_module_package_index
+        snippet="import complex_module_dependencies_mod1", autostd=False, python_package_sources=[local_module_package_index]
     )
     assert "complex_module_dependencies_mod1" not in project.modules
     assert "complex_module_dependencies_mod2" not in project.modules

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -25,7 +25,7 @@ import pytest
 
 from inmanta.compiler.config import feature_compiler_cache
 from inmanta.env import LocalPackagePath
-from inmanta.module import ModuleNotFoundException, ModuleV1, ModuleV2, Project
+from inmanta.module import DummyProject, ModuleNotFoundException, ModuleV1, ModuleV2, Project
 from inmanta.moduletool import DummyProject, ModuleConverter
 
 
@@ -200,7 +200,7 @@ def test_load_module_v2_module_using_install(
     """
     module_name = "minimalv2module"
     project: Project = snippetcompiler_clean.setup_for_snippet(
-        snippet=f"import {module_name}", python_package_source=local_module_package_index
+        snippet=f"import {module_name}", python_package_source=[local_module_package_index]
     )
     assert module_name not in project.modules
     assert module_name not in os.listdir(project.downloadpath)


### PR DESCRIPTION
# Description

- expanded tests for project install
- added support for dev tagged versions for v2 modules

This PR uses the `setup_simple_project` helper function in tests while concurrent work expanded the snippetcompiler fixture to support required behavior. #3235 has been created to fix this.

Closes #3204

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
