### PR TITLE
removed bugfix note from change entry

### DIFF
--- a/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
+++ b/changelogs/unreleased/3565-compatibility-iso4-modulev2.yml
@@ -3,5 +3,4 @@ issue-nr: 3565
 description: Raise a warning when trying to use repo of type package.
 destination-branches: [iso4]
 sections:
-    bugfix: "{{description}}"
     upgrade-note: "Creating new modules using the cookiecutter template now requires the --checkout v1 option."


### PR DESCRIPTION
#3638 contained a bugfix note in the change entry that I believe is not in its place here. The new project metadata format has not yet been released so there is no bug. I only noticed when the `merge-tool-ready` label had already been added.

Will be merged manually.