### PR TITLE
added inmanta-ui links to docs link check ignore list

### DIFF
--- a/changelogs/unreleased/docs-link-check-ignores.yml
+++ b/changelogs/unreleased/docs-link-check-ignores.yml
@@ -1,0 +1,4 @@
+description: Added inmanta-ui links to docs link check ignore list
+change-type: patch
+destination-branches:
+  - master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,7 +287,15 @@ texinfo_documents = [
 
 # Ingnore link check of openapi.html because it's used in a toctree.
 # A trick was required to include a non-sphinx document in a toctee.
-linkcheck_ignore = [r'http(s)?://localhost:\d+/', r'http://127.0.0.1:\d+', r'openapi.html', r'https://twitter.com/inmanta_com', '../_specs/openapi.json']
+linkcheck_ignore = [
+    r'http(s)?://localhost:\d+/',
+    r'http://127.0.0.1:\d+',
+    r'openapi.html',
+    r'https://twitter.com/inmanta_com',
+    '../_specs/openapi.json',
+    'extensions/inmanta-ui/index.html',
+    '../extensions/inmanta-ui/index.html',
+]
 
 # Do not print the warning that tabs only work in html
 # https://github.com/djungelorm/sphinx-tabs/issues/39


### PR DESCRIPTION
# Description

The docs link check is currently failing on the links to the `inmanta-ui` extension because the test runs against core only. The extension is only included in the product build. This PR adds these links to the ignore list. inmanta/inmanta#72 was created as a stable fix to be picked up later.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
