### PR TITLE
fixed inmanta-ui link in docs

### DIFF
--- a/changelogs/unreleased/docs-link-fix.yml
+++ b/changelogs/unreleased/docs-link-fix.yml
@@ -1,0 +1,4 @@
+description: Fixed inmanta-ui link in docs
+change-type: patch
+destination-branches:
+  - master

--- a/docs/dashboard.rst
+++ b/docs/dashboard.rst
@@ -1,5 +1,5 @@
 .. warning::
-    The Inmanta dashboard has been deprecated in favour of the `Inmanta Web Console <../extensions/inmanta-ui/index.html>`_.
+    The Inmanta dashboard has been deprecated in favour of the `Inmanta Web Console <extensions/inmanta-ui/index.html>`_.
 
 Dashboard documentation
 =======================

--- a/docs/dashboard/dashboard.rst
+++ b/docs/dashboard/dashboard.rst
@@ -1,5 +1,5 @@
 .. warning::
-    The Inmanta dashboard has been deprecated in favour of the `Inmanta Web Console <../../extensions/inmanta-ui/index.html>`_.
+    The Inmanta dashboard has been deprecated in favour of the `Inmanta Web Console <../extensions/inmanta-ui/index.html>`_.
 
 The project overview
 --------------------


### PR DESCRIPTION
# Description

There was a `..` too many in the rel link to the inmanta-ui docs.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
