### PR TITLE
Optimize resource list query

### DIFF
--- a/changelogs/unreleased/3374-optimize-resource-list-query.yml
+++ b/changelogs/unreleased/3374-optimize-resource-list-query.yml
@@ -1,3 +1,5 @@
 description: Optimize resource list query
 change-type: patch
 destination-branches: [master, iso4, iso5]
+sections:
+    bugfix: "{{description}}"

--- a/changelogs/unreleased/3374-optimize-resource-list-query.yml
+++ b/changelogs/unreleased/3374-optimize-resource-list-query.yml
@@ -1,0 +1,3 @@
+description: Optimize resource list query
+change-type: patch
+destination-branches: [master, iso4, iso5]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4039,7 +4039,8 @@ class Resource(BaseDocument):
         # btree index efficiently; rather than scanning all equal values of a key,
         # as soon as a new value is found, restart the search by looking for a larger value"
         # In this case we don't scan all equal values of a resource_id
-        # just one, (in descending order according to the version number) and move on to the next resource_id
+        # we just look for the first one that satisfies the conditions (in descending order according to the version number)
+        # and move on to the next resource_id
         return (
             f"""
             /* the recursive CTE is the second one, but it has to be specified after 'WITH' if any of them are recursive */

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4035,22 +4035,48 @@ class Resource(BaseDocument):
         environment_db_value = cls._get_value(environment)
         return (
             f"""
-            {select_clause}
-            FROM (
-                SELECT DISTINCT ON (r.resource_id) r.resource_id, r.attributes, r.resource_version_id, r.resource_type,
-                    r.agent, r.resource_id_value, r.environment,
-                    (CASE WHEN
-                            (SELECT r.model < MAX(public.configurationmodel.version)
-                            FROM public.configurationmodel
-                            WHERE public.configurationmodel.released=TRUE
-                            AND environment=${offset})
+            /* the recursive CTE is the second one, but it has to be specified after 'WITH' if any of them are recursive */
+            WITH RECURSIVE cm_version AS (
+                  SELECT
+                    MAX(public.configurationmodel.version) as max_version
+                    FROM public.configurationmodel
+                WHERE public.configurationmodel.released=TRUE
+                AND environment=${offset}
+                ), -- the latest released version number in the environment is calculated once, before the others
+            /* emulate a loose (or skip) index scan */
+            cte AS (
+               ( -- specify the necessary columns
+               SELECT r.resource_id, r.attributes, r.resource_version_id, r.resource_type,
+                    r.agent, r.resource_id_value, r.model, r.environment, (CASE WHEN
+                            (SELECT r.model < cm_version.max_version
+                            FROM cm_version)
+                        THEN 'orphaned' -- use the CTE to check the status
+                    ELSE r.status::text END) as status
+               FROM   resource r JOIN configurationmodel cm on r.model = cm.version AND r.environment = cm.environment AND cm.released = TRUE
+               WHERE  r.environment = ${offset}
+               ORDER  BY resource_id, model DESC
+               LIMIT  1
+               )
+               UNION ALL
+               SELECT r.*
+               FROM   cte c
+               CROSS JOIN LATERAL
+               /* specify the same columns in the recursive part */
+                (SELECT r.resource_id, r.attributes, r.resource_version_id, r.resource_type,
+                    r.agent, r.resource_id_value, r.model, r.environment, (CASE WHEN
+                            (SELECT r.model < cm_version.max_version
+                            FROM cm_version)
                         THEN 'orphaned'
                     ELSE r.status::text END) as status
-                FROM {cls.table_name()} as r
-                    JOIN public.configurationmodel as cm ON r.model=cm.version AND r.environment=cm.environment
-                    WHERE cm.released=TRUE AND r.environment=${offset}
-                    ORDER BY r.resource_id, r.model DESC)
-            as res
+               FROM   resource r JOIN configurationmodel cm on r.model = cm.version AND r.environment = cm.environment AND cm.released = TRUE
+               /* One result from the recursive call is the latest released version of one specific resource.
+                  We always start looking for this based on the previous resource_id. */
+               WHERE  r.resource_id > c.resource_id AND r.environment = ${offset}
+               ORDER  BY r.resource_id, r.model DESC
+               LIMIT  1) r
+               )
+            {select_clause}
+            FROM   cte
             """,
             environment_db_value,
         )

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4033,27 +4033,37 @@ class Resource(BaseDocument):
         """A partial query describing the conditions for selecting the latest released resources,
         according to the model version number."""
         environment_db_value = cls._get_value(environment)
+        # Emulate a loose index scan with a recursive common table expression (CTE),
+        # Based on https://stackoverflow.com/a/25536748 and https://wiki.postgresql.org/wiki/Loose_indexscan
+        # A loose index scan is "an operation that finds the distinct values of the leading columns of a
+        # btree index efficiently; rather than scanning all equal values of a key,
+        # as soon as a new value is found, restart the search by looking for a larger value"
+        # In this case we don't scan all equal values of a resource_id
+        # just one, (in descending order according to the version number) and move on to the next resource_id
         return (
             f"""
             /* the recursive CTE is the second one, but it has to be specified after 'WITH' if any of them are recursive */
+            /* The cm_version CTE finds the maximum released version number in the environment  */
             WITH RECURSIVE cm_version AS (
                   SELECT
                     MAX(public.configurationmodel.version) as max_version
                     FROM public.configurationmodel
                 WHERE public.configurationmodel.released=TRUE
                 AND environment=${offset}
-                ), -- the latest released version number in the environment is calculated once, before the others
+                ),
             /* emulate a loose (or skip) index scan */
             cte AS (
-               ( -- specify the necessary columns
+               (
+               /* specify the necessary columns */
                SELECT r.resource_id, r.attributes, r.resource_version_id, r.resource_type,
                     r.agent, r.resource_id_value, r.model, r.environment, (CASE WHEN
                             (SELECT r.model < cm_version.max_version
                             FROM cm_version)
                         THEN 'orphaned' -- use the CTE to check the status
                     ELSE r.status::text END) as status
-               FROM   resource r JOIN configurationmodel cm on r.model = cm.version AND r.environment = cm.environment AND cm.released = TRUE
-               WHERE  r.environment = ${offset}
+               FROM   resource r
+               JOIN configurationmodel cm ON r.model = cm.version AND r.environment = cm.environment
+               WHERE  r.environment = ${offset} AND cm.released = TRUE
                ORDER  BY resource_id, model DESC
                LIMIT  1
                )
@@ -4068,10 +4078,10 @@ class Resource(BaseDocument):
                             FROM cm_version)
                         THEN 'orphaned'
                     ELSE r.status::text END) as status
-               FROM   resource r JOIN configurationmodel cm on r.model = cm.version AND r.environment = cm.environment AND cm.released = TRUE
+               FROM   resource r JOIN configurationmodel cm on r.model = cm.version AND r.environment = cm.environment
                /* One result from the recursive call is the latest released version of one specific resource.
                   We always start looking for this based on the previous resource_id. */
-               WHERE  r.resource_id > c.resource_id AND r.environment = ${offset}
+               WHERE  r.resource_id > c.resource_id AND r.environment = ${offset} AND cm.released = TRUE
                ORDER  BY r.resource_id, r.model DESC
                LIMIT  1) r
                )

