### PR TITLE
Issue/3623 modules update dependencies

### DIFF
--- a/changelogs/unreleased/3623-module-update-dependencies.yml
+++ b/changelogs/unreleased/3623-module-update-dependencies.yml
@@ -1,0 +1,6 @@
+description: "Make sure `inmanta project update` installs and updates Python dependencies"
+issue-nr: 3623
+change-type: minor
+sections:
+  feature: "`inmanta project update` now updates modules' Python dependencies to the latest compatible version. The same goes for triggering an update and recompile from the web console."
+  deprecation-note: "`inmanta modules update` has been replaced by `inmanta project update`. The old command has been deprecated and will be removed in a future release."

--- a/changelogs/unreleased/3623-module-update-dependencies.yml
+++ b/changelogs/unreleased/3623-module-update-dependencies.yml
@@ -4,3 +4,5 @@ change-type: minor
 sections:
   feature: "`inmanta project update` now updates modules' Python dependencies to the latest compatible version. The same goes for triggering an update and recompile from the web console."
   deprecation-note: "`inmanta modules update` has been replaced by `inmanta project update`. The old command has been deprecated and will be removed in a future release."
+destination-branches:
+  - master

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -819,10 +819,16 @@ os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
             raise Exception(f"Not using venv {self.env_path}. use_virtual_env() should be called first.")
         super(VirtualEnv, self).install_from_source(paths, constraint_files)
 
-    def install_from_list(self, requirements_list: List[str]) -> None:
+    def install_from_list(
+        self,
+        requirements_list: Sequence[str],
+        *,
+        upgrade: bool = False,
+        upgrade_strategy: PipUpgradeStrategy = PipUpgradeStrategy.ONLY_IF_NEEDED,
+    ) -> None:
         if not self.__using_venv:
             raise Exception(f"Not using venv {self.env_path}. use_virtual_env() should be called first.")
-        super(VirtualEnv, self).install_from_list(requirements_list)
+        super(VirtualEnv, self).install_from_list(requirements_list, upgrade=upgrade, upgrade_strategy=upgrade_strategy)
 
 
 class VenvCreationFailedError(Exception):

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -590,7 +590,6 @@ class ActiveEnv(PythonEnvironment):
         the change. Namespace packages installed in editable mode in particular require this method to allow them to be found by
         get_module_file().
         """
-        PythonWorkingSet.rebuild_working_set()
         # Make sure that the .pth files in the site-packages directory are processed.
         # This is required to make editable installs work.
         site.addsitedir(self.site_packages_dir)
@@ -627,6 +626,7 @@ class ActiveEnv(PythonEnvironment):
                            are executed in a subprocess.
                     """
                     importlib.reload(mod)
+        PythonWorkingSet.rebuild_working_set()
 
 
 process_env: ActiveEnv = ActiveEnv(python_path=sys.executable)

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -373,7 +373,7 @@ class ActiveEnv(PythonEnvironment):
         else:
             return requirements
 
-    def _are_installed(self, requirements: req_list) -> bool:
+    def are_installed(self, requirements: req_list) -> bool:
         """
         Return True iff the given requirements are installed in this venv.
         """
@@ -391,7 +391,7 @@ class ActiveEnv(PythonEnvironment):
         allow_pre_releases: bool = False,
         constraint_files: Optional[List[str]] = None,
     ) -> None:
-        if not upgrade and self._are_installed(requirements):
+        if not upgrade and self.are_installed(requirements):
             return
         try:
             super(ActiveEnv, self).install_from_index(requirements, index_urls, upgrade, allow_pre_releases, constraint_files)
