### PR TITLE
Update .ci-integration-tests.yml config to run tests against python3.6

### DIFF
--- a/.ci-integration-tests.yml
+++ b/.ci-integration-tests.yml
@@ -1,2 +1,3 @@
 pipeline_template: ci/inmanta-extensions/Jenkinsfile-integration-tests-with-fast
 repo_name: inmanta-core
+python_version: 36

--- a/changelogs/unreleased/run-tests-using-python36.yml
+++ b/changelogs/unreleased/run-tests-using-python36.yml
@@ -1,0 +1,6 @@
+---
+description: Update the .ci-integration-tests.yml file as such the test run using python3.6 by default
+issue-nr: 917
+issue-repo: irt
+change-type: patch
+destination-branches: [iso4]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py36-fast,mypy,docs
+envlist = pep8,py36,mypy,docs
 skip_missing_interpreters=True
 requires = pip
            virtualenv >= 20.2.2


### PR DESCRIPTION
# Description

This PR applies the following changes:

* Update the `.ci-integration-tests.yml` config file as such that the tests on the ISO4 branch run using Python3.6
* Fix a bug in the `tox.ini` file that causes the nightly build to run in fast mode. 

Part of inmanta/irt#917

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
