### PR TITLE
Use pytest-postgresql>=4

### DIFF
--- a/changelogs/unreleased/use-pytest-postgresql3.yml
+++ b/changelogs/unreleased/use-pytest-postgresql3.yml
@@ -1,0 +1,4 @@
+---
+description: Use pytest-postgresql>=4
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -29,8 +29,8 @@ requires = [
     "pyformance",
     "pytest-asyncio",
     "pytest-env",
-    "pytest-postgresql",
-    "psycopg2",
+    "pytest-postgresql>=4",
+    "psycopg>=3",
     "tornado",
 ]
 


### PR DESCRIPTION
# Description

`pytest-postgresql>=4` requires `psycopg>=3` instead of `psycopg2`. This PR implements this change.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
