### PR TITLE
Issue/3209 modules v2 compilation tests

### DIFF
--- a/changelogs/unreleased/3209-modules-v2-compilation-tests.yml
+++ b/changelogs/unreleased/3209-modules-v2-compilation-tests.yml
@@ -1,0 +1,5 @@
+description: Added compilation test for modules v2
+issue-nr: 3209
+change-type: patch
+destination-branches:
+  - master

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -315,7 +315,7 @@ value = {expected_value}
         new_content_init_cf=test_module_model,
         new_content_init_py=test_module_plugin_contents(2),
         install=True,
-        editable=True,
+        editable=True,  # ! this is editable for the next test step
     )
     verify_compile(2)
 

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -237,8 +237,7 @@ def test_modules_v2_compile(tmpdir: str, snippetcompiler_clean, modules_dir: str
         """
         Returns the contents of the plugin file for the test module.
         """
-        return (
-            f"""
+        return f"""
 from inmanta.plugins import plugin
 
 
@@ -247,8 +246,7 @@ VALUE: str = {value}
 @plugin
 def get_value() -> "int":
     return VALUE
-            """.strip()
-        )
+        """.strip()
 
     # The model for the test module, regardless of value
     test_module_model: str = f"value = {test_module}::get_value()"
@@ -283,7 +281,7 @@ def get_test_module_value() -> "int":
         """
         Verify compilation by importing main module and checking its variable's value.
         """
-        project = snippetcompiler_clean.setup_for_snippet(
+        snippetcompiler_clean.setup_for_snippet(
             f"""
 import {main_module}
 

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -327,7 +327,7 @@ value = {expected_value}
     # verify editable mode for model
     with open(os.path.join(v2_module_path, "model", "_init.cf"), "w") as fh:
         fh.write("value = 4")
+    # can't just verify_compile(4) because the plugin is still at 3 and promoting it to 4 would not test changes in the model
     with pytest.raises(DoubleSetException) as excinfo:
         verify_compile(3)
     assert excinfo.value.newvalue == 4
-    # TODO: check both model and plugins are editable (might need to change generation with plain var

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -361,6 +361,7 @@ def module_from_template(
     editable: bool = False,
     publish_index: Optional[PipIndex] = None,
     new_content_init_cf: Optional[str] = None,
+    new_content_init_py: Optional[str] = None,
 ) -> module.ModuleV2Metadata:
     """
     Creates a v2 module from a template.
@@ -375,6 +376,7 @@ def module_from_template(
     :param editable: Whether to install the module in editable mode, ignored if install is False.
     :param publish_index: Publish to the given local path index. Requires virtualenv to be installed in the python environment.
     :param new_content_init_cf: The new content of the _init.cf file.
+    :param new_content_init_py: The new content of the __init__.py file.
     """
     shutil.copytree(source_dir, dest_dir)
     config_file: str = os.path.join(dest_dir, module.ModuleV2.MODULE_FILE)
@@ -401,6 +403,15 @@ def module_from_template(
         init_cf_file = os.path.join(dest_dir, "model", "_init.cf")
         with open(init_cf_file, "w", encoding="utf-8") as fd:
             fd.write(new_content_init_cf)
+    if new_content_init_py is not None:
+        init_py_file: str =  os.path.join(
+            dest_dir,
+            const.PLUGINS_PACKAGE,
+            module.ModuleV2Source.get_inmanta_module_name(config["metadata"]["name"]),
+            "__init__.py",
+        )
+        with open(init_py_file, "w", encoding="utf-8") as fd:
+            fd.write(new_content_init_py)
     with open(config_file, "w") as fh:
         config.write(fh)
     if install:
@@ -420,6 +431,7 @@ def v1_module_from_template(
     new_name: Optional[str] = None,
     new_requirements: Optional[Sequence[Union[module.InmantaModuleRequirement, Requirement]]] = None,
     new_content_init_cf: Optional[str] = None,
+    new_content_init_py: Optional[str] = None,
 ) -> module.ModuleV2Metadata:
     """
     Creates a v1 module from a template.
@@ -430,6 +442,7 @@ def v1_module_from_template(
     :param new_name: The new name of the inmanta module, if any.
     :param new_requirements: The new Python requirements for the module, if any.
     :param new_content_init_cf: The new content of the _init.cf file.
+    :param new_content_init_py: The new content of the __init__.py file.
     """
     shutil.copytree(source_dir, dest_dir)
     config_file: str = os.path.join(dest_dir, module.ModuleV1.MODULE_FILE)
@@ -444,6 +457,12 @@ def v1_module_from_template(
         init_cf_file = os.path.join(dest_dir, "model", "_init.cf")
         with open(init_cf_file, "w", encoding="utf-8") as fd:
             fd.write(new_content_init_cf)
+    if new_content_init_py is not None:
+        plugins_dir: str =  os.path.join(dest_dir, "plugins")
+        os.makedirs(plugins_dir, exist_ok=True)
+        init_py_file: str = os.path.join(plugins_dir, "__init__.py")
+        with open(init_py_file, "w", encoding="utf-8") as fd:
+            fd.write(new_content_init_py)
     with open(config_file, "w") as fd:
         yaml.dump(config, fd)
     if new_requirements:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -404,7 +404,7 @@ def module_from_template(
         with open(init_cf_file, "w", encoding="utf-8") as fd:
             fd.write(new_content_init_cf)
     if new_content_init_py is not None:
-        init_py_file: str =  os.path.join(
+        init_py_file: str = os.path.join(
             dest_dir,
             const.PLUGINS_PACKAGE,
             module.ModuleV2Source.get_inmanta_module_name(config["metadata"]["name"]),
@@ -458,7 +458,7 @@ def v1_module_from_template(
         with open(init_cf_file, "w", encoding="utf-8") as fd:
             fd.write(new_content_init_cf)
     if new_content_init_py is not None:
-        plugins_dir: str =  os.path.join(dest_dir, "plugins")
+        plugins_dir: str = os.path.join(dest_dir, "plugins")
         os.makedirs(plugins_dir, exist_ok=True)
         init_py_file: str = os.path.join(plugins_dir, "__init__.py")
         with open(init_py_file, "w", encoding="utf-8") as fd:


### PR DESCRIPTION
# Description

Added compilation test for modules v2. This test should cover compilation-specific behavior that has not been covered yet by the module and project loader tests.

closes #3209

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
