### PR TITLE
constrained pip to compatible range

### DIFF
--- a/changelogs/unreleased/3552-constrain-pip.yml
+++ b/changelogs/unreleased/3552-constrain-pip.yml
@@ -1,0 +1,4 @@
+description: Constrain pip to range that supports editable V2 module installation.
+change-type: patch
+destination-branches:
+  - master

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-__requires__ = ['pip >= 21.3']
 from setuptools import setup, find_packages
 from os import path
 
@@ -18,6 +17,8 @@ requires = [
     "more-itertools",
     "netifaces",
     "packaging",
+    # pip>=21.3 required for editable pyproject.toml + setup.cfg based install support
+    "pip>=21.3",
     "ply",
     # Exclude pre-release due to https://github.com/samuelcolvin/pydantic/issues/3546
     "pydantic!=1.9.0a1",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+__requires__ = ['pip >= 21.3']
 from setuptools import setup, find_packages
 from os import path
 


### PR DESCRIPTION
# Description

Constrained pip to range that supports editable V2 module installation. Verified to update outdated pip as it would any other package.

closes #3552

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
