### PR TITLE
improved client's method typing

### DIFF
--- a/changelogs/unreleased/client-typing-improvements.yml
+++ b/changelogs/unreleased/client-typing-improvements.yml
@@ -1,0 +1,5 @@
+description: "Improved typing of `inmanta.protocol.endpoints.{,Sync}Client` methods."
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -370,7 +370,7 @@ class Client(Endpoint):
 
         return None
 
-    def __getattr__(self, name: str) -> Callable:
+    def __getattr__(self, name: str) -> Callable[..., Coroutine[Any, Any, common.Result]]:
         """
         Return a function that will call self._call with the correct method properties associated
         """
@@ -397,11 +397,11 @@ class SyncClient(object):
         self.timeout = timeout
         self._client = Client(self.name, self.timeout)
 
-    def __getattr__(self, name: str) -> Callable[..., object]:
-        def async_call(*args: List[object], **kwargs: Dict[str, object]) -> object:
-            method = getattr(self._client, name)
+    def __getattr__(self, name: str) -> Callable[..., common.Result]:
+        def async_call(*args: List[object], **kwargs: Dict[str, object]) -> common.Result:
+            method: Callable[..., Coroutine[Any, Any, common.Result]] = getattr(self._client, name)
 
-            def method_call() -> object:
+            def method_call() -> Coroutine[Any, Any, common.Result]:
                 return method(*args, **kwargs)
 
             try:


### PR DESCRIPTION
# Description

While working on inmanta/pytest-inmanta-lsm#182 I noticed the methods on `Client` and `SyncClient` had return type `object` instead of the more appropriate `Result`. I decided to fix this. The other changes are simple fixes to type errors that were exposed by this change. The mypy diff for this PR is listed below (red are resolved errors, green are newly exposed ones).

```diff
- src/inmanta/protocol/endpoints.py:373: error: Missing type parameters for generic type "Callable"  [type-arg]
+ src/inmanta/protocol/endpoints.py:408: error: Returning Any from function declared to return "Result"  [no-any-return]
- src/inmanta/agent/handler.py:616: error: Returning Any from function declared to return "Awaitable[Result]"  [no-any-return]
- src/inmanta/agent/handler.py:769: error: Returning Any from function declared to return "Awaitable[Result]"  [no-any-return]
- src/inmanta/agent/handler.py:792: error: Returning Any from function declared to return "Awaitable[Result]"  [no-any-return]
- src/inmanta/agent/handler.py:806: error: Returning Any from function declared to return "Awaitable[Result]"  [no-any-return]
+ src/inmanta/agent/agent.py:114: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:285: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:290: error: Unsupported right operand type for in ("Optional[Dict[str, Any]]")  [operator]
+ src/inmanta/agent/agent.py:290: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:291: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:723: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:985: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:988: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:1134: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:1142: error: Unsupported right operand type for in ("Optional[Dict[str, Any]]")  [operator]
+ src/inmanta/agent/agent.py:1142: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:1143: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/agent/agent.py:1176: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/export.py:87: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
- src/inmanta/export.py:309: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/export.py:310: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/export.py:311: error: "object" has no attribute "result"  [attr-defined]
+ src/inmanta/export.py:311: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
- src/inmanta/export.py:451: error: Argument 1 to "deploy_code" of "Exporter" has incompatible type "SyncClient"; expected "Client"  [arg-type]
- src/inmanta/export.py:461: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/export.py:464: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/export.py:472: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/export.py:495: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/export.py:496: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/export.py:497: error: "object" has no attribute "result"  [attr-defined]
+ src/inmanta/export.py:464: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/export.py:496: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/export.py:497: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
- src/inmanta/deploy.py:189: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:193: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:198: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:202: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:204: error: Argument 1 to "_check_result" of "Deploy" has incompatible type "object"; expected "Result"  [arg-type]
- src/inmanta/deploy.py:205: error: Argument 1 to "_check_result" of "Deploy" has incompatible type "object"; expected "Result"  [arg-type]
- src/inmanta/deploy.py:206: error: Argument 1 to "_check_result" of "Deploy" has incompatible type "object"; expected "Result"  [arg-type]
- src/inmanta/deploy.py:207: error: Argument 1 to "_check_result" of "Deploy" has incompatible type "object"; expected "Result"  [arg-type]
- src/inmanta/deploy.py:213: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:217: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:218: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:252: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:257: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:269: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:274: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:367: error: Argument 1 to "_check_result" of "Deploy" has incompatible type "object"; expected "Result"  [arg-type]
- src/inmanta/deploy.py:378: error: Argument 1 to "_check_result" of "Deploy" has incompatible type "object"; expected "Result"  [arg-type]
- src/inmanta/deploy.py:385: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:393: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:429: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:432: error: "object" has no attribute "result"  [attr-defined]
- src/inmanta/deploy.py:461: error: "object" has no attribute "code"  [attr-defined]
- src/inmanta/deploy.py:463: error: "object" has no attribute "result"  [attr-defined]
+ src/inmanta/deploy.py:202: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:217: error: Unsupported right operand type for in ("Optional[Dict[str, Any]]")  [operator]
+ src/inmanta/deploy.py:217: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:218: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:257: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:274: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:379: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:393: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:432: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
+ src/inmanta/deploy.py:464: error: Value of type "Optional[Dict[str, Any]]" is not indexable  [index]
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] ~~Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
