### PR TITLE
Issue/3202 test module name conversion

### DIFF
--- a/changelogs/unreleased/3202-test-module-name-conversion.yml
+++ b/changelogs/unreleased/3202-test-module-name-conversion.yml
@@ -1,0 +1,5 @@
+---
+description: Added tests to ensure that v1_to_v2 converts module names correctly to python package names
+issue-nr: 3202
+change-type: patch
+destination-branches: [master]

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -76,12 +76,12 @@ def test_to_v2():
     Test whether the `to_v2()` method of `ModuleV1Metadata` works correctly.
     """
     v1_metadata = module.ModuleV1Metadata(
-        name="test_module",
+        name="a_test_module",
         description="A description",
         version="1.2.3",
         license="Apache 2.0",
         compiler_version="4.5.6",
-        requires=["module_dep1", "module_dep2"],
+        requires=["module_dep_1", "module_dep_2"],
     )
     v2_metadata = v1_metadata.to_v2()
     for attr_name in ["description", "version", "license"]:

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -76,18 +76,22 @@ def test_to_v2():
     Test whether the `to_v2()` method of `ModuleV1Metadata` works correctly.
     """
     v1_metadata = module.ModuleV1Metadata(
-        name="test",
+        name="test_module",
         description="A description",
         version="1.2.3",
         license="Apache 2.0",
         compiler_version="4.5.6",
-        requires=["mod1", "mod2"],
+        requires=["module_dep1", "module_dep2"],
     )
     v2_metadata = v1_metadata.to_v2()
     for attr_name in ["description", "version", "license"]:
         assert v1_metadata.__getattribute__(attr_name) == v2_metadata.__getattribute__(attr_name)
-    assert f"{module.ModuleV2.PKG_NAME_PREFIX}{v1_metadata.name}" == v2_metadata.name
-    assert [f"{module.ModuleV2.PKG_NAME_PREFIX}{req}" for req in v1_metadata.requires] == v2_metadata.install_requires
+
+    def _convert_module_to_package_name(module_name: str) -> str:
+        return f"{module.ModuleV2.PKG_NAME_PREFIX}{module_name.replace('_', '-')}"
+
+    assert _convert_module_to_package_name(v1_metadata.name) == v2_metadata.name
+    assert [_convert_module_to_package_name(req) for req in v1_metadata.requires] == v2_metadata.install_requires
 
 
 def test_is_versioned(snippetcompiler_clean, modules_dir: str, modules_v2_dir: str, caplog, tmpdir) -> None:


### PR DESCRIPTION
# Description

Added tests to ensure that v1_to_v2 converts module names correctly to python package names.

closes #3202 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