--- a/tests/server/test_resource_list.py
+++ b/tests/server/test_resource_list.py
@@ -147,13 +147,13 @@ async def env_with_resources(server, client):
     await env.insert()
 
     # Add multiple versions of model, with 2 of them released
-    for i in range(1, 5):
+    for i in range(1, 4):
         cm = data.ConfigurationModel(
             environment=env.id,
             version=i,
             date=datetime.now(),
             total=1,
-            released=i != 1 and i != 5,
+            released=i != 1,
             version_info={},
         )
         await cm.insert()
@@ -171,12 +171,12 @@ async def env_with_resources(server, client):
             )
             await res.insert()
 
-    await create_resource("agent1", "/etc/file1", "std::File", ResourceState.available, [1, 2, 3, 4])
+    await create_resource("agent1", "/etc/file1", "std::File", ResourceState.available, [1, 2, 3])
     await create_resource("agent1", "/etc/file2", "std::File", ResourceState.deploying, [1, 2])  # Orphaned
     await create_resource("agent2", "/etc/file3", "std::File", ResourceState.deployed, [2])  # Orphaned
-    await create_resource("agent2", "/tmp/file4", "std::File", ResourceState.unavailable, [3, 4])
-    await create_resource("agent2", "/tmp/dir5", "std::Directory", ResourceState.skipped, [3, 4])
-    await create_resource("agent3", "/tmp/dir6", "std::Directory", ResourceState.deployed, [3, 4])
+    await create_resource("agent2", "/tmp/file4", "std::File", ResourceState.unavailable, [3])
+    await create_resource("agent2", "/tmp/dir5", "std::Directory", ResourceState.skipped, [3])
+    await create_resource("agent3", "/tmp/dir6", "std::Directory", ResourceState.deployed, [3])
 
     env2 = data.Environment(name="dev-test2", project=project.id, repo_url="", repo_branch="")
     await env2.insert()


### PR DESCRIPTION
# Description

The optimized query is based on https://stackoverflow.com/a/25536748, 1.a variant. I also added this link to the source

With the changes the average execution time on the same data (and database version) goes from the 500-600 ms range (https://explain.dalibo.com/plan/uWK#plan) to the 100-200 ms range (https://explain.dalibo.com/plan/yS8). 
Note: These results are based on the query plan analyzer and not on extensive performance testing.

closes #3374 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
