### PR TITLE
Issue/version constraint dependabot

### DIFF
--- a/changelogs/unreleased/improve-version-constraint-pydantic.yml
+++ b/changelogs/unreleased/improve-version-constraint-pydantic.yml
@@ -1,0 +1,4 @@
+---
+description: Improve version constraint in pydantic dependency
+change-type: patch
+destination-branches: [master, iso4]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ requires = [
     "netifaces",
     "packaging",
     "ply",
-    "pydantic>=1.8.2,<1.10.0",
+    # Exclude pre-release due to https://github.com/samuelcolvin/pydantic/issues/3546
+    "pydantic!=1.9.0a1",
     "pyformance",
     "PyJWT",
     "python-dateutil",


### PR DESCRIPTION
# Description

A version constraint was set on the pydantic dependency to work around an incompatibility with a specific version of pydantic (See: https://github.com/inmanta/inmanta-core/pull/3585). But Dependabot seems to make a mess of this. This PR fixes that problem. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
