### PR TITLE
Remove references to v2 branch of inmanta module template

### DIFF
--- a/changelogs/unreleased/remove-refs-v2-branch-on-module-template.yml
+++ b/changelogs/unreleased/remove-refs-v2-branch-on-module-template.yml
@@ -1,0 +1,6 @@
+---
+description: Remove the references to the v2 branch of the inmanta module tempate in documentation.
+issue-nr: 16
+issue-repo: inmanta-module-template
+change-type: patch
+destination-branches: [master, iso5]

--- a/docs/model_developers/developer_getting_started.rst
+++ b/docs/model_developers/developer_getting_started.rst
@@ -195,7 +195,7 @@ Same as :ref:`Working on a New Project <dgs-new-project>` part, modules can also
 .. code-block:: bash
 
     pip install cookiecutter
-    cookiecutter https://github.com/inmanta/inmanta-module-template.git
+    cookiecutter --checkout v1 https://github.com/inmanta/inmanta-module-template.git
 
 for a v1 module. If you want to use the module in a project, make sure to put it in the project's module path.
 
@@ -204,7 +204,7 @@ For a v2 module, use the v2 cookiecutter template, then install the module:
 .. code-block:: bash
 
     pip install cookiecutter
-    cookiecutter --checkout v2 https://github.com/inmanta/inmanta-module-template.git
+    cookiecutter https://github.com/inmanta/inmanta-module-template.git
     inmanta module install -e ./<module-name>
 
 This will install a Python package with the name ``inmanta-module-<module-name>`` in the active environment.

--- a/docs/model_developers/module_creation.rst
+++ b/docs/model_developers/module_creation.rst
@@ -15,7 +15,7 @@ For a v1 module:
   :linenos:
 
   pip install cookiecutter
-  cookiecutter gh:inmanta/inmanta-module-template
+  cookiecutter --checkout v1 gh:inmanta/inmanta-module-template
 
 For a v2 module:
 
@@ -23,7 +23,7 @@ For a v2 module:
   :linenos:
 
   pip install cookiecutter
-  cookiecutter --checkout v2 gh:inmanta/inmanta-module-template
+  cookiecutter gh:inmanta/inmanta-module-template
 
 .. note::
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -654,7 +654,6 @@ mode.
                 raise Exception(f"Directory {module_dir} already exists")
             cookiecutter(
                 "https://github.com/inmanta/inmanta-module-template.git",
-                checkout="v2",
                 no_input=no_input,
                 extra_context={"module_name": name},
             )


### PR DESCRIPTION
# Description

Remove the references to the v2 branch of the inmanta module tempate in documentation.

closes inmanta/inmanta-module-template#16

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
