### PR TITLE
Issue/3789 symmetric increments

### DIFF
--- a/changelogs/unreleased/3789-correct-increment-calculations.yml
+++ b/changelogs/unreleased/3789-correct-increment-calculations.yml
@@ -1,0 +1,7 @@
+---
+description: Fix bug in incremental deploy where event processing can be delayed
+issue-nr: 3789
+change-type: minor
+destination-branches: [master, iso5]
+sections:
+    bugfix: "{{description}}"

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -199,7 +199,11 @@ class MultiVersionSetup(object):
         assert set(pos).isdisjoint(set(neg)), set(pos).intersection(set(neg))
 
         # increments are complements, without the undeployables
-        assert {resource["id"] for resource in self.versions[version] if self.states[resource["id"]] not in [ResourceState.skipped_for_undefined, ResourceState.undefined]} == set(pos).union(set(neg))
+        assert {
+            resource["id"]
+            for resource in self.versions[version]
+            if self.states[resource["id"]] not in [ResourceState.skipped_for_undefined, ResourceState.undefined]
+        } == set(pos).union(set(neg))
 
         allresources = {}
 

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -194,6 +194,13 @@ class MultiVersionSetup(object):
             )
             assert result == 200
 
+        # increments are disjoint
+        pos, neg = await data.ConfigurationModel.get_increment(env.id, version)
+        assert set(pos).isdisjoint(set(neg)), set(pos).intersection(set(neg))
+
+        # increments are complements, without the undeployables
+        assert {resource["id"] for resource in self.versions[version] if self.states[resource["id"]] not in [ResourceState.skipped_for_undefined, ResourceState.undefined]} == set(pos).union(set(neg))
+
         allresources = {}
 
         for agent, results in self.results.items():


### PR DESCRIPTION
# Description

Fixes an issue where increments are not symmetric: the negative and positive part overlap, where it concerns event propagation

This fix causes

- slightly slower deploy due to more accurate (larger) increments
- faster event response

Does this require more testing?

closes #3789 

# Backstory

The worst effect of this bug is in ISO5:

Given:
- Resource A on agent a
- LifeCycleTransferResource on agent internal depends on A
 - Resource A is included in the increment by event (it is in the increment and in the negative increment)

Scenario:
- When agent a pulls A
  - resource A is marked as 'deployed because of known good state' (due to the negative increment)
  - resource A is returned to be deployed, because it is in the increment 
  - resource A is marked as deploying
- the state transfer
  - starts to execute, because all resources are in a deployed state
  - pulls the state of A when beginning the deploy
  - get deploying for A (this is a race with the above)
  - skips and hangs for a while


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

