### PR TITLE
Fix bug where environment clear doesn't notify listeners

### DIFF
--- a/changelogs/unreleased/fix-listeners-calls-on-clear-env.yml
+++ b/changelogs/unreleased/fix-listeners-calls-on-clear-env.yml
@@ -1,0 +1,7 @@
+---
+description: Fix bug where the listeners of the environment clear action are not notified when files of that environment cannot be deleted from the filesystem.
+issue-nr: 3637
+change-type: patch
+destination-branches: [master, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -462,6 +462,9 @@ class EnvironmentService(protocol.ServerSlice):
 
         project_dir = os.path.join(self.server_slice._server_storage["environments"], str(env.id))
         if os.path.exists(project_dir):
+            # This call might fail when someone manually creates a directory or file that is owned
+            # by another user than the user running the inmanta server. Execute rmtree() after
+            # notify_listeners() to ensure that the listeners are notified.
             shutil.rmtree(project_dir)
 
     @handle(methods_v2.environment_create_token, env="tid")

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -458,10 +458,11 @@ class EnvironmentService(protocol.ServerSlice):
         await self.autostarted_agent_manager.stop_agents(env)
         await env.delete_cascade(only_content=True)
 
+        await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
+
         project_dir = os.path.join(self.server_slice._server_storage["environments"], str(env.id))
         if os.path.exists(project_dir):
             shutil.rmtree(project_dir)
-        await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
 
     @handle(methods_v2.environment_create_token, env="tid")
     async def environment_create_token(self, env: data.Environment, client_types: List[str], idempotent: bool) -> str:


### PR DESCRIPTION
# Description

Fix bug where the listeners of the environment clear action are not notified when files of that environment cannot be deleted from the filesystem.

closes #3637

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x]  Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
