### PR TITLE
Bump version inmanta-dev-dependencies dependency

### DIFF
--- a/changelogs/unreleased/bump-inmanta-dev-dependencies.yml
+++ b/changelogs/unreleased/bump-inmanta-dev-dependencies.yml
@@ -1,0 +1,4 @@
+---
+description: Bump the version of inmanta-dev-dependencies in order to have the latest fixes in inmanta-sphinx
+change-type: patch
+destination-branches: [iso4]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==1.33.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==1.54.0
 bumpversion==0.6.0
 openapi_spec_validator==0.3.1
 types-PyYAML==5.4.6


### PR DESCRIPTION
# Description

Bump the version of the `inmanta-dev-dependencies` dependency in order to have the latest fixes in `inmanta-sphinx` dependency. The latest `inmanta-sphinx` fixes are required to make the documentation build work. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
