### PR TITLE
disable venv installation guard fixture in plugin mode

### DIFF
--- a/changelogs/unreleased/irt-840-venv-installation-guard.yml
+++ b/changelogs/unreleased/irt-840-venv-installation-guard.yml
@@ -1,0 +1,6 @@
+description: Disabled venv installation guard fixture when running in plugin mode
+issue-repo: irt
+issue-nr: 840
+change-type: patch
+destination-branches:
+  - master

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1426,7 +1426,7 @@ async def migrate_db_from(
     await bootloader.stop()
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=not PYTEST_PLUGIN_MODE)
 def guard_testing_venv():
     """
     Ensure that the tests don't install packages into the venv that runs the tests.


### PR DESCRIPTION
# Description

disable venv installation guard fixture in plugin mode

closes inmanta/irt#840

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
