### PR TITLE
Issue/3536  build failure fedora-latest

### DIFF
--- a/changelogs/unreleased/3536-multi-digit-python-version.yml
+++ b/changelogs/unreleased/3536-multi-digit-python-version.yml
@@ -2,4 +2,5 @@ change-type: patch
 issue-nr: 3536
 description: Fixes a bug where minor version of python were wrongly set as only the first digit of multi-digit number was used.
 destination-branches: [iso4]
-  bugfix: "minor version of python were wrongly set"
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/3536-multi-digit-python-version.yml
+++ b/changelogs/unreleased/3536-multi-digit-python-version.yml
@@ -1,0 +1,5 @@
+change-type: patch
+issue-nr: 3536
+description: Fixes a bug where minor version of python where wrongly set as only the first digit of multi-digit number was used.
+destination-branches: [iso4]
+  bugfix: " minor version of python where wrongly set"

--- a/changelogs/unreleased/3536-multi-digit-python-version.yml
+++ b/changelogs/unreleased/3536-multi-digit-python-version.yml
@@ -2,4 +2,4 @@ change-type: patch
 issue-nr: 3536
 description: Fixes a bug where minor version of python were wrongly set as only the first digit of multi-digit number was used.
 destination-branches: [iso4]
-  bugfix: " minor version of python were wrongly set"
+  bugfix: "minor version of python were wrongly set"

--- a/changelogs/unreleased/3536-multi-digit-python-version.yml
+++ b/changelogs/unreleased/3536-multi-digit-python-version.yml
@@ -1,5 +1,5 @@
 change-type: patch
 issue-nr: 3536
-description: Fixes a bug where minor version of python where wrongly set as only the first digit of multi-digit number was used.
+description: Fixes a bug where minor version of python were wrongly set as only the first digit of multi-digit number was used.
 destination-branches: [iso4]
-  bugfix: " minor version of python where wrongly set"
+  bugfix: " minor version of python were wrongly set"

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -137,7 +137,9 @@ class VirtualEnv(object):
         else:
             binpath = os.path.abspath(os.path.join(self.env_path, "bin"))
             base = os.path.dirname(binpath)
-            site_packages = os.path.join(base, "lib", "python%s" % sys.version[:3], "site-packages")
+            site_packages = os.path.join(
+                base, "lib", "python%s" % ".".join(str(digit) for digit in sys.version_info[:2]), "site-packages"
+            )
 
         old_os_path = os.environ.get("PATH", "")
         os.environ["PATH"] = binpath + os.pathsep + old_os_path


### PR DESCRIPTION
# Description

Fixes a bug where minor version of python where wrongly set as only the first digit of multi-digits was used.

closes #3536 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
