### PR TITLE
Issue/3290 fix unstable tests

### DIFF
--- a/changelogs/unreleased/3290-fix-unstable-tests.yml
+++ b/changelogs/unreleased/3290-fix-unstable-tests.yml
@@ -1,0 +1,5 @@
+description: Fixed unstable tests by clearing build.env cache
+issue-nr: 3290
+change-type: patch
+destination-branches:
+  - master

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,6 @@ environment.
 
 
 import asyncio
-import build.env
 import concurrent
 import csv
 import datetime
@@ -96,6 +95,7 @@ from pyformance.registry import MetricsRegistry
 from tornado import netutil
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
+import build.env
 import inmanta.agent
 import inmanta.app
 import inmanta.compiler as compiler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,7 @@ environment.
 
 
 import asyncio
+import build.env
 import concurrent
 import csv
 import datetime
@@ -1320,9 +1321,15 @@ def tmpvenv_active(
     env.process_env.init_namespace(const.PLUGINS_PACKAGE)
     env.process_env.notify_change()
 
+    # Force refresh build's decision on whether it should use virtualenv or venv. This decision is made based on the active
+    # environment, which we're changing now.
+    build.env._should_use_virtualenv.cache_clear()
+
     yield tmpvenv
 
     unload_modules_for_path(site_packages)
+    # Force refresh build's cache once more
+    build.env._should_use_virtualenv.cache_clear()
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report 
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME
 
 [testenv:{py36,py38}-fast]
-commands=py.test --randomly-seed=2547936051 --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv --fast --durations=50 tests/
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv --fast --durations=50 tests/
 
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report 
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME
 
 [testenv:{py36,py38}-fast]
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv --fast --durations=50 tests/
+commands=py.test --randomly-seed=2547936051 --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv --fast --durations=50 tests/
 
 
 [testenv:pep8]


### PR DESCRIPTION
# Description

Fixes some unstable tests by clearing `build.env._should_use_virtualenv` cache before and after yielding isolated fixture. A potential issue with this approach is that it accesses a private method, but since we only do so in our tests I think that should be acceptable.

closes #3290

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
