### PR TITLE
removed newline from v2 test module description

### DIFF
--- a/changelogs/unreleased/modules-v2-fix-newline.yml
+++ b/changelogs/unreleased/modules-v2-fix-newline.yml
@@ -1,0 +1,4 @@
+description: removed newline from v2 test module description
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -992,7 +992,8 @@ class ModuleV1Metadata(ModuleMetadata, MetadataFieldRequires):
 
     def to_v2(self) -> "ModuleV2Metadata":
         values = self.dict()
-        values["description"] = values["description"].replace("\n", " ")
+        if values["description"] is not None:
+            values["description"] = values["description"].replace("\n", " ")
         del values["compiler_version"]
         install_requires = [ModuleV2Source.get_package_name_for(r) for r in values["requires"]]
         del values["requires"]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -992,6 +992,7 @@ class ModuleV1Metadata(ModuleMetadata, MetadataFieldRequires):
 
     def to_v2(self) -> "ModuleV2Metadata":
         values = self.dict()
+        values["description"] = values["description"].replace("\n", " ")
         del values["compiler_version"]
         install_requires = [ModuleV2Source.get_package_name_for(r) for r in values["requires"]]
         del values["requires"]

--- a/tests/data/modules/elaboratev1module/module.yml
+++ b/tests/data/modules/elaboratev1module/module.yml
@@ -4,5 +4,6 @@ version: 1.2
 description: |
     This is test module with
     a long description
+    accross multiple lines
 requires:
     - mod1 == 1.0

--- a/tests/data/modules_v2/complex_module_dependencies_mod2/setup.cfg
+++ b/tests/data/modules_v2/complex_module_dependencies_mod2/setup.cfg
@@ -1,8 +1,7 @@
 [metadata]
 name = inmanta-module-complex-module-dependencies-mod2
 version = 2.2.2
-description = A module with an internal circular dependency between _init.cf and submod.cf and an external dependency on
-              complex-module-dependencies-mod1.
+description = A module with an internal circular dependency between _init.cf and submod.cf and an external dependency on complex-module-dependencies-mod1.
 license = Apache 2.0
 author = Inmanta <code@inmanta.com>
 


### PR DESCRIPTION
# Description

There was a newline in one of our test modules' description field. Setuptools does not support this and if I understand correctly has had a warning about this for some time. In the latest release they converted this warning to a `ValueError` (https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v5900).

This warning seems to have been hidden from us (not confirmed). I'm adding this to #3388 to make sure similar warnings are reported correctly in the future.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] ~~Correct, in line with design~~
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
