### PR TITLE
Don't escape special characters in resource action log

### DIFF
--- a/changelogs/unreleased/escaping-special-characters.yml
+++ b/changelogs/unreleased/escaping-special-characters.yml
@@ -1,0 +1,8 @@
+---
+description: Ensure that special characters in the resource action log are not escaped.
+issue-nr: 699
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [master, iso3, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -664,7 +664,7 @@ class ResourceHandler(object):
             ctx.exception(
                 "An error occurred during deployment of %(resource_id)s (exception: %(exception)s",
                 resource_id=resource.id,
-                exception=repr(e),
+                exception=f"{e.__class__.__name__}('{e}')",
             )
         finally:
             try:
@@ -673,7 +673,7 @@ class ResourceHandler(object):
                 ctx.exception(
                     "An error occurred after deployment of %(resource_id)s (exception: %(exception)s",
                     resource_id=resource.id,
-                    exception=repr(e),
+                    exception=f"{e.__class__.__name__}('{e}')",
                 )
 
     def facts(self, ctx: HandlerContext, resource: resources.Resource) -> dict:
@@ -709,7 +709,7 @@ class ResourceHandler(object):
                 ctx.exception(
                     "An error occurred after getting facts about %(resource_id)s (exception: %(exception)s",
                     resource_id=resource.id,
-                    exception=repr(e),
+                    exception=f"{e.__class__.__name__}('{e}')",
                 )
 
         return facts
@@ -900,7 +900,7 @@ class CRUDHandler(ResourceHandler):
             ctx.exception(
                 "An error occurred during deployment of %(resource_id)s (exception: %(exception)s)",
                 resource_id=resource.id,
-                exception=repr(e),
+                exception=f"{e.__class__.__name__}('{e}')",
                 traceback=traceback.format_exc(),
             )
         finally:
@@ -910,7 +910,7 @@ class CRUDHandler(ResourceHandler):
                 ctx.exception(
                     "An error occurred after deployment of %(resource_id)s (exception: %(exception)s",
                     resource_id=resource.id,
-                    exception=repr(e),
+                    exception=f"{e.__class__.__name__}('{e}')",
                 )
 
 

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -165,7 +165,7 @@ def resource_container():
     @resource("test::FailFast", agent="agent", id_attribute="key")
     class FailFastR(Resource):
         """
-        A file on a filesystem
+        Raise an exception in the check_resource() method.
         """
 
         fields = ("key", "value", "purged")
@@ -178,13 +178,29 @@ def resource_container():
 
         fields = ("key", "value", "purged")
 
+    @resource("test::FailFastCRUD", agent="agent", id_attribute="key")
+    class FailFastPR(PurgeableResource):
+        """
+        Raise an exception at the beginning of the read_resource() method
+        """
+
+        fields = ("key", "value", "purged", "purge_on_delete")
+
     @resource("test::BadPost", agent="agent", id_attribute="key")
     class BadPostR(Resource):
         """
-        A file on a filesystem
+        Raise an exception in the post() method of the ResourceHandler.
         """
 
         fields = ("key", "value", "purged")
+
+    @resource("test::BadPostCRUD", agent="agent", id_attribute="key")
+    class BadPostPR(PurgeableResource):
+        """
+        Raise an exception in the post() method of the CRUDHandler.
+        """
+
+        fields = ("key", "value", "purged", "purge_on_delete")
 
     @provider("test::Resource", name="test_resource")
     class Provider(ResourceHandler):
@@ -344,8 +360,13 @@ def resource_container():
 
     @provider("test::FailFast", name="test_failfast")
     class FailFast(ResourceHandler):
-        def check_resource(self, ctx, resource):
-            raise Exception()
+        def check_resource(self, ctx: HandlerContext, resource: Resource) -> Resource:
+            raise Exception("An\nError\tMessage")
+
+    @provider("test::FailFastCRUD", name="test_failfast_crud")
+    class FailFastCRUD(CRUDHandler):
+        def read_resource(self, ctx: HandlerContext, resource: PurgeableResource) -> None:
+            raise Exception("An\nError\tMessage")
 
     @provider("test::Fact", name="test_fact")
     class Fact(ResourceHandler):
@@ -415,8 +436,13 @@ def resource_container():
 
     @provider("test::BadPost", name="test_bad_posts")
     class BadPost(Provider):
-        def post(self, ctx, resource) -> None:
-            raise Exception()
+        def post(self, ctx: HandlerContext, resource: Resource) -> None:
+            raise Exception("An\nError\tMessage")
+
+    @provider("test::BadPostCRUD", name="test_bad_posts_crud")
+    class BadPostCRUD(CRUDHandler):
+        def post(self, ctx: HandlerContext, resource: PurgeableResource) -> None:
+            raise Exception("An\nError\tMessage")
 
     @resource("test::AgentConfig", agent="agent", id_attribute="agentname")
     class AgentConfig(PurgeableResource):

--- a/tests/agent_server/test_resource_handler.py
+++ b/tests/agent_server/test_resource_handler.py
@@ -18,7 +18,6 @@
 import base64
 import typing
 from typing import TypeVar
-import logging
 
 import pytest
 
@@ -27,7 +26,7 @@ from inmanta.agent import Agent
 from inmanta.agent.handler import ResourceHandler
 from inmanta.protocol import SessionClient, VersionMatch, common
 from test_protocol import make_random_file
-from utils import _wait_until_deployment_finishes, log_contains
+from utils import _wait_until_deployment_finishes
 
 T = TypeVar("T")
 
@@ -77,43 +76,6 @@ def test_get_file_not_found():
     resource_handler = MockGetFileResourceHandler(client)
     result = resource_handler.get_file("hash")
     assert result is None
-
-
-@pytest.mark.asyncio(timeout=15)
-async def test_logging_error(resource_container, environment, client, agent, clienthelper, caplog):
-    """
-    When a log call uses an argument that is not JSON serializable, the corresponding resource should be marked as failed,
-    and the exception logged.
-    """
-    resource_container.Provider.reset()
-    version = await clienthelper.get_version()
-
-    res_id_1 = "test::BadLogging[agent1,key=key1],v=%d" % version
-    resources = [
-        {
-            "key": "key1",
-            "value": "value1",
-            "id": res_id_1,
-            "send_event": False,
-            "purged": False,
-            "requires": [],
-        },
-    ]
-
-    await clienthelper.put_version_simple(resources, version)
-
-    result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
-    assert result.code == 200
-
-    result = await client.get_version(environment, version)
-    assert result.code == 200
-
-    await _wait_until_deployment_finishes(client, environment, version)
-    result = await client.get_resource(tid=environment, id=res_id_1, logs=False, status=True)
-    assert result.code == 200
-    assert result.result["status"] == "failed"
-
-    log_contains(caplog, "inmanta.agent", logging.ERROR, "Exception during serializing log message arguments")
 
 
 @pytest.mark.asyncio

--- a/tests/agent_server/test_resource_handler.py
+++ b/tests/agent_server/test_resource_handler.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2019 Inmanta
+    Copyright 2021 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -18,12 +18,16 @@
 import base64
 import typing
 from typing import TypeVar
+import logging
 
 import pytest
 
+from inmanta import const
+from inmanta.agent import Agent
 from inmanta.agent.handler import ResourceHandler
 from inmanta.protocol import SessionClient, VersionMatch, common
 from test_protocol import make_random_file
+from utils import _wait_until_deployment_finishes, log_contains
 
 T = TypeVar("T")
 
@@ -73,3 +77,86 @@ def test_get_file_not_found():
     resource_handler = MockGetFileResourceHandler(client)
     result = resource_handler.get_file("hash")
     assert result is None
+
+
+@pytest.mark.asyncio(timeout=15)
+async def test_logging_error(resource_container, environment, client, agent, clienthelper, caplog):
+    """
+    When a log call uses an argument that is not JSON serializable, the corresponding resource should be marked as failed,
+    and the exception logged.
+    """
+    resource_container.Provider.reset()
+    version = await clienthelper.get_version()
+
+    res_id_1 = "test::BadLogging[agent1,key=key1],v=%d" % version
+    resources = [
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": res_id_1,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+    ]
+
+    await clienthelper.put_version_simple(resources, version)
+
+    result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
+    assert result.code == 200
+
+    result = await client.get_version(environment, version)
+    assert result.code == 200
+
+    await _wait_until_deployment_finishes(client, environment, version)
+    result = await client.get_resource(tid=environment, id=res_id_1, logs=False, status=True)
+    assert result.code == 200
+    assert result.result["status"] == "failed"
+
+    log_contains(caplog, "inmanta.agent", logging.ERROR, "Exception during serializing log message arguments")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resource_type",
+    ["test::FailFast", "test::FailFastCRUD", "test::BadPost", "test::BadPostCRUD"],
+)
+async def test_formatting_exception_messages(
+    resource_container, environment: str, client, agent: Agent, clienthelper, resource_type: str
+) -> None:
+    """
+    Ensure that exception raised in the Handler are correctly formatted in the resource action log.
+    Special characters should not be escaped (see: inmanta/inmanta-lsm#699).
+    """
+    resource_container.Provider.reset()
+    version = await clienthelper.get_version()
+    res_id_1 = f"{resource_type}[agent1,key=key1],v={version}"
+    resources = [
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": res_id_1,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+            **({"purge_on_delete": False} if resource_type.endswith("CRUD") else {}),
+        },
+    ]
+
+    await clienthelper.put_version_simple(resources, version)
+    result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
+    assert result.code == 200
+    await _wait_until_deployment_finishes(client, environment, version)
+
+    result = await client.get_resource_actions(
+        tid=environment,
+        resource_type=resource_type,
+        agent="agent1",
+        log_severity=const.LogLevel.ERROR.value,
+        limit=1,
+    )
+    assert result.code == 200, result.result
+    assert len(result.result["data"]) == 1
+    error_messages = [msg for msg in result.result["data"][0]["messages"] if msg["level"] == const.LogLevel.ERROR.value]
+    assert len(error_messages) == 1, error_messages
+    assert "(exception: Exception('An\nError\tMessage')" in error_messages[0]["msg"]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -2637,10 +2637,12 @@ async def test_bad_post_get_facts(
     assert result.code == 503
 
     env_uuid = uuid.UUID(environment)
-    params = await data.Parameter.get_list(environment=env_uuid, resource_id=resource_id_wov)
-    while len(params) < 3:
+
+    async def has_at_least_three_parameters() -> bool:
         params = await data.Parameter.get_list(environment=env_uuid, resource_id=resource_id_wov)
-        await asyncio.sleep(0.1)
+        return len(params) >= 3
+
+    await retry_limited(has_at_least_three_parameters, timeout=10)
 
     result = await client.get_param(environment, "key1", resource_id_wov)
     assert result.code == 200


### PR DESCRIPTION
# Description

Ensure that special characters in the resource action log are not escaped. I kept the structure of the message identical to the previous one.

Same PR as #3356 but applied on the ISO3 branch due to a merge conflict.

closes inmanta/inmanta-lsm#699

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design