### PR TITLE
iso4 compatibility with module and project template v2

### DIFF
--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -1,0 +1,6 @@
+change-type: patch
+issue-nr: 3536
+description: Raise a warning when trying to use repo type package.
+destination-branches: [iso4]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -4,5 +4,5 @@ description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]
 sections:
     bugfix: "{{description}}"
-    upgrade-note: "Creating new modules using the template should be done using the v1 branch"
+    upgrade-note: "Creating new modules using the template should be done by first checking out on the v1 branch"
 

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -4,4 +4,4 @@ description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]
 sections:
     bugfix: "{{description}}"
-    upgrade-note: "Creating new modules using the cookiecutter template should now requires the --checkout v1 option."
+    upgrade-note: "Creating new modules using the cookiecutter template now requires the --checkout v1 option."

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -4,5 +4,5 @@ description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]
 sections:
     bugfix: "{{description}}"
-    upgrade-note: "Creating new modules using the template should be done by first checking out on the v1 branch"
+    upgrade-note: "Creating new modules using the template should be done by first checking out on the v1 branch. This can be done using 'cookiecutter --checkout v1 https://github.com/inmanta/inmanta-module-template.git'."
 

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -1,5 +1,5 @@
 change-type: patch
-issue-nr: 3536
+issue-nr: 3565
 description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]
 sections:

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -2,3 +2,7 @@ change-type: patch
 issue-nr: 3536
 description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]
+sections:
+    bugfix: "{{description}}"
+    upgrade-note: "Creating new modules using the template should be done using the v1 branch"
+

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -2,5 +2,3 @@ change-type: patch
 issue-nr: 3536
 description: Raise a warning when trying to use repo type package.
 destination-branches: [iso4]
-sections:
-  bugfix: "{{description}}"

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -1,4 +1,4 @@
 change-type: patch
 issue-nr: 3536
-description: Raise a warning when trying to use repo type package.
+description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]

--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -4,5 +4,4 @@ description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]
 sections:
     bugfix: "{{description}}"
-    upgrade-note: "Creating new modules using the template should be done by first checking out on the v1 branch. This can be done using 'cookiecutter --checkout v1 https://github.com/inmanta/inmanta-module-template.git'."
-
+    upgrade-note: "Creating new modules using the cookiecutter template should now requires the --checkout v1 option."

--- a/docs/model_developers/developer_getting_started.rst
+++ b/docs/model_developers/developer_getting_started.rst
@@ -173,7 +173,7 @@ Same as :ref:`Working on a New Project` part, modules can also be created like:
 
     pip install cookiecutter
 
-    cookiecutter https://github.com/inmanta/inmanta-module-template.git
+    cookiecutter --checkout v1 https://github.com/inmanta/inmanta-module-template.git
 
 
 There are also guides :ref:`here <moddev-module>` and `here <https://github.com/inmanta/inmanta-module-template>`_ that help you get up and running.

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -318,16 +318,12 @@ class Namespace(Namespaced):
         return self.visible_namespaces[parts[0]].target.get_scope().direct_lookup(parts[1])
 
     def get_type(self, typ: LocatableString) -> "Type":
-        print("------")
         name: str = str(typ)
-        print(name)
         assert self.primitives is not None
         if "::" in name:
             parts = name.rsplit("::", 1)
-            print(parts)
             if parts[0] in self.visible_namespaces:
                 ns = self.visible_namespaces[parts[0]].target
-                print(ns)
                 if parts[1] in ns.defines_types:
                     return ns.defines_types[parts[1]]
                 else:

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -318,12 +318,16 @@ class Namespace(Namespaced):
         return self.visible_namespaces[parts[0]].target.get_scope().direct_lookup(parts[1])
 
     def get_type(self, typ: LocatableString) -> "Type":
+        print("------")
         name: str = str(typ)
+        print(name)
         assert self.primitives is not None
         if "::" in name:
             parts = name.rsplit("::", 1)
+            print(parts)
             if parts[0] in self.visible_namespaces:
                 ns = self.visible_namespaces[parts[0]].target
