### PR TITLE
split off product specific part of configure agents docs

### DIFF
--- a/changelogs/unreleased/inmanta-service-orchestrator-145-configure-agents-product-specific.yml
+++ b/changelogs/unreleased/inmanta-service-orchestrator-145-configure-agents-product-specific.yml
@@ -1,0 +1,7 @@
+description: Split off product specific part of configure agents docs
+issue-repo: inmanta-service-orchestrator
+issue-nr: 245
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/docs/install/2-configure-agents.rst
+++ b/docs/install/2-configure-agents.rst
@@ -51,7 +51,7 @@ Option name  Default value  Description
 ===========  =============  =====================================================================================================================
 retries      10             The amount of times the orchestrator will try to establish the SSH connection when the initial attempt failed.
 retry_wait   30             The amount of second between two attempts to establish the SSH connection.
-python       python         The Python2 interpreter available on the remote side. This executable has to be discoverable through the system PATH.
+python       python         The Python3 interpreter available on the remote side. This executable has to be discoverable through the system PATH.
 ===========  =============  =====================================================================================================================
 
 

--- a/docs/install/2-configure-agents.rst
+++ b/docs/install/2-configure-agents.rst
@@ -90,24 +90,7 @@ device is remote with respect to the Inmanta agent and the agent has to execute 
 Step 1: Installing the required Inmanta packages
 ================================================
 
-In order to run a manually started agent, the ``inmanta-oss`` and the ``inmanta-oss-agent`` packages are required on the
-machine that will run the agent.
-
-.. code-block:: sh
-
-    sudo tee /etc/yum.repos.d/inmanta_oss_stable.repo <<EOF
-    [inmanta-oss-stable]
-    name=Inmanta OSS stable
-    baseurl=https://pkg.inmanta.com/inmanta-oss-stable/el7/
-    gpgcheck=1
-    gpgkey=https://pkg.inmanta.com/inmanta-oss-stable/inmanta-oss-stable-public-key
-    repo_gpgcheck=1
-    enabled=1
-    enabled_metadata=1
-    EOF
-
-    sudo yum install -y epel-release
-    sudo yum install -y inmanta-oss inmanta-oss-agent
+.. include:: ./configure-agents/install-packages.inc
 
 
 Step 2: Configuring the manually-started agent

--- a/docs/install/configure-agents/install-packages.inc
+++ b/docs/install/configure-agents/install-packages.inc
@@ -3,12 +3,12 @@ machine that will run the agent.
 
 .. code-block:: sh
 
-    sudo tee /etc/yum.repos.d/inmanta_oss_stable.repo <<EOF
+    sudo tee /etc/yum.repos.d/inmanta-oss-stable.repo <<EOF
     [inmanta-oss-stable]
     name=Inmanta OSS stable
-    baseurl=https://pkg.inmanta.com/inmanta-oss-stable/el8/
+    baseurl=https://packages.inmanta.com/public/oss-stable/rpm/el/\$releasever/\$basearch
     gpgcheck=1
-    gpgkey=https://pkg.inmanta.com/inmanta-oss-stable/inmanta-oss-stable-public-key
+    gpgkey=https://packages.inmanta.com/public/oss-stable/gpg.A34DD0A274F07713.key
     repo_gpgcheck=1
     enabled=1
     enabled_metadata=1

--- a/docs/install/configure-agents/install-packages.inc
+++ b/docs/install/configure-agents/install-packages.inc
@@ -14,4 +14,4 @@ machine that will run the agent.
     enabled_metadata=1
     EOF
 
-    sudo yum install -y inmanta-oss-agent
+    sudo dnf install -y inmanta-oss-agent

