### PR TITLE
fixed inmanta module install behavior for reinstall

### DIFF
--- a/changelogs/unreleased/3321-inmanta-module-install-reinstall.yml
+++ b/changelogs/unreleased/3321-inmanta-module-install-reinstall.yml
@@ -1,0 +1,5 @@
+description: Fixed inmanta module install behavior for module that had already been installed.
+change-type: patch
+issue-nr: 3321
+destination-branches:
+  - master

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -712,7 +712,7 @@ version: 0.0.1dev0"""
         """
 
         def install(install_path: str) -> None:
-            env.process_env.install_from_source([env.LocalPackagePath(path=install_path, editable=editable)])
+            env.process_env.install_from_source([env.LocalPackagePath(path=install_path, editable=editable)], reinstall=True)
 
         module_path: str = os.path.abspath(path) if path is not None else os.getcwd()
         module: Module = self.construct_module(None, module_path)

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -22,14 +22,14 @@ import shutil
 import subprocess
 from importlib.abc import Loader
 from itertools import chain
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 import py
 import pytest
 import yaml
 from pkg_resources import Requirement
 
-from inmanta import env, loader, module
+from inmanta import const, env, loader, module
 from inmanta.ast import CompilerException
 from inmanta.config import Config
 from inmanta.module import InstallMode, ModuleLoadingException
@@ -253,6 +253,44 @@ def test_module_install_version(
     # check version
     mod: module.Module = ModuleTool().get_module(module_name)
     assert mod.version == module_version
+
+
+@pytest.mark.slowtest
+def test_module_install_reinstall(
+    tmpdir: py.path.local,
+    snippetcompiler_clean,
+    modules_v2_dir,
+) -> None:
+    """
+    Verify that reinstalling a module from source without bumping the version installs any changes to model and Python files.
+    """
+    module_name: str = "minimalv2module"
+    module_path: str = str(tmpdir.join(module_name))
+    shutil.copytree(os.path.join(modules_v2_dir, module_name), module_path)
+
+    # set up simple project and activate snippetcompiler venv
+    project: module.Project = snippetcompiler_clean.setup_for_snippet("")
+    os.chdir(project.path)
+
+    def new_files_exist() -> Iterator[bool]:
+        return (
+            os.path.exists(os.path.join(env.process_env.site_packages_dir, const.PLUGINS_PACKAGE, module_name, rel_path))
+            for rel_path in [os.path.join("model", "newmod.cf"), "newmod.py"]
+        )
+
+    # install module
+    ModuleTool().install(editable=False, path=module_path)
+
+    assert not any(new_files_exist())
+
+    # make some changes to the source and install again
+    model_dir: str = os.path.join(module_path, "model")
+    os.makedirs(model_dir, exist_ok=True)
+    open(os.path.join(model_dir, "newmod.cf"), "w").close()
+    open(os.path.join(module_path, const.PLUGINS_PACKAGE, module_name, "newmod.py"), "w").close()
+    ModuleTool().install(editable=False, path=module_path)
+
+    assert all(new_files_exist())
 
 
 @pytest.mark.parametrize_any(

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -269,8 +269,7 @@ def test_module_install_reinstall(
     shutil.copytree(os.path.join(modules_v2_dir, module_name), module_path)
 
     # set up simple project and activate snippetcompiler venv
-    project: module.Project = snippetcompiler_clean.setup_for_snippet("")
-    os.chdir(project.path)
+    snippetcompiler_clean.setup_for_snippet("")
 
     def new_files_exist() -> Iterator[bool]:
         return (


### PR DESCRIPTION
# Description

Fixed `inmanta module install` not working when already installed.

closes #3321

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