@@ -499,7 +499,7 @@ class ActiveEnv(PythonEnvironment):
         :param upgrade: Upgrade requirements to the latest compatible version.
         :param upgrade_strategy: The upgrade strategy to use for requirements' dependencies.
         """
-        if not upgrade and self._are_installed(requirements_list):
+        if not upgrade and self.are_installed(requirements_list):
             # don't fork subprocess if requirements are already met
             return
         try:

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -33,7 +33,7 @@ from importlib.abc import Loader
 from importlib.machinery import ModuleSpec
 from itertools import chain
 from subprocess import CalledProcessError
-from typing import Any, Dict, Iterator, List, Optional, Pattern, Set, Sequence, Tuple, TypeVar
+from typing import Any, Dict, Iterator, List, Optional, Pattern, Sequence, Set, Tuple, TypeVar
 
 import pkg_resources
 from pkg_resources import DistInfoDistribution, Requirement

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1539,8 +1539,11 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         # do python install
         pyreq = self.collect_python_requirements()
         if len(pyreq) > 0:
-            # upgrade both direct and transitive module dependencies: eager upgrade strategy
-            self.virtualenv.install_from_list(pyreq, upgrade=True, upgrade_strategy=env.PipUpgradeStrategy.EAGER)
+            if update_dependencies:
+                # upgrade both direct and transitive module dependencies: eager upgrade strategy
+                self.virtualenv.install_from_list(pyreq, upgrade=True, upgrade_strategy=env.PipUpgradeStrategy.EAGER)
+            else:
+                self.virtualenv.install_from_list(pyreq, upgrade=False)
             # installing new dependencies into the virtual environment might introduce new conflicts
             self.verify_python_environment()
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1527,16 +1527,20 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
             loader.unload_inmanta_plugins()
         loader.PluginModuleFinder.reset()
 
-    def install_modules(self) -> None:
+    def install_modules(self, *, bypass_module_cache: bool = False, update_dependencies: bool = False) -> None:
         """
         Installs all modules, both v1 and v2.
+
+        :param bypass_module_cache: Fetch the module data from disk even if a cache entry exists.
+        :param update_dependencies: Update all Python dependencies (recursive) to their latest versions.
         """
-        self.load_module_recursive(install=True)
+        self.load_module_recursive(install=True, bypass_module_cache=bypass_module_cache)
         self.verify()
         # do python install
         pyreq = self.collect_python_requirements()
         if len(pyreq) > 0:
-            self.virtualenv.install_from_list(pyreq)
+            # upgrade both direct and transitive module dependencies: eager upgrade strategy
+            self.virtualenv.install_from_list(pyreq, upgrade=True, upgrade_strategy=env.PipUpgradeStrategy.EAGER)
             # installing new dependencies into the virtual environment might introduce new conflicts
             self.verify_python_environment()
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1539,11 +1539,8 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         # do python install
         pyreq = self.collect_python_requirements()
         if len(pyreq) > 0:
-            if update_dependencies:
-                # upgrade both direct and transitive module dependencies: eager upgrade strategy
-                self.virtualenv.install_from_list(pyreq, upgrade=True, upgrade_strategy=env.PipUpgradeStrategy.EAGER)
-            else:
-                self.virtualenv.install_from_list(pyreq, upgrade=False)
+            # upgrade both direct and transitive module dependencies: eager upgrade strategy
+            self.virtualenv.install_from_list(pyreq, upgrade=update_dependencies, upgrade_strategy=env.PipUpgradeStrategy.EAGER)
             # installing new dependencies into the virtual environment might introduce new conflicts
             self.verify_python_environment()
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -705,7 +705,7 @@ version: 0.0.1dev0"""
                     LOGGER.exception("Failed to update module %s", v1_module)
 
             # Load the newly installed modules into the modules cache
-            my_project.load_module_recursive(bypass_module_cache=True)
+            my_project.install_modules(bypass_module_cache=True)
 
         attempt = 0
         done = False

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -301,7 +301,7 @@ compatible with the dependencies specified by the updated modules.
         """
         install all modules the project requires.
         """
-        project: project = self.get_project(load=False)
+        project: Project = self.get_project(load=False)
         project.install_modules()
 
     def update(self, module: Optional[str] = None, project: Optional[Project] = None) -> None:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -299,7 +299,7 @@ compatible with the dependencies specified by the updated modules.
 
     def install(self) -> None:
         """
-        install all modules the project requires.
+        Install all modules the project requires.
         """
         project: Project = self.get_project(load=False)
         project.install_modules()

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -797,14 +797,12 @@ version: 0.0.1dev0"""
         Update all modules to the latest version compatible with the given module version constraints.
         """
 
