### PR TITLE
fixed inmanta --version

### DIFF
--- a/changelogs/unreleased/inmanta-version-fix.yml
+++ b/changelogs/unreleased/inmanta-version-fix.yml
@@ -1,0 +1,6 @@
+description: "Fixed `inmanta --version` command reporting incomplete list of extensions"
+change-type: patch
+destination-branches:
+  - master
+  - iso5
+  - iso4

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -737,14 +737,14 @@ def app() -> None:
 
     logging.captureWarnings(True)
 
-    if options.inmanta_version:
-        print_versions_installed_components_and_exit()
-
     if options.config_file and not os.path.exists(options.config_file):
         LOGGER.warning("Config file %s doesn't exist", options.config_file)
 
     # Load the configuration
     Config.load_config(options.config_file, options.config_dir)
+
+    if options.inmanta_version:
+        print_versions_installed_components_and_exit()
 
     if options.warnings is not None:
         Config.set("warnings", "default", options.warnings)


### PR DESCRIPTION
# Description

`inmanta --version` would attempt to print extension version information before loading all config. As a result, extensions that are enabled in `inmanta.d/extensions.cfg` would not be included.

Can I cherry-pick this into the iso5 RC release? As far as I can tell this has been broken forever.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
