### PR TITLE
Fix resource_logs endpoint when the messages don't have kwargs

### DIFF
--- a/changelogs/unreleased/3316-resource-log-kwargs.yml
+++ b/changelogs/unreleased/3316-resource-log-kwargs.yml
@@ -1,0 +1,5 @@
+---
+description: Fix resource_logs endpoint when the messages don't have kwargs
+issue-nr: 3316
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2964,7 +2964,7 @@ class ResourceAction(BaseDocument):
         end: Optional[Any] = None,
         connection: Optional[asyncpg.connection.Connection] = None,
         **query: Tuple[QueryType, object],
-    ) -> List["ResourceAction"]:
+    ) -> List["m.ResourceLog"]:
         order_by_column = database_order.get_order_by_column_db_name()
         order = database_order.get_order()
         filter_statements, values = cls._get_list_query_pagination_parameters(
@@ -3013,8 +3013,8 @@ class ResourceAction(BaseDocument):
                     timestamp=record["timestamp"],
                     level=message.get("level"),
                     msg=message.get("msg"),
-                    args=message.get("args"),
-                    kwargs=message.get("kwargs"),
+                    args=message.get("args", []),
+                    kwargs=message.get("kwargs", {}),
                 )
             )
         return logs

--- a/tests/server/test_resource_action_logs.py
+++ b/tests/server/test_resource_action_logs.py
@@ -291,3 +291,43 @@ async def test_filter_validation(server, client, filter, expected_status, env_wi
     environment, _ = env_with_logs
     result = await client.resource_logs(environment, "std::File[agent1,path=/tmp/file1.txt]", limit=2, filter=filter)
     assert result.code == expected_status
+
+
+@pytest.mark.asyncio
+async def test_log_without_kwargs(server, client, environment):
+
+    await data.ConfigurationModel(
+        environment=uuid.UUID(environment),
+        version=1,
+        date=datetime.datetime.now(),
+        total=1,
+        released=True,
+        version_info={},
+    ).insert()
+
+    resource_action = data.ResourceAction(
+        environment=uuid.UUID(environment),
+        version=1,
+        resource_version_ids=[
+            "std::File[agent1,path=/tmp/file1.txt],v=1",
+            "std::Directory[agent1,path=/tmp/dir2],v=1",
+        ],
+        action_id=uuid.uuid4(),
+        action=const.ResourceAction.deploy,
+        started=datetime.datetime.now(),
+    )
+    await resource_action.insert()
+
+    resource_action.add_logs(
+        [
+            {
+                "level": "INFO",
+                "msg": "Setting deployed due to known good status",
+                "timestamp": datetime.datetime.now().astimezone(),
+                "args": [],
+            }
+        ]
+    )
+    await resource_action.save()
+    result = await client.resource_logs(environment, "std::File[agent1,path=/tmp/file1.txt]")
+    assert result.code == 200

--- a/tests/server/test_resource_action_logs.py
+++ b/tests/server/test_resource_action_logs.py
@@ -323,7 +323,7 @@ async def test_log_without_kwargs(server, client, environment):
             {
                 "level": "INFO",
                 "msg": "Setting deployed due to known good status",
-                "timestamp": datetime.datetime.now().astimezone(),
+                "timestamp": datetime.datetime.now(),
                 "args": [],
             }
         ]


### PR DESCRIPTION
# Description

closes #3316 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
