### PR TITLE
Ensure consistent behavior environment fixtures

### DIFF
--- a/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
+++ b/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
@@ -1,0 +1,5 @@
+---
+description: Ensure that the `environment` and `environment_multi` fixtures use consistent environment settings.
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso4]

--- a/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
+++ b/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
@@ -1,5 +1,4 @@
 ---
 description: Ensure that the `environment` and `environment_multi` fixtures use consistent environment settings.
-issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso4]


### PR DESCRIPTION
# Description

The `environment` and `environment_multi` fixtures do not behave consistently. The `environment` fixture disables the `AUTO_DEPLOY` setting and sets the agent trigger method to `push_full_deploy`, while the `environment_multi` fixtures leave the environment settings to their default values. This PR fixes that inconsistency. Both fixtures will now disables the `AUTO_DEPLOY` setting and sets the agent trigger method to `push_full_deploy`.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