-        LOGGER.warning(
-            "The `inmanta modules update` command has been deprecated in favor of `inmanta project update`."
-        )
+        LOGGER.warning("The `inmanta modules update` command has been deprecated in favor of `inmanta project update`.")
         ProjectTool().update(module, project)
 
     def status(self, module: Optional[str] = None) -> None:
         """
-         a git status on all modules and report
+        a git status on all modules and report
         """
         for mod in self.get_modules(module):
             if not isinstance(mod, ModuleV1):

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -340,7 +340,7 @@ compatible with the dependencies specified by the updated modules.
                     LOGGER.exception("Failed to update module %s", v1_module)
 
             # Load the newly installed modules into the modules cache
-            my_project.install_modules(bypass_module_cache=True)
+            my_project.install_modules(bypass_module_cache=True, update_dependencies=True)
 
         attempt = 0
         done = False

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -229,6 +229,20 @@ with the dependencies specified by the different Inmanta modules.
         """.strip(),
         )
 
+        subparser.add_parser(
+            "update",
+            help=(
+                "Update all modules to the latest version compatible with the module version constraints and install missing "
+                "modules"
+            ),
+            description="""
+Update all modules to the latest version compatible with the module version constraints and install missing modules.
+
+This command might reinstall Python packages in the development venv if the currently installed versions are not the latest
+compatible with the dependencies specified by the updated modules.
+            """.strip(),
+        )
+
     def freeze(self, outfile: Optional[str], recursive: Optional[bool], operator: Optional[str]) -> None:
         """
         !!! Big Side-effect !!! sets yaml parser to be order preserving
@@ -285,10 +299,95 @@ with the dependencies specified by the different Inmanta modules.
 
     def install(self) -> None:
         """
-        Install all modules the project requires.
+        install all modules the project requires.
         """
-        project: Project = self.get_project(load=False)
+        project: project = self.get_project(load=False)
         project.install_modules()
+
+    def update(self, module: Optional[str] = None, project: Optional[Project] = None) -> None:
+        """
+        Update all modules to the latest version compatible with the given module version constraints.
+        """
+
+        if project is None:
+            # rename var to make mypy happy
+            my_project = self.get_project(load=False)
+        else:
+            my_project = project
+
+        def do_update(specs: "Dict[str, List[InmantaModuleRequirement]]", modules: List[str]) -> None:
+            v2_modules = {module for module in modules if my_project.module_source.path_for(module) is not None}
+
+            v2_python_specs: List[Requirement] = [
+                ModuleV2Source.get_python_package_requirement(module_spec)
+                for module, module_specs in specs.items()
+                for module_spec in module_specs
+                if module in v2_modules
+            ]
+            if v2_python_specs:
+                env.process_env.install_from_index(
+                    v2_python_specs,
+                    my_project.module_source.urls,
+                    upgrade=True,
+                    allow_pre_releases=my_project.install_mode != InstallMode.release,
+                )
+
+            for v1_module in set(modules).difference(v2_modules):
+                spec = specs.get(v1_module, [])
+                try:
+                    ModuleV1.update(my_project, v1_module, spec, install_mode=my_project.install_mode)
+                except Exception:
+                    LOGGER.exception("Failed to update module %s", v1_module)
+
+            # Load the newly installed modules into the modules cache
+            my_project.install_modules(bypass_module_cache=True)
+
+        attempt = 0
+        done = False
+        last_failure = None
+
+        while not done and attempt < MAX_UPDATE_ATTEMPT:
+            LOGGER.info("Performing update attempt %d of %d", attempt + 1, MAX_UPDATE_ATTEMPT)
+            try:
+                loaded_mods_pre_update = {module_name: mod.version for module_name, mod in my_project.modules.items()}
+
+                # get AST
+                my_project.load_module_recursive(install=True)
+                # get current full set of requirements
+                specs: Dict[str, List[InmantaModuleRequirement]] = my_project.collect_imported_requirements()
+                if module is None:
+                    modules = list(specs.keys())
+                else:
+                    modules = [module]
+                do_update(specs, modules)
+
+                loaded_mods_post_update = {module_name: mod.version for module_name, mod in my_project.modules.items()}
+                if loaded_mods_pre_update == loaded_mods_post_update:
+                    # No changes => state has converged
+                    done = True
+                else:
+                    # New modules were downloaded or existing modules were updated to a new version. Perform another pass to
+                    # make sure that all dependencies, defined in these new modules, are taken into account.
+                    last_failure = CompilerException("Module update did not converge")
+            except CompilerException as e:
+                last_failure = e
+                # model is corrupt
+                LOGGER.info(
+                    "The model is not currently in an executable state, performing intermediate updates", stack_info=True
+                )
+                # get all specs from all already loaded modules
+                specs = my_project.collect_requirements()
+
+                if module is None:
+                    # get all loaded/partly loaded modules
+                    modules = list(my_project.modules.keys())
+                else:
+                    modules = [module]
+                do_update(specs, modules)
+            attempt += 1
+
+        if last_failure is not None and not done:
+            raise last_failure
 
 
 class ModuleTool(ModuleLikeTool):
