### PR TITLE
inherit config dir

### DIFF
--- a/changelogs/unreleased/3765-preventconfigleakage.yml
+++ b/changelogs/unreleased/3765-preventconfigleakage.yml
@@ -1,0 +1,9 @@
+change-type: patch
+issue-nr: 3668
+description: Ensure processes forked by Inmanta commands load the same config folder as their parent process
+destination-branches:
+- master
+- iso5
+- iso4
+sections:
+    feature: "{{description}}"

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -55,6 +55,7 @@ class LenientConfigParser(ConfigParser):
 
 class Config(object):
     __instance: Optional[ConfigParser] = None
+    _config_dir: Optional[str] = None  # The directory this config was loaded from
     __config_definition: Dict[str, Dict[str, "Option"]] = defaultdict(lambda: {})
 
     @classmethod
@@ -92,6 +93,7 @@ class Config(object):
         config = LenientConfigParser(interpolation=Interpolation())
         config.read(files)
         cls.__instance = config
+        cls._config_dir = config_dir
 
     @classmethod
     def _get_instance(cls) -> ConfigParser:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -105,6 +105,7 @@ class Config(object):
     @classmethod
     def _reset(cls) -> None:
         cls.__instance = None
+        cls._config_dir = None
 
     @overload
     @classmethod

--- a/src/inmanta/deploy.py
+++ b/src/inmanta/deploy.py
@@ -25,6 +25,7 @@ import time
 from typing import Dict, List, Optional, Set, Tuple
 
 from inmanta import config, const, module, postgresproc, protocol
+from inmanta.config import Config
 from inmanta.server import config as server_opts
 from inmanta.types import JsonType
 from inmanta.util import get_free_tcp_port
@@ -136,7 +137,19 @@ port=%(server_port)s
             fd.write(config_file)
 
         log_file = os.path.join(log_dir, "inmanta.log")
-        args = [sys.executable, "-m", "inmanta.app", "-vvv", "-c", server_config, "--log-file", log_file, "server"]
+        args = [
+            sys.executable,
+            "-m",
+            "inmanta.app",
+            "-vvv",
+            "-c",
+            server_config,
+            "--config-dir",
+            Config._config_dir if Config._config_dir is not None else "",
+            "--log-file",
+            log_file,
+            "server",
+        ]
 
         self._server_proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -314,6 +327,8 @@ port=%(server_port)s
         inmanta_path = [sys.executable, "-m", "inmanta.app"]
 
         cmd = inmanta_path + [
+            "--config-dir",
+            Config._config_dir if Config._config_dir is not None else "",
             "-vvv",
             "export",
             "-e",

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -1053,7 +1053,19 @@ class AutostartedAgentManager(ServerSlice):
         proc: Optional[subprocess.Process] = None
         try:
             proc = await self._fork_inmanta(
-                ["-vvvv", "--timed-logs", "--config", config_path, "--log-file", agent_log, "agent"], out, err
+                [
+                    "-vvvv",
+                    "--timed-logs",
+                    "--config",
+                    config_path,
+                    "--config-dir",
+                    Config._config_dir if Config._config_dir is not None else "",
+                    "--log-file",
+                    agent_log,
+                    "agent",
+                ],
+                out,
+                err,
             )
 
             if env.id in self._agent_procs and self._agent_procs[env.id] is not None:


### PR DESCRIPTION
# Description

Ensure every command forked inherits the config dir of its parent

closes  #3765 

This can be tested by putting an invalid file in `/etc/inmanta.d/` but that is outside the reach of the testsuite. 
So there is no specific testcase for this.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
