### PR TITLE
added db migration test fixture

### DIFF
--- a/changelogs/unreleased/db-migration-test-fixture.yml
+++ b/changelogs/unreleased/db-migration-test-fixture.yml
@@ -1,0 +1,5 @@
+description: Added a generic fixture for db migration tests that can be used by core and extensions.
+change-type: patch
+destination-branches:
+  - master
+  - iso4

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ markers =
     slowtest
     link_check
     parametrize_any: only execute one of the parameterized cases when in fast mode (see documentation in conftest.py)
+    db_restore_dump(dump): mark the db dump to restore. To be used in conjunction with the `migrate_db_from` fixture.

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4561,7 +4561,7 @@ async def connect(
             async with pool.acquire() as con:
                 await schema.DBSchema(CORE_SCHEMA_NAME, PACKAGE_WITH_UPDATE_FILES, con).ensure_db_schema()
             # expire connections after db schema migration to ensure cache consistency
-            pool.expire_connections()
+            await pool.expire_connections()
         return pool
     except Exception as e:
         await pool.close()

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4560,6 +4560,8 @@ async def connect(
         if create_db_schema:
             async with pool.acquire() as con:
                 await schema.DBSchema(CORE_SCHEMA_NAME, PACKAGE_WITH_UPDATE_FILES, con).ensure_db_schema()
+            # expire connections after db schema migration to ensure cache consistency
+            pool.expire_connections()
         return pool
     except Exception as e:
         await pool.close()

--- a/src/inmanta/data/schema.py
+++ b/src/inmanta/data/schema.py
@@ -208,6 +208,8 @@ class DBSchema(object):
                     update_function = version.function
                     await update_function(self.connection)
                     await self.set_installed_version(version.version)
+                    # inform asyncpg of the type change so it knows to refresh its caches
+                    await self.connection.reload_schema_state()
                 except Exception:
                     self.logger.exception(
                         "Database schema update for version %d failed. Rolling back all updates.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1417,7 +1417,12 @@ async def migrate_db_from(
 
     bootloader: InmantaBootloader = InmantaBootloader()
 
-    # start boatloader, triggering db migration
-    yield bootloader.start
+    async def migrate() -> None:
+        # start boatloader, triggering db migration
+        await bootloader.start()
+        # inform asyncpg of any type changes so it knows to refresh its caches
+        await postgresql_client.reload_schema_state()
+
+    yield migrate
 
     await bootloader.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1407,7 +1407,7 @@ async def migrate_db_from(
 
     :param db_restore_dump: The db version dump file to restore (set via `@pytest.mark.db_restore_dump(<file>)`.
     """
-    marker: pytest.mark.Mark = request.node.get_closest_marker("db_restore_dump")
+    marker: Optional[pytest.mark.Mark] = request.node.get_closest_marker("db_restore_dump")
     if marker is None or len(marker.args) != 1:
         raise ValueError("Please set the db version to restore using `@pytest.mark.db_restore_dump(<file>)`")
     # restore old version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,6 @@ from pyformance.registry import MetricsRegistry
 from tornado import netutil
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
-import _pytest.config
 import build.env
 import inmanta.agent
 import inmanta.app
@@ -133,7 +132,7 @@ logger = logging.getLogger(__name__)
 TABLES_TO_KEEP = [x.table_name() for x in data._classes]
 
 
-def _pytest_configure_plugin_mode(config: _pytest.config.Config) -> None:
+def _pytest_configure_plugin_mode(config: "pytest.Config") -> None:
     # register custom markers
     config.addinivalue_line(
         "markers",
@@ -149,7 +148,7 @@ def _pytest_configure_plugin_mode(config: _pytest.config.Config) -> None:
     )
 
 
-def pytest_configure(config: _pytest.config.Config) -> None:
+def pytest_configure(config: "pytest.Config") -> None:
     if PYTEST_PLUGIN_MODE:
         _pytest_configure_plugin_mode(config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ from libpip2pi.commands import dir2pi
 
 # Import test modules differently when conftest is put into the inmanta_tests packages
 PYTEST_PLUGIN_MODE: bool = __file__ and os.path.dirname(__file__).split("/")[-1] == "inmanta_tests"
-if PYTEST_PLUGIN_MODE
+if PYTEST_PLUGIN_MODE:
     from inmanta_tests import utils  # noqa: F401
     from inmanta_tests.db.common import PGRestore  # noqa: F401
 else:
@@ -133,7 +133,7 @@ logger = logging.getLogger(__name__)
 TABLES_TO_KEEP = [x.table_name() for x in data._classes]
 
 
-def pytest_configure_plugin_mode(config: _pytest.config.Config) -> None:
+def _pytest_configure_plugin_mode(config: _pytest.config.Config) -> None:
     # register custom markers
     config.addinivalue_line(
         "markers",
@@ -151,7 +151,7 @@ def pytest_configure_plugin_mode(config: _pytest.config.Config) -> None:
 
 def pytest_configure(config: _pytest.config.Config) -> None:
     if PYTEST_PLUGIN_MODE:
-        pytest_configure_plugin_mode(config)
+        _pytest_configure_plugin_mode(config)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
# Description

Added a generic fixture for db migration tests. We'd discussed this on slack a couple of weeks ago. Now that we needed a new db migration test I thought it would be a good time to give this a try.
Let me know what you think (this is more a suggestion than anything else). The parametrization of fixtures isn't super clean, so you might not like it. Overall I'm of the opinion that it's an improvement over the fixture-per-test approach we had up till now. Another approach could be to just have a helper method instead of a fixture but I believe the fixture's advantage outweigh the disadvantages (simple setup and teardown, which would require more care when calling a helper method).

Have a look at inmanta/inmanta-lsm#687 to see this in use.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