+                print(ns)
                 if parts[1] in ns.defines_types:
                     return ns.defines_types[parts[1]]
                 else:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -461,19 +461,17 @@ class ProjectMetadata(Metadata):
         v_as_list = cls.to_list(v)
         result = []
         for elem in v_as_list:
-            if isinstance(elem, ModuleRepoInfoV2):
-                if "type" in elem and "url" in elem and elem["type"] == ModuleRepoType.git:
-                    result.append(elem["url"])
-                elif "type" in elem and "url" in elem and elem["type"] == ModuleRepoType.package:
-                    LOGGER.warning("Repos of type %s where introduced in Modules v2, which are not supported by current Inmanta version.", elem["type"])
-                elif "type" in elem and "url" in elem:
-                    LOGGER.warning("Repos of type %s are not supported", elem["type"])
-                else:
-                    raise ValueError(f"Repo should be a string(url) or a dict containing an 'url' and 'type: git', got {elem}")
-            elif isinstance(elem, str):
+            if isinstance(elem, str):
                 result.append(elem)
             else:
-                raise ValueError(f"Value should be either a string or a dict, got {elem}")
+                try:
+                    repo = ModuleRepoInfoV2(**elem)
+                    if repo.type == ModuleRepoType.package:
+                        LOGGER.warning("Repos of type %s where introduced in Modules v2, which are not supported by current Inmanta version.", elem["type"])
+                    else:
+                        result.append(elem["url"])
+                except TypeError:
+                    raise ValueError(f"Value should be either a string or a dict containing an 'url' and 'type: git', got {elem}")
         return result
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -403,15 +403,18 @@ class ModuleMetadata(Metadata):
             raise ValueError(f"Version {v} is not PEP440 compliant") from e
         return v
 
+
 @stable_api
 class ModuleRepoType(enum.Enum):
     git = "git"
     package = "package"
 
+
 @stable_api
 class ModuleRepoInfoV2(BaseModel):
     url: str
     type: ModuleRepoType = ModuleRepoType.git
