### PR TITLE
fixed project load constraint verification for std

### DIFF
--- a/changelogs/unreleased/fix-std-constraint-verification.yml
+++ b/changelogs/unreleased/fix-std-constraint-verification.yml
@@ -1,0 +1,4 @@
+description: Fixed project load constraint verification for constraints on std
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1921,14 +1921,11 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         Check if all the required modules for this module have been loaded. Assumes the modules cache is valid and up to date.
         """
         LOGGER.info("verifying project")
-        imports = set([x.name for x in self.get_complete_ast()[0] if isinstance(x, DefineImport)])
 
         good = True
 
         requirements: Dict[str, List[InmantaModuleRequirement]] = self.collect_requirements()
         for name, spec in requirements.items():
-            if name not in imports:
-                continue
             module = self.modules[name]
             version = parse_version(str(module.version))
             for r in spec:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -749,7 +749,7 @@ version: 0.0.1dev0"""
         """
         Verify dependencies and frozen module versions
         """
-        Project.get().verify()
+        self.get_project(load=True)
 
     def commit(
         self,

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -626,7 +626,8 @@ def test_project_install_incompatible_versions(
         import v1mod2
         import v1mod1
         %s
-        """ % (f"import {v2_mod_name}" if not autostd else ""),
+        """
+        % (f"import {v2_mod_name}" if not autostd else ""),
         autostd=autostd,
         install_project=False,
         add_to_module_path=[v1_modules_path],


### PR DESCRIPTION
Fixed project load constraint verification for constraints on std, as turned out to be bugged during the demo.