### PR TITLE
Constrain version bumps setuptools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     # importlib-metadata>=4.9.0 requires Python>=3.7
     - dependency-name: "importlib-metadata"
       versions: [">=4.9.0"]
+    # setuptools>=59.7.0 requires Python>=3.7
+    - dependency-name: "setuptools"
+      versions: [">=59.7.0"]
 - package-ecosystem: pip
   target-branch: iso4
   directory: "/"
@@ -26,3 +29,6 @@ updates:
     # importlib-metadata>=4.9.0 requires Python>=3.7
     - dependency-name: "importlib-metadata"
       versions: [">=4.9.0"]
+    # setuptools>=59.7.0 requires Python>=3.7
+    - dependency-name: "setuptools"
+      versions: [">=59.7.0"]

--- a/changelogs/unreleased/constrain-version-bumps-setuptools.yml
+++ b/changelogs/unreleased/constrain-version-bumps-setuptools.yml
@@ -1,0 +1,4 @@
+---
+description: Constrain allowed version bumps of setuptools because setuptools>=59.7.0 requires Python3.7
+change-type: patch
+destination-branches: [master]


### PR DESCRIPTION
# Description

Constrain allowed version bumps of `setuptools` because `setuptools>=59.7.0` requires `Python>=3.7`.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
