### PR TITLE
updated Makefile to disable mypy error limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ pep8:
 	flake8 src tests tests_common
 
 .PHONY: mypy mypy-diff mypy-save
-RUN_MYPY=MYPYPATH=stubs:src python -m mypy --html-report mypy -p inmanta
+RUN_MYPY=MYPYPATH=stubs:src python -m mypy --soft-error-limit=-1 --html-report mypy -p inmanta
 
 mypy:
 	$(RUN_MYPY)

--- a/changelogs/unreleased/mypy-error-limit-fix.yml
+++ b/changelogs/unreleased/mypy-error-limit-fix.yml
@@ -1,0 +1,6 @@
+description: Updated Makefile to disable mypy error limit
+change-type: patch
+destination-branches:
+  - iso4
+  - iso5
+  - master

--- a/tox.ini
+++ b/tox.ini
@@ -55,5 +55,5 @@ commands_pre = mkdir -p coverage
 whitelist_externals = */mkdir
 setenv = MYPYPATH=stubs:src
 commands =
-    python -m mypy --junit-xml mypy.xml --cobertura-xml-report coverage -p inmanta
+    python -m mypy --soft-error-limit=-1 --junit-xml mypy.xml --cobertura-xml-report coverage -p inmanta
 ignore_outcome = true


### PR DESCRIPTION
# Description

Fixes python/mypy#10956

Thanks @bartv 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
