### PR TITLE
Enable the UI extension by default

### DIFF
--- a/changelogs/unreleased/3653-enable-ui-default.yml
+++ b/changelogs/unreleased/3653-enable-ui-default.yml
@@ -5,3 +5,4 @@ sections:
   feature: "{{description}}"
 destination-branches:
   - master
+  - iso5

--- a/changelogs/unreleased/3653-enable-ui-default.yml
+++ b/changelogs/unreleased/3653-enable-ui-default.yml
@@ -1,0 +1,7 @@
+description: "Enable the UI extension by default"
+issue-nr: 3653
+change-type: minor
+sections:
+  feature: "{{description}}"
+destination-branches:
+  - master

--- a/inmanta.spec
+++ b/inmanta.spec
@@ -163,6 +163,7 @@ rm -rf %{buildroot}
 %config %attr(-, root, root)/etc/inmanta
 %config(noreplace) %attr(-, root, root)/etc/inmanta/inmanta.cfg
 %config %attr(-, root, root)/etc/inmanta/inmanta.d
+%config(noreplace) %attr(-, root, root)/etc/inmanta/inmanta.d/extensions.cfg
 %config(noreplace) %attr(-, root, root)/etc/logrotate.d/inmanta
 %config(noreplace) %attr(-, root, root)/etc/sysconfig/inmanta-server
 %config(noreplace) %attr(-, root, root)/etc/sysconfig/inmanta-agent

--- a/inmanta.spec
+++ b/inmanta.spec
@@ -129,6 +129,10 @@ mkdir -p %{buildroot}/var/log/inmanta
 mkdir -p %{buildroot}/etc/logrotate.d
 install -p -m 644 misc/inmanta.cfg %{buildroot}/etc/inmanta/inmanta.cfg
 install -p -m 644 misc/logrotation_config %{buildroot}/etc/logrotate.d/inmanta
+cat <<EOF > %{buildroot}/etc/inmanta/inmanta.d/extensions.cfg
+[server]
+enabled_extensions=ui
+EOF
 
 # Setup systemd
 mkdir -p %{buildroot}%{_unitdir}


### PR DESCRIPTION
# Description

Enable the UI extension by default

closes #3653 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
