### PR TITLE
Add stable_api annotations to types used by IRT

### DIFF
--- a/changelogs/unreleased/add-types-to-stable-api.yml
+++ b/changelogs/unreleased/add-types-to-stable-api.yml
@@ -1,0 +1,4 @@
+---
+description: Add a `stable_api` annotation to the types used by IRT
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -99,6 +99,7 @@ TProject = TypeVar("TProject", bound="Project")
 TInmantaModuleRequirement = TypeVar("TInmantaModuleRequirement", bound="InmantaModuleRequirement")
 
 
+@stable_api
 class InmantaModuleRequirement:
     """
     Represents a requirement on an inmanta module. This is a wrapper around Requirement. This class is provided for the
@@ -466,6 +467,7 @@ class ModuleSource(Generic[TModule]):
         return module_name
 
 
+@stable_api
 class ModuleV2Source(ModuleSource["ModuleV2"]):
     def __init__(self, urls: List[str]) -> None:
         self.urls: List[str] = [url if not os.path.exists(url) else os.path.abspath(url) for url in urls]
@@ -2090,6 +2092,7 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         return any(True for repo in self._metadata.repo if repo.type == ModuleRepoType.package)
 
 
+@stable_api
 class DummyProject(Project):
     """Placeholder project that does nothing"""
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -61,6 +61,7 @@ from inmanta.module import (
     Project,
     gitprovider,
 )
+from inmanta.stable_api import stable_api
 
 if TYPE_CHECKING:
     from pkg_resources import Requirement  # noqa: F401
@@ -390,6 +391,7 @@ compatible with the dependencies specified by the updated modules.
             raise last_failure
 
 
+@stable_api
 class ModuleTool(ModuleLikeTool):
     """
     A tool to manage configuration modules
@@ -1026,6 +1028,7 @@ class V2ModuleBuilder:
             raise ModuleBuildFailedError(msg="Module build failed")
 
 
+@stable_api
 class ModuleConverter:
     def __init__(self, module: ModuleV1) -> None:
         self._module = module


### PR DESCRIPTION
# Description

Added `stable_api` annotations on types used by IRT.

Part of inmanta/irt#898

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
