### PR TITLE
Better string representation in debug logline

### DIFF
--- a/changelogs/unreleased/3457-helpful-log.yml
+++ b/changelogs/unreleased/3457-helpful-log.yml
@@ -1,0 +1,4 @@
+description: Helpful string representation in debug logline
+issue-nr: 3457
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -238,15 +238,15 @@ class PluginFunction(Function):
             except UnknownException as e:
                 result.set_value(e.unknown, self.ast_node.location)
             except UnsetException as e:
-                # Don't handle it here!
-                # This exception is used by the scheduler to re-queue the unit
-                # If it is handled here, the re-queueing can not be done,
-                # leading to very subtle errors such as #2787
                 call: str = str(self.plugin)
                 location: str = str(self.ast_node.location)
                 LOGGER.debug(
                     "Unset value in python code in plugin at call: %s (%s) (Will be rescheduled by compiler)", call, location
                 )
+                # Don't handle it here!
+                # This exception is used by the scheduler to re-queue the unit
+                # If it is handled here, the re-queueing can not be done,
+                # leading to very subtle errors such as #2787
                 raise e
             except RuntimeException as e:
                 raise WrappingRuntimeException(self.ast_node, "Exception in plugin %s" % self.ast_node.name, e)

--- a/src/inmanta/ast/statements/call.py
+++ b/src/inmanta/ast/statements/call.py
@@ -238,9 +238,11 @@ class PluginFunction(Function):
             except UnknownException as e:
                 result.set_value(e.unknown, self.ast_node.location)
             except UnsetException as e:
-                module: str = self.plugin.__module__
-                func: str = self.plugin.__function_name__
-                call: str = f"{module}::{func}"
+                # Don't handle it here!
+                # This exception is used by the scheduler to re-queue the unit
+                # If it is handled here, the re-queueing can not be done,
+                # leading to very subtle errors such as #2787
+                call: str = str(self.plugin)
                 location: str = str(self.ast_node.location)
                 LOGGER.debug(
                     "Unset value in python code in plugin at call: %s (%s) (Will be rescheduled by compiler)", call, location

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -275,7 +275,7 @@ a.other = A()
         compiler.do_compile()
     dir: str = snippetcompiler.project_dir
     message: str = (
-        "Unset value in python code in plugin at call: inmanta_plugins.std::attr "
+        "Unset value in python code in plugin at call: std::attr "
         f"({dir}/main.cf:7) (Will be rescheduled by compiler)"
     )
     log_contains(caplog, "inmanta.ast.statements.call", logging.DEBUG, message)

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -275,7 +275,6 @@ a.other = A()
         compiler.do_compile()
     dir: str = snippetcompiler.project_dir
     message: str = (
-        "Unset value in python code in plugin at call: std::attr "
-        f"({dir}/main.cf:7) (Will be rescheduled by compiler)"
+        "Unset value in python code in plugin at call: std::attr " f"({dir}/main.cf:7) (Will be rescheduled by compiler)"
     )
     log_contains(caplog, "inmanta.ast.statements.call", logging.DEBUG, message)

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import logging
 import os
 import re
 
@@ -22,6 +23,7 @@ import pytest
 
 import inmanta.compiler as compiler
 from inmanta.ast import CompilerException, ExplicitPluginException, Namespace
+from utils import log_contains
 
 
 def test_plugin_excn(snippetcompiler):
@@ -255,3 +257,25 @@ def test_plugin_load_exception(snippetcompiler):
     )
     with pytest.raises(CompilerException, match=re.escape(expected)):
         compiler.do_compile()
+
+
+def test_3457_helpful_string(snippetcompiler, caplog):
+    with caplog.at_level(logging.DEBUG):
+        snippetcompiler.setup_for_snippet(
+            """
+entity A:
+end
+A.other [0:] -- A
+implement A using std::none
+a = A()
+std::attr(a, "other")
+a.other = A()
+            """
+        )
+        compiler.do_compile()
+    dir: str = snippetcompiler.project_dir
+    message: str = (
+        "Unset value in python code in plugin at call: inmanta_plugins.std::attr "
+        f"({dir}/main.cf:7) (Will be rescheduled by compiler)"
+    )
+    log_contains(caplog, "inmanta.ast.statements.call", logging.DEBUG, message)


### PR DESCRIPTION
# Description

When the compiler tries to execute a plugin but fails because
one of its dependencies is still unknown, a log line is added.
Currently this debugline is not really human readable. This commit
makes is easier to read.

closes #3457

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
