### PR TITLE
bump inmanta-dev-dependencies for docs build

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==2.1.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==2.2.0
 bumpversion==0.6.0
 openapi_spec_validator==0.4.0
 pip2pi==0.8.2


### PR DESCRIPTION
The OSS stable docs build failed because of a dependency conflict between the pinned requirements and the version of black pinned in `inmanta-dev-dependencies`. This PR should fix that. I have just released a new version of `inmanta-dev-dependencies`, which is used here.

I will fast-forward to appropriate branches.