### PR TITLE
improve snippetcompiler path_process_env performance

### DIFF
--- a/changelogs/unreleased/snippetcompiler-improve-performance.yml
+++ b/changelogs/unreleased/snippetcompiler-improve-performance.yml
@@ -1,0 +1,4 @@
+description: improve snippetcompiler path_process_env performance
+change-type: patch
+destination-branches:
+  - master

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -855,7 +855,6 @@ class SnippetCompilationTest(KeepOnFail):
         self._keep = False
         self.project_dir = tempfile.mkdtemp()
         self.modules_dir = module_dir
-        os.symlink(self.env, os.path.join(self.project_dir, ".env"))
 
     def tear_down_func(self):
         if not self._keep:
@@ -907,7 +906,7 @@ class SnippetCompilationTest(KeepOnFail):
         main_file: str = "main.cf",
     ):
         loader.PluginModuleFinder.reset()
-        project = Project(self.project_dir, autostd=autostd, main_file=main_file)
+        project = Project(self.project_dir, autostd=autostd, main_file=main_file, venv_path=self.env)
         Project.set(project)
         project.use_virtual_env()
         self._patch_process_env()
@@ -922,7 +921,6 @@ class SnippetCompilationTest(KeepOnFail):
         running process.
         """
         env.process_env.__init__(env_path=self.env)
-        env.process_env.notify_change()
         env.process_env.init_namespace(const.PLUGINS_PACKAGE)
 
     def _install_v2_modules(self, project: Project, install_v2_modules: Optional[List[LocalPackagePath]] = None) -> None:
@@ -937,7 +935,7 @@ class SnippetCompilationTest(KeepOnFail):
                 project.install_in_compiler_venv(path=install_path, editable=mod.editable)
 
     def reset(self):
-        Project.set(Project(self.project_dir, autostd=Project.get().autostd))
+        Project.set(Project(self.project_dir, autostd=Project.get().autostd, venv_path=self.env))
         loader.unload_inmanta_plugins()
         loader.PluginModuleFinder.reset()
 


### PR DESCRIPTION
# Description

`SnippetCompilationTest._patch_process_env()` does not actually change venvs, it just updates the mocking of the active process env. As a result, calling `notify_change` should not be required. Additionally, getting rid of the symlink makes sure each compile uses the same path for the shared venv, which makes venv switching simpler.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
