### PR TITLE
Remove the init_namespace method

### DIFF
--- a/changelogs/unreleased/remove-init-namespace-method.yml
+++ b/changelogs/unreleased/remove-init-namespace-method.yml
@@ -1,0 +1,4 @@
+---
+description: Remove the init_namespace() method in favor of using the notify_change() method
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -279,7 +279,7 @@ class ActiveEnv(PythonEnvironment):
                 ):
                     # A V2 module was installed in this virtual environment, but the inmanta_plugins package was already
                     # loaded before this venv was activated. As such, the site_packages_dir of this virtual environment
-                    # doesn't appear in the submodule_search_locations of the loaded module. Reload the inmanta_plugins package
+                    # doesn't appear in the submodule_search_locations of the loaded package. Reload the inmanta_plugins package
                     # to ensure that all V2 modules installed in this virtual environment are discovered correctly.
                     importlib.reload(mod)
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -274,9 +274,8 @@ class ActiveEnv(PythonEnvironment):
             if mod is not None:
                 # Make mypy happy
                 assert mod.__spec__.submodule_search_locations is not None
-                if (
-                    self.site_packages_dir not in mod.__spec__.submodule_search_locations
-                    and os.path.exists(os.path.join(self.site_packages_dir, const.PLUGINS_PACKAGE))
+                if self.site_packages_dir not in mod.__spec__.submodule_search_locations and os.path.exists(
+                    os.path.join(self.site_packages_dir, const.PLUGINS_PACKAGE)
                 ):
                     # A V2 module was installed in this virtual environment, but the inmanta_plugins package was already
                     # loaded before this venv was activated. As such, the site_packages_dir of this virtual environment

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -448,7 +448,6 @@ class ModuleSource(Generic[TModule]):
 class ModuleV2Source(ModuleSource["ModuleV2"]):
     def __init__(self, urls: List[str]) -> None:
         self.urls: List[str] = [url if not os.path.exists(url) else os.path.abspath(url) for url in urls]
-        env.process_env.init_namespace(const.PLUGINS_PACKAGE)
 
     @classmethod
     def get_installed_version(cls, module_name: str) -> Optional[version.Version]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -972,7 +972,6 @@ class SnippetCompilationTest(KeepOnFail):
         running process.
         """
         env.process_env.__init__(env_path=self.env)
-        env.process_env.init_namespace(const.PLUGINS_PACKAGE)
 
     def _install_v2_modules(self, project: Project, install_v2_modules: Optional[List[LocalPackagePath]] = None) -> None:
         install_v2_modules = install_v2_modules if install_v2_modules is not None else []
@@ -1341,8 +1340,6 @@ def tmpvenv_active(
 
     # patch env.process_env to recognize this environment as the active one, deactive_venv restores it
     env.process_env.__init__(python_path=str(python_path))
-    # patch inmanta_plugins namespace path so importlib.util.find_spec("inmanta_plugins") includes the venv path
-    env.process_env.init_namespace(const.PLUGINS_PACKAGE)
     env.process_env.notify_change()
 
     # Force refresh build's decision on whether it should use virtualenv or venv. This decision is made based on the active


### PR DESCRIPTION
# Description

While trying the find out why the `ActiveEnv.init_namespace()` method was required, I noticed it would be better to make this logic part of the `ActiveEnv.notify_change()` method. In the previous implementation `init_namespace()` has to be called manually from different locations and in a specific order. The new implementation hides all the complexity in the `ActiveEnv` class. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
