### PR TITLE
Prevent that test cases start two inmanta server

### DIFF
--- a/changelogs/unreleased/fix-tests-start-two-inmanta-servers.yml
+++ b/changelogs/unreleased/fix-tests-start-two-inmanta-servers.yml
@@ -1,0 +1,4 @@
+---
+description: Fix test cases that accidentally start two Inmanta servers side-by-side.
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -811,7 +811,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
     bundle query methods and generate validate and query methods for optimized DB access. This is not a full ODM.
     """
 
-    _connection_pool: asyncpg.pool.Pool = None
+    _connection_pool: Optional[asyncpg.pool.Pool] = None
 
     @classmethod
     def get_connection(cls) -> asyncpg.pool.PoolAcquireContext:
@@ -919,7 +919,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
             return
         try:
             await asyncio.wait_for(cls._connection_pool.close(), config.db_connection_timeout.get())
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, asyncio.CancelledError):
             cls._connection_pool.terminate()
         finally:
             cls._connection_pool = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ from tornado import netutil
 import inmanta.agent.config as cfg
 from inmanta import protocol
 from inmanta.config import Config, Option, option_as_default
+from inmanta.const import ClientType
 from inmanta.server.protocol import Server, ServerSlice
 from utils import LogSequence
 
@@ -189,7 +190,7 @@ client-id=test456
 
 
 @pytest.mark.asyncio
-async def test_bind_address_ipv4(async_finalizer, client):
+async def test_bind_address_ipv4(async_finalizer):
     """This test case check if the Inmanta server doesn't bind on another interface than 127.0.0.1 when bind-address is equal
     to 127.0.0.1. Procedure:
         1) Get free port on all interfaces.
@@ -197,7 +198,7 @@ async def test_bind_address_ipv4(async_finalizer, client):
         3) Start the Inmanta server with bind-address 127.0.0.1. and execute an API call
     """
 
-    @protocol.method(path="/test", operation="POST", client_types=["api"])
+    @protocol.method(path="/test", operation="POST", client_types=[ClientType.api])
     async def test_endpoint():
         pass
 
@@ -232,6 +233,7 @@ async def test_bind_address_ipv4(async_finalizer, client):
         async_finalizer(rs.stop)
 
         # Check if server is reachable on loopback interface
+        client = protocol.Client("client")
         result = await client.test_endpoint()
         assert result.code == 200
     finally:
@@ -239,8 +241,8 @@ async def test_bind_address_ipv4(async_finalizer, client):
 
 
 @pytest.mark.asyncio
-async def test_bind_address_ipv6(async_finalizer, client):
-    @protocol.method(path="/test", operation="POST", client_types=["api"])
+async def test_bind_address_ipv6(async_finalizer) -> None:
+    @protocol.method(path="/test", operation="POST", client_types=[ClientType.api])
     async def test_endpoint():
         pass
 
@@ -267,14 +269,15 @@ async def test_bind_address_ipv6(async_finalizer, client):
     await rs.start()
     async_finalizer(rs.stop)
 
+    client = protocol.Client("client")
     # Check if server is reachable on loopback interface
     result = await client.test_endpoint()
     assert result.code == 200
 
 
 @pytest.mark.asyncio
-async def test_bind_port(unused_tcp_port, async_finalizer, client, caplog):
-    @protocol.method(path="/test", operation="POST", client_types=["api"])
+async def test_bind_port(unused_tcp_port, async_finalizer, caplog):
+    @protocol.method(path="/test", operation="POST", client_types=[ClientType.api])
     async def test_endpoint():
         pass
 
@@ -291,6 +294,7 @@ async def test_bind_port(unused_tcp_port, async_finalizer, client, caplog):
         async_finalizer(rs.stop)
 
         # Check if server is reachable on loopback interface
+        client = protocol.Client("client")
         result = await client.test_endpoint()
         assert result.code == 200
         await rs.stop()


### PR DESCRIPTION
# Description

This PR applies the following changes:

* Ensure that test cases don't accidentally start two Inmanta server side-by-side by using the `client` fixture
* Ensure that the `close_connection_poo()` method catches the `CancelledError` as well in case the task was cancelled by the `server` fixture
* Fix typing problems related to the `_connection_pool` attribute

closes #3802

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
