### PR TITLE
Use empty strings as a string representation of nulls for the diff endpoint

### DIFF
--- a/changelogs/unreleased/diff-empty-string.yml
+++ b/changelogs/unreleased/diff-empty-string.yml
@@ -1,0 +1,3 @@
+description: Use empty strings as a string representation of nulls for the diff endpoint
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -482,8 +482,8 @@ class AttributeDiff(BaseModel):
 
     from_value: Optional[object] = None
     to_value: Optional[object] = None
-    from_value_compare: Optional[str] = None
-    to_value_compare: Optional[str] = None
+    from_value_compare: str
+    to_value_compare: str
 
 
 class ResourceDiff(BaseModel):

--- a/src/inmanta/server/diff.py
+++ b/src/inmanta/server/diff.py
@@ -40,7 +40,7 @@ class Attribute:
         return self._value
 
     @property
-    def compare_value(self) -> Optional[str]:
+    def compare_value(self) -> str:
         """The string representation of the value, which can be used for comparison"""
         self._generate_compare_value()
 

--- a/src/inmanta/server/diff.py
+++ b/src/inmanta/server/diff.py
@@ -51,7 +51,9 @@ class Attribute:
         if self._compare_value is not None:
             return
 
-        if isinstance(self.value, (dict, list)):
+        if self.value is None:
+            self._compare_value = ""
+        elif isinstance(self.value, (dict, list)):
             self._compare_value = json.dumps(self.value, indent=4, sort_keys=True)
         else:
             self._compare_value = str(self.value)
@@ -74,7 +76,7 @@ class Attribute:
         return AttributeDiff(
             from_value=None,
             to_value=self.value,
-            from_value_compare=None,
+            from_value_compare="",
             to_value_compare=self.compare_value,
         )
 
@@ -84,7 +86,7 @@ class Attribute:
             from_value=self.value,
             to_value=None,
             from_value_compare=self.compare_value,
-            to_value_compare=None,
+            to_value_compare="",
         )
 
 

--- a/tests/server/test_diff.py
+++ b/tests/server/test_diff.py
@@ -127,12 +127,12 @@ async def test_list_attr_diff(client, environment, env_with_versions):
         "from_value": [1, 2],
         "to_value": None,
         "from_value_compare": "[\n    1,\n    2\n]",
-        "to_value_compare": None,
+        "to_value_compare": "",
     }
     assert result.result["data"][0]["attributes"]["list_attr_added"] == {
         "from_value": None,
         "to_value": [3, 4],
-        "from_value_compare": None,
+        "from_value_compare": "",
         "to_value_compare": "[\n    3,\n    4\n]",
     }
     # Make sure that the order of the list elements doesn't change during comparison (so the [5,4,3] list is not sorted)
@@ -217,12 +217,12 @@ async def test_dict_attr_diff(client, environment, env_with_versions):
         "from_value": {"a": "b"},
         "to_value": None,
         "from_value_compare": json.dumps({"a": "b"}, indent=4),
-        "to_value_compare": None,
+        "to_value_compare": "",
     }
     assert result.result["data"][0]["attributes"]["dict_attr_added"] == {
         "from_value": None,
         "to_value": {"x": "y"},
-        "from_value_compare": None,
+        "from_value_compare": "",
         "to_value_compare": json.dumps({"x": "y"}, indent=4),
     }
     assert result.result["data"][0]["attributes"]["dict_attr_modified"] == {
@@ -257,14 +257,14 @@ def assert_resource_deleted(resource):
     assert resource["status"] == "deleted"
     for name, attr in resource["attributes"].items():
         assert attr["to_value"] is None
-        assert attr["to_value_compare"] is None
+        assert attr["to_value_compare"] == ""
 
 
 def assert_resource_added(resource):
     assert resource["status"] == "added"
     for name, attr in resource["attributes"].items():
         assert attr["from_value"] is None
-        assert attr["from_value_compare"] is None
+        assert attr["from_value_compare"] == ""
 
 
 @pytest.mark.asyncio
@@ -359,7 +359,7 @@ async def test_resources_diff(client, environment, env_with_versions):
         "from_value": False,
         "to_value": None,
         "from_value_compare": "False",
-        "to_value_compare": None,
+        "to_value_compare": "",
     }
     assert result.result["data"][1]["resource_id"] == "std::File[internal,path=/tmp/file2]"
     assert_resource_added(result.result["data"][1])


### PR DESCRIPTION
# Description

Based on the slack discussion, it's easier to handle these values on the frontend if they are set to an empty string instead of `null`

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
