### PR TITLE
Fix incomplete kwargs of resource logs

### DIFF
--- a/changelogs/unreleased/3791-fix-resource-log-incomplete-kwargs.yml
+++ b/changelogs/unreleased/3791-fix-resource-log-incomplete-kwargs.yml
@@ -1,0 +1,4 @@
+description: Fix incomplete kwargs of resource logs
+issue-nr: 3791
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -353,7 +353,7 @@ class LogLine(BaseModel):
     level: const.LogLevel
     msg: str
     args: List[Optional[ArgumentTypes]] = []
-    kwargs: Dict[str, Optional[ArgumentTypes]] = {}
+    kwargs: JsonType = {}
     timestamp: datetime.datetime
 
 

--- a/tests/server/test_resource_action_logs.py
+++ b/tests/server/test_resource_action_logs.py
@@ -331,3 +331,47 @@ async def test_log_without_kwargs(server, client, environment):
     await resource_action.save()
     result = await client.resource_logs(environment, "std::File[agent1,path=/tmp/file1.txt]")
     assert result.code == 200
+
+
+@pytest.mark.asyncio
+async def test_log_nested_kwargs(server, client, environment):
+
+    await data.ConfigurationModel(
+        environment=uuid.UUID(environment),
+        version=1,
+        date=datetime.datetime.now(),
+        total=1,
+        released=True,
+        version_info={},
+    ).insert()
+
+    resource_action = data.ResourceAction(
+        environment=uuid.UUID(environment),
+        version=1,
+        resource_version_ids=[
+            "std::File[agent1,path=/tmp/file1.txt],v=1",
+            "std::Directory[agent1,path=/tmp/dir2],v=1",
+        ],
+        action_id=uuid.uuid4(),
+        action=const.ResourceAction.deploy,
+        started=datetime.datetime.now(),
+    )
+    await resource_action.insert()
+
+    resource_action.add_logs(
+        [
+            data.LogLine.log(
+                logging.INFO,
+                "Calling update_resource ",
+                timestamp=datetime.datetime.now(),
+                changes={"characteristics": {"current": {"Status": "Planned"}, "desired": {"Status": "In Service"}}},
+            ),
+        ]
+    )
+    await resource_action.save()
+    result = await client.resource_logs(environment, "std::File[agent1,path=/tmp/file1.txt]")
+    assert result.code == 200
+    assert result.result["data"][0]["kwargs"]["changes"]["characteristics"] == {
+        "current": {"Status": "Planned"},
+        "desired": {"Status": "In Service"},
+    }


### PR DESCRIPTION
# Description

closes #3791 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
