### PR TITLE
added __cfcache__ as ignore dir for module packaging warnings

### DIFF
--- a/changelogs/unreleased/module-package-cfcache-ignore.yml
+++ b/changelogs/unreleased/module-package-cfcache-ignore.yml
@@ -1,0 +1,4 @@
+description: Added __cfcache__ as ignore dir for module packaging warnings
+change-type: patch
+destination-branches:
+  - master

--- a/changelogs/unreleased/module-package-cfcache-ignore.yml
+++ b/changelogs/unreleased/module-package-cfcache-ignore.yml
@@ -1,4 +1,4 @@
-description: Added __cfcache__ as ignore dir for module packaging warnings
+description: Added `__cfcache__` as ignore dir for module packaging warnings
 change-type: patch
 destination-branches:
   - master

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -756,7 +756,9 @@ class V2ModuleBuilder:
         """
         rel_path_namespace_package = os.path.join("inmanta_plugins", self._module.name)
         abs_path_namespace_package = os.path.join(build_path, rel_path_namespace_package)
-        files_in_python_package_dir = self._get_files_in_directory(abs_path_namespace_package, ignore={"__pycache__"})
+        files_in_python_package_dir = self._get_files_in_directory(
+            abs_path_namespace_package, ignore={"__pycache__", "__cfcache__"}
+        )
         with zipfile.ZipFile(path_to_wheel) as z:
             dir_prefix = f"{rel_path_namespace_package}/"
             files_in_wheel = set(


### PR DESCRIPTION
See [this test failure](https://jenkins.inmanta.com/job/core/job/inmanta-core/job/issue%252F3203-test-module-source-methods/1/testReport/junit/tests.moduletool/test_build/test_build_v2_module_incomplete_package_data/).