### PR TITLE
Run tests against postgresql 10

### DIFF
--- a/changelogs/unreleased/run-tests-against-postgresql-10.yml
+++ b/changelogs/unreleased/run-tests-against-postgresql-10.yml
@@ -1,0 +1,5 @@
+---
+description: Update the `pytest.ini` file as such that the tests run against PostgreSQL 10 by default
+issue-nr: 3595
+change-type: patch
+destination-branches: [iso4]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+# Ensure that the tests for this branch run against PostgreSQL 10
+postgresql_exec=/usr/pgsql-10/bin/pg_ctl
+env =
+    PATH=/usr/pgsql-10/bin/:{PATH}
 markers =
     slowtest
     link_check


### PR DESCRIPTION
# Description

Update the `pytest.ini` file as such that the tests run against PostgreSQL 10 by default.

Part of inmanta/inmanta-core#3595

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
