### PR TITLE
Modified pth file to skip already loaded paths

### DIFF
--- a/changelogs/unreleased/3346-pth-loading-max-recursion-depth.yml
+++ b/changelogs/unreleased/3346-pth-loading-max-recursion-depth.yml
@@ -1,0 +1,4 @@
+description: Modified pth file to skip already loaded paths
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -721,7 +721,6 @@ os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
         script_as_oneliner = "; ".join(
             [line for line in script.split("\n") if line.strip() and not line.strip().startswith("#")]
         )
-        # TODO: don't write it if venv is parent venv
         with open(self._path_pth_file, "w", encoding="utf-8") as fd:
             fd.write(script_as_oneliner)
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -703,15 +703,18 @@ python -m pip $@
         activate the parent venv. The site directories of the parent venv should appear later in sys.path than the ones of
         this venv.
         """
-        site_dirs_lst: str = "[" + ", ".join('"' + p.replace('"', r"\"") + '"' for p in list(sys.path)) + "]"
-        script = f"""import os
+        site_dir_strings: List[str] = ['"' + p.replace('"', r"\"") + '"' for p in list(sys.path)]
+        add_site_dir_statements: str = "\n".join(
+            [f"site.addsitedir({p}) if {p} not in sys.path else None" for p in site_dir_strings]
+        )
+        script = f"""
+import os
 import site
 import sys
 
 
 # Ensure inheritance from all parent venvs + process their .pth files
-# use list comprehension to enable simple oneliner generation
-[site.addsitedir(dir) for dir in {site_dirs_lst} if dir not in sys.path]
+{add_site_dir_statements}
 # Also set the PYTHONPATH environment variable for any subprocess
 os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
         """

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -703,18 +703,22 @@ python -m pip $@
         activate the parent venv. The site directories of the parent venv should appear later in sys.path than the ones of
         this venv.
         """
-        add_site_dir_statements = "\n".join(['site.addsitedir("' + p.replace('"', r"\"") + '")' for p in list(sys.path)])
+        site_dirs_lst: str = "[" + ", ".join('"' + p.replace('"', r"\"") + '"' for p in list(sys.path)) + "]"
         script = f"""import os
 import site
 import sys
+
+
 # Ensure inheritance from all parent venvs + process their .pth files
-{add_site_dir_statements}
+# use list comprehension to enable simple oneliner generation
+[site.addsite_dir(dir) for dir in {site_dirs_lst} if dir not in sys.path]
 # Also set the PYTHONPATH environment variable for any subprocess
 os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
         """
         script_as_oneliner = "; ".join(
             [line for line in script.split("\n") if line.strip() and not line.strip().startswith("#")]
         )
+        # TODO: don't write it if venv is parent venv
         with open(self._path_pth_file, "w", encoding="utf-8") as fd:
             fd.write(script_as_oneliner)
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -711,7 +711,7 @@ import sys
 
 # Ensure inheritance from all parent venvs + process their .pth files
 # use list comprehension to enable simple oneliner generation
-[site.addsite_dir(dir) for dir in {site_dirs_lst} if dir not in sys.path]
+[site.addsitedir(dir) for dir in {site_dirs_lst} if dir not in sys.path]
 # Also set the PYTHONPATH environment variable for any subprocess
 os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
         """


### PR DESCRIPTION
# Description

The pth file written by `inmanta.env.VirtualEnv` loads all paths from the parent venv. This pull request modifies it to only load those paths that are not already in `sys.path`. This fixes the test performance regression and prevents infinite recursion when the project venv is set to the encapsulating venv.

Do you think this requires an explicit test case or do we consider the fact that no infinite recursion occurs sufficient?

closes #3344
closes #3346 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
