### PR TITLE
fixed project install when requirement not loaded

### DIFF
--- a/changelogs/unreleased/fix-project-requires-not-loaded.yml
+++ b/changelogs/unreleased/fix-project-requires-not-loaded.yml
@@ -1,0 +1,4 @@
+description: Fixed project installation when the project has a requirement on a module that is not loaded by the model
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1931,6 +1931,11 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
 
         requirements: Dict[str, List[InmantaModuleRequirement]] = self.collect_requirements()
         for name, spec in requirements.items():
+            if name not in self.modules:
+                # the module is in the project requirements but it is not part of the loaded AST so there is no need to verify
+                # its compatibility
+                LOGGER.warning("Module %s is present in requires but it is not used by the model.", name)
+                continue
             module = self.modules[name]
             version = parse_version(str(module.version))
             for r in spec:

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -744,6 +744,7 @@ def test_project_install_requirement_not_loaded(
     message: str = "Module thismoduledoesnotexist is present in requires but it is not used by the model."
     assert message in (rec.message for rec in caplog.records)
 
+
 @pytest.mark.parametrize_any("install_mode", [None, InstallMode.release, InstallMode.prerelease, InstallMode.master])
 def test_project_install_with_install_mode(
     tmpdir: py.path.local, modules_v2_dir: str, snippetcompiler_clean, install_mode: Optional[str]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import argparse
+import logging
 import os
 import re
 import shutil
@@ -723,6 +724,25 @@ def test_project_install_incompatible_dependencies(
         for rec in caplog.records
     )
 
+
+def test_project_install_requirement_not_loaded(
+    caplog,
+    snippetcompiler,
+) -> None:
+    """
+    Verify that installing a project with a module requirement does not fail if the module is not loaded in the project's AST.
+    """
+    module_name: str = "thismoduledoesnotexist"
+    with caplog.at_level(logging.WARNING):
+        # make sure the project installation does not fail on verification
+        snippetcompiler.setup_for_snippet(
+            "",
+            project_requires=[module.InmantaModuleRequirement.parse(module_name)],
+            install_project=True,
+        )
+
+    message: str = "Module thismoduledoesnotexist is present in requires but it is not used by the model."
+    assert message in (rec.message for rec in caplog.records)
 
 @pytest.mark.parametrize_any("install_mode", [None, InstallMode.release, InstallMode.prerelease, InstallMode.master])
 def test_project_install_with_install_mode(


### PR DESCRIPTION
# Description

I discovered when modifying a project I had previously added requirements to that there was the following behavior. If a project has a module in the `requires` field of its config file but that module is not loaded by the model, the verification logic would fail with a `KeyError`. This is definitely not desired. I opted to resolve it by ignoring such modules for verification. Another approach would be to discover the installed version dynamically in such a case (instead of getting it out of `self.modules`) but that would be more complex and I'm not sure we really gain anything.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
