### PR TITLE
Issue/3803 disallow multiline strings with single quotes

### DIFF
--- a/changelogs/unreleased/3803-disallow-multiline-strings-with-single-quotes.yml
+++ b/changelogs/unreleased/3803-disallow-multiline-strings-with-single-quotes.yml
@@ -1,6 +1,7 @@
-description: Trying to write a single quoted string over multiple lines now raises a syntax error.
+description: Writing a string over multiple lines is now only supported for strings within triple quotes.
 change-type: major
 destination-branches: [master, iso5]
 sections: {
-  bugfix: "{{description}}"
+  bugfix: "{{description}}",
+  deprecation-note: "{{description}} This was previously allowed for strings within single quotes due to a bug."
 }

--- a/changelogs/unreleased/3803-disallow-multiline-strings-with-single-quotes.yml
+++ b/changelogs/unreleased/3803-disallow-multiline-strings-with-single-quotes.yml
@@ -1,0 +1,6 @@
+description: Trying to write a single quoted string over multiple lines now raises a syntax error.
+change-type: major
+destination-branches: [master, iso5]
+sections: {
+  bugfix: "{{description}}"
+}

--- a/changelogs/unreleased/3803-disallow-multiline-strings-with-single-quotes.yml
+++ b/changelogs/unreleased/3803-disallow-multiline-strings-with-single-quotes.yml
@@ -1,5 +1,5 @@
 description: Writing a string over multiple lines is now only supported for strings within triple quotes.
-change-type: major
+change-type: minor
 destination-branches: [master, iso5]
 sections: {
   bugfix: "{{description}}",

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -65,7 +65,7 @@ tokens = ["INT", "FLOAT", "ID", "CID", "SEP", "STRING", "MLS", "MLS_END", "CMP_O
 
 
 def t_RSTRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"r(\"([^\\\"]|\\.)*\")|r(\'([^\\\']|\\.)*\')"
+    r"r(\"([^\\\"\n\r]|\\.)*\")|r(\'([^\\\'\n\r]|\\.)*\')"
     t.value = t.value[2:-1]
     lexer = t.lexer
 

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -184,7 +184,7 @@ def t_INT(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
 
 
 def t_STRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"(\"([^\\\"]|\\.)*\")|(\'([^\\\']|\\.)*\')"
+    r"(\"([^\\\"\r\n]|\\.)*\")|(\'([^\\\'\r\n]|\\.)*\')"
     t.value = bytes(t.value[1:-1], "utf-8").decode("unicode_escape")
     lexer = t.lexer
 

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -65,7 +65,7 @@ tokens = ["INT", "FLOAT", "ID", "CID", "SEP", "STRING", "MLS", "MLS_END", "CMP_O
 
 
 def t_RSTRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"r(\"([^\\\"\n\r]|\\.)*\")|r(\'([^\\\'\n\r]|\\.)*\')"
+    r"r(\"([^\\\"\n]|\\.)*\")|r(\'([^\\\'\n]|\\.)*\')"
     t.value = t.value[2:-1]
     lexer = t.lexer
 
@@ -184,7 +184,7 @@ def t_INT(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
 
 
 def t_STRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"(\"([^\\\"\r\n]|\\.)*\")|(\'([^\\\'\r\n]|\\.)*\')"
+    r"(\"([^\\\"\n]|\\.)*\")|(\'([^\\\'\n]|\\.)*\')"
     t.value = bytes(t.value[1:-1], "utf-8").decode("unicode_escape")
     lexer = t.lexer
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -50,3 +50,85 @@ end
         """,
     )
     compiler.do_compile()
+
+
+def test_no_multiline_in_single_quoted_string_double_apostrophe(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+std::print(
+  "test
+  string"
+)
+        """,
+        "Syntax error: Illegal character '\"' ({dir}/main.cf:3:3)",
+    )
+
+def test_no_multiline_in_single_quoted_string_simple_apostrophe(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+std::print(
+  'test
+  string'
+)
+        """,
+        "Syntax error: Illegal character '\'' ({dir}/main.cf:3:3)",
+    )
+
+def test_no_multiline_in_single_quoted_raw_string_double_apostrophe(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+std::print(
+  r"test
+  string"
+)
+        """,
+        "Syntax error: Illegal character '\"' ({dir}/main.cf:3:4)",
+    )
+
+def test_no_multiline_in_single_quoted_raw_string_simple_apostrophe(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+std::print(
+  r'test
+  string'
+)
+        """,
+        "Syntax error: Illegal character '\'' ({dir}/main.cf:3:4)",
+    )
+
+
+def test_allowed_line_breaks(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        r'''
+test_string_1 = "TESTSTRING"
+test_string_2 = "TEST\nSTR\rING"
+test_string_3 = r"TESTSTRING"
+test_string_4 = r"TEST\nSTR\rING"
+
+test_string_5 = 'TESTSTRING'
+test_string_6 = 'TEST\nSTR\rING'
+test_string_7 = r'TESTSTRING'
+test_string_8 = r'TEST\nSTR\rING'
+
+
+test_string_9 =  """TESTSTRING"""
+test_string_10 = """TEST\nSTR\rING"""
+test_string_11 = """TEST
+STRING"""
+
+
+std::print(test_string_1)
+std::print(test_string_2)
+std::print(test_string_3)
+std::print(test_string_4)
+std::print(test_string_5)
+std::print(test_string_6)
+std::print(test_string_7)
+std::print(test_string_8)
+std::print(test_string_9)
+std::print(test_string_10)
+std::print(test_string_11)
+
+'''
+    )
+    compiler.do_compile()

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -63,6 +63,7 @@ std::print(
         "Syntax error: Illegal character '\"' ({dir}/main.cf:3:3)",
     )
 
+
 def test_no_multiline_in_single_quoted_string_simple_apostrophe(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
@@ -71,8 +72,9 @@ std::print(
   string'
 )
         """,
-        "Syntax error: Illegal character '\'' ({dir}/main.cf:3:3)",
+        "Syntax error: Illegal character ''' ({dir}/main.cf:3:3)",
     )
+
 
 def test_no_multiline_in_single_quoted_raw_string_double_apostrophe(snippetcompiler):
     snippetcompiler.setup_for_error(
@@ -85,6 +87,7 @@ std::print(
         "Syntax error: Illegal character '\"' ({dir}/main.cf:3:4)",
     )
 
+
 def test_no_multiline_in_single_quoted_raw_string_simple_apostrophe(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
@@ -93,7 +96,7 @@ std::print(
   string'
 )
         """,
-        "Syntax error: Illegal character '\'' ({dir}/main.cf:3:4)",
+        "Syntax error: Illegal character ''' ({dir}/main.cf:3:4)",
     )
 
 


### PR DESCRIPTION
# Description

Trying to write a single quoted string over multiple lines now raises a syntax error.

closes #3803 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
