### PR TITLE
Remove .ci-integration-tests-python38.yml file

### DIFF
--- a/.ci-integration-tests-python38.yml
+++ b/.ci-integration-tests-python38.yml
@@ -1,2 +1,0 @@
-pipeline_template: ci/inmanta-extensions/Jenkinsfile-integration-tests-python38
-repo_name: inmanta-core

--- a/changelogs/unreleased/remove-ci-file-to-run-tests-using-python38.yml
+++ b/changelogs/unreleased/remove-ci-file-to-run-tests-using-python38.yml
@@ -1,0 +1,4 @@
+---
+description: Remove the `.ci-integration-tests-python38.yml` file as we don't need to run tests against python3.8 anymore.
+change-type: patch
+destination-branches: [master, iso4]


### PR DESCRIPTION
# Description

Remove the `.ci-integration-tests-python38.yml` file as we don't need to run tests against python3.8 anymore.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
