### PR TITLE
Added v2 endpoint to list dryruns

### DIFF
--- a/changelogs/unreleased/3724-dryrun-list.yml
+++ b/changelogs/unreleased/3724-dryrun-list.yml
@@ -1,0 +1,4 @@
+description: Added v2 endpoint to list dryruns
+issue-nr: 3724
+change-type: minor
+destination-branches: [master, iso5]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5285,6 +5285,16 @@ class DryRun(BaseDocument):
         dict_result["resources"] = resources
         return dict_result
 
+    def to_dto(self) -> m.DryRun:
+        return m.DryRun(
+            id=self.id,
+            environment=self.environment,
+            model=self.model,
+            date=self.date,
+            total=self.total,
+            todo=self.todo,
+        )
+
 
 _classes = [
     Project,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5279,6 +5279,31 @@ class DryRun(BaseDocument):
         await obj.insert()
         return obj
 
+    @classmethod
+    async def list_dryruns(
+        cls,
+        order_by_column: Optional[str] = None,
+        order: str = "ASC",
+        **query: object,
+    ) -> List[m.DryRun]:
+        records = await cls.get_list_with_columns(
+            order_by_column=order_by_column,
+            order=order,
+            columns=["id", "environment", "model", "date", "total", "todo"],
+            **query,
+        )
+        return [
+            m.DryRun(
+                id=record.id,
+                environment=record.environment,
+                model=record.model,
+                date=record.date,
+                total=record.total,
+                todo=record.todo,
+            )
+            for record in records
+        ]
+
     def to_dict(self) -> JsonType:
         dict_result = BaseDocument.to_dict(self)
         resources = {r["id"]: r for r in dict_result["resources"].values()}

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -564,3 +564,12 @@ class NoPushTriggerMethod(str, Enum):
 PromoteTriggerMethod = StrEnum(
     "PromoteTriggerMethod", [(i.name, i.value) for i in chain(const.AgentTriggerMethod, NoPushTriggerMethod)]
 )
+
+
+class DryRun(BaseModel):
+    id: uuid.UUID
+    environment: uuid.UUID
+    model: int
+    date: Optional[datetime.datetime]
+    total: int = 0
+    todo: int = 0

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1078,5 +1078,18 @@ def dryrun_trigger(tid: uuid.UUID, id: int) -> uuid.UUID:
 
     :param tid: The id of the environment
     :param id: The version of the configuration model to execute the dryrun for
+    :raise NotFound: This exception is raised when the referenced environment or version is not found
     :return: The id of the new dryrun
+    """
+
+
+@typedmethod(path="/dryrun", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2)
+def list_dryruns(tid: uuid.UUID, version: int) -> List[model.DryRun]:
+    """
+    Query a list of dry runs for a specific version
+
+    :param tid: The id of the environment
+    :param version: The configuration model version to return dryruns for
+    :raise NotFound: This exception is raised when the referenced environment or version is not found
+    :return: The list of dryruns for the specified version in descending order by date
     """

--- a/src/inmanta/server/services/dryrunservice.py
+++ b/src/inmanta/server/services/dryrunservice.py
@@ -21,7 +21,7 @@ import uuid
 from typing import List, Optional, cast
 
 from inmanta import data
-from inmanta.data.model import ResourceVersionIdStr
+from inmanta.data.model import DryRun, ResourceVersionIdStr
 from inmanta.protocol import handle, methods, methods_v2
 from inmanta.protocol.exceptions import NotFound
 from inmanta.resources import Id
@@ -156,6 +156,16 @@ class DyrunService(protocol.ServerSlice):
             200,
             {"dryruns": [{"id": x.id, "version": x.model, "date": x.date, "total": x.total, "todo": x.todo} for x in dryruns]},
         )
+
+    @handle(methods_v2.list_dryruns, env="tid")
+    async def list_dryruns(self, env: data.Environment, version: int) -> List[DryRun]:
+        model = await data.ConfigurationModel.get_version(environment=env.id, version=version)
+        if model is None:
+            raise NotFound("The requested version does not exist.")
+
+        dryruns = await data.DryRun.get_list(order_by_column="date", order="DESC", environment=env.id, model=version)
+        dtos = [dryrun.to_dto() for dryrun in dryruns]
+        return dtos
 
     @handle(methods.dryrun_report, dryrun_id="id", env="tid")
     async def dryrun_report(self, env: data.Environment, dryrun_id: uuid.UUID) -> Apireturn:

--- a/src/inmanta/server/services/dryrunservice.py
+++ b/src/inmanta/server/services/dryrunservice.py
@@ -163,8 +163,7 @@ class DyrunService(protocol.ServerSlice):
         if model is None:
             raise NotFound("The requested version does not exist.")
 
-        dryruns = await data.DryRun.get_list(order_by_column="date", order="DESC", environment=env.id, model=version)
-        dtos = [dryrun.to_dto() for dryrun in dryruns]
+        dtos = await data.DryRun.list_dryruns(order_by_column="date", order="DESC", environment=env.id, model=version)
         return dtos
 
     @handle(methods.dryrun_report, dryrun_id="id", env="tid")


### PR DESCRIPTION
# Description

closes #3724 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
