### PR TITLE
Update installation documentation from Postgresql 10  to 13

### DIFF
--- a/changelogs/unreleased/use-pg13-in-installation-doc.yml
+++ b/changelogs/unreleased/use-pg13-in-installation-doc.yml
@@ -1,0 +1,7 @@
+---
+description: Added support for PostgreSQL 13
+issue-nr: 2893
+change-type: patch
+destination-branches: [master]
+sections:
+  feature: "{{description}}"

--- a/docs/install/install-server/configure-postgres.inc
+++ b/docs/install/install-server/configure-postgres.inc
@@ -1,10 +1,17 @@
 .. _install-step-2:
 
-Step 2: Install PostgreSQL 10
+Step 2: Install PostgreSQL 13
 -----------------------------
 
-PostgreSQL 10 can be installed by following the `installation guide <https://www.postgresql.org/download/>`_ for your
+PostgreSQL 13 can be installed by following the `installation guide <https://www.postgresql.org/download/>`_ for your
 platform.
+
+On RHEL8-based systems, it's required to disable the postgresql module first. Otherwise some postgresql packages
+from the PostgreSQL yum repository will not be visible to the `dnf install` command.
+
+.. code-block:: sh
+
+  sudo dnf module disable postgresql
 
 .. _install-step-3:
 
@@ -15,13 +22,13 @@ Initialize the PostgreSQL server:
 
 .. code-block:: sh
 
-  sudo /usr/pgsql-10/bin/postgresql-10-setup initdb
+  sudo /usr/pgsql-13/bin/postgresql-13-setup initdb
 
 Start the PostgreSQL database and make sure it is started at boot.
 
 .. code-block:: sh
 
-   sudo systemctl enable --now postgresql-10
+   sudo systemctl enable --now postgresql-13
 
 Create a inmanta user and an inmanta database by executing the following command. This command will request you to choose a
 password for the inmanta database.
@@ -31,7 +38,7 @@ password for the inmanta database.
   sudo -u postgres -i sh -c "createuser --pwprompt inmanta; createdb -O inmanta inmanta"
 
 Change the authentication method for local connections to md5 by changing the following lines in the
-``/var/lib/pgsql/10/data/pg_hba.conf`` file
+``/var/lib/pgsql/13/data/pg_hba.conf`` file
 
 .. code-block:: text
 
@@ -54,4 +61,4 @@ Restart the PostgreSQL server to apply the changes made in the ``pg_hba.conf`` f
 
 .. code-block:: sh
 
-   sudo systemctl restart postgresql-10
+   sudo systemctl restart postgresql-13

--- a/docs/install/install-server/install-server.inc
+++ b/docs/install/install-server/install-server.inc
@@ -60,7 +60,7 @@ Install the software
         files and systemd unit files. The dashboard is installed with the server package.
 
 
-    .. tab:: Debian, Ubuntu and derivatives. 
+    .. tab:: Debian, Ubuntu and derivatives.
 
         First make sure Python >= 3.6 and git are installed. Inmanta requires many dependencies so it is recommended to create a virtual env.
         Next install inmanta with pip install in the newly created virtual env.
@@ -80,7 +80,7 @@ Install the software
             sudo /opt/inmanta/bin/pip install wheel
             sudo /opt/inmanta/bin/pip install inmanta
             sudo /opt/inmanta/bin/inmanta --help
-            
+
             # Install PostgreSQL
             sudo apt-get install postgresql postgresql-client
 
@@ -123,9 +123,9 @@ Install the software
             sudo python3 -m venv /opt/inmanta
             sudo /opt/inmanta/bin/pip install inmanta
             sudo /opt/inmanta/bin/inmanta --help
-            
 
-        Install PostgreSQL using this `guide <https://www.postgresql.org/docs/10/tutorial-install.html>`_
+
+        Install PostgreSQL using this `guide <https://www.postgresql.org/docs/13/tutorial-install.html>`_
 
 
         Download the configuration file named ``inmanta.cfg`` (this name is arbitrary) in your virtual env:


### PR DESCRIPTION
# Description

This PR updates the installation documentation as such that it mentions that PostgreSQL 13 should be installed instead of PostgreSQL 10.

Part of #2893

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
