### PR TITLE
Issue/3248 modules v2 disable import based install

### DIFF
--- a/changelogs/unreleased/3248-modules-v2-disable-import-based-install.yml
+++ b/changelogs/unreleased/3248-modules-v2-disable-import-based-install.yml
@@ -1,0 +1,4 @@
+description: Disable import-based install for v2 modules for security reasons
+change-type: major
+destination-branches:
+  - master

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1410,7 +1410,7 @@ class Project(ModuleLike[ProjectMetadata]):
             Loads all v2 modules explicitly required by the supplied module like instance, installing them if install=True. If
             any of these requirements have already been loaded as v1, queues them for reload.
             """
-            for requirement in module.get_module_requirements():
+            for requirement in module_like.get_module_requirements():
                 req_name: str = InmantaModuleRequirement.parse(requirement).key
                 # load module
                 self.get_module(

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -195,7 +195,7 @@ class ModuleLoadingException(WrappingRuntimeException):
         :param msg: A description of the error.
         """
         if msg is None:
-            msg = "Failed to load module %s, caused by: %s" % (name, str(cause))
+            msg = "Failed to load module %s" % name
         WrappingRuntimeException.__init__(self, stmt, msg, cause)
         self.name = name
 
@@ -1937,7 +1937,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
         for impor in todo:
             if impor not in out:
                 v1_mode: bool = self.GENERATION == ModuleGeneration.V1
-                mainmod = self._project.get_module(impor, install=v1_mode, allow_v1=v1_mode)
+                mainmod = self._project.get_module(impor, install_v1=v1_mode, allow_v1=v1_mode)
                 vers: version.Version = mainmod.version
                 # track submodules for cycle avoidance
                 out[impor] = mode + " " + str(vers)

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1486,7 +1486,10 @@ class Project(ModuleLike[ProjectMetadata]):
 
         def setup_module(module: Module) -> None:
             """
-            Sets up a top level module, making sure all its v2 requirements are loaded correctly.
+            Sets up a top level module, making sure all its v2 requirements are loaded correctly. V2 modules do not support
+            import-based installation because of security reasons (it would mean we implicitly trust any `inmanta-module-x`
+            package for the module we're trying to load). As a result we need to make sure all required v2 modules are present
+            in a set up stage.
             """
             if module.name in set_up:
                 # already set up

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -195,7 +195,7 @@ class ModuleLoadingException(WrappingRuntimeException):
         :param msg: A description of the error.
         """
         if msg is None:
-            msg = "could not find module %s" % name
+            msg = "Failed to load module %s, caused by: %s" % (name, str(cause))
         WrappingRuntimeException.__init__(self, stmt, msg, cause)
         self.name = name
 
@@ -1415,7 +1415,8 @@ class Project(ModuleLike[ProjectMetadata]):
         self, install: bool = False, bypass_module_cache: bool = False
     ) -> List[Tuple[str, List[Statement], BasicBlock]]:
         """
-        Loads this project's modules and submodules by recursively following import statements starting from the project's main file.
+        Loads this project's modules and submodules by recursively following import statements starting from the project's main
+        file.
 
         For each imported submodule, return a triple of name, statements, basicblock
 
@@ -1526,7 +1527,6 @@ class Project(ModuleLike[ProjectMetadata]):
 
             try:
                 # get module
