### PR TITLE
Issue/3619 module v2 install without module source

### DIFF
--- a/changelogs/unreleased/3619-module-v2-install-without-source.yml
+++ b/changelogs/unreleased/3619-module-v2-install-without-source.yml
@@ -1,0 +1,5 @@
+description: Added clear error message when attempting to install v2 module without v2 module source
+issue-nr: 3619
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -513,7 +513,10 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
         if not self.urls:
             raise Exception(
                 "Attempting to install a v2 module but no v2 module source is configured. Add at least one repo of type"
-                ' "package" to the project config file.'
+                ' "package" to the project config file. e.g. to add PyPi as a module source, add the following to the `repo`'
+                " section of the project's `project.yml`:"
+                "\n\t- type: package"
+                "\n\t  url: https://pypi.org/simple"
             )
         module_name: str = self._get_module_name(module_spec)
         requirements: List[Requirement] = [self.get_python_package_requirement(req) for req in module_spec]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -510,6 +510,11 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
         return f"{const.PLUGINS_PACKAGE}.{module_name}"
 
     def install(self, project: "Project", module_spec: List[InmantaModuleRequirement]) -> Optional["ModuleV2"]:
+        if not self.urls:
+            raise Exception(
+                "Attempting to install a v2 module but no v2 module source is configured. Add at least one repo of type"
+                " \"package\" to the project config file."
+            )
         module_name: str = self._get_module_name(module_spec)
         requirements: List[Requirement] = [self.get_python_package_requirement(req) for req in module_spec]
         allow_pre_releases = project is not None and project.install_mode in {InstallMode.prerelease, InstallMode.master}

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -513,7 +513,7 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
         if not self.urls:
             raise Exception(
                 "Attempting to install a v2 module but no v2 module source is configured. Add at least one repo of type"
-                " \"package\" to the project config file."
+                ' "package" to the project config file.'
             )
         module_name: str = self._get_module_name(module_spec)
         requirements: List[Requirement] = [self.get_python_package_requirement(req) for req in module_spec]

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -160,7 +160,7 @@ def test_install_module_no_v2_source(snippetcompiler) -> None:
         )
     message: str = (
         "Attempting to install a v2 module but no v2 module source is configured. Add at least one repo of type"
-        " \"package\" to the project config file."
+        ' "package" to the project config file.'
     )
     assert message in e.value.format_trace()
 


### PR DESCRIPTION
# Description

The error message when attempting to install a v2 module (for example via `inmanta module add --v2`) when no v2 module source has been configured was very unhelpful, as @FloLey encountered this week. I've created this ticket as a response. Since it has never been vetted during planning I'm requesting both your reviews @arnaudsjs @wouterdb.

closes #3619

# Output

```
(inmanta-core) sander@arthur:~/documents/projects/inmanta/inmanta-model-test$ inmanta project install
Could not load module std
caused by:
  Exception: Attempting to install a v2 module but no v2 module source is configured. Add at least one repo of type "package" to the project config file.

(inmanta-core) sander@arthur:~/documents/projects/inmanta/inmanta-model-test$ inmanta module add --v2 std --override
Attempting to install a v2 module but no v2 module source is configured. Add at least one repo of type "package" to the project config file.

```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
