### PR TITLE
enable dependabot on iso4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
 - package-ecosystem: pip
+  target-branch: master
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  allow:
+    # Allow both direct and indirect updates for all packages
+    - dependency-type: "all"
+- package-ecosystem: pip
+  target-branch: iso4
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
# Description

In order to make life of the buildmaster a bit easier and to ease us along to switching to iso5, I start with the rollout of long delayed rollout of https://github.com/inmanta/irt/issues/512

This is a first cautious step, enabling dependency updates on iso4.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
