### PR TITLE
clarify inmanta module name vs Python package name

### DIFF
--- a/changelogs/unreleased/3621-clarify-module-name.yml
+++ b/changelogs/unreleased/3621-clarify-module-name.yml
@@ -1,0 +1,5 @@
+change-type: patch
+description:  Add to the docs that an inmanta module with name x is distributed as inmanta-module-x
+destination-branches:
+- master
+sections: {}

--- a/changelogs/unreleased/3621-clarify-module-name.yml
+++ b/changelogs/unreleased/3621-clarify-module-name.yml
@@ -3,4 +3,3 @@ change-type: patch
 description:  Add to the docs that an inmanta module with name x is distributed as inmanta-module-x
 destination-branches:
 - master
-sections: {}

--- a/changelogs/unreleased/3621-clarify-module-name.yml
+++ b/changelogs/unreleased/3621-clarify-module-name.yml
@@ -1,3 +1,4 @@
+issue-nr: 3555
 change-type: patch
 description:  Add to the docs that an inmanta module with name x is distributed as inmanta-module-x
 destination-branches:

--- a/docs/model_developers/developer_getting_started.rst
+++ b/docs/model_developers/developer_getting_started.rst
@@ -207,11 +207,11 @@ For a v2 module, use the v2 cookiecutter template, then install the module:
     cookiecutter --checkout v2 https://github.com/inmanta/inmanta-module-template.git
     inmanta module install -e ./<module-name>
 
+This will install a Python package with the name ``inmanta-module-<module-name>`` in the active environment.
+
 If you want to use the v2 module in a project, make sure to set up a v2 module source as outlined in the section above,
 then add the module as a dependency of the project as described in :ref:`dgs-existing-module`.
 The location of the module directory is not important for a v2 module.
-
-The Inmanta module with name <module-name> will be distributed as a Python package with name inmanta-module-<module-name>.
 
 
 

--- a/docs/model_developers/developer_getting_started.rst
+++ b/docs/model_developers/developer_getting_started.rst
@@ -205,11 +205,13 @@ For a v2 module, use the v2 cookiecutter template, then install the module:
 
     pip install cookiecutter
     cookiecutter --checkout v2 https://github.com/inmanta/inmanta-module-template.git
-    inmanta module install -e ./inmanta-module-<module-name>
+    inmanta module install -e ./<module-name>
 
 If you want to use the v2 module in a project, make sure to set up a v2 module source as outlined in the section above,
 then add the module as a dependency of the project as described in :ref:`dgs-existing-module`.
 The location of the module directory is not important for a v2 module.
+
+The Inmanta module with name <module-name> will be distributed as a Python package with name inmanta-module-<module-name>.
 
 
 

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -309,6 +309,7 @@ to consider it released.
 You can package a v2 module with ``inmanta module build`` which will create a Python wheel.
 You can then publish this to the Python package repository of your choice,
 for example the public PyPi repository.
+The module with name <module-name> will be distributed as a Python package with name inmanta-module-<module-name>.
 
 The orchestrator server generally (see
 :ref:`Advanced concepts<modules-distribution-advanced-concepts>`) installs modules from the configured Python package

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -309,7 +309,7 @@ to consider it released.
 You can package a v2 module with ``inmanta module build`` which will create a Python wheel.
 You can then publish this to the Python package repository of your choice,
 for example the public PyPi repository.
-The module with name <module-name> will be distributed as a Python package with name inmanta-module-<module-name>.
+The inmanta module ``my_module`` will be packaged as a Python package ``inmanta-module-my-module``.
 
 The orchestrator server generally (see
 :ref:`Advanced concepts<modules-distribution-advanced-concepts>`) installs modules from the configured Python package


### PR DESCRIPTION
# Description

Add to the docs that an inmanta module with name x is distributed as inmanta-module-x

closes #3555 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