--- a/docs/install/configure-agents/install-packages.inc
+++ b/docs/install/configure-agents/install-packages.inc
@@ -1,0 +1,17 @@
+In order to run a manually started agent, the ``inmanta-oss-agent`` package is required on the
+machine that will run the agent.
+
+.. code-block:: sh
+
+    sudo tee /etc/yum.repos.d/inmanta_oss_stable.repo <<EOF
+    [inmanta-oss-stable]
+    name=Inmanta OSS stable
+    baseurl=https://pkg.inmanta.com/inmanta-oss-stable/el8/
+    gpgcheck=1
+    gpgkey=https://pkg.inmanta.com/inmanta-oss-stable/inmanta-oss-stable-public-key
+    repo_gpgcheck=1
+    enabled=1
+    enabled_metadata=1
+    EOF
+
+    sudo yum install -y inmanta-oss-agent

--- a/docs/install/install-server/configure-postgres.inc
+++ b/docs/install/install-server/configure-postgres.inc
@@ -6,12 +6,11 @@ Step 2: Install PostgreSQL 13
 PostgreSQL 13 can be installed by following the `installation guide <https://www.postgresql.org/download/>`_ for your
 platform.
 
-On RHEL8-based systems, it's required to disable the postgresql module first. Otherwise some postgresql packages
-from the PostgreSQL yum repository will not be visible to the `dnf install` command.
+For RHEL8-based systems:
 
 .. code-block:: sh
 
-  sudo dnf module disable postgresql
+  sudo yum module install postgresql:13/server
 
 .. _install-step-3:
 
@@ -22,13 +21,13 @@ Initialize the PostgreSQL server:
 
 .. code-block:: sh
 
-  sudo /usr/pgsql-13/bin/postgresql-13-setup initdb
+  sudo /usr/bin/postgresql-setup initdb
 
 Start the PostgreSQL database and make sure it is started at boot.
 
 .. code-block:: sh
 
-   sudo systemctl enable --now postgresql-13
+   sudo systemctl enable --now postgresql
 
 Create a inmanta user and an inmanta database by executing the following command. This command will request you to choose a
 password for the inmanta database.
@@ -38,7 +37,7 @@ password for the inmanta database.
   sudo -u postgres -i sh -c "createuser --pwprompt inmanta; createdb -O inmanta inmanta"
 
 Change the authentication method for local connections to md5 by changing the following lines in the
-``/var/lib/pgsql/13/data/pg_hba.conf`` file
+``/var/lib/pgsql/data/pg_hba.conf`` file
 
 .. code-block:: text
 
@@ -61,4 +60,4 @@ Restart the PostgreSQL server to apply the changes made in the ``pg_hba.conf`` f
 
 .. code-block:: sh
 
-   sudo systemctl restart postgresql-13
+   sudo systemctl restart postgresql

--- a/docs/install/install-server/configure-postgres.inc
+++ b/docs/install/install-server/configure-postgres.inc
@@ -10,7 +10,7 @@ For RHEL8-based systems:
 
 .. code-block:: sh
 
-  sudo yum module install postgresql:13/server
+  sudo dnf module install postgresql:13/server
 
 .. _install-step-3:
 

--- a/docs/install/install-server/install-server.inc
+++ b/docs/install/install-server/install-server.inc
@@ -37,7 +37,7 @@ Install the software
 
         .. code-block:: sh
 
-          sudo tee /etc/yum.repos.d/inmanta_oss_stable.repo <<EOF
+          sudo tee /etc/yum.repos.d/inmanta-oss-stable.repo <<EOF
           [inmanta-oss-stable]
           name=inmanta-oss-stable
           baseurl=https://packages.inmanta.com/public/oss-stable/rpm/el/\$releasever/\$basearch

--- a/docs/install/install-server/install-server.inc
+++ b/docs/install/install-server/install-server.inc
@@ -53,7 +53,6 @@ Install the software
           type=rpm-md
           EOF
 
-          sudo dnf install -y epel-release
           sudo dnf install -y inmanta-oss inmanta-oss-server inmanta-oss-agent
 
         The first package (inmanta-oss) contains all the code and the commands. The server and the agent packages install config


### PR DESCRIPTION
# Description

- Split off product specific part of configure agents docs so that product docs can overwrite it.
- Updated postgres installation instructions to be more in line with the iso instructions.

part of inmanta/inmanta-service-orchestrator#245
companion PR inmanta/inmanta-service-orchestrator#247

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