+
 
 class ProjectMetadata(Metadata):
     """
@@ -467,11 +470,16 @@ class ProjectMetadata(Metadata):
                 try:
                     repo = ModuleRepoInfoV2(**elem)
                     if repo.type == ModuleRepoType.package:
-                        LOGGER.warning("Repos of type %s where introduced in Modules v2, which are not supported by current Inmanta version.", elem["type"])
+                        LOGGER.warning(
+                            "Repos of type %s where introduced in Modules v2, which are not supported by current Inmanta version.",
+                            elem["type"],
+                        )
                     else:
                         result.append(elem["url"])
                 except TypeError:
-                    raise ValueError(f"Value should be either a string or a dict containing an 'url' and 'type: git', got {elem}")
+                    raise ValueError(
+                        f"Value should be either a string or a dict containing an 'url' and 'type: git', got {elem}"
+                    )
         return result
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -446,7 +446,6 @@ class ProjectMetadata(Metadata):
     def modulepath_to_list(cls, v: object) -> object:
         return cls.to_list(v)
 
-
     @validator("repo", pre=True)
     @classmethod
     def validate_repo_field(cls, v: object) -> object:
@@ -1054,7 +1053,6 @@ class Module(ModuleLike[ModuleMetadata]):
                     f"Can not install module {modulename} because 'downloadpath' is not set in {project.PROJECT_FILE}"
                 )
             path = os.path.join(project.downloadpath, modulename)
-            print(path)
             result = project.externalResolver.clone(modulename, project.downloadpath)
             if not result:
                 raise InvalidModuleException("could not locate module with name: %s" % modulename)

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -31,7 +31,23 @@ from io import BytesIO, TextIOBase
 from subprocess import CalledProcessError
 from tarfile import TarFile
 from time import time
-from typing import Any, Dict, Generic, Iterable, Iterator, List, Mapping, NewType, Optional, Set, TextIO, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    NewType,
+    Optional,
+    Set,
+    TextIO,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import yaml
 from pkg_resources import parse_requirements, parse_version

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -458,11 +458,11 @@ class ProjectMetadata(Metadata):
                 elif "type" in elem and "url" in elem:
                     LOGGER.warning("Repos of type %s are not supported", elem["type"])
                 else:
-                    raise ValueError(f"Repo should be a string or a dict containing keys 'url' and 'type', got {elem}")
+                    raise ValueError(f"Repo should be a string(url) or a dict containing an 'url' and 'type: git', got {elem}")
             elif isinstance(elem, str):
                 result.append(elem)
             else:
-                raise ValueError(f"Value should be either a string of a dict, got {elem}")
+                raise ValueError(f"Value should be either a string or a dict, got {elem}")
         return result
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -31,7 +31,7 @@ from io import BytesIO, TextIOBase
 from subprocess import CalledProcessError
 from tarfile import TarFile
 from time import time
-from typing import Dict, Generic, Iterable, Iterator, List, Mapping, NewType, Optional, Set, TextIO, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, Iterator, List, Mapping, NewType, Optional, Set, TextIO, Tuple, Type, TypeVar, Union
 
 import yaml
 from pkg_resources import parse_requirements, parse_version
@@ -461,7 +461,7 @@ class ProjectMetadata(Metadata):
 
     @validator("repo", pre=True)
     @classmethod
-    def validate_repo_field(cls, v: object) -> List[ModuleRepoInfo]:
+    def validate_repo_field(cls, v: object) -> List[Dict[Any, Any]]:
         v_as_list = cls.to_list(v)
         result = []
         for elem in v_as_list:
@@ -475,7 +475,7 @@ class ProjectMetadata(Metadata):
         return result
 
     @validator("repo")
-    def warn_repo_type_unsupported(v: List[ModuleRepoInfo]) -> object:
+    def warn_repo_type_unsupported(v: List[ModuleRepoInfo]) -> List[ModuleRepoInfo]:
         if any(repo.type == ModuleRepoType.package for repo in v):
             LOGGER.warning(
                 "Repos of type %s where introduced in Modules v2, which are not supported by current Inmanta version.",

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -453,16 +453,16 @@ class ProjectMetadata(Metadata):
         result = []
         for elem in v_as_list:
             if isinstance(elem, dict):
-                if('type' in elem and 'url' in elem and elem['type'] == 'git'):
-                    result.append(elem['url'])
-                elif('type' in elem and 'url' in elem):
-                    LOGGER.warning("Repos of type %s are not supported", elem['type'])
+                if "type" in elem and "url" in elem and elem["type"] == "git":
+                    result.append(elem["url"])
+                elif "type" in elem and "url" in elem:
+                    LOGGER.warning("Repos of type %s are not supported", elem["type"])
                 else:
-                    raise ValueError(f"Repo should be a string or a dict containing keys 'url' and 'type', got {elem}") 
+                    raise ValueError(f"Repo should be a string or a dict containing keys 'url' and 'type', got {elem}")
             elif isinstance(elem, str):
                 result.append(elem)
             else:
-                raise ValueError(f"Value should be either a string of a dict, got {elem}") 
+                raise ValueError(f"Value should be either a string of a dict, got {elem}")
         return result
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -403,6 +403,15 @@ class ModuleMetadata(Metadata):
             raise ValueError(f"Version {v} is not PEP440 compliant") from e
         return v
 
+@stable_api
+class ModuleRepoType(enum.Enum):
+    git = "git"
+    package = "package"
+
+@stable_api
+class ModuleRepoInfoV2(BaseModel):
+    url: str
+    type: ModuleRepoType = ModuleRepoType.git
 
 class ProjectMetadata(Metadata):
     """
@@ -452,9 +461,11 @@ class ProjectMetadata(Metadata):
         v_as_list = cls.to_list(v)
         result = []
         for elem in v_as_list:
-            if isinstance(elem, dict):
-                if "type" in elem and "url" in elem and elem["type"] == "git":
+            if isinstance(elem, ModuleRepoInfoV2):
+                if "type" in elem and "url" in elem and elem["type"] == ModuleRepoType.git:
                     result.append(elem["url"])
