### PR TITLE
Constraint version bumps of importlib metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
   allow:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
+  ignore:
+    # importlib-metadata>=4.9.0 requires Python>=3.7
+    - dependency-name: "importlib-metadata"
+      versions: [">=4.9.0"]
 - package-ecosystem: pip
   target-branch: iso4
   directory: "/"
@@ -18,3 +22,7 @@ updates:
   allow:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
+  ignore:
+    # importlib-metadata>=4.9.0 requires Python>=3.7
+    - dependency-name: "importlib-metadata"
+      versions: [">=4.9.0"]

--- a/changelogs/unreleased/constraint-version-bumps-importlib-metadata.yml
+++ b/changelogs/unreleased/constraint-version-bumps-importlib-metadata.yml
@@ -1,0 +1,4 @@
+---
+description: Constraint allowed version bumps of importlib-metadata because importlib-metadata>=4.9.0 requires Python3.7
+change-type: patch
+destination-branches: [master]


### PR DESCRIPTION
# Description

Constraint allowed version bumps of `importlib-metadata` because `importlib-metadata>=4.9.0` requires `python>=3.7`

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
