### PR TITLE
Added Module.get_plugin_files to stable API

### DIFF
--- a/changelogs/unreleased/stable-api-module-get-plugin-files.yml
+++ b/changelogs/unreleased/stable-api-module-get-plugin-files.yml
@@ -1,0 +1,7 @@
+description: Added Module.get_plugin_files to stable API
+change-type: patch
+issue-repo: pytest-inmanta
+issue-nr: 76
+destination-branches:
+  - iso4
+  - iso3

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -132,6 +132,12 @@ Modules
 
 .. autoclass:: inmanta.module.Module
     :show-inheritance:
+    :members: get_plugin_files
+    :undoc-members:
+
+.. autodata:: inmanta.module.ModuleName
+
+.. autodata:: inmanta.module.Path
 
 
 Project


### PR DESCRIPTION
iso3/4 part: Added `Module.get_plugin_files` to stable API (for `pytest-inmanta`). Note in the change entry that I'm proposing to add this to all iso versions.

part of inmanta/pytest-inmanta#76, inmanta/pytest-inmanta#236

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] ~~Correct, in line with design~~
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
