### PR TITLE
Constraint version pydantic to ~=1.8.2

### DIFF
--- a/changelogs/unreleased/constraint-version-pydantic.yml
+++ b/changelogs/unreleased/constraint-version-pydantic.yml
@@ -1,0 +1,4 @@
+---
+description: Constraint `pydantic~=1.8.2` in order to work around incompatibility problem
+change-type: patch
+destination-branches: [master, iso4]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requires = [
     "netifaces",
     "packaging",
     "ply",
-    "pydantic",
+    "pydantic~=1.8.2",
     "pyformance",
     "PyJWT",
     "python-dateutil",


### PR DESCRIPTION
# Description

Constraint version pydantic to `pydantic~=1.8.2` in order to work around incompatibility issue that causes the following exception:

```
Traceback (most recent call last):
  File "env/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/config/__init__.py", line 185, in console_main
    code = main()
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/config/__init__.py", line 143, in main
    config = _prepareconfig(args, plugins)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/config/__init__.py", line 319, in _prepareconfig
    pluginmanager=pluginmanager, args=args
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/pluggy/_hooks.py", line 265, in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/pluggy/_manager.py", line 80, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/pluggy/_callers.py", line 55, in _multicall
    gen.send(outcome)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/helpconfig.py", line 100, in pytest_cmdline_parse
    config: Config = outcome.get_result()
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/pluggy/_result.py", line 60, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/pluggy/_callers.py", line 39, in _multicall
    res = hook_impl.function(*args)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/config/__init__.py", line 1003, in pytest_cmdline_parse
    self.parse(args)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/config/__init__.py", line 1283, in parse
    self._preparse(args, addopts=addopts)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/config/__init__.py", line 1172, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/pluggy/_manager.py", line 287, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/importlib_metadata/__init__.py", line 194, in load
    module = import_module(match.group('module'))
  File "/usr/lib64/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/_pytest/assertion/rewrite.py", line 170, in exec_module
    exec(co, module.__dict__)
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/pytest_inmanta/plugin.py", line 44, in <module>
    from inmanta import compiler, config, const, module, plugins, protocol
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/compiler/__init__.py", line 25, in <module>
    from inmanta import const, module
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/module.py", line 67, in <module>
    from inmanta import const, env, loader, plugins
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/plugins.py", line 26, in <module>
    from inmanta import const, protocol
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/protocol/__init__.py", line 56, in <module>
    from . import methods, methods_v2
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/protocol/methods.py", line 25, in <module>
    from inmanta import const, data
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/data/__init__.py", line 58, in <module>
    from inmanta import const, resources, util
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/resources.py", line 40, in <module>
    from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
  File "/home/jenkins/workspace/modules_apt_master/env/lib64/python3.6/site-packages/inmanta/data/model.py", line 34, in <module>
    old_field_type_schema = pydantic.schema.field_type_schema
AttributeError: 'cython_function_or_method' object has no attribute 'field_type_schema'
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
