### PR TITLE
added fast mode

### DIFF
--- a/changelogs/unreleased/add-fast-mode-to-test.yml
+++ b/changelogs/unreleased/add-fast-mode-to-test.yml
@@ -1,0 +1,5 @@
+description: Add fast mode to tests
+change-type: patch
+destination-branches:
+  - iso4
+  - master

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     slowtest
     link_check
+    parametrize_any: only execute one of the parameterized cases when in fast mode

--- a/tests/compiler/test_compile_export.py
+++ b/tests/compiler/test_compile_export.py
@@ -95,7 +95,7 @@ x = 1
     )
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize_any(
     "snippet,exception,category,message,report_exnc",
     [
         (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def pytest_generate_tests(metafunc: "pytest.Metafunc") -> None:
     is_fast = metafunc.config.getoption("fast")
     for marker in metafunc.definition.iter_markers(name="parametrize_any"):
         variations = len(marker.args[1])
-        if not is_fast or variations <= 2:
+        if not is_fast or variations < 2:
             metafunc.definition.add_marker(pytest.mark.parametrize(*marker.args))
         else:
             # select one random item

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ TABLES_TO_KEEP = [x.table_name() for x in data._classes]
 def pytest_addoption(parser):
     parser.addoption(
         "--fast",
-        action='store_true',
+        action="store_true",
         help="Don't run all test, but a representative set",
     )
 
@@ -106,7 +106,7 @@ def pytest_generate_tests(metafunc: "pytest.Metafunc") -> None:
     is_fast = metafunc.config.getoption("fast")
     for marker in metafunc.definition.iter_markers(name="parametrize_any"):
         variations = len(marker.args[1])
-        if not is_fast or variations<=2:
+        if not is_fast or variations <= 2:
             metafunc.definition.add_marker(pytest.mark.parametrize(*marker.args))
         else:
             # select one random item
@@ -124,7 +124,7 @@ def pytest_runtest_setup(item: "pytest.Item"):
     if not is_fast:
         return
     if any(True for mark in item.iter_markers(name="slowtest")):
-         pytest.skip("Skipping slow tests")
+        pytest.skip("Skipping slow tests")
 
 
 # Database

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py36,mypy,docs
+envlist = pep8,py36-fast,mypy,docs
 skip_missing_interpreters=True
 requires = pip
            virtualenv >= 20.2.2
@@ -20,6 +20,10 @@ commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report 
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME
+
+[testenv:{py36,py38}-fast]
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv --fast --durations=50 tests/
+
 
 [testenv:pep8]
 deps=


### PR DESCRIPTION
# Description

This PR contains the basic mechanisms for a '--fast' option on the tests.

The fast mode:

- reduces parameterized sets to a single (random) item
- skips slow tests

The idea would be

- run fast mode on commit
- run full mode nightly (or on demand)

# Todo

- [ ] roll out annotations
- [ ] update jenkinsfile