+                elif "type" in elem and "url" in elem and elem["type"] == ModuleRepoType.package:
+                    LOGGER.warning("Repos of type %s where introduced in Modules v2, which are not supported by current Inmanta version.", elem["type"])
                 elif "type" in elem and "url" in elem:
                     LOGGER.warning("Repos of type %s are not supported", elem["type"])
                 else:

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -337,7 +337,7 @@ requires:
 
 
 def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
-    """ LOOK TO REMOVE MODULES_DIR
+    """LOOK TO REMOVE MODULES_DIR
     Tests that repos that are strings and repos that are dict with
     type 'git' are accepted and that repos with another type
     will raise a warning. (issue #3565)

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -16,13 +16,13 @@
     Contact: code@inmanta.com
 """
 import asyncio
+import logging
 import os
 import re
 import shutil
 import subprocess
 import sys
 import warnings
-import logging
 
 import pytest
 import yaml
@@ -338,11 +338,11 @@ requires:
 
 def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     """
-    Tests that repos of type 'git' are accepted and that repos with 
+    Tests that repos of type 'git' are accepted and that repos with
     another type set will raise a warning. (issue #3565)
     """
     make_module_simple(modules_repo, "module")
-    project = makeproject(modules_repo, "project",[],["module"])
+    project = makeproject(modules_repo, "project", [], ["module"])
     commitmodule(project, "first commit")
 
     proj = install_project(modules_dir, "project")
@@ -361,7 +361,7 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     no_error_in_logs(caplog)
 
     # repo is a dict instance with type git (accepted)
-    repo = {'url':"https://github.com/inmanta/", 'type':'git'}
+    repo = {"url": "https://github.com/inmanta/", "type": "git"}
     pyml["repo"] = repo
 
     with open(projectyml, "w", encoding="utf-8") as fh:
@@ -372,7 +372,7 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     no_error_in_logs(caplog)
 
     # repo is a dict instance with type package (raises warning)
-    repo = {'url':"https://github.com/inmanta/", 'type':'package'}
+    repo = {"url": "https://github.com/inmanta/", "type": "package"}
     pyml["repo"] = repo
 
     with open(projectyml, "w", encoding="utf-8") as fh:

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -28,8 +28,7 @@ import pytest
 import yaml
 from pkg_resources import Requirement, parse_version
 
-
-from inmanta import module, compiler
+from inmanta import compiler, module
 from inmanta.module import InvalidMetadata, MetadataDeprecationWarning, Project
 from inmanta.moduletool import ModuleTool
 from inmanta.parser import ParserException
@@ -337,57 +336,9 @@ requires:
         module.Module(None, inmanta_module.get_root_dir_of_module())
 
 
-# def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
-#     """
-#     Tests that repos that are strings and repos that are dict with 
-#     type 'git' are accepted and that repos with another type
-#     will raise a warning. (issue #3565)
-#     """
-#     make_module_simple(modules_repo, "module")
-#     project = makeproject(modules_repo, "project", [], ["module"])
-#     commitmodule(project, "first commit")
-
-#     proj = install_project(modules_dir, "project")
-#     print(os.listdir(proj))
-
-#     projectyml = os.path.join(proj, "project.yml")
-#     assert os.path.exists(projectyml)
-#     app(["modules", "install"])
-#     with open(projectyml, "r", encoding="utf-8") as fh:
-#         pyml = yaml.safe_load(fh)
-
-#     # repo is a string instance (accepted)
-#     Project._project = None
-#     with caplog.at_level(logging.WARNING):
-#         app(["compile"])
-#     no_error_in_logs(caplog)
-
-#     # repo is a dict instance with type git (accepted)
-#     repo = {"url": "https://github.com/inmanta/", "type": "git"}
-#     pyml["repo"] = repo
-
-#     with open(projectyml, "w", encoding="utf-8") as fh:
-#         yaml.dump(pyml, fh)
-#     Project._project = None
-#     with caplog.at_level(logging.WARNING):
-#         app(["compile"])
-#     no_error_in_logs(caplog)
-
-#     # repo is a dict instance with type package (raises warning)
-#     repo = {"url": "https://github.com/inmanta/", "type": "package"}
-#     pyml["repo"] = repo
-
-#     with open(projectyml, "w", encoding="utf-8") as fh:
-#         yaml.dump(pyml, fh)
-#     Project._project = None
-#     with caplog.at_level(logging.WARNING):
-#         app(["compile"])
-#     warning = "Repos of type package are not supported"
-#     log_contains(caplog, "inmanta.module", logging.WARNING, warning)
-
 def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     """
-    Tests that repos that are strings and repos that are dict with 
+    Tests that repos that are strings and repos that are dict with
     type 'git' are accepted and that repos with another type
     will raise a warning. (issue #3565)
     """
@@ -396,18 +347,18 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     commitmodule(project, "first commit")
 
     install_project(modules_dir, "project")
-    projectdir = os.path.join(modules_repo,"project")
+    projectdir = os.path.join(modules_repo, "project")
     Project.set(Project(projectdir, autostd=True))
 
     projectyml = os.path.join(projectdir, "project.yml")
     with open(projectyml, "r", encoding="utf-8") as fh:
         pyml = yaml.safe_load(fh)
-    
+
     # repo is a string instance (accepted)
     with caplog.at_level(logging.WARNING):
         compiler.do_compile()
     no_error_in_logs(caplog)
-    
+
     # repo is a dict instance with type package (raises warning)
     Project._project = None
     repo = {"url": "https://github.com/inmanta/", "type": "package"}
@@ -419,7 +370,6 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
         compiler.do_compile()
     warning = "Repos of type package are not supported"
     log_contains(caplog, "inmanta.module", logging.WARNING, warning)
-
 
     # repo is a dict instance with type git (accepted)
     Project._project = None

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -342,11 +342,10 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     type 'git' are accepted and that repos with another type
     will raise a warning. (issue #3565)
     """
-    makeproject(modules_repo, "project", [], [])
-    projectdir = os.path.join(modules_repo, "project")
+    projectdir = makeproject(modules_repo, "project_repo_type_module_v2", [], [])
     Project.set(Project(projectdir, autostd=True))
 
-    projectyml = os.path.join(projectdir, "project.yml")
+    projectyml = os.path.join(projectdir, "project_repo_type_module_v2.yml")
     with open(projectyml, "r", encoding="utf-8") as fh:
         pyml = yaml.safe_load(fh)
 
@@ -354,7 +353,18 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     Project._project = None
     with caplog.at_level(logging.WARNING):
         compiler.do_compile()
-    no_error_in_logs(caplog)
+    no_error_in_logs(caplog, levels=(logging.ERROR, logging.WARNING))
+
+    # repo is a dict instance with type git (accepted)
+    Project._project = None
+    repo = {"url": "https://github.com/inmanta/", "type": "git"}
+    pyml["repo"] = repo
+
+    with open(projectyml, "w", encoding="utf-8") as fh:
+        yaml.dump(pyml, fh)
+    with caplog.at_level(logging.WARNING):
+        compiler.do_compile()
+    no_error_in_logs(caplog, levels=(logging.ERROR, logging.WARNING))
 
     # repo is a dict instance with type package (raises warning)
     Project._project = None
@@ -367,14 +377,3 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
         compiler.do_compile()
     warning = "Repos of type package are not supported"
     log_contains(caplog, "inmanta.module", logging.WARNING, warning)
-
-    # repo is a dict instance with type git (accepted)
-    Project._project = None
-    repo = {"url": "https://github.com/inmanta/", "type": "git"}
-    pyml["repo"] = repo
-
-    with open(projectyml, "w", encoding="utf-8") as fh:
-        yaml.dump(pyml, fh)
-    with caplog.at_level(logging.WARNING):
-        compiler.do_compile()
-    no_error_in_logs(caplog)

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -337,7 +337,7 @@ requires:
 
 
 def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
-    """
+    """ LOOK TO REMOVE MODULES_DIR
     Tests that repos that are strings and repos that are dict with
     type 'git' are accepted and that repos with another type
     will raise a warning. (issue #3565)

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -375,5 +375,5 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
         yaml.dump(pyml, fh)
     with caplog.at_level(logging.WARNING):
         compiler.do_compile()
-    warning = "Repos of type package are not supported"
+    warning = "Repos of type package where introduced in Modules v2, which are not supported by current Inmanta version."
     log_contains(caplog, "inmanta.module", logging.WARNING, warning)

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -342,11 +342,7 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     type 'git' are accepted and that repos with another type
     will raise a warning. (issue #3565)
     """
-    make_module_simple(modules_repo, "module")
-    project = makeproject(modules_repo, "project", [], ["module"])
-    commitmodule(project, "first commit")
-
-    install_project(modules_dir, "project")
+    makeproject(modules_repo, "project", [], [])
     projectdir = os.path.join(modules_repo, "project")
     Project.set(Project(projectdir, autostd=True))
 
@@ -355,6 +351,7 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
         pyml = yaml.safe_load(fh)
 
     # repo is a string instance (accepted)
+    Project._project = None
     with caplog.at_level(logging.WARNING):
         compiler.do_compile()
     no_error_in_logs(caplog)

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -338,8 +338,9 @@ requires:
 
 def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     """
-    Tests that repos of type 'git' are accepted and that repos with
-    another type set will raise a warning. (issue #3565)
+    Tests that repos that are strings and repos that are dict with 
+    type 'git' are accepted and that repos with another type
+    will raise a warning. (issue #3565)
     """
     make_module_simple(modules_repo, "module")
     project = makeproject(modules_repo, "project", [], ["module"])

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -248,7 +248,7 @@ async def test_module_version_non_pep440_complient(inmanta_module):
         """
 name: mod
 license: ASL
-version: non_pep440_valuemo
+version: non_pep440_value
 compiler_version: 2017.2
     """
     )

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -28,7 +28,8 @@ import pytest
 import yaml
 from pkg_resources import Requirement, parse_version
 
-from inmanta import module
+
+from inmanta import module, compiler
 from inmanta.module import InvalidMetadata, MetadataDeprecationWarning, Project
 from inmanta.moduletool import ModuleTool
 from inmanta.parser import ParserException
@@ -336,6 +337,54 @@ requires:
         module.Module(None, inmanta_module.get_root_dir_of_module())
 
 
+# def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
+#     """
+#     Tests that repos that are strings and repos that are dict with 
+#     type 'git' are accepted and that repos with another type
+#     will raise a warning. (issue #3565)
+#     """
+#     make_module_simple(modules_repo, "module")
+#     project = makeproject(modules_repo, "project", [], ["module"])
+#     commitmodule(project, "first commit")
+
+#     proj = install_project(modules_dir, "project")
+#     print(os.listdir(proj))
+
+#     projectyml = os.path.join(proj, "project.yml")
+#     assert os.path.exists(projectyml)
+#     app(["modules", "install"])
+#     with open(projectyml, "r", encoding="utf-8") as fh:
+#         pyml = yaml.safe_load(fh)
+
+#     # repo is a string instance (accepted)
+#     Project._project = None
+#     with caplog.at_level(logging.WARNING):
+#         app(["compile"])
+#     no_error_in_logs(caplog)
+
+#     # repo is a dict instance with type git (accepted)
+#     repo = {"url": "https://github.com/inmanta/", "type": "git"}
+#     pyml["repo"] = repo
+
+#     with open(projectyml, "w", encoding="utf-8") as fh:
+#         yaml.dump(pyml, fh)
+#     Project._project = None
+#     with caplog.at_level(logging.WARNING):
+#         app(["compile"])
+#     no_error_in_logs(caplog)
+
+#     # repo is a dict instance with type package (raises warning)
+#     repo = {"url": "https://github.com/inmanta/", "type": "package"}
+#     pyml["repo"] = repo
+
+#     with open(projectyml, "w", encoding="utf-8") as fh:
+#         yaml.dump(pyml, fh)
+#     Project._project = None
+#     with caplog.at_level(logging.WARNING):
+#         app(["compile"])
+#     warning = "Repos of type package are not supported"
+#     log_contains(caplog, "inmanta.module", logging.WARNING, warning)
+
 def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     """
     Tests that repos that are strings and repos that are dict with 
@@ -346,22 +395,34 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     project = makeproject(modules_repo, "project", [], ["module"])
     commitmodule(project, "first commit")
 
-    proj = install_project(modules_dir, "project")
-    print(os.listdir(proj))
+    install_project(modules_dir, "project")
+    projectdir = os.path.join(modules_repo,"project")
+    Project.set(Project(projectdir, autostd=True))
 
-    projectyml = os.path.join(proj, "project.yml")
-    assert os.path.exists(projectyml)
-    app(["modules", "install"])
+    projectyml = os.path.join(projectdir, "project.yml")
     with open(projectyml, "r", encoding="utf-8") as fh:
         pyml = yaml.safe_load(fh)
-
+    
     # repo is a string instance (accepted)
-    Project._project = None
     with caplog.at_level(logging.WARNING):
-        app(["compile"])
+        compiler.do_compile()
     no_error_in_logs(caplog)
+    
+    # repo is a dict instance with type package (raises warning)
+    Project._project = None
+    repo = {"url": "https://github.com/inmanta/", "type": "package"}
+    pyml["repo"] = repo
+
+    with open(projectyml, "w", encoding="utf-8") as fh:
+        yaml.dump(pyml, fh)
+    with caplog.at_level(logging.WARNING):
+        compiler.do_compile()
+    warning = "Repos of type package are not supported"
+    log_contains(caplog, "inmanta.module", logging.WARNING, warning)
+
 
     # repo is a dict instance with type git (accepted)
+    Project._project = None
     repo = {"url": "https://github.com/inmanta/", "type": "git"}
     pyml["repo"] = repo
 
@@ -369,17 +430,5 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
         yaml.dump(pyml, fh)
     Project._project = None
     with caplog.at_level(logging.WARNING):
-        app(["compile"])
+        compiler.do_compile()
     no_error_in_logs(caplog)
-
-    # repo is a dict instance with type package (raises warning)
-    repo = {"url": "https://github.com/inmanta/", "type": "package"}
-    pyml["repo"] = repo
-
-    with open(projectyml, "w", encoding="utf-8") as fh:
-        yaml.dump(pyml, fh)
-    Project._project = None
-    with caplog.at_level(logging.WARNING):
-        app(["compile"])
-    warning = "Repos of type package are not supported"
-    log_contains(caplog, "inmanta.module", logging.WARNING, warning)

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -345,7 +345,7 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
     projectdir = makeproject(modules_repo, "project_repo_type_module_v2", [], [])
     Project.set(Project(projectdir, autostd=True))
 
-    projectyml = os.path.join(projectdir, "project_repo_type_module_v2.yml")
+    projectyml = os.path.join(projectdir, "project.yml")
     with open(projectyml, "r", encoding="utf-8") as fh:
         pyml = yaml.safe_load(fh)
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -378,7 +378,6 @@ def test_project_repo_type_module_v2(modules_dir, modules_repo, caplog):
 
     with open(projectyml, "w", encoding="utf-8") as fh:
         yaml.dump(pyml, fh)
-    Project._project = None
     with caplog.at_level(logging.WARNING):
         compiler.do_compile()
     no_error_in_logs(caplog)


### PR DESCRIPTION
# Description

Modules v2 has introduced multiple repo types. Previously all repos were of type "git", while for iso5+ repos of type "package" are possible as well. The project template will include one such repo. This means iso4 needs to be compatible with both the new format and the new type (only in the sense that it should not break, iso4 should not actually use repos of type "package"). Iso4 should raise a warning for repos of type "package" but otherwise ignore them, and accept explicit specification of the git type, instead of failing on the new syntax.

issue #3565 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
