### PR TITLE
Fix resource history endpoint when the version numbers aren't continuous

### DIFF
--- a/changelogs/unreleased/3302-resource-history-fix.yml
+++ b/changelogs/unreleased/3302-resource-history-fix.yml
@@ -1,0 +1,5 @@
+---
+description: Fix `resource_history` endpoint when the version numbers aren't continuous
+issue-nr: 3302
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3813,7 +3813,7 @@ class Resource(BaseDocument):
                     model,
                     attributes,
                     date,
-                    model - ROW_NUMBER() OVER (
+                    ROW_NUMBER() OVER (ORDER BY date) - ROW_NUMBER() OVER (
                       PARTITION BY attribute_hash
                       ORDER BY date
                     ) AS seqid


### PR DESCRIPTION
# Description

closes #3302 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
