### PR TITLE
removed redundant import of setuptools.find_namespace_packages

### DIFF
--- a/changelogs/unreleased/remove-redundant-import.yml
+++ b/changelogs/unreleased/remove-redundant-import.yml
@@ -1,0 +1,4 @@
+description: removed redundant import of setuptools.find_namespace_packages
+change-type: patch
+destination-branches:
+  - master

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages, find_namespace_packages
+from setuptools import setup, find_packages
 from os import path
 
 requires = [


### PR DESCRIPTION
# Description

Removed what seems to be a redundant import of setuptools.find_namespace_packages introduced in #3164. @arnaudsjs could you confirm this is indeed no longer required?
In addition to being redundant this somehow caused the docs build to fail with "ImportError: cannot import name 'find_namespace_packages'".

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] ~~Correct, in line with design~~
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
