### PR TITLE
Disable version bumps on the iso4 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,19 +16,3 @@ updates:
     # setuptools>=59.7.0 requires Python>=3.7
     - dependency-name: "setuptools"
       versions: [">=59.7.0"]
-- package-ecosystem: pip
-  target-branch: iso4
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  allow:
-    # Allow both direct and indirect updates for all packages
-    - dependency-type: "all"
-  ignore:
-    # importlib-metadata>=4.9.0 requires Python>=3.7
-    - dependency-name: "importlib-metadata"
-      versions: [">=4.9.0"]
-    # setuptools>=59.7.0 requires Python>=3.7
-    - dependency-name: "setuptools"
-      versions: [">=59.7.0"]

--- a/changelogs/unreleased/disable-version-bumps-iso4-branch.yml
+++ b/changelogs/unreleased/disable-version-bumps-iso4-branch.yml
@@ -1,4 +1,4 @@
 ---
 description: Disable Dependabot on the iso4 branch
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso5]

--- a/changelogs/unreleased/disable-version-bumps-iso4-branch.yml
+++ b/changelogs/unreleased/disable-version-bumps-iso4-branch.yml
@@ -1,0 +1,4 @@
+---
+description: Disable Dependabot on the iso4 branch
+change-type: patch
+destination-branches: [master]


### PR DESCRIPTION
# Description

Disable Dependabot version bump PRs for the ISO4 branch as it is in maintenance mode now.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
