### PR TITLE
Update .ci-integration-tests.yml config to run tests against python3.9

### DIFF
--- a/.ci-integration-tests.yml
+++ b/.ci-integration-tests.yml
@@ -1,2 +1,3 @@
 pipeline_template: ci/inmanta-extensions/Jenkinsfile-integration-tests-with-fast
 repo_name: inmanta-core
+python_version: 39

--- a/changelogs/unreleased/run-test-against-python39.yml
+++ b/changelogs/unreleased/run-test-against-python39.yml
@@ -1,0 +1,6 @@
+---
+description: Update tox.ini to run tests against python3.9
+issue-nr: 917
+issue-repo: irt
+change-type: patch
+destination-branches: [master]

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = pep8,py36,mypy,docs
+envlist = pep8,py39,mypy,docs
 skip_missing_interpreters=True
 requires = pip
            virtualenv >= 20.2.2
 
-[testenv:py36]
-basepython=python3.6
-
-[testenv:py38]
-basepython=python3.8
+[testenv:py39]
+basepython=python3.9
 
 [testenv]
 deps=
@@ -21,7 +18,7 @@ commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report 
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME
 
-[testenv:{py36,py38}-fast]
+[testenv:py39-fast]
 commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv --fast --durations=50 tests/
 
 


### PR DESCRIPTION
# Description

This PR updates the `.ci-integration-tests.yml` config file as such that the tests on the master branch run using Python3.6

Part of inmanta/irt#917

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