@@ -338,14 +437,16 @@ class ModuleTool(ModuleLikeTool):
 
         subparser.add_parser(
             "update",
-            help="Update all modules to the latest version compatible with the module version constraints and install missing "
-            "modules",
+            help=(
+                "(deprecated: use `inmanta project update` instead) Update all modules to the latest version compatible with"
+                " the module version constraints and install missing modules"
+            ),
             description="""
 Update all modules to the latest version compatible with the module version constraints and install missing modules.
 
-This command might reinstall Python packages in the development venv if the currently installed versions are not compatible
-with the dependencies specified by the updated modules.
-        """.strip(),
+This command might reinstall Python packages in the development venv if the currently installed versions are not the latest
+compatible with the dependencies specified by the updated modules.
+            """.strip(),
         )
 
         install: ArgumentParser = subparser.add_parser(
@@ -669,91 +770,6 @@ version: 0.0.1dev0"""
                 t.add_row(row)
             print(t.draw())
 
-    def update(self, module: Optional[str] = None, project: Optional[Project] = None) -> None:
-        """
-        Update all modules to the latest version compatible with the given module version constraints.
-        """
-
-        if project is None:
-            # rename var to make mypy happy
-            my_project = self.get_project(False)
-        else:
-            my_project = project
-
-        def do_update(specs: "Dict[str, List[InmantaModuleRequirement]]", modules: List[str]) -> None:
-            v2_modules = {module for module in modules if my_project.module_source.path_for(module) is not None}
-
-            v2_python_specs: List[Requirement] = [
-                ModuleV2Source.get_python_package_requirement(module_spec)
-                for module, module_specs in specs.items()
-                for module_spec in module_specs
-                if module in v2_modules
-            ]
-            if v2_python_specs:
-                env.process_env.install_from_index(
-                    v2_python_specs,
-                    my_project.module_source.urls,
-                    upgrade=True,
-                    allow_pre_releases=my_project.install_mode != InstallMode.release,
-                )
-
-            for v1_module in set(modules).difference(v2_modules):
-                spec = specs.get(v1_module, [])
-                try:
-                    ModuleV1.update(my_project, v1_module, spec, install_mode=my_project.install_mode)
-                except Exception:
-                    LOGGER.exception("Failed to update module %s", v1_module)
-
-            # Load the newly installed modules into the modules cache
-            my_project.install_modules(bypass_module_cache=True)
-
-        attempt = 0
-        done = False
-        last_failure = None
-
-        while not done and attempt < MAX_UPDATE_ATTEMPT:
-            LOGGER.info("Performing update attempt %d of %d", attempt + 1, MAX_UPDATE_ATTEMPT)
-            try:
-                loaded_mods_pre_update = {module_name: mod.version for module_name, mod in my_project.modules.items()}
-
-                # get AST
-                my_project.load_module_recursive(install=True)
-                # get current full set of requirements
-                specs: Dict[str, List[InmantaModuleRequirement]] = my_project.collect_imported_requirements()
-                if module is None:
-                    modules = list(specs.keys())
-                else:
-                    modules = [module]
-                do_update(specs, modules)
-
-                loaded_mods_post_update = {module_name: mod.version for module_name, mod in my_project.modules.items()}
-                if loaded_mods_pre_update == loaded_mods_post_update:
-                    # No changes => state has converged
-                    done = True
-                else:
-                    # New modules were downloaded or existing modules were updated to a new version. Perform another pass to
-                    # make sure that all dependencies, defined in these new modules, are taken into account.
-                    last_failure = CompilerException("Module update did not converge")
-            except CompilerException as e:
-                last_failure = e
-                # model is corrupt
-                LOGGER.info(
-                    "The model is not currently in an executable state, performing intermediate updates", stack_info=True
-                )
-                # get all specs from all already loaded modules
-                specs = my_project.collect_requirements()
-
-                if module is None:
-                    # get all loaded/partly loaded modules
-                    modules = list(my_project.modules.keys())
-                else:
-                    modules = [module]
-                do_update(specs, modules)
-            attempt += 1
-
-        if last_failure is not None and not done:
-            raise last_failure
-
     def install(self, editable: bool = False, path: Optional[str] = None) -> None:
         """
         Install a module in the active Python environment. Only works for v2 modules: v1 modules can only be installed in the
@@ -776,9 +792,19 @@ version: 0.0.1dev0"""
                 build_artifact: str = self.build(module_path, build_dir)
                 install(build_artifact)
 
+    def update(self, module: Optional[str] = None, project: Optional[Project] = None) -> None:
+        """
+        Update all modules to the latest version compatible with the given module version constraints.
+        """
+
+        LOGGER.warning(
+            "The `inmanta modules update` command has been deprecated in favor of `inmanta project update`."
+        )
+        ProjectTool().update(module, project)
+
     def status(self, module: Optional[str] = None) -> None:
         """
-        Run a git status on all modules and report
+         a git status on all modules and report
         """
         for mod in self.get_modules(module):
             if not isinstance(mod, ModuleV1):

--- a/tests/moduletool/test_update.py
+++ b/tests/moduletool/test_update.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 import py.path
 import pytest
@@ -25,11 +25,11 @@ from pkg_resources import Requirement
 from inmanta.config import Config
 from inmanta.env import LocalPackagePath, process_env
 from inmanta.module import InmantaModuleRequirement, InstallMode, ModuleV1, ModuleV2Source
-from inmanta.moduletool import ModuleTool
+from inmanta.moduletool import ModuleTool, ProjectTool
 from inmanta.parser import ParserException
 from moduletool.common import add_file, clone_repo
 from packaging.version import Version
-from utils import PipIndex, module_from_template
+from utils import PipIndex, create_python_package, module_from_template, v1_module_from_template
 
 
 @pytest.mark.parametrize_any(
@@ -181,6 +181,63 @@ def test_module_update_with_v2_module(
     assert_version_installed(module_name="module1", version="1.2.4")
     assert_version_installed(module_name="module2", version="2.2.0" if install_mode == InstallMode.release else "2.2.1.dev0")
     assert ModuleV1(project=None, path=mod11_dir).version == Version("4.1.2")
+
+
+def test_module_update_dependencies(
+    tmpdir: py.path.local,
+    snippetcompiler_clean,
+    modules_dir: str,
+) -> None:
+    """
+    Verify that `inmanta project update` correctly handles module's Python dependencies:
+        - update should include install
+        - update should update Python dependencies within module's constraints
+        - update should update transitive Python dependencies
+    """
+    snippetcompiler_clean.setup_for_snippet(
+        snippet="import my_mod",
+        autostd=False,
+        install_project=False,
+        add_to_module_path=[str(tmpdir.join("modules"))],
+    )
+
+    # create index with multiple versions for packages a, b and c
+    index: PipIndex = PipIndex(str(tmpdir.join("index")))
+    create_python_package("a", Version("1.0.0"), str(tmpdir.join("a-1.0.0")), publish_index=index)
+    for v in ("1.0.0", "1.0.1", "2.0.0"):
+        create_python_package(
+            "b", Version(v), str(tmpdir.join(f"b-{v}")), requirements=[Requirement.parse("c")], publish_index=index
+        )
+    for v in ("1.0.0", "2.0.0"):
+        create_python_package("c", Version(v), str(tmpdir.join(f"c-{v}")), publish_index=index)
+
+    # install b-1.0.0 and c-1.0.0
+    process_env.install_from_index([Requirement.parse(req) for req in ("b==1.0.0", "c==1.0.0")], index_urls=[index.url])
+
+    # create my_mod
+    v1_module_from_template(
+        source_dir=os.path.join(modules_dir, "minimalv1module"),
+        dest_dir=str(tmpdir.join("modules", "my_mod")),
+        new_name="my_mod",
+        new_requirements=[Requirement.parse(req) for req in ("a", "b~=1.0.0")],
+    )
+
+    # run `inmanta project update` without running install first
+    environ_index: Optional[str] = os.environ.get("PIP_INDEX_URL", None)
+    try:
+        os.environ["PIP_INDEX_URL"] = index.url
+        ProjectTool().update()
+    finally:
+        if environ_index is None:
+            del os.environ["PIP_INDEX_URL"]
+        else:
+            os.environ["PIP_INDEX_URL"] = environ_index
+
+    # Verify that:
+    #   - direct dependency a has been installed
+    #   - direct depdendency b has been updated but not past the allowed constraint
+    #   - transitive dependency c has been updated
+    assert process_env.are_installed(("a==1.0.0", "b==1.0.1", "c==2.0.0"))
 
 
 def test_module_update_syntax_error_in_project(tmpdir: py.path.local, modules_v2_dir: str, snippetcompiler_clean) -> None:

--- a/tests/moduletool/test_update.py
+++ b/tests/moduletool/test_update.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 import os
-from typing import Dict, Optional
+from typing import Dict
 
 import py.path
 import pytest

--- a/tests/moduletool/test_update.py
+++ b/tests/moduletool/test_update.py
@@ -183,6 +183,7 @@ def test_module_update_with_v2_module(
     assert ModuleV1(project=None, path=mod11_dir).version == Version("4.1.2")
 
 
+@pytest.mark.slowtest
 def test_module_update_dependencies(
     tmpdir: py.path.local,
     snippetcompiler_clean,

--- a/tests/moduletool/test_update.py
+++ b/tests/moduletool/test_update.py
@@ -186,6 +186,7 @@ def test_module_update_with_v2_module(
 @pytest.mark.slowtest
 def test_module_update_dependencies(
     tmpdir: py.path.local,
+    monkeypatch,
     snippetcompiler_clean,
     modules_dir: str,
 ) -> None:
@@ -224,15 +225,8 @@ def test_module_update_dependencies(
     )
 
     # run `inmanta project update` without running install first
-    environ_index: Optional[str] = os.environ.get("PIP_INDEX_URL", None)
-    try:
-        os.environ["PIP_INDEX_URL"] = index.url
-        ProjectTool().update()
-    finally:
-        if environ_index is None:
-            del os.environ["PIP_INDEX_URL"]
-        else:
-            os.environ["PIP_INDEX_URL"] = environ_index
+    monkeypatch.setenv("PIP_INDEX_URL", index.url)
+    ProjectTool().update()
 
     # Verify that:
     #   - direct dependency a has been installed

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -461,7 +461,7 @@ def test_cache_on_active_env(tmpvenv_active_inherit: env.ActiveEnv, local_module
     def _assert_install(requirement: str, installed: bool) -> None:
         parsed_requirement = Requirement.parse(requirement)
         for r in [requirement, parsed_requirement]:
-            assert tmpvenv_active_inherit._are_installed(requirements=[r]) == installed
+            assert tmpvenv_active_inherit.are_installed(requirements=[r]) == installed
 
     _assert_install("inmanta-module-elaboratev2module==1.2.3", installed=False)
     tmpvenv_active_inherit.install_from_index(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -395,7 +395,9 @@ requires = ["setuptools"]
             f"""
 [egg_info]
 tag_build = .dev{pkg_version.dev}
-            """.strip() if pkg_version.is_devrelease else ""
+            """.strip()
+            if pkg_version.is_devrelease
+            else ""
         )
         fd.write(
             f"""
@@ -410,7 +412,8 @@ author = Inmanta <code@inmanta.com>
 
 [options]
 install_requires =%s
-            """.strip() % "".join(f"\n  {req}" for req in (requirements if requirements is not None else []))
+            """.strip()
+            % "".join(f"\n  {req}" for req in (requirements if requirements is not None else []))
         )
 
     if install:


### PR DESCRIPTION
# Description

- Moved `inmanta module update` to `inmanta project update`. The former still works but triggers a deprecation warning.
- Fixed bug where `inmanta project update` would not install v1 modules' Python dependencies (bug exists on master only).
- `inmanta project update` now also updates Python dependencies, in contrast to iso4 behavior.

Additional notes:
- While I put in the issue description that a test should be added to test this behavior on the server, I now believe the test on the module tool covers this sufficiently. I have not added a test for the server.

closes #3623

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
