### PR TITLE
Ensure consistency environment fixtures iso4

### DIFF
--- a/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
+++ b/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
@@ -1,4 +1,4 @@
 ---
 description: Ensure that the `environment` and `environment_multi` fixtures use consistent environment settings.
 change-type: patch
-destination-branches: [master, iso4]
+destination-branches: [iso4]

--- a/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
+++ b/changelogs/unreleased/ensure-consistency-environment-fixtures.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that the `environment` and `environment_multi` fixtures use consistent environment settings.
+change-type: patch
+destination-branches: [master, iso4]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -726,24 +726,14 @@ def capture_warnings():
     logging.captureWarnings(False)
 
 
-@pytest.fixture(scope="function")
-async def environment(client, server, environment_default):
+async def create_environment(client, use_custom_env_settings: bool) -> str:
     """
-    Create a project and environment, with auto_deploy turned off. This fixture returns the uuid of the environment
-    """
+    Create a project (env-test) and an environment (dev).
 
-    env = await data.Environment.get_by_id(uuid.UUID(environment_default))
-    await env.set(data.AUTO_DEPLOY, False)
-    await env.set(data.PUSH_ON_AUTO_DEPLOY, False)
-    await env.set(data.AGENT_TRIGGER_METHOD_ON_AUTO_DEPLOY, const.AgentTriggerMethod.push_full_deploy)
-
-    yield environment_default
-
-
-@pytest.fixture(scope="function")
-async def environment_default(client, server):
-    """
-    Create a project and environment. This fixture returns the uuid of the environment
+    :param client: The client that should be used to create the project and environment.
+    :param use_custom_env_settings: True iff the auto_deploy features is disabled and the
+                                    agent trigger method is set to push_full_deploy.
+    :return: The uuid of the newly created environment as a string.
     """
     result = await client.create_project("env-test")
     assert result.code == 200
@@ -754,23 +744,42 @@ async def environment_default(client, server):
 
     cfg_env.set(env_id)
 
+    if use_custom_env_settings:
+        env_obj = await data.Environment.get_by_id(uuid.UUID(env_id))
+        await env_obj.set(data.AUTO_DEPLOY, False)
+        await env_obj.set(data.PUSH_ON_AUTO_DEPLOY, False)
+        await env_obj.set(data.AGENT_TRIGGER_METHOD_ON_AUTO_DEPLOY, const.AgentTriggerMethod.push_full_deploy)
+
+    return env_id
+
+
+@pytest.fixture(scope="function")
+async def environment(client, server) -> AsyncIterator[str]:
+    """
+    Create a project and environment, with auto_deploy turned off and push_full_deploy set to push_full_deploy.
+    This fixture returns the uuid of the environment.
+    """
+    env_id = await create_environment(client, use_custom_env_settings=True)
     yield env_id
 
 
 @pytest.fixture(scope="function")
-async def environment_multi(client_multi, server_multi):
+async def environment_default(client, server) -> AsyncIterator[str]:
     """
-    Create a project and environment. This fixture returns the uuid of the environment
+    Create a project and environment with default environment settings.
+    This fixture returns the uuid of the environment.
     """
-    result = await client_multi.create_project("env-test")
-    assert result.code == 200
-    project_id = result.result["project"]["id"]
+    env_id = await create_environment(client, use_custom_env_settings=False)
+    yield env_id
 
-    result = await client_multi.create_environment(project_id=project_id, name="dev")
-    env_id = result.result["environment"]["id"]
 
-    cfg_env.set(env_id)
-
+@pytest.fixture(scope="function")
+async def environment_multi(client_multi, server_multi) -> AsyncIterator[str]:
+    """
+    Create a project and environment, with auto_deploy turned off and the agent trigger method set to push_full_deploy.
+    This fixture returns the uuid of the environment.
+    """
+    env_id = await create_environment(client_multi, use_custom_env_settings=True)
     yield env_id
 
 


### PR DESCRIPTION
# Description

The `environment` and `environment_multi` fixtures do not behave consistently. The `environment` fixture disables the `AUTO_DEPLOY` setting and sets the agent trigger method to `push_full_deploy`, while the `environment_multi` fixtures leave the environment settings to their default values. This PR fixes that inconsistency. Both fixtures will now disables the `AUTO_DEPLOY` setting and sets the agent trigger method to `push_full_deploy`.

Same PR as #3568, but now only for the ISO4 branch due to a merge conflict.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design