### PR TITLE
Issue/pytest inmanta 76 stable api get plugin files

### DIFF
--- a/changelogs/unreleased/stable-api-module-get-plugin-files.yml
+++ b/changelogs/unreleased/stable-api-module-get-plugin-files.yml
@@ -1,0 +1,8 @@
+description: Added Module.get_plugin_files to stable API
+change-type: patch
+issue-repo: pytest-inmanta
+issue-nr: 76
+destination-branches:
+  - master
+  - iso4
+  - iso3

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -133,8 +133,10 @@ Modules
 
 .. autoclass:: inmanta.module.Module
     :show-inheritance:
-    :members: from_path
+    :members: from_path, get_plugin_files
     :undoc-members:
+
+.. autodata:: inmanta.module.ModuleName
 
 .. autoclass:: inmanta.module.ModuleV1
     :show-inheritance:
@@ -153,6 +155,8 @@ Modules
 
 .. autoclass:: inmanta.module.ModuleV2Source
     :show-inheritance:
+
+.. autodata:: inmanta.module.Path
 
 
 Project


### PR DESCRIPTION
# Description

Added `Module.get_plugin_files` to stable API (for `pytest-inmanta`). Note in the change entry that I'm proposing to add this to all iso versions.

part of inmanta/pytest-inmanta#76, inmanta/pytest-inmanta#236

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] ~~Correct, in line with design~~
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