-                # TODO: make sure this doesn't install v2
                 module: Module = self.get_module(
                     module_name,
                     allow_v1=module_name not in v2_modules,
@@ -1579,8 +1579,8 @@ class Project(ModuleLike[ProjectMetadata]):
 
         if module is None:
             raise ModuleNotFoundException(
-                # TODO: update error message to say something about adding the module dependency?
-                f"Could not find module {module_name}. Please make sure to install it by running `inmanta project install`."
+                f"Could not find module {module_name}. Please make sure to add any module v2 requirements with"
+                " `inmanta module add` and to install all the project's dependencies with `inmanta project install`."
             )
 
         self.modules[module_name] = module

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1468,7 +1468,7 @@ class Project(ModuleLike[ProjectMetadata]):
                 if module_name in ast_by_top_level_mod:
                     del ast_by_top_level_mod[module_name]
 
-        def load_module_requirements(module_like: ModuleLike) -> None:
+        def load_module_v2_requirements(module_like: ModuleLike) -> None:
             """
             Loads all v2 modules explicitly required by the supplied module like instance, installing them if install=True. If
             any of these requirements have already been loaded as v1, queues them for reload.
@@ -1491,7 +1491,7 @@ class Project(ModuleLike[ProjectMetadata]):
             if module.name in set_up:
                 # already set up
                 return
-            load_module_requirements(module)
+            load_module_v2_requirements(module)
             set_up.add(module.name)
 
         def load_sub_module(module: Module, submod: str) -> None:
@@ -1521,7 +1521,7 @@ class Project(ModuleLike[ProjectMetadata]):
                         require_v2(dep_module_name)
 
         # load this project's v2 requirements
-        load_module_requirements(self)
+        load_module_v2_requirements(self)
 
         # Loop over imports. For each import:
         # 1. Load the top level module. For v1, install if install=True, for v2 import-based installation is disabled for

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1184,7 +1184,6 @@ class ModuleLike(ABC, Generic[T]):
         """
         return [req for req in self.get_all_python_requirements_as_list() if not req.startswith(ModuleV2.PKG_NAME_PREFIX)]
 
-    # TODO: add tests
     def get_module_v2_requirements(self) -> List[InmantaModuleRequirement]:
         """
         Returns all requirements this module like has on v2 modules.

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -413,6 +413,7 @@ class ModuleTool(ModuleLikeTool):
             except (ModuleMetadataFileNotFound, InvalidMetadata, InvalidModuleException):
                 raise InvalidModuleException(f"No module can be found at {path}")
 
+    # TODO: this and other moduletool commands
     def get_module(self, module: Optional[str] = None, project: Optional[Project] = None) -> Module:
         """Finds and loads a module, either based on the CWD or based on the name passed in as an argument and the project"""
         if module is None:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -413,7 +413,6 @@ class ModuleTool(ModuleLikeTool):
             except (ModuleMetadataFileNotFound, InvalidMetadata, InvalidModuleException):
                 raise InvalidModuleException(f"No module can be found at {path}")
 
-    # TODO: this and other moduletool commands
     def get_module(self, module: Optional[str] = None, project: Optional[Project] = None) -> Module:
         """Finds and loads a module, either based on the CWD or based on the name passed in as an argument and the project"""
         if module is None:

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -60,7 +60,7 @@ def test_module_error(snippetcompiler):
     path_modules_yml_file = os.path.join(modpath, "module.yml")
     snippetcompiler.setup_for_error(
         "import badmodule",
-        f"""could not find module badmodule (reported in import badmodule ({snippetcompiler.project_dir}/main.cf:1))
+        f"""Failed to load module badmodule (reported in import badmodule ({snippetcompiler.project_dir}/main.cf:1))
 caused by:
   Could not load module badmodule
   caused by:

--- a/tests/compiler/test_import.py
+++ b/tests/compiler/test_import.py
@@ -39,7 +39,8 @@ def test_1480_1767_invalid_repo(snippetcompiler_clean):
         """
 
         """,
-        "could not find module std (reported in import std (__internal__:1:1))"
+        "Failed to load module std (reported in import std (__internal__:1:1))"
         "\ncaused by:"
-        "\n  Could not find module std. Please make sure to install it by running `inmanta project install`.",
+        "\n  Could not find module std. Please make sure to add any module v2 requirements with `inmanta module add` and to"
+        " install all the project's dependencies with `inmanta project install`.",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -892,7 +892,6 @@ class SnippetCompilationTest(KeepOnFail):
                 cfg.write(f"\n            install_mode: {install_mode.value}")
         with open(os.path.join(self.project_dir, "requirements.txt"), "w", encoding="utf-8") as fd:
             fd.write("\n".join(str(req) for req in python_requires))
-            print("WRITING", "\n".join(str(req) for req in python_requires), "to", self.project_dir)
         self.main = os.path.join(self.project_dir, "main.cf")
         with open(self.main, "w", encoding="utf-8") as x:
             x.write(snippet)

--- a/tests/data/modules_v2/complex_module_dependencies_mod1/setup.cfg
+++ b/tests/data/modules_v2/complex_module_dependencies_mod1/setup.cfg
@@ -1,6 +1,3 @@
-# Note: This module doesn't define its dependency on complex-module-dependencies-mod2 in order to test the import-based loading
-#       logic.
-
 [metadata]
 name = inmanta-module-complex-module-dependencies-mod1
 version = 1.1.1
@@ -12,6 +9,8 @@ author = Inmanta <code@inmanta.com>
 zip_safe=False
 include_package_data=True
 packages=find_namespace:
+install_requires =
+    inmanta-module-complex-module-dependencies-mod2
 
 [options.package_data]
 *=files/*, model/*, templates/*, setup.cfg

--- a/tests/data/modules_v2/complex_module_dependencies_mod2/setup.cfg
+++ b/tests/data/modules_v2/complex_module_dependencies_mod2/setup.cfg
@@ -1,6 +1,3 @@
-# Note: This module doesn't define its dependency on complex-module-dependencies-mod1 in order to test the import-based loading
-#       logic.
-
 [metadata]
 name = inmanta-module-complex-module-dependencies-mod2
 version = 2.2.2
@@ -13,6 +10,8 @@ author = Inmanta <code@inmanta.com>
 zip_safe=False
 include_package_data=True
 packages=find_namespace:
+install_requires =
+    inmanta-module-complex-module-dependencies-mod1
 
 [options.package_data]
 *=files/*, model/*, templates/*, setup.cfg

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -35,8 +35,9 @@ from inmanta.ast import CompilerException
 from inmanta.config import Config
 from inmanta.module import InstallMode, ModuleLoadingException
 from inmanta.moduletool import DummyProject, ModuleConverter, ModuleTool, ProjectTool
-from moduletool.common import BadModProvider, PipIndex, install_project, module_from_template
+from moduletool.common import BadModProvider, install_project
 from packaging import version
+from utils import PipIndex, module_from_template
 
 
 @pytest.fixture

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -482,7 +482,7 @@ def test_project_install_modules_cache_invalid(
         add_to_module_path=[libs_dir],
         python_package_sources=[index.url, local_module_package_index],
         # make sure main module gets installed, pulling in newest version of dependency module
-        python_requires=[Requirement.parse(main_module)],
+        python_requires=[Requirement.parse(module.ModuleV2Source.get_python_package_name(main_module))],
     )
 
     # populate project.modules[dependency_module] to force the error conditions in this simplified example

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -418,77 +418,77 @@ def test_project_install_modules_cache_invalid(
     """
     Verify that introducing invalidities in the modules cache results in the appropriate exception and warnings.
 
+    - preinstall old (v1 or v2) version of {dependency_module}
+    - install project with {main_module} that depends on {dependency_module}>={v2_version}
+
     :param preinstall_v2: Whether the preinstalled module should be a v2.
     """
-    module_name: str = "minimalv1module"
+    main_module: str = "main_module"
+    dependency_module: str = "minimalv1module"
     fq_mod_name: str = "inmanta_plugins.minimalv1module"
     index: PipIndex = PipIndex(artifact_dir=os.path.join(str(tmpdir), ".custom-index"))
+    libs_dir: str = os.path.join(str(tmpdir), "libs")
+    os.makedirs(libs_dir)
 
     assert env.process_env.get_module_file(fq_mod_name) is None
 
-    # prepare v2 module
-    v2_template_path: str = os.path.join(str(tmpdir), module_name)
-    v1: module.ModuleV1 = module.ModuleV1(project=DummyProject(autostd=False), path=os.path.join(modules_dir, module_name))
+    # prepare most recent v2 module
+    v2_template_path: str = os.path.join(str(tmpdir), dependency_module)
+    v1: module.ModuleV1 = module.ModuleV1(
+        project=DummyProject(autostd=False), path=os.path.join(modules_dir, dependency_module)
+    )
     v2_version: version.Version = version.Version(str(v1.version.major + 1) + ".0.0")
     ModuleConverter(v1).convert(output_directory=v2_template_path)
     module_from_template(
-        v2_template_path, os.path.join(str(tmpdir), module_name, "stable"), new_version=v2_version, publish_index=index
+        v2_template_path, os.path.join(str(tmpdir), dependency_module, "stable"), new_version=v2_version, publish_index=index
     )
 
-    # prepare second module that depends on stable v2 version of first module
-    new_module_name: str = f"{module_name}2"
+    # prepare main module that depends on stable v2 version of first module
     module_from_template(
         v2_template_path,
-        os.path.join(str(tmpdir), new_module_name),
-        new_name=new_module_name,
+        os.path.join(str(tmpdir), main_module),
+        new_name=main_module,
         # requires stable version, not currently installed dev version
-        new_requirements=[module.InmantaModuleRequirement.parse(f"{module_name}>={v2_version}")],
+        new_requirements=[module.InmantaModuleRequirement.parse(f"{dependency_module}>={v2_version}")],
         install=False,
         publish_index=index,
     )
 
     # preinstall module
     if preinstall_v2:
-        # set up project, including activation of venv
+        # set up project, including activation of venv before installing the module
         snippetcompiler_clean.setup_for_snippet("", install_project=False)
         # install older v2 module
         module_from_template(
             v2_template_path,
-            os.path.join(str(tmpdir), module_name, "dev"),
+            os.path.join(str(tmpdir), dependency_module, "dev"),
             new_version=version.Version(f"{v2_version}.dev0"),
             install=True,
         )
     else:
         # install module as v1
         snippetcompiler_clean.setup_for_snippet(
-            f"import {module_name}",
+            f"import {dependency_module}",
             autostd=False,
             install_project=False,
         )
         ProjectTool().execute("install", [])
 
     # set up project for installation
-    snippetcompiler_clean.setup_for_snippet(
-        f"""
-        import {new_module_name}
-        import {module_name}
-        """,
+    project: module.Project = snippetcompiler_clean.setup_for_snippet(
+        "",
         autostd=False,
         install_project=False,
+        add_to_module_path=[libs_dir],
         python_package_sources=[index.url, local_module_package_index],
-        # don't include preinstalled module to make sure to trigger the v1 loading error
-        python_requires=[Requirement.parse(module.ModuleV2Source.get_python_package_name(new_module_name))],
+        # make sure main module gets installed, pulling in newest version of dependency module
+        python_requires=[Requirement.parse(main_module)],
     )
 
-    if not preinstall_v2:
-        # populate project.modules[module_name]
-        module.Project.get().get_module(module_name, allow_v1=True)
+    # populate project.modules[dependency_module] to force the error conditions in this simplified example
+    project.get_module(dependency_module, allow_v1=True)
 
-    os.chdir(module.Project.get().path)
-    # TODO: this fails for the v1 preinstalled test because the v2 modules now get installed before starting the import based
-    # install flow for v1 modules. This means the v1 error is very much an edge case that can only occur when a v2 module is
-    # a transient dependency of a v1 module and this v2 module promotes another v1 to v2. Not sure whether the test should cover
-    # this or whether we should just drop the v1 preinstalled test.
+    os.chdir(project.path)
     with pytest.raises(
         CompilerException,
         match=(
@@ -499,10 +499,10 @@ def test_project_install_modules_cache_invalid(
         ProjectTool().execute("install", [])
 
     message: str = (
-        f"Compiler has loaded module {module_name}=={v2_version}.dev0 but {module_name}=={v2_version} has"
+        f"Compiler has loaded module {dependency_module}=={v2_version}.dev0 but {dependency_module}=={v2_version} has"
         " later been installed as a side effect."
         if preinstall_v2
-        else f"Compiler has loaded module {module_name} as v1 but it has later been installed as v2 as a side effect."
+        else f"Compiler has loaded module {dependency_module} as v1 but it has later been installed as v2 as a side effect."
     )
 
     assert message in (rec.message for rec in caplog.records)

--- a/tests/moduletool/test_update.py
+++ b/tests/moduletool/test_update.py
@@ -27,8 +27,9 @@ from inmanta.env import LocalPackagePath, process_env
 from inmanta.module import InmantaModuleRequirement, InstallMode, ModuleV1, ModuleV2
 from inmanta.moduletool import ModuleTool
 from inmanta.parser import ParserException
-from moduletool.common import PipIndex, add_file, clone_repo, module_from_template
+from moduletool.common import add_file, clone_repo
 from packaging.version import Version
+from utils import PipIndex, module_from_template
 
 
 @pytest.mark.parametrize(

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -297,7 +297,7 @@ def test_load_module_recursive_v2_module_depends_on_v1(
         project.get_module("mod1", allow_v1=True)
     assert ("mod1" in project.modules) == preload_v1_module
 
-    with pytest.raises(ModuleLoadingException, match="Could not find module mod1"):
+    with pytest.raises(ModuleLoadingException, match="Failed to load module mod1"):
         project.load_module_recursive(install=True)
 
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -28,6 +28,7 @@ import pytest
 from _io import StringIO
 from inmanta import module
 from inmanta.env import LocalPackagePath
+from inmanta.module import InmantaModuleRequirement
 
 
 def test_module():
@@ -154,15 +155,22 @@ def test_is_versioned(snippetcompiler_clean, modules_dir: str, modules_v2_dir: s
 
 
 @pytest.mark.parametrize(
-    "v1_module, all_python_requirements,strict_python_requirements,module_requirements",
+    "v1_module, all_python_requirements,strict_python_requirements,module_requirements,module_v2_requirements",
     [
         (
             True,
             ["jinja2~=3.2.1", "inmanta-module-v2-module==1.2.3"],
             ["jinja2~=3.2.1"],
             ["v2_module==1.2.3", "v1_module==1.1.1"],
+            [InmantaModuleRequirement.parse("v2_module==1.2.3")],
         ),
-        (False, ["jinja2~=3.2.1", "inmanta-module-v2-module==1.2.3"], ["jinja2~=3.2.1"], ["v2_module==1.2.3"]),
+        (
+            False,
+            ["jinja2~=3.2.1", "inmanta-module-v2-module==1.2.3"],
+            ["jinja2~=3.2.1"],
+            ["v2_module==1.2.3"],
+            [InmantaModuleRequirement.parse("v2_module==1.2.3")],
+        ),
     ],
 )
 def test_get_requirements(
@@ -172,6 +180,7 @@ def test_get_requirements(
     all_python_requirements: List[str],
     strict_python_requirements: List[str],
     module_requirements: List[str],
+    module_v2_requirements: List[str],
 ) -> None:
     """
     Test the different methods to get the requirements of a module.
@@ -188,4 +197,5 @@ def test_get_requirements(
     assert set(mod.get_all_python_requirements_as_list()) == set(all_python_requirements)
     assert set(mod.get_strict_python_requirements_as_list()) == set(strict_python_requirements)
     assert set(mod.get_module_requirements()) == set(module_requirements)
+    assert set(mod.get_module_v2_requirements()) == set(module_v2_requirements)
     assert set(mod.requires()) == set(module.InmantaModuleRequirement.parse(req) for req in module_requirements)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -348,7 +348,7 @@ def test_project_load_no_install(snippetcompiler_clean) -> None:
     Verify that loading a project does not install any modules.
     """
     project: Project = snippetcompiler_clean.setup_for_snippet("", autostd=True, install_project=False)
-    with pytest.raises(ModuleLoadingException, match="could not find module std"):
+    with pytest.raises(ModuleLoadingException, match="Failed to load module std"):
         project.load()
     project.install_modules()
     project.load()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -428,7 +428,7 @@ def v1_module_from_template(
     :param dest_dir: The directory to use to copy the original to and to stage any changes in.
     :param new_version: The new version for the module, if any.
     :param new_name: The new name of the inmanta module, if any.
-    :param new_requirements: The new requirements for the module, if any.
+    :param new_requirements: The new Python requirements for the module, if any.
     :param new_content_init_cf: The new content of the _init.cf file.
     """
     shutil.copytree(source_dir, dest_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2016 Inmanta
+    Copyright 2021 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,23 +16,30 @@
     Contact: code@inmanta.com
 """
 import asyncio
+import configparser
 import inspect
 import json
 import logging
+import os
+import shutil
 import time
 import uuid
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence, Union
 
 import pytest
-from pkg_resources import parse_version
+from pkg_resources import Requirement, parse_version
 from pydantic.tools import lru_cache
 
 from _pytest.mark import MarkDecorator
-from inmanta import data
+from inmanta import const, data, module
+from inmanta.moduletool import ModuleTool
 from inmanta.protocol import Client
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.extensions import ProductMetadata
 from inmanta.util import get_compiler_version
+from libpip2pi.commands import dir2pi
+from packaging import version
 
 
 async def retry_limited(fun, timeout, *args, **kwargs):
@@ -324,3 +331,82 @@ def mark_only_for_version_higher_than(version: str) -> "MarkDecorator":
         product_version_lower_or_equal_than(version),
         reason=f"This test is only intended for version larger than {version} currently at {current}",
     )
+
+
+@dataclass
+class PipIndex:
+    """
+    Local pip index that makes use of dir2pi to publish its artifacts.
+    """
+
+    artifact_dir: str
+
+    @property
+    def url(self) -> str:
+        return f"{self.artifact_dir}/simple"
+
+    def publish(self) -> None:
+        dir2pi(argv=["dir2pi", self.artifact_dir])
+
+
+def module_from_template(
+    source_dir: str,
+    dest_dir: str,
+    *,
+    new_version: Optional[version.Version] = None,
+    new_name: Optional[str] = None,
+    new_requirements: Optional[Sequence[Union[module.InmantaModuleRequirement, Requirement]]] = None,
+    install: bool = False,
+    editable: bool = False,
+    publish_index: Optional[PipIndex] = None,
+    new_content_init_cf: Optional[str] = None,
+) -> module.ModuleV2Metadata:
+    """
+    Creates a v2 module from a template.
+
+    :param source_dir: The directory where the original module lives.
+    :param dest_dir: The directory to use to copy the original to and to stage any changes in.
+    :param new_version: The new version for the module, if any.
+    :param new_name: The new name of the inmanta module, if any.
+    :param new_requirements: The new requirements for the module, if any.
+    :param install: Install the newly created module with the module tool. Requires virtualenv to be installed in the
+        python environment unless editable is True.
+    :param editable: Whether to install the module in editable mode, ignored if install is False.
+    :param publish_index: Publish to the given local path index. Requires virtualenv to be installed in the python environment.
+    :param new_content_init_cf: The new content of the _init.cf file.
+    """
+    # preinstall older version of module
+    shutil.copytree(source_dir, dest_dir)
+    config_file: str = os.path.join(dest_dir, module.ModuleV2.MODULE_FILE)
+    config: configparser.ConfigParser = configparser.ConfigParser()
+    config.read(config_file)
+    if new_version is not None:
+        config["metadata"]["version"] = str(new_version)
+        if new_version.is_devrelease:
+            config["egg_info"] = {"tag_build": f".dev{new_version.dev}"}
+    if new_name is not None:
+        os.rename(
+            os.path.join(
+                dest_dir, const.PLUGINS_PACKAGE, module.ModuleV2Source.get_inmanta_module_name(config["metadata"]["name"])
+            ),
+            os.path.join(dest_dir, const.PLUGINS_PACKAGE, new_name),
+        )
+        config["metadata"]["name"] = module.ModuleV2Source.get_python_package_name(new_name)
+    if new_requirements:
+        config["options"]["install_requires"] = "\n    ".join(
+            str(req if isinstance(req, Requirement) else module.ModuleV2Source.get_python_package_requirement(req))
+            for req in new_requirements
+        )
+    if new_content_init_cf is not None:
+        init_cf_file = os.path.join(dest_dir, "model", "_init.cf")
+        with open(init_cf_file, "w", encoding="utf-8") as fd:
+            fd.write(new_content_init_cf)
+    with open(config_file, "w") as fh:
+        config.write(fh)
+    if install:
+        ModuleTool().install(editable=editable, path=dest_dir)
+    if publish_index is not None:
+        ModuleTool().build(path=dest_dir, output_dir=publish_index.artifact_dir)
+        publish_index.publish()
+    with open(config_file, "r") as fh:
+        return module.ModuleV2Metadata.parse(fh)


### PR DESCRIPTION
# Description

Security fix: disable import based installation for v2 modules.

closes #3248

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
