### PR TITLE
Fix a potential encoding issue

### DIFF
--- a/changelogs/unreleased/fix-encoding-problem.yml
+++ b/changelogs/unreleased/fix-encoding-problem.yml
@@ -1,0 +1,6 @@
+description: Fix a potential encoding issue with unknown types or dicts and wrong encoding
+change-type: patch
+destination-branches:
+  - iso4
+  - iso5
+  - master

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -96,13 +96,20 @@ class RESTHandler(tornado.web.RequestHandler):
 
         self.set_status(status)
 
-    def _encode_body(self, body: ReturnTypes, content_type: str) -> Union[ReturnTypes, bytes]:
+    def _encode_body(self, body: ReturnTypes, content_type: str) -> Union[str, bytes]:
         if content_type == common.JSON_CONTENT:
             return common.json_encode(body)
         if content_type == common.HTML_CONTENT:
+            assert isinstance(body, str)
             return body.encode(common.HTML_ENCODING)
         if content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
+            assert isinstance(body, str)
             return body.encode(common.UTF8_ENCODING)
+        elif not isinstance(body, (str, bytes)):
+            raise exceptions.ServerError(
+                f"Body should be str or bytes and not {type(body)}."
+                " For dict make sure content type is set to {common.JSON_CONTENT}"
+            )
         return body
 
     async def _call(self, kwargs: Dict[str, str], http_method: str, call_config: common.UrlMethod) -> None:


### PR DESCRIPTION
# Description

This fixes a potential encoding issue. The write methods of tornado
excepts str, bytes and dict. The encode method will ensure that if the
JSON type is set (manually or by using the default) our own json encoder
is used.

There are two issues with this:
1. If the user sets a wrong encoding tornado will use its own json
   encoder which does not have our custom types. This is a potential
   silent failure.
2. An unsupported type is passed raising a server error in tornado.

It also removes a number of type errors.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
