### PR TITLE
Fix deploy summary links

### DIFF
--- a/changelogs/unreleased/fix-deploy-summary-links.yml
+++ b/changelogs/unreleased/fix-deploy-summary-links.yml
@@ -1,0 +1,3 @@
+description: Fix deploy summary links
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -940,6 +940,7 @@ class ResourceService(protocol.ServerSlice):
             end=end,
             has_next=paging_metadata.after > 0,
             has_prev=paging_metadata.before > 0,
+            deploy_summary=deploy_summary,
         )
         metadata = vars(paging_metadata)
         if deploy_summary:

--- a/tests/server/test_resource_list.py
+++ b/tests/server/test_resource_list.py
@@ -435,6 +435,11 @@ async def test_deploy_summary(server, client, env_with_resources):
     assert result.code == 200
     assert result.result["metadata"]["deploy_summary"] == expected_summary
 
+    # If the page is requested with the deploy summary, the links have it enabled as well
+    result = await client.resource_list(env.id, deploy_summary=True, limit=2)
+    assert result.code == 200
+    assert "deploy_summary=True" in result.result["links"]["next"]
+
     # The summary is returned only when the parameter is set
     result = await client.resource_list(env.id)
     assert result.code == 200


### PR DESCRIPTION
# Description

The links to the next and previous pages didn't include the `deploy_summary` parameter

Related to #3379 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
