### PR TITLE
Ensure that the cwd is restored correctly after each test

### DIFF
--- a/changelogs/unreleased/restore-cwd-correctly-after-each-test.yml
+++ b/changelogs/unreleased/restore-cwd-correctly-after-each-test.yml
@@ -1,4 +1,4 @@
 ---
 description: Ensure that the cwd is restored correctly after each test.
 change-type: patch
-destination-branches: [master, iso4]
+destination-branches: [iso4]

--- a/changelogs/unreleased/restore-cwd-correctly-after-each-test.yml
+++ b/changelogs/unreleased/restore-cwd-correctly-after-each-test.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that the cwd is restored correctly after each test.
+change-type: patch
+destination-branches: [master, iso4]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,10 @@ logger = logging.getLogger(__name__)
 
 TABLES_TO_KEEP = [x.table_name() for x in data._classes]
 
+# Save the cwd as early as possible to prevent that it gets overridden by another fixture
+# before it's saved.
+initial_cwd = os.getcwd()
+
 
 def _pytest_configure_plugin_mode(config: "pytest.Config") -> None:
     # register custom markers
@@ -388,9 +392,8 @@ def restore_cwd():
     """
     Restore the current working directory after search test.
     """
-    cwd = os.getcwd()
     yield
-    os.chdir(cwd)
+    os.chdir(initial_cwd)
 
 
 @pytest.fixture(scope="function")
@@ -824,15 +827,12 @@ class SnippetCompilationTest(KeepOnFail):
         self.repo = "https://github.com/inmanta/"
         self.env = tempfile.mkdtemp()
         config.Config.load_config()
-        self.cwd = os.getcwd()
         self.keep_shared = False
 
     def tearDownClass(self):
         if not self.keep_shared:
             shutil.rmtree(self.libs)
             shutil.rmtree(self.env)
-        # reset cwd
-        os.chdir(self.cwd)
 
     def setup_func(self, module_dir):
         # init project


### PR DESCRIPTION
# Description

Ensure that the cwd is restored correctly after each test.

Same PR a #3333, but now on ISO4 only due to a merge conflict.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
