### PR TITLE
Fix pytest deprecation warning

### DIFF
--- a/changelogs/unreleased/3764-fix-deprecation-pytest.yml
+++ b/changelogs/unreleased/3764-fix-deprecation-pytest.yml
@@ -1,0 +1,6 @@
+description: Add pytest-asyncio mode to remove deprecation warnings
+change-type: patch
+destination-branches: [master, iso4, iso5]
+sections: { 
+  bugfix: "{{description}}" 
+}

--- a/changelogs/unreleased/3764-fix-deprecation-pytest.yml
+++ b/changelogs/unreleased/3764-fix-deprecation-pytest.yml
@@ -1,6 +1,3 @@
 description: Add pytest-asyncio mode to remove deprecation warnings
 change-type: patch
-destination-branches: [master, iso4, iso5]
-sections: { 
-  bugfix: "{{description}}" 
-}
+destination-branches: [master, iso5]

--- a/docs/extract_openapi_json.py
+++ b/docs/extract_openapi_json.py
@@ -17,10 +17,7 @@
 """
 import json
 
-import pytest
 
-
-@pytest.mark.asyncio
 async def test_extract_openapi_for_docs(server, client):
     result = await client.get_api_docs("openapi")
     assert result.code == 200

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_mode = auto
 markers =
     slowtest
     link_check

--- a/tests/agent_server/test_agent_timeout.py
+++ b/tests/agent_server/test_agent_timeout.py
@@ -17,14 +17,11 @@
 """
 import logging
 
-import pytest
-
 from agent_server.conftest import get_agent
 from inmanta import config
 from utils import get_resource, log_index, retry_limited
 
 
-@pytest.mark.asyncio
 async def test_agent_disconnect(resource_container, environment, server, client, clienthelper, async_finalizer, caplog):
     caplog.set_level(logging.INFO)
     config.Config.set("config", "server-timeout", "1")

--- a/tests/agent_server/test_deploy_trigger.py
+++ b/tests/agent_server/test_deploy_trigger.py
@@ -17,7 +17,6 @@
 """
 import logging
 
-
 from agent_server.conftest import _deploy_resources, get_agent
 from utils import get_resource, log_contains, log_doesnt_contain, retry_limited
 

--- a/tests/agent_server/test_deploy_trigger.py
+++ b/tests/agent_server/test_deploy_trigger.py
@@ -17,13 +17,11 @@
 """
 import logging
 
-import pytest
 
 from agent_server.conftest import _deploy_resources, get_agent
 from utils import get_resource, log_contains, log_doesnt_contain, retry_limited
 
 
-@pytest.mark.asyncio(timeout=150)
 async def test_deploy_trigger(
     server, client, clienthelper, resource_container, environment, caplog, no_agent_backoff, async_finalizer
 ):

--- a/tests/agent_server/test_dryrun.py
+++ b/tests/agent_server/test_dryrun.py
@@ -20,8 +20,6 @@ import json
 import logging
 import uuid
 
-import pytest
-
 from inmanta import const, data, execute
 from inmanta.agent.agent import Agent
 from inmanta.server import SLICE_AGENT_MANAGER
@@ -31,7 +29,6 @@ from utils import ClientHelper, _wait_until_deployment_finishes, retry_limited
 logger = logging.getLogger("inmanta.test.dryrun")
 
 
-@pytest.mark.asyncio(timeout=150)
 async def test_dryrun_and_deploy(server, client, resource_container, environment):
     """
     dryrun and deploy a configuration model
@@ -185,7 +182,6 @@ async def test_dryrun_and_deploy(server, client, resource_container, environment
     await agent.stop()
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_dryrun_failures(resource_container, server, agent, client, environment, clienthelper):
     """
     test dryrun scaling
@@ -271,7 +267,6 @@ async def test_dryrun_failures(resource_container, server, agent, client, enviro
     await agent.stop()
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_dryrun_scale(resource_container, server, client, environment, agent, clienthelper):
     """
     test dryrun scaling
@@ -316,7 +311,6 @@ async def test_dryrun_scale(resource_container, server, client, environment, age
     await agent.stop()
 
 
-@pytest.mark.asyncio(timeout=150)
 async def test_dryrun_v2(server, client, resource_container, environment, agent_factory):
     """
     Dryrun a configuration model with the v2 api, where applicable

--- a/tests/agent_server/test_evolution.py
+++ b/tests/agent_server/test_evolution.py
@@ -17,8 +17,6 @@
 """
 from collections import defaultdict
 
-import pytest
-
 from agent_server.conftest import get_agent, stop_agent
 from inmanta import const, data, resources
 from inmanta.agent import handler
@@ -164,7 +162,6 @@ def resource_container_b():
     return BProvider
 
 
-@pytest.mark.asyncio(timeout=150)
 async def test_resource_evolution(server, client, environment, no_agent_backoff, snippetcompiler, monkeypatch, async_finalizer):
 
     provider = resource_container_a()

--- a/tests/agent_server/test_facts.py
+++ b/tests/agent_server/test_facts.py
@@ -19,15 +19,12 @@ import asyncio
 import logging
 import uuid
 
-import pytest
-
 from inmanta import const, data, resources
 from inmanta.server import SLICE_AGENT_MANAGER
 from inmanta.util import get_compiler_version
 from utils import LogSequence, _wait_until_deployment_finishes, no_error_in_logs, retry_limited, wait_until_logs_are_available
 
 
-@pytest.mark.asyncio
 async def test_get_facts(resource_container, client, clienthelper, environment, agent, caplog):
     """
     Test retrieving facts from the agent
@@ -62,7 +59,6 @@ async def test_get_facts(resource_container, client, clienthelper, environment, 
     no_error_in_logs(caplog)
 
 
-@pytest.mark.asyncio
 async def test_purged_facts(resource_container, client, clienthelper, agent, environment, no_agent_backoff, caplog):
     """
     Test if facts are purged when the resource is purged.
@@ -123,7 +119,6 @@ async def test_purged_facts(resource_container, client, clienthelper, agent, env
     no_error_in_logs(caplog)
 
 
-@pytest.mark.asyncio
 async def test_get_facts_extended(server, client, agent, clienthelper, resource_container, environment, caplog):
     """
     dryrun and deploy a configuration model automatically
@@ -289,7 +284,6 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
     ).no_more_errors()
 
 
-@pytest.mark.asyncio
 async def test_purged_resources(resource_container, client, clienthelper, server, environment, agent, no_agent_backoff):
     """
     Test if:
@@ -392,7 +386,6 @@ async def test_purged_resources(resource_container, client, clienthelper, server
     assert len(result.result["parameters"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_get_fact_no_code(resource_container, client, clienthelper, environment, agent):
     """
     Test retrieving facts from the agent when resource cannot be loaded

--- a/tests/agent_server/test_resource_handler.py
+++ b/tests/agent_server/test_resource_handler.py
@@ -79,7 +79,6 @@ def test_get_file_not_found():
     assert result is None
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_logging_error(resource_container, environment, client, agent, clienthelper, caplog):
     """
     When a log call uses an argument that is not JSON serializable, the corresponding resource should be marked as failed,
@@ -116,7 +115,6 @@ async def test_logging_error(resource_container, environment, client, agent, cli
     log_contains(caplog, "inmanta.agent", logging.ERROR, "Exception during serializing log message arguments")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "resource_type",
     ["test::FailFast", "test::FailFastCRUD", "test::BadPost", "test::BadPostCRUD"],

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -51,7 +51,6 @@ from utils import (
 logger = logging.getLogger("inmanta.test.server_agent")
 
 
-@pytest.mark.asyncio(timeout=150)
 async def test_deploy_empty(server, client, clienthelper, environment, no_agent_backoff, async_finalizer):
     """
     Test deployment of empty model
@@ -83,7 +82,6 @@ async def test_deploy_empty(server, client, clienthelper, environment, no_agent_
     assert result.result["model"]["result"] == const.VersionState.success.name
 
 
-@pytest.mark.asyncio(timeout=100)
 async def test_deploy_with_undefined(server, client, resource_container, async_finalizer, no_agent_backoff):
     """
     Test deploy of resource with undefined
@@ -218,7 +216,6 @@ async def test_deploy_with_undefined(server, client, resource_container, async_f
     await retry_limited(done, 100)
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_server_restart(
     resource_container, server, agent, environment, clienthelper, postgres_db, client, no_agent_backoff
 ):
@@ -295,7 +292,6 @@ async def test_server_restart(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_spontaneous_deploy(
     resource_container, server, client, environment, clienthelper, no_agent_backoff, async_finalizer
 ):
@@ -369,7 +365,6 @@ async def test_spontaneous_deploy(
     assert not resource_container.Provider.isset("agent1", "key3")
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_spontaneous_repair(
     resource_container, environment, client, clienthelper, no_agent_backoff, async_finalizer, server
 ):
@@ -461,7 +456,6 @@ async def test_spontaneous_repair(
     await verify_deployment_result()
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_failing_deploy_no_handler(
     resource_container, agent, environment, client, clienthelper, async_finalizer, no_agent_backoff
 ):
@@ -512,7 +506,6 @@ async def test_failing_deploy_no_handler(
     assert any("traceback" in log["kwargs"] for log in logs), "\n".join(result.result["resources"][0]["actions"][0]["messages"])
 
 
-@pytest.mark.asyncio
 async def test_dual_agent(resource_container, server, client, clienthelper, environment, no_agent_backoff, async_finalizer):
     """
     dryrun and deploy a configuration model
@@ -591,7 +584,6 @@ async def test_dual_agent(resource_container, server, client, clienthelper, envi
     await myagent.stop()
 
 
-@pytest.mark.asyncio
 async def test_server_agent_api(
     resource_container, client, server, environment, clienthelper, no_agent_backoff, async_finalizer
 ):
@@ -709,7 +701,6 @@ async def test_server_agent_api(
     assert result.code == 404
 
 
-@pytest.mark.asyncio
 async def test_get_set_param(resource_container, environment, client, server):
     """
     Test getting and setting params
@@ -728,7 +719,6 @@ async def test_get_set_param(resource_container, environment, client, server):
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_unkown_parameters(resource_container, environment, client, server, clienthelper, agent, no_agent_backoff):
     """
     Test retrieving facts from the agent
@@ -771,7 +761,6 @@ async def test_unkown_parameters(resource_container, environment, client, server
     assert result.code == 200
 
 
-@pytest.mark.asyncio()
 async def test_fail(resource_container, client, agent, environment, clienthelper, async_finalizer, no_agent_backoff):
     """
     Test results when a step fails
@@ -850,7 +839,6 @@ async def test_fail(resource_container, client, agent, environment, clienthelper
     assert states["test::Resource[agent1,key=key5],v=%d" % version] == "skipped"
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_wait(resource_container, client, clienthelper, environment, server, no_agent_backoff, async_finalizer):
     """
     If this test fail due to timeout,
@@ -982,7 +970,6 @@ async def test_wait(resource_container, client, clienthelper, environment, serve
     assert states["test::Resource[agent1,key=key5],v=%d" % version1] == const.ResourceState.available.name
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_multi_instance(resource_container, client, clienthelper, server, environment, no_agent_backoff, async_finalizer):
     """
     Test for multi threaded deploy
@@ -1111,7 +1098,6 @@ async def test_multi_instance(resource_container, client, clienthelper, server, 
     await agent.stop()
 
 
-@pytest.mark.asyncio
 async def test_cross_agent_deps(resource_container, server, client, environment, clienthelper, no_agent_backoff):
     """
     deploy a configuration model with cross host dependency
@@ -1214,7 +1200,6 @@ async def test_cross_agent_deps(resource_container, server, client, environment,
     "agent_trigger_method, read_resource1, change_resource1, read_resource2, change_resource2",
     [(const.AgentTriggerMethod.push_incremental_deploy, 1, 1, 2, 2), (const.AgentTriggerMethod.push_full_deploy, 2, 1, 2, 2)],
 )
-@pytest.mark.asyncio
 async def test_auto_deploy(
     agent,
     client,
@@ -1302,7 +1287,6 @@ async def test_auto_deploy(
     assert resource_container.Provider.changecount("agent1", "key2") == change_resource2
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_auto_deploy_no_splay(server, client, clienthelper, resource_container, environment, no_agent_backoff):
     """
     dryrun and deploy a configuration model automatically with agent autostart
@@ -1383,7 +1367,6 @@ def ps_diff_inmanta_agent_processes(original: List[psutil.Process], current_proc
     )
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_autostart_mapping(server, client, clienthelper, resource_container, environment, no_agent_backoff):
     """
     Test whether an autostarted agent updates its agent-map correctly when the autostart_agent_map is updated on the server.
@@ -1503,7 +1486,6 @@ async def test_autostart_mapping(server, client, clienthelper, resource_containe
     assert len(newchildren) == 0, newchildren
 
 
-@pytest.mark.asyncio
 async def test_autostart_mapping_update_uri(server, client, environment, async_finalizer, caplog):
     caplog.set_level(logging.INFO)
     agent_config.use_autostart_agent_map.set("true")
@@ -1542,7 +1524,6 @@ async def test_autostart_mapping_update_uri(server, client, environment, async_f
     await retry_limited(lambda: f"Updating the URI of the endpoint {agent_name} from localhost to " in caplog.text, 10)
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_autostart_clear_environment(server, client, resource_container, environment, no_agent_backoff):
     """
     Test clearing an environment with autostarted agents. After clearing, autostart should still work
@@ -1720,7 +1701,6 @@ def _get_inmanta_agent_child_processes(parent_process: psutil.Process) -> List[p
     return [p for p in parent_process.children(recursive=True) if "inmanta.app" in p.cmdline() and "agent" in p.cmdline()]
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_stop_autostarted_agents_on_environment_removal(server, client, resource_container, no_agent_backoff):
     current_process = psutil.Process()
     inmanta_agent_child_processes: List[psutil.Process] = _get_inmanta_agent_child_processes(current_process)
@@ -1737,7 +1717,6 @@ async def test_stop_autostarted_agents_on_environment_removal(server, client, re
     ps_diff_inmanta_agent_processes(original=inmanta_agent_child_processes, current_process=current_process, diff=0)
 
 
-@pytest.mark.asyncio(timeout=15)
 async def test_stop_autostarted_agents_on_project_removal(server, client, resource_container, no_agent_backoff):
     current_process = psutil.Process()
     inmanta_agent_child_processes: List[psutil.Process] = _get_inmanta_agent_child_processes(current_process)
@@ -1756,7 +1735,6 @@ async def test_stop_autostarted_agents_on_project_removal(server, client, resour
     ps_diff_inmanta_agent_processes(original=inmanta_agent_child_processes, current_process=current_process, diff=1)
 
 
-@pytest.mark.asyncio
 async def test_export_duplicate(resource_container, snippetcompiler):
     """
     The exported should provide a compilation error when a resource is defined twice in a model
@@ -1863,7 +1841,6 @@ succ    n    n    y    n
 
 @pytest.mark.parametrize("self_state", self_states, ids=lambda x: x.name)
 @pytest.mark.parametrize("dep_state", dep_states, ids=lambda x: x.name)
-@pytest.mark.asyncio
 async def test_deploy_and_events(
     client, agent, clienthelper, environment, resource_container, self_state, dep_state, async_finalizer, no_agent_backoff
 ):
@@ -1935,7 +1912,6 @@ dep_states_reload = [
 
 
 @pytest.mark.parametrize("dep_state", dep_states_reload, ids=lambda x: x.name)
-@pytest.mark.asyncio(timeout=5000)
 async def test_reload(server, client, clienthelper, environment, resource_container, dep_state, no_agent_backoff):
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
 
@@ -1993,7 +1969,6 @@ async def test_reload(server, client, clienthelper, environment, resource_contai
     await agent.stop()
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_s_repair_postponed_due_to_running_deploy(
     resource_container, agent, client, clienthelper, environment, no_agent_backoff, caplog
 ):
@@ -2070,7 +2045,6 @@ async def test_s_repair_postponed_due_to_running_deploy(
 debug_timeout = 10
 
 
-@pytest.mark.asyncio(timeout=debug_timeout * 2)
 async def test_s_repair_interrupted_by_deploy_request(
     resource_container, agent, client, clienthelper, environment, no_agent_backoff, caplog
 ):
@@ -2199,7 +2173,6 @@ async def test_s_repair_interrupted_by_deploy_request(
     )
 
 
-@pytest.mark.asyncio
 async def test_s_repair_during_repair(resource_container, agent, client, clienthelper, environment, no_agent_backoff, caplog):
     caplog.set_level(logging.INFO)
     resource_container.Provider.reset()
@@ -2278,7 +2251,6 @@ async def test_s_repair_during_repair(resource_container, agent, client, clienth
     log_contains(caplog, "inmanta.agent.agent.agent1", logging.INFO, "Terminating run 'Repair 1' for 'Repair 2'")
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_s_deploy_during_deploy(resource_container, agent, client, clienthelper, environment, no_agent_backoff, caplog):
     caplog.set_level(logging.INFO)
     resource_container.Provider.reset()
@@ -2356,7 +2328,6 @@ async def test_s_deploy_during_deploy(resource_container, agent, client, clienth
     log_contains(caplog, "inmanta.agent.agent.agent1", logging.INFO, "Terminating run 'Deploy 1' for 'Deploy 2'")
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_s_full_deploy_interrupts_incremental_deploy(
     resource_container, agent, client, clienthelper, environment, no_agent_backoff, caplog
 ):
@@ -2443,7 +2414,6 @@ async def test_s_full_deploy_interrupts_incremental_deploy(
     log_contains(caplog, "inmanta.agent.agent.agent1", logging.INFO, "Terminating run 'Initial Deploy' for 'Second Deploy'")
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_s_incremental_deploy_interrupts_full_deploy(
     resource_container, client, agent, environment, clienthelper, no_agent_backoff, caplog
 ):
@@ -2525,7 +2495,6 @@ async def test_s_incremental_deploy_interrupts_full_deploy(
     log_contains(caplog, "inmanta.agent.agent.agent1", logging.INFO, "Terminating run 'Initial Deploy' for 'Second Deploy'")
 
 
-@pytest.mark.asyncio
 async def test_bad_post_get_facts(
     resource_container, server, client, agent, clienthelper, environment, caplog, no_agent_backoff
 ):
@@ -2574,7 +2543,6 @@ async def test_bad_post_get_facts(
     await agent.stop()
 
 
-@pytest.mark.asyncio
 async def test_inprogress(resource_container, server, client, clienthelper, environment, no_agent_backoff):
     """
     Test retrieving facts from the agent
@@ -2613,7 +2581,6 @@ async def test_inprogress(resource_container, server, client, clienthelper, envi
 
 
 @pytest.mark.parametrize("use_agent_trigger_method_setting", [(True,), (False)])
-@pytest.mark.asyncio
 async def test_push_incremental_deploy(
     resource_container,
     environment,
@@ -2718,7 +2685,6 @@ async def test_push_incremental_deploy(
 
 
 @pytest.mark.parametrize("push, agent_trigger_method", [(True, None), (True, const.AgentTriggerMethod.push_full_deploy)])
-@pytest.mark.asyncio
 async def test_push_full_deploy(
     resource_container, environment, server, client, clienthelper, no_agent_backoff, push, agent_trigger_method, async_finalizer
 ):
@@ -2797,7 +2763,6 @@ async def test_push_full_deploy(
     await agent.stop()
 
 
-@pytest.mark.asyncio
 async def test_agent_run_sync(resource_container, environment, server, client, clienthelper, no_agent_backoff, async_finalizer):
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
 
@@ -2843,7 +2808,6 @@ async def test_agent_run_sync(resource_container, environment, server, client, c
     assert "agent2" in (await client.get_setting(tid=environment, id=data.AUTOSTART_AGENT_MAP)).result["value"]
 
 
-@pytest.mark.asyncio
 async def test_format_token_in_logline(server, agent, client, environment, resource_container, caplog, no_agent_backoff):
     """Deploy a resource that logs a line that after formatting on the agent contains an invalid formatting character."""
     version = (await client.reserve_version(environment)).result["data"]
@@ -2888,7 +2852,6 @@ async def test_format_token_in_logline(server, agent, client, environment, resou
     assert log_string in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_1016_cache_invalidation(
     server, agent, client, clienthelper, environment, resource_container, no_agent_backoff, caplog
 ):
@@ -2960,7 +2923,6 @@ async def test_1016_cache_invalidation(
     log_index(caplog, "inmanta.agent.agent.agent1", logging.DEBUG, "Pulled 1 resources because call to trigger_update", idx2)
 
 
-@pytest.mark.asyncio
 async def test_agent_lockout(resource_container, environment, server, client, clienthelper, async_finalizer, no_agent_backoff):
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
 
@@ -3007,7 +2969,6 @@ async def test_agent_lockout(resource_container, environment, server, client, cl
     assert result.code == 409
 
 
-@pytest.mark.asyncio
 async def test_deploy_no_code(resource_container, client, clienthelper, environment, autostarted_agent):
     """
     Test retrieving facts from the agent when there is no handler code available. We use an autostarted agent, these
@@ -3050,7 +3011,6 @@ async def test_deploy_no_code(resource_container, client, clienthelper, environm
     assert "Failed to load handler code " in result["logs"][1]["messages"][0]["msg"]
 
 
-@pytest.mark.asyncio
 async def test_issue_1662(resource_container, server, client, clienthelper, environment, monkeypatch, request):
     agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
     autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
@@ -3099,7 +3059,6 @@ async def test_issue_1662(resource_container, server, client, clienthelper, envi
     await _wait_until_deployment_finishes(client, environment, version, timeout=10)
 
 
-@pytest.mark.asyncio
 async def test_restart_agent_with_outdated_agent_map(server, client, environment):
     """
     Due to a race condition, it is possible that an autostarted agent get's started with an outdated agent_map.
@@ -3131,7 +3090,6 @@ async def test_restart_agent_with_outdated_agent_map(server, client, environment
     await retry_limited(lambda: len(agent_manager.tid_endpoint_to_session) == 2, 10)
 
 
-@pytest.mark.asyncio
 async def test_agent_stop_deploying_when_paused(
     server, client, environment, agent_factory, clienthelper, resource_container, no_agent_backoff
 ):
@@ -3218,7 +3176,6 @@ async def test_agent_stop_deploying_when_paused(
     assert rvid_to_actual_states_dct == rvis_to_expected_states
 
 
-@pytest.mark.asyncio
 async def test_agentinstance_stops_deploying_when_stopped(
     server, client, environment, agent, clienthelper, resource_container, no_agent_backoff
 ):
@@ -3284,7 +3241,6 @@ async def test_agentinstance_stops_deploying_when_stopped(
     )
 
 
-@pytest.mark.asyncio
 async def test_set_fact_in_handler(server, client, environment, agent, clienthelper, resource_container, no_agent_backoff):
     """
     Test whether facts set in the handler via the ctx.set_fact() method arrive on the server.
@@ -3381,7 +3337,6 @@ async def test_set_fact_in_handler(server, client, environment, agent, clienthel
     compare_params(params, [param1, param2, param3, param4])
 
 
-@pytest.mark.asyncio
 async def test_deploy_handler_method(server, client, environment, agent, clienthelper, resource_container, no_agent_backoff):
     """
     Test whether the resource states are set correctly when the deploy() method is overridden.

--- a/tests/db/dump_tool.py
+++ b/tests/db/dump_tool.py
@@ -22,7 +22,6 @@ import asyncio
 import os
 import shutil
 
-
 from inmanta import const
 from inmanta.protocol import methods
 from inmanta.server import SLICE_SERVER

--- a/tests/db/dump_tool.py
+++ b/tests/db/dump_tool.py
@@ -22,7 +22,6 @@ import asyncio
 import os
 import shutil
 
-import pytest
 
 from inmanta import const
 from inmanta.protocol import methods
@@ -38,7 +37,6 @@ def check_result(result):
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_dump_db(server, client, postgres_db, database_name):
     """
     Note: remove following line from the dump: SELECT pg_catalog.set_config('search_path', '', false);

--- a/tests/db/test_db_schema.py
+++ b/tests/db/test_db_schema.py
@@ -85,7 +85,6 @@ async def assert_core_untouched(postgresql_client, corev: Optional[Set[int]] = N
     assert current_db_versions == corev
 
 
-@pytest.mark.asyncio
 async def test_dbschema_clean(postgresql_client: asyncpg.Connection, get_columns_in_db_table, hard_clean_db, caplog):
     with caplog.at_level(logging.INFO):
         dbm = schema.DBSchema("test_dbschema_clean", inmanta.db.versions, postgresql_client)
@@ -98,7 +97,6 @@ async def test_dbschema_clean(postgresql_client: asyncpg.Connection, get_columns
         log_contains(caplog, "inmanta.data.schema.schema:test_dbschema_clean", logging.INFO, "Creating schema version table")
 
 
-@pytest.mark.asyncio
 async def test_dbschema_unclean(postgresql_client: asyncpg.Connection, get_columns_in_db_table, hard_clean_db):
     dbm = schema.DBSchema("test_dbschema_unclean", inmanta.db.versions, postgresql_client)
     await dbm.ensure_self_update()
@@ -112,7 +110,6 @@ async def test_dbschema_unclean(postgresql_client: asyncpg.Connection, get_colum
     await assert_core_untouched(postgresql_client)
 
 
-@pytest.mark.asyncio
 async def test_dbschema_update_legacy_1(
     postgresql_client: asyncpg.Connection, get_columns_in_db_table, hard_clean_db, hard_clean_db_post
 ):
@@ -135,7 +132,6 @@ CREATE TABLE IF NOT EXISTS public.schemamanager(
     await run_updates_and_verify(get_columns_in_db_table, dbm, set())
 
 
-@pytest.mark.asyncio
 async def test_dbschema_update_legacy_2(
     postgresql_client: asyncpg.Connection, get_columns_in_db_table, hard_clean_db, hard_clean_db_post
 ):
@@ -158,7 +154,6 @@ CREATE TABLE IF NOT EXISTS public.schemamanager(
     await run_updates_and_verify(get_columns_in_db_table, dbm, {0, 1})
 
 
-@pytest.mark.asyncio
 async def test_dbschema_update_legacy_contained(
     postgresql_client: asyncpg.Connection, get_columns_in_db_table, hard_clean_db, hard_clean_db_post
 ):
@@ -190,7 +185,6 @@ CREATE TABLE IF NOT EXISTS public.schemamanager(
     assert await dbm2.get_installed_versions() == {1, 3}
 
 
-@pytest.mark.asyncio
 async def test_dbschema_update_legacy_table_concurrent(
     postgres_db, database_name, get_columns_in_db_table, hard_clean_db, hard_clean_db_post
 ):
@@ -232,7 +226,6 @@ CREATE TABLE IF NOT EXISTS public.schemamanager(
     assert await dbm2.get_installed_versions() == set()
 
 
-@pytest.mark.asyncio
 async def test_dbschema_ensure_self_update(
     postgresql_client: asyncpg.Connection, get_columns_in_db_table, hard_clean_db, hard_clean_db_post
 ):
@@ -255,7 +248,6 @@ CREATE TABLE IF NOT EXISTS public.schemamanager(
     assert await dbm.get_installed_versions() == {1, 3}
 
 
-@pytest.mark.asyncio
 async def test_dbschema_update_db_schema(postgresql_client, get_columns_in_db_table, hard_clean_db, hard_clean_db_post):
 
     db_schema = schema.DBSchema("test_dbschema_update_db_schema", inmanta.db.versions, postgresql_client)
@@ -268,7 +260,6 @@ async def test_dbschema_update_db_schema(postgresql_client, get_columns_in_db_ta
     await run_updates_and_verify(get_columns_in_db_table, db_schema, set(), prefix="c")
 
 
-@pytest.mark.asyncio
 async def test_dbschema_update_db_schema_failure(postgresql_client, get_columns_in_db_table):
     corev: Set[int] = await get_core_versions(postgresql_client)
     db_schema = schema.DBSchema("test_dbschema_update_db_schema_failure", inmanta.db.versions, postgresql_client)
@@ -315,7 +306,6 @@ def make_versions(idx, *fcts):
     return [make_version(idx + i, fct) for i, fct in enumerate(fcts)]
 
 
-@pytest.mark.asyncio
 async def test_dbschema_partial_update_db_schema_failure(postgresql_client, get_columns_in_db_table):
     corev: Set[int] = await get_core_versions(postgresql_client)
     db_schema = schema.DBSchema("test_dbschema_partial_update_db_schema_failure", inmanta.db.versions, postgresql_client)
@@ -383,7 +373,6 @@ def test_dbschema_get_dct_with_update_functions():
         assert inspect.getfullargspec(version.function)[0] == ["connection"]
 
 
-@pytest.mark.asyncio
 async def test_multi_upgrade_lockout(postgresql_pool, get_columns_in_db_table, hard_clean_db):
     async with postgresql_pool.acquire() as postgresql_client:
         async with postgresql_pool.acquire() as postgresql_client2:
@@ -453,7 +442,6 @@ async def test_multi_upgrade_lockout(postgresql_pool, get_columns_in_db_table, h
             await assert_core_untouched(postgresql_client, corev)
 
 
-@pytest.mark.asyncio
 async def test_dbschema_get_dct_filter_disabled():
     db_schema = schema.DBSchema(CORE_SCHEMA_NAME, versions, None)
     update_function_map = db_schema._get_update_functions()
@@ -465,7 +453,6 @@ async def test_dbschema_get_dct_filter_disabled():
         assert inspect.getfullargspec(version.function)[0] == ["connection"]
 
 
-@pytest.mark.asyncio
 async def test_dbschema_get_dct_filter_invalid_names(caplog):
     db_schema = schema.DBSchema(CORE_SCHEMA_NAME, invalid_versions, None)
     update_function_map = db_schema._get_update_functions()

--- a/tests/db/test_restore_tool.py
+++ b/tests/db/test_restore_tool.py
@@ -15,13 +15,11 @@
 
     Contact: code@inmanta.com
 """
-import pytest
 from asyncpg import Connection
 
 from db.common import PGRestore
 
 
-@pytest.mark.asyncio
 async def test_pg_restore(hard_clean_db, hard_clean_db_post, postgresql_client: Connection):
 
     inp = r"""

--- a/tests/db/test_v17_to_v202105170.py
+++ b/tests/db/test_v17_to_v202105170.py
@@ -50,7 +50,6 @@ async def migrate_v17_to_v202105170(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_timestamp_timezones(
     migrate_v17_to_v202105170: Callable[[], Awaitable[None]], postgresql_client: Connection
 ) -> None:

--- a/tests/db/test_v202105170_to_v202106080.py
+++ b/tests/db/test_v202105170_to_v202106080.py
@@ -44,7 +44,6 @@ async def migrate_v202105170_to_v202106080(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_timestamp_timezones(
     migrate_v202105170_to_v202106080: Callable[[], Awaitable[None]],
     postgresql_client: Connection,

--- a/tests/db/test_v202106080_to_v202106210.py
+++ b/tests/db/test_v202106080_to_v202106210.py
@@ -44,7 +44,6 @@ async def migrate_v202106080_to_v202106210(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_add_value_to_resource_table(
     migrate_v202106080_to_v202106210: Callable[[], Awaitable[None]],
     postgresql_client: Connection,

--- a/tests/db/test_v202106210_to_v202109100.py
+++ b/tests/db/test_v202106210_to_v202109100.py
@@ -46,7 +46,6 @@ async def migrate_v202106210_to_v202109100(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_valid_loglevels(migrate_v202106210_to_v202109100: Callable[[], Awaitable[None]]) -> None:
     """
     Test whether the value column was added to the resource table.

--- a/tests/db/test_v202109100_to_v202111260.py
+++ b/tests/db/test_v202109100_to_v202111260.py
@@ -44,7 +44,6 @@ async def migrate_v202109100_to_v202111260(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_added_environment_columns(
     migrate_v202109100_to_v202111260: Callable[[], Awaitable[None]],
     get_columns_in_db_table: Callable[[str], Awaitable[List[str]]],

--- a/tests/db/test_v2_to_v3.py
+++ b/tests/db/test_v2_to_v3.py
@@ -40,7 +40,6 @@ async def migrate_v2_to_v3(hard_clean_db, hard_clean_db_post, postgresql_client:
     await ibl.stop()
 
 
-@pytest.mark.asyncio
 @pytest.mark.slowtest
 async def test_environment_update(migrate_v2_to_v3, async_finalizer, server_config):
     client = protocol.Client("client")
@@ -74,7 +73,6 @@ async def test_environment_update(migrate_v2_to_v3, async_finalizer, server_conf
     assert e3_next == 2
 
 
-@pytest.mark.asyncio
 async def test_addition_resource_type_column(migrate_v2_to_v3, postgresql_client: Connection):
     results = await postgresql_client.fetch("SELECT resource_version_id, resource_type FROM public.Resource")
     for r in results:

--- a/tests/db/test_v3_to_v4.py
+++ b/tests/db/test_v3_to_v4.py
@@ -51,7 +51,6 @@ async def migrate_v3_to_v4(hard_clean_db, hard_clean_db_post, postgresql_client:
     await ibl.stop()
 
 
-@pytest.mark.asyncio
 async def test_db_migration(migrate_v3_to_v4, postgresql_client: Connection):
     for table_name in ["form", "formrecord", "resourceversionid"]:
         assert not await does_table_exist(postgresql_client, table_name)

--- a/tests/db/test_v4_to_v5.py
+++ b/tests/db/test_v4_to_v5.py
@@ -43,7 +43,6 @@ async def migrate_v4_to_v5(
     await ibl.stop()
 
 
-@pytest.mark.asyncio
 async def test_db_migration_compile_data(migrate_v4_to_v5, postgresql_client: Connection) -> None:
     compiles = await postgresql_client.fetch("SELECT * FROM public.compile;")
     for c in compiles:
@@ -53,7 +52,6 @@ async def test_db_migration_compile_data(migrate_v4_to_v5, postgresql_client: Co
         assert c["compile_data"] is None
 
 
-@pytest.mark.asyncio
 async def test_db_migration_environment_halt(migrate_v4_to_v5, postgresql_client: Connection) -> None:
     environments = await postgresql_client.fetch("SELECT * FROM public.environment;")
     for env in environments:

--- a/tests/db/test_v5_to_v6.py
+++ b/tests/db/test_v5_to_v6.py
@@ -43,7 +43,6 @@ async def migrate_v5_to_v6(
     await ibl.stop()
 
 
-@pytest.mark.asyncio
 async def test_add_on_delete_cascade_constraint(migrate_v5_to_v6, postgresql_client: Connection) -> None:
     """
     Verify that the ON DELETE CASCADE constraint is set correctly on the substitute_compile_id column

--- a/tests/db/test_v6_to_v7.py
+++ b/tests/db/test_v6_to_v7.py
@@ -47,7 +47,6 @@ async def migrate_v6_to_v7(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_unique_agent_instances(migrate_v6_to_v7: None, postgresql_client: Connection) -> None:
     # assert that existing documents have been merged and expired state has been set correctly
     async with postgresql_client.transaction():

--- a/tests/db/test_v7_to_v17.py
+++ b/tests/db/test_v7_to_v17.py
@@ -49,7 +49,6 @@ async def migrate_v7_to_v17(
     await ibl.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_foreign_key_agent_to_agentinstance(migrate_v7_to_v17: None, postgresql_client: Connection) -> None:
     """
     Deleting an entry in the agentInstance table should not be allowed when it's references from the agent stable.

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -279,7 +279,6 @@ def test_commit_no_tags(git_modules_dir, module_without_tags, dev, tag, version_
     assert ("5.0" in str(output)) is version_tag_in_output
 
 
-@pytest.mark.asyncio
 async def test_version_argument(modules_repo):
     make_module_simple(modules_repo, "mod-version", [], "1.2")
     module_path = os.path.join(modules_repo, "mod-version")

--- a/tests/server/test_agents_api.py
+++ b/tests/server/test_agents_api.py
@@ -69,7 +69,6 @@ async def env_with_agents(client, environment: str) -> None:
     await create_agent(name="failover2", with_process=True, last_failover=datetime.datetime.now())  # up
 
 
-@pytest.mark.asyncio
 async def test_agent_list_filters(client, environment: str, env_with_agents: None) -> None:
     result = await client.get_agents(environment)
     assert result.code == 200
@@ -117,7 +116,6 @@ def agent_names(agents: List[Dict[str, str]]) -> List[str]:
 
 @pytest.mark.parametrize("order_by_column", ["name", "status", "process_name", "last_failover", "paused"])
 @pytest.mark.parametrize("order", ["DESC", "ASC"])
-@pytest.mark.asyncio
 async def test_agents_paging(server, client, env_with_agents: None, environment: str, order_by_column: str, order: str) -> None:
     result = await client.get_agents(
         environment,
@@ -218,7 +216,6 @@ async def test_agents_paging(server, client, env_with_agents: None, environment:
     assert result.result["metadata"] == {"total": 7, "before": 0, "after": 0, "page_size": 100}
 
 
-@pytest.mark.asyncio
 async def test_sorting_validation(client, environment: str, env_with_agents: None) -> None:
     sort_status_map = {
         "date.desc": 400,
@@ -234,7 +231,6 @@ async def test_sorting_validation(client, environment: str, env_with_agents: Non
         assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_agent_process_details(client, environment: str) -> None:
     env_uuid = uuid.UUID(environment)
     process_sid = uuid.uuid4()
@@ -264,7 +260,6 @@ async def test_agent_process_details(client, environment: str) -> None:
     assert result.result["data"]["state"] is None
 
 
-@pytest.mark.asyncio
 async def test_agent_process_details_with_report(server, client, environment: str, agent) -> None:
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
     env = await data.Environment.get_by_id(uuid.UUID(environment))

--- a/tests/server/test_compile_details.py
+++ b/tests/server/test_compile_details.py
@@ -86,7 +86,6 @@ async def env_with_compiles(client, environment):
     return environment, ids, compile_requested_timestamps
 
 
-@pytest.mark.asyncio
 async def test_compile_details(server, client, env_with_compiles):
     environment, ids, compile_requested_timestamps = env_with_compiles
 

--- a/tests/server/test_compilereport_list.py
+++ b/tests/server/test_compilereport_list.py
@@ -64,7 +64,6 @@ async def env_with_compile_reports(client, environment):
         ("requested", "ASC"),
     ],
 )
-@pytest.mark.asyncio
 async def test_compile_reports_paging(server, client, env_with_compile_reports, order_by_column, order):
     environment, compile_requested_timestamps = env_with_compile_reports
 
@@ -161,7 +160,6 @@ async def test_compile_reports_paging(server, client, env_with_compile_reports, 
     assert result.result["metadata"] == {"total": 6, "before": 0, "after": 0, "page_size": 6}
 
 
-@pytest.mark.asyncio
 async def test_compile_reports_filters(server, client, env_with_compile_reports):
     environment, compile_requested_timestamps = env_with_compile_reports
 
@@ -233,7 +231,6 @@ async def test_compile_reports_filters(server, client, env_with_compile_reports)
         ("Dates.ASC", 400),
     ],
 )
-@pytest.mark.asyncio
 async def test_sorting_validation(server, client, sort, expected_status, env_with_compile_reports):
     environment, _ = env_with_compile_reports
     result = await client.get_compile_reports(environment, limit=2, sort=sort)
@@ -256,7 +253,6 @@ async def test_sorting_validation(server, client, sort, expected_status, env_wit
         ({"requested": f"{datetime.datetime.now()}"}, 400),
     ],
 )
-@pytest.mark.asyncio
 async def test_filter_validation(server, client, filter, expected_status, env_with_compile_reports):
     environment, _ = env_with_compile_reports
     result = await client.get_compile_reports(environment, filter=filter)

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -228,7 +228,7 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
 
         if idx < len(remote_ids):
             current = remote_ids[idx]
-            after = remote_ids[idx + 1:]
+            after = remote_ids[idx + 1 :]
 
             assert await cs.is_compiling(env.id) == 200
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -111,7 +111,6 @@ class EnvironmentFactory:
         subprocess.check_output(["git", "commit", "-m", "write main.cf", "--allow-empty"], cwd=self.src_dir)
 
 
-@pytest.mark.asyncio
 async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog):
     """Test the scheduler part in isolation, mock out compile runner and listen to state updates"""
 
@@ -229,7 +228,7 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
 
         if idx < len(remote_ids):
             current = remote_ids[idx]
-            after = remote_ids[idx + 1 :]
+            after = remote_ids[idx + 1:]
 
             assert await cs.is_compiling(env.id) == 200
 
@@ -297,7 +296,6 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
     await report_db_index_usage()
 
 
-@pytest.mark.asyncio
 @pytest.mark.slowtest
 async def test_compile_runner(environment_factory: EnvironmentFactory, server, client, tmpdir):
     testmarker_env = "TESTMARKER"
@@ -427,7 +425,6 @@ async def test_compile_runner(environment_factory: EnvironmentFactory, server, c
     assert "inmanta-core" in output
 
 
-@pytest.mark.asyncio
 @pytest.mark.slowtest
 async def test_compilerservice_compile_data(environment_factory: EnvironmentFactory, client, server) -> None:
     async def get_compile_data(main: str) -> model.CompileData:
@@ -464,7 +461,6 @@ async def test_compilerservice_compile_data(environment_factory: EnvironmentFact
     assert error.message == "value set twice:\n\told value: 0\n\t\tset at ./main.cf:1\n\tnew value: 1\n\t\tset at ./main.cf:1\n"
 
 
-@pytest.mark.asyncio
 async def test_e2e_recompile_failure(compilerservice: CompilerService):
     project = data.Project(name="test")
     await project.insert()
@@ -516,7 +512,6 @@ async def test_e2e_recompile_failure(compilerservice: CompilerService):
     assert f1 < s2
 
 
-@pytest.mark.asyncio(timeout=90)
 async def test_server_recompile(server, client, environment, monkeypatch):
     """
     Test a recompile on the server and verify recompile triggers
@@ -628,7 +623,6 @@ async def run_compile_and_wait_until_compile_is_done(
     await retry_limited(_is_compile_finished, timeout=10)
 
 
-@pytest.mark.asyncio(timeout=90)
 async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, server, client, environment):
     """
     Test the inspection of the compile queue. The compile runner is mocked out so the "started" field does not have the
@@ -730,7 +724,6 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_compilerservice_halt(mocked_compiler_service_block, server, client, environment: uuid.UUID) -> None:
     config.Config.set("server", "auto-recompile-wait", "0")
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
@@ -845,7 +838,6 @@ async def old_and_new_compile_report(server_with_frequent_cleanups, environment_
     yield compile_id_old, compile_id_new
 
 
-@pytest.mark.asyncio
 async def test_compileservice_cleanup(
     server_with_frequent_cleanups,
     client_for_cleanup,
@@ -879,7 +871,6 @@ async def test_compileservice_cleanup(
     assert len(result.result["reports"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_issue_2361(environment_factory: EnvironmentFactory, server, client, tmpdir):
     env = await environment_factory.create_environment(main="")
 
@@ -909,7 +900,6 @@ async def test_issue_2361(environment_factory: EnvironmentFactory, server, clien
     assert compile_data is None
 
 
-@pytest.mark.asyncio
 async def test_git_uses_environment_variables(environment_factory: EnvironmentFactory, server, client, tmpdir, monkeypatch):
     """
     Make sure that the git clone command on the compilerservice takes into account the environment variables
@@ -942,7 +932,6 @@ async def test_git_uses_environment_variables(environment_factory: EnvironmentFa
     assert "trace: " in report.errstream
 
 
-@pytest.mark.asyncio(timeout=90)
 async def test_compileservice_auto_recompile_wait(mocked_compiler_service_block, server, client, environment, caplog):
     """
     Test the auto-recompile-wait setting when multiple recompiles are requested in a short amount of time
@@ -986,7 +975,6 @@ async def test_compileservice_auto_recompile_wait(mocked_compiler_service_block,
         )
 
 
-@pytest.mark.asyncio
 async def test_compileservice_calculate_auto_recompile_wait(mocked_compiler_service_block, server):
     """
     Test the recompile waiting time calculation when auto-recompile-wait configuration option is enabled
@@ -1017,7 +1005,6 @@ async def test_compileservice_calculate_auto_recompile_wait(mocked_compiler_serv
     assert waiting_time == 0
 
 
-@pytest.mark.asyncio
 async def test_compileservice_api(client, environment):
     # Exceed max value for limit
     result = await client.get_reports(environment, limit=APILIMIT + 1)

--- a/tests/server/test_databaseservice.py
+++ b/tests/server/test_databaseservice.py
@@ -17,7 +17,6 @@
 """
 import asyncio
 
-
 from inmanta import data
 from inmanta.server import config as opt
 from inmanta.server.services import databaseservice

--- a/tests/server/test_databaseservice.py
+++ b/tests/server/test_databaseservice.py
@@ -17,7 +17,6 @@
 """
 import asyncio
 
-import pytest
 
 from inmanta import data
 from inmanta.server import config as opt
@@ -25,7 +24,6 @@ from inmanta.server.services import databaseservice
 from utils import retry_limited
 
 
-@pytest.mark.asyncio
 async def test_agent_process_cleanup(server, environment, agent_factory):
     opt.agent_processes_to_keep.set("1")
     a1 = await agent_factory(environment, hostname="host", agent_map=[], agent_names=["agent1"])

--- a/tests/server/test_desired_state_versions.py
+++ b/tests/server/test_desired_state_versions.py
@@ -94,7 +94,6 @@ async def environments_with_versions(server, client) -> Tuple[Dict[str, uuid.UUI
     yield environments, cm_timestamps
 
 
-@pytest.mark.asyncio
 async def test_filter_versions(
     server, client, environments_with_versions: Tuple[Dict[str, uuid.UUID], List[datetime.datetime]]
 ):
@@ -190,7 +189,6 @@ def version_numbers(desired_state_objects):
         ("ASC"),
     ],
 )
-@pytest.mark.asyncio
 async def test_desired_state_versions_paging(
     server, client, order: str, environments_with_versions: Tuple[Dict[str, uuid.UUID], List[datetime.datetime]]
 ):
@@ -290,7 +288,6 @@ async def test_desired_state_versions_paging(
     assert result.result["metadata"] == {"total": 7, "before": 0, "after": 0, "page_size": 100}
 
 
-@pytest.mark.asyncio
 async def test_sorting_validation(
     server, client, environments_with_versions: Tuple[Dict[str, uuid.UUID], List[datetime.datetime]]
 ):
@@ -309,7 +306,6 @@ async def test_sorting_validation(
         assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_filter_validation(
     server, client, environments_with_versions: Tuple[Dict[str, uuid.UUID], List[datetime.datetime]]
 ):
@@ -328,7 +324,6 @@ async def test_filter_validation(
         assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_promote_no_versions(server, client, environment: str):
     result = await client.promote_desired_state_version(environment, version=1)
     assert result.code == 404
@@ -338,7 +333,6 @@ async def test_promote_no_versions(server, client, environment: str):
     "trigger_method",
     [None, PromoteTriggerMethod.no_push, PromoteTriggerMethod.push_incremental_deploy, PromoteTriggerMethod.push_full_deploy],
 )
-@pytest.mark.asyncio
 async def test_promote_version(server, client, clienthelper, agent, environment: str, trigger_method):
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
     env_obj = await data.Environment.get_by_id(uuid.UUID(environment))

--- a/tests/server/test_diff.py
+++ b/tests/server/test_diff.py
@@ -64,7 +64,6 @@ async def create_resource_in_multiple_versions(
         await res.insert()
 
 
-@pytest.mark.asyncio
 async def test_list_attr_diff(client, environment, env_with_versions):
     """Test the diff functionality with simple values and lists."""
     env_id = uuid.UUID(environment)
@@ -165,7 +164,6 @@ async def test_list_attr_diff(client, environment, env_with_versions):
     assert result.result["data"][0]["attributes"] == {**v1_v2_diff, **v2_v3_diff}
 
 
-@pytest.mark.asyncio
 async def test_dict_attr_diff(client, environment, env_with_versions):
     """Test the diff functionality with dicts and nested structures"""
     env_id = uuid.UUID(environment)
@@ -267,7 +265,6 @@ def assert_resource_added(resource):
         assert attr["from_value_compare"] == ""
 
 
-@pytest.mark.asyncio
 async def test_resources_diff(client, environment, env_with_versions):
     """Test the diff functionality on multiple resources across multiple versions"""
     env_id = uuid.UUID(environment)
@@ -365,7 +362,6 @@ async def test_resources_diff(client, environment, env_with_versions):
     assert_resource_added(result.result["data"][1])
 
 
-@pytest.mark.asyncio
 async def test_validate_versions(client, environment, env_with_versions):
     """Test the version parameter validation of the diff endpoint."""
     result = await client.get_diff_of_versions(environment, 1, 2)

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -15,13 +15,11 @@
 
     Contact: code@inmanta.com
 """
-import pytest
 
 from inmanta import data
 from inmanta.util import get_compiler_version
 
 
-@pytest.mark.asyncio
 async def test_environment_settings(client, server, environment_default):
     """
     Test environment settings
@@ -112,7 +110,6 @@ async def test_environment_settings(client, server, environment_default):
     assert result.result["value"] == agent_map
 
 
-@pytest.mark.asyncio
 async def test_environment_settings_v2(client_v2, server, environment_default):
     """
     Test environment settings
@@ -140,7 +137,6 @@ async def test_environment_settings_v2(client_v2, server, environment_default):
     assert response.code == 404
 
 
-@pytest.mark.asyncio
 async def test_delete_protected_environment(server, client):
     result = await client.create_project("env-test")
     assert result.code == 200
@@ -175,7 +171,6 @@ async def test_delete_protected_environment(server, client):
     await assert_env_deletion(env_id, deletion_succeeds=True)
 
 
-@pytest.mark.asyncio
 async def test_clear_protected_environment(server, client):
     result = await client.create_project("env-test")
     assert result.code == 200
@@ -227,7 +222,6 @@ async def test_clear_protected_environment(server, client):
     await assert_clear_env(env_id, clear_succeeds=True)
 
 
-@pytest.mark.asyncio
 async def test_decommission_protected_environment(server, client):
     result = await client.create_project("env-test")
     assert result.code == 200
@@ -281,7 +275,6 @@ async def test_decommission_protected_environment(server, client):
     await assert_decomission_env(env_id, decommission_succeeds=True)
 
 
-@pytest.mark.asyncio
 async def test_default_value_purge_on_delete_setting(server, client):
     """
     Ensure that the purge_on_delete setting of an environment is set to false by default.

--- a/tests/server/test_facts_api.py
+++ b/tests/server/test_facts_api.py
@@ -101,7 +101,6 @@ async def env_with_facts(environment, client) -> Tuple[str, List[str], List[str]
     yield environment, [param_id_1, param_id_3], [resource_id, resource_id_2, resource_id_3, resource_id_4]
 
 
-@pytest.mark.asyncio
 async def test_get_facts(client, env_with_facts):
     """
     Test retrieving facts via the API
@@ -137,7 +136,6 @@ async def test_get_facts(client, env_with_facts):
     assert result.code == 404
 
 
-@pytest.mark.asyncio
 async def test_fact_list_filters(client, env_with_facts: Tuple[str, List[str], List[str]]):
     environment, param_ids, resource_ids = env_with_facts
     result = await client.get_all_facts(
@@ -176,7 +174,6 @@ def fact_ids(fact_objects):
 
 @pytest.mark.parametrize("order_by_column", ["name", "resource_id"])
 @pytest.mark.parametrize("order", ["DESC", "ASC"])
-@pytest.mark.asyncio
 async def test_facts_paging(server, client, order_by_column, order, env_with_facts):
     """Test querying facts with paging, using different sorting parameters."""
     env, _, _ = env_with_facts
@@ -254,7 +251,6 @@ async def test_facts_paging(server, client, order_by_column, order, env_with_fac
     assert response["metadata"] == {"total": 6, "before": 2, "after": 2, "page_size": 2}
 
 
-@pytest.mark.asyncio
 async def test_sorting_validation(server, client, env_with_facts):
     env, _, _ = env_with_facts
     sort_status_map = {
@@ -271,7 +267,6 @@ async def test_sorting_validation(server, client, env_with_facts):
         assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_filter_validation(server, client, env_with_facts):
     env, _, _ = env_with_facts
     filter_status_map = [

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -24,8 +24,6 @@ from re import sub
 from typing import Any, Dict, List
 from uuid import UUID, uuid4
 
-import pytest
-
 import utils
 from inmanta import config, const, data
 from inmanta.agent.agent import Agent
@@ -217,7 +215,6 @@ class MultiVersionSetup(object):
         return allresources
 
 
-@pytest.mark.asyncio
 async def test_deploy(server, agent: Agent, environment, caplog):
     """
     Test basic deploy mechanism mocking
@@ -333,7 +330,6 @@ def strip_version(v):
     return sub(",v=[0-9]+", "", v)
 
 
-@pytest.mark.asyncio
 async def test_deploy_scenarios(server, agent: Agent, environment, caplog):
     with caplog.at_level(logging.WARNING):
         # acquire raw server
@@ -377,7 +373,6 @@ async def test_deploy_scenarios(server, agent: Agent, environment, caplog):
         assert record.levelname != "WARNING"
 
 
-@pytest.mark.asyncio
 async def test_deploy_scenarios_removed_req_by_increment(server, agent: Agent, environment, caplog):
     with caplog.at_level(logging.WARNING):
         # acquire raw server
@@ -400,7 +395,6 @@ async def test_deploy_scenarios_removed_req_by_increment(server, agent: Agent, e
         assert record.levelname != "WARNING"
 
 
-@pytest.mark.asyncio
 async def test_deploy_scenarios_removed_req_by_increment2(server, environment, caplog):
     with caplog.at_level(logging.WARNING):
         # acquire raw server
@@ -434,7 +428,6 @@ async def test_deploy_scenarios_removed_req_by_increment2(server, environment, c
         assert record.levelname != "WARNING" or record.name == "inmanta.config"
 
 
-@pytest.mark.asyncio
 async def test_deploy_scenarios_added_by_send_event(server, agent: Agent, environment, caplog):
     with caplog.at_level(logging.WARNING):
         # acquire raw server
@@ -459,7 +452,6 @@ async def test_deploy_scenarios_added_by_send_event(server, agent: Agent, enviro
         assert record.levelname != "WARNING"
 
 
-@pytest.mark.asyncio
 async def test_deploy_scenarios_added_by_send_event_cad(server, agent: Agent, environment, caplog):
     # ensure CAD does not change send_event
     with caplog.at_level(logging.WARNING):

--- a/tests/server/test_parameters_api.py
+++ b/tests/server/test_parameters_api.py
@@ -73,7 +73,6 @@ async def env_with_parameters(server, client, environment: str):
     yield environment, timestamps
 
 
-@pytest.mark.asyncio
 async def test_parameter_list_filters(client, env_with_parameters: Tuple[str, List[datetime.datetime]]):
     environment, timestamps = env_with_parameters
     result = await client.get_parameters(
@@ -112,7 +111,6 @@ def parameter_ids(parameter_objects):
 
 @pytest.mark.parametrize("order_by_column", ["name", "source", "updated"])
 @pytest.mark.parametrize("order", ["DESC", "ASC"])
-@pytest.mark.asyncio
 async def test_parameters_paging(server, client, order_by_column, order, env_with_parameters):
     """Test querying parameters with paging, using different sorting parameters."""
     env, timestamps = env_with_parameters
@@ -198,7 +196,6 @@ async def test_parameters_paging(server, client, order_by_column, order, env_wit
     assert response["metadata"] == {"total": 6, "before": 2, "after": 2, "page_size": 2}
 
 
-@pytest.mark.asyncio
 async def test_sorting_validation(server, client, env_with_parameters):
     env, _ = env_with_parameters
     sort_status_map = {
@@ -215,7 +212,6 @@ async def test_sorting_validation(server, client, env_with_parameters):
         assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_filter_validation(server, client, env_with_parameters):
     env, _ = env_with_parameters
     filter_status_map = [

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -45,7 +45,6 @@ async def environment(environment, client):
     yield environment
 
 
-@pytest.mark.asyncio
 async def test_purge_on_delete_requires(client: Client, server: Server, environment: str, clienthelper: ClientHelper):
     """
     Test purge on delete of resources and inversion of requires
@@ -141,7 +140,6 @@ async def test_purge_on_delete_requires(client: Client, server: Server, environm
     await agent.stop()
 
 
-@pytest.mark.asyncio(timeout=20)
 async def test_purge_on_delete_compile_failed_with_compile(
     event_loop, client: Client, server: Server, environment: str, snippetcompiler
 ):
@@ -172,7 +170,6 @@ async def test_purge_on_delete_compile_failed_with_compile(
     assert result.result["model"]["total"] == 0
 
 
-@pytest.mark.asyncio
 async def test_purge_on_delete_compile_failed(client: Client, server: Server, clienthelper: ClientHelper, environment: str):
     """
     Test purge on delete of resources
@@ -274,7 +271,6 @@ async def test_purge_on_delete_compile_failed(client: Client, server: Server, cl
     assert len(result.result["unknowns"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, server: Server, environment: str):
     """
     Test purge on delete of resources
@@ -405,7 +401,6 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
     await agent.stop()
 
 
-@pytest.mark.asyncio
 async def test_purge_on_delete_ignore(client: Client, clienthelper: ClientHelper, server: Server, environment: str):
     """
     Test purge on delete behavior for resources that have not longer purged_on_delete set
@@ -528,7 +523,6 @@ async def test_purge_on_delete_ignore(client: Client, clienthelper: ClientHelper
     await agent.stop()
 
 
-@pytest.mark.asyncio
 async def test_disable_purge_on_delete(client: Client, clienthelper: ClientHelper, server: Server, environment: str):
     """
     Test disable purge on delete of resources

--- a/tests/server/test_resource_action_logs.py
+++ b/tests/server/test_resource_action_logs.py
@@ -99,7 +99,6 @@ async def env_with_logs(client, server, environment):
     yield environment, msg_timings
 
 
-@pytest.mark.asyncio
 async def test_resource_action_logs_filtering(client, server, env_with_logs):
     """Test the filters for the resource action logs"""
     environment, msg_timings = env_with_logs
@@ -168,7 +167,6 @@ def log_messages(resource_log_objects):
         ("timestamp", "ASC"),
     ],
 )
-@pytest.mark.asyncio
 async def test_resource_logs_paging(server, client, order_by_column, order, env_with_logs):
     """Test querying resource logs with paging, using different sorting parameters."""
     environment, msg_timings = env_with_logs
@@ -266,7 +264,6 @@ async def test_resource_logs_paging(server, client, order_by_column, order, env_
         ("Dates.ASC", 400),
     ],
 )
-@pytest.mark.asyncio
 async def test_sorting_validation(server, client, sort, expected_status, env_with_logs):
     environment, _ = env_with_logs
     result = await client.resource_logs(environment, "std::File[agent1,path=/tmp/file1.txt]", limit=2, sort=sort)
@@ -286,14 +283,12 @@ async def test_sorting_validation(server, client, sort, expected_status, env_wit
         ({"message": ["deployed to", "setting"]}, 200),
     ],
 )
-@pytest.mark.asyncio
 async def test_filter_validation(server, client, filter, expected_status, env_with_logs):
     environment, _ = env_with_logs
     result = await client.resource_logs(environment, "std::File[agent1,path=/tmp/file1.txt]", limit=2, filter=filter)
     assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_log_without_kwargs(server, client, environment):
 
     await data.ConfigurationModel(
@@ -333,7 +328,6 @@ async def test_log_without_kwargs(server, client, environment):
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_log_nested_kwargs(server, client, environment):
 
     await data.ConfigurationModel(

--- a/tests/server/test_resource_details.py
+++ b/tests/server/test_resource_details.py
@@ -382,7 +382,6 @@ async def env_with_resources(server, client):
     yield env, cm_times, ids, resources
 
 
-@pytest.mark.asyncio
 async def test_resource_details(server, client, env_with_resources):
     """Test the resource details endpoint with multiple resources
     The released versions in the test environment are 2, 3 and 4, while 1 and 5 are not released.

--- a/tests/server/test_resource_history.py
+++ b/tests/server/test_resource_history.py
@@ -318,7 +318,6 @@ async def env_with_resources(server, client):
     yield env, cm_times, ids, resources
 
 
-@pytest.mark.asyncio
 async def test_resource_history(client, server, env_with_resources):
     env, cm_times, ids, resources = env_with_resources
     resource_with_long_history = ids["long_history"]
@@ -393,7 +392,6 @@ def attribute_hashes(resource_objects):
         ("date", "ASC"),
     ],
 )
-@pytest.mark.asyncio
 async def test_resource_history_paging(server, client, order_by_column, order, env_with_resources):
     """Test querying resource history with paging, using different sorting parameters."""
     env, cm_times, ids, resources = env_with_resources
@@ -475,7 +473,6 @@ async def test_resource_history_paging(server, client, order_by_column, order, e
     assert result.result["metadata"] == {"total": 5, "before": 0, "after": 0, "page_size": 5}
 
 
-@pytest.mark.asyncio
 async def test_history_not_continuous_versions(server, client, environment):
     """Test the scenario when there are gaps in the version numbers,
     but the attributes remain the same. There should be only one item in the history in this case."""

--- a/tests/server/test_resource_list.py
+++ b/tests/server/test_resource_list.py
@@ -30,7 +30,6 @@ from inmanta.data.model import LatestReleasedResource, ResourceVersionIdStr
 from inmanta.server.config import get_bind_port
 
 
-@pytest.mark.asyncio
 async def test_resource_list_no_released_version(server, client):
     """Test that if there are no released versions of a resource, the result set is empty"""
     project = data.Project(name="test")
@@ -62,7 +61,6 @@ async def test_resource_list_no_released_version(server, client):
     assert len(result.result["data"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_has_only_one_version_from_resource(server, client):
     """Test querying resources, when there are multiple released versions of a resource.
     The query should return only the latest one from those
@@ -209,7 +207,6 @@ async def env_with_resources(server, client):
     yield env
 
 
-@pytest.mark.asyncio
 async def test_filter_resources(server, client, env_with_resources):
     """Test querying resources."""
     env = env_with_resources
@@ -280,7 +277,6 @@ def resource_ids(resource_objects):
         ("resource_id_value", "ASC"),
     ],
 )
-@pytest.mark.asyncio
 async def test_resources_paging(server, client, order_by_column, order, env_with_resources):
     """Test querying resources with paging, using different sorting parameters."""
     env = env_with_resources
@@ -378,7 +374,6 @@ async def test_resources_paging(server, client, order_by_column, order, env_with
         ("resource_id_value.desc", 200),
     ],
 )
-@pytest.mark.asyncio
 async def test_sorting_validation(server, client, sort, expected_status, env_with_resources):
     result = await client.resource_list(env_with_resources.id, limit=2, sort=sort)
     assert result.code == expected_status
@@ -396,13 +391,11 @@ async def test_sorting_validation(server, client, sort, expected_status, env_wit
         ({"state": ["deployed"]}, 400),
     ],
 )
-@pytest.mark.asyncio
 async def test_filter_validation(server, client, filter, expected_status, env_with_resources):
     result = await client.resource_list(env_with_resources.id, limit=2, filter=filter)
     assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_paging_param_validation(server, client, env_with_resources):
     result = await client.resource_list(env_with_resources.id, limit=2, start="1", end="10")
     assert result.code == 400
@@ -417,7 +410,6 @@ async def test_paging_param_validation(server, client, env_with_resources):
     assert result.code == 400
 
 
-@pytest.mark.asyncio
 async def test_deploy_summary(server, client, env_with_resources):
     """Test querying the deployment summary of resources."""
     env = env_with_resources

--- a/tests/server/test_resourceservice.py
+++ b/tests/server/test_resourceservice.py
@@ -63,7 +63,6 @@ def resource_deployer(environment, agent):
     yield ResourceDeploymentHelperFunctions
 
 
-@pytest.mark.asyncio
 async def test_events_api_endpoints_basic_case(server, client, environment, clienthelper, agent, resource_deployer):
     """
     Test whether the `get_resource_events` and the `resource_did_dependency_change`
@@ -158,7 +157,6 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
     await resource_deployer.deployment_finished(rvid=rvid_r1_v1, action_id=action_id)
 
 
-@pytest.mark.asyncio
 async def test_events_api_endpoints_events_across_versions(server, client, environment, clienthelper, agent, resource_deployer):
     """
     Ensure that events are captured across versions.
@@ -239,7 +237,6 @@ async def test_events_api_endpoints_events_across_versions(server, client, envir
     assert not result.result["data"]
 
 
-@pytest.mark.asyncio
 async def test_events_resource_without_dependencies(server, client, environment, clienthelper, agent, resource_deployer):
     """
     Ensure that events are captured across versions.

--- a/tests/server/test_server_status.py
+++ b/tests/server/test_server_status.py
@@ -15,12 +15,10 @@
 
     Contact: code@inmanta.com
 """
-import pytest
 
 from inmanta import data
 
 
-@pytest.mark.asyncio
 async def test_server_status(server, client):
     result = await client.get_server_status()
 
@@ -40,7 +38,6 @@ async def test_server_status(server, client):
     assert len(status["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_server_status_database_unreachable(server, client):
     await data.Environment.close_connection_pool()
     result = await client.get_server_status()

--- a/tests/server/test_versioned_resource_list.py
+++ b/tests/server/test_versioned_resource_list.py
@@ -88,7 +88,6 @@ async def env_with_resources(server, client):
     yield env
 
 
-@pytest.mark.asyncio
 async def test_filter_resources(server, client, env_with_resources):
     """Test querying resources."""
 
@@ -150,7 +149,6 @@ def resource_ids(resource_objects):
 
 @pytest.mark.parametrize("order_by_column", ["agent", "resource_type", "resource_id_value"])
 @pytest.mark.parametrize("order", ["DESC", "ASC"])
-@pytest.mark.asyncio
 async def test_resources_paging(server, client, order_by_column, order, env_with_resources):
     """Test querying resources with paging, using different sorting parameters."""
     env = env_with_resources
@@ -238,7 +236,6 @@ async def test_resources_paging(server, client, order_by_column, order, env_with
     assert response["metadata"] == {"total": 5, "before": 2, "after": 1, "page_size": 2}
 
 
-@pytest.mark.asyncio
 async def test_sorting_validation(server, client, env_with_resources):
     sort_status_map = {
         "agents.Desc": 400,
@@ -254,7 +251,6 @@ async def test_sorting_validation(server, client, env_with_resources):
         assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_filter_validation(server, client, env_with_resources):
     filter_status_map = [
         ("version.desc", 400),
@@ -270,7 +266,6 @@ async def test_filter_validation(server, client, env_with_resources):
         assert result.code == expected_status
 
 
-@pytest.mark.asyncio
 async def test_versioned_resource_details(server, client, env_with_resources):
     result = await client.get_resources_in_version(env_with_resources.id, version=3, sort="resource_id_value.asc")
     assert result.code == 200

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -112,7 +112,6 @@ async def assert_agent_counter(agent: Agent, reconnect: int, disconnected: int) 
     await retry_limited(is_same, 10)
 
 
-@pytest.mark.asyncio
 async def test_2way_protocol(unused_tcp_port, no_tid_check, postgres_db, database_name):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -152,7 +151,6 @@ async def check_sessions(sessions):
 
 
 @pytest.mark.slowtest
-@pytest.mark.asyncio(timeout=30)
 async def test_agent_timeout(unused_tcp_port, no_tid_check, async_finalizer, postgres_db, database_name):
     from inmanta.config import Config
 
@@ -215,7 +213,6 @@ async def test_agent_timeout(unused_tcp_port, no_tid_check, async_finalizer, pos
 
 
 @pytest.mark.slowtest
-@pytest.mark.asyncio(timeout=30)
 async def test_server_timeout(unused_tcp_port, no_tid_check, async_finalizer, postgres_db, database_name):
     from inmanta.config import Config
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -36,7 +36,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.slowtest
-@pytest.mark.asyncio
 async def test_agent_get_status(server, environment, agent):
     clients = server.get_slice(SLICE_SESSION_MANAGER)._sessions.values()
     assert len(clients) == 1
@@ -114,7 +113,6 @@ async def startable_server(server_config):
         logger.exception("Timeout during stop of the server in teardown")
 
 
-@pytest.mark.asyncio
 async def test_agent_cannot_retrieve_autostart_agent_map(async_started_agent, startable_server, caplog):
     """
     When an agent with the config option use_autostart_agent_map set to true, cannot retrieve the autostart_agent_map
@@ -145,7 +143,6 @@ async def test_agent_cannot_retrieve_autostart_agent_map(async_started_agent, st
     await retry_limited(lambda: (async_started_agent.environment, "agent1") in agent_manager.tid_endpoint_to_session, 10)
 
 
-@pytest.mark.asyncio
 async def test_set_agent_map(server, environment, agent_factory):
     """
     This test verifies whether an agentmap is set correct when set via:
@@ -170,7 +167,6 @@ async def test_set_agent_map(server, environment, agent_factory):
     assert agent3.agent_map == agent_map
 
 
-@pytest.mark.asyncio
 async def test_hostname(server, environment, agent_factory):
     """
     This test verifies whether the hostname of an agent is set correct when set via:
@@ -193,7 +189,6 @@ async def test_hostname(server, environment, agent_factory):
     assert list(agent3.get_end_point_names()) == ["node3"]
 
 
-@pytest.mark.asyncio
 async def test_update_agent_map(server, environment, agent_factory):
     """
     If the URI of an enabled agent changes, it should still be enabled after the change

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -142,7 +142,6 @@ def assert_state_agents_retry(
     return func
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_primary_selection(server, environment):
     env_id = UUID(environment)
     env = await data.Environment.get_by_id(env_id)
@@ -227,7 +226,6 @@ async def test_primary_selection(server, environment):
     assert not am.is_primary(env, ts2.id, "agent3")
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_api(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -490,7 +488,6 @@ async def test_api(init_dataclasses_and_load_schema):
     assert_equal_ish(shouldbe, all_agents)
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_expire_all_sessions_in_db(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -612,7 +609,6 @@ async def assert_agent_db_state(
     await retry_limited(is_db_state_reached, 10)
 
 
-@pytest.mark.asyncio
 async def test_session_renewal(init_dataclasses_and_load_schema):
     """
     Agent got timeout but agent process was still running (e.g, network connectivity was disrupted).
@@ -659,7 +655,6 @@ async def test_session_renewal(init_dataclasses_and_load_schema):
     await assert_agent_db_state(tid, nr_procs=1, nr_non_expired_procs=1, nr_agent_instances=1, nr_non_expired_instances=1)
 
 
-@pytest.mark.asyncio
 async def test_fix_corrupted_database(init_dataclasses_and_load_schema):
     """
     When the database connection is lost, the agent session information might get
@@ -723,7 +718,6 @@ async def test_fix_corrupted_database(init_dataclasses_and_load_schema):
     await assert_agent_db_state(tid, nr_procs=1, nr_non_expired_procs=1, nr_agent_instances=1, nr_non_expired_instances=1)
 
 
-@pytest.mark.asyncio
 async def test_session_creation_fails(server, environment, async_finalizer, caplog):
     """
     Verify that:
@@ -776,7 +770,6 @@ async def test_session_creation_fails(server, environment, async_finalizer, capl
     assert len(session_manager._sessions) == 0
 
 
-@pytest.mark.asyncio
 async def test_agent_actions(server, client, async_finalizer):
     """
     Test the agent_action() and the all_agents_action() API call.
@@ -961,7 +954,6 @@ async def test_agent_actions(server, client, async_finalizer):
     await assert_agents_halt_state(env2_id, {"agent1": False}, False)
 
 
-@pytest.mark.asyncio
 async def test_process_already_terminated(server, environment):
     """
     This test case tests whether the termination of autostarted agents (processes) happens correctly,
@@ -981,7 +973,6 @@ async def test_process_already_terminated(server, environment):
     await autostarted_agent_manager._terminate_agents()
 
 
-@pytest.mark.asyncio
 async def test_exception_occurs_while_processing_session_action(server, environment, async_finalizer, monkeypatch, caplog):
     """
     This test verifies that the consumer of the _session_listener_actions queue keeps working
@@ -1023,7 +1014,6 @@ async def test_exception_occurs_while_processing_session_action(server, environm
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
 
-@pytest.mark.asyncio
 async def test_restart_on_environment_setting(server, client, environment, caplog):
     with caplog.at_level(logging.DEBUG):
         response = await client.environment_settings_set(tid=environment, id="autostart_agent_deploy_interval", value=300)
@@ -1044,7 +1034,6 @@ async def test_restart_on_environment_setting(server, client, environment, caplo
         )
 
 
-@pytest.mark.asyncio
 async def test_failover_doesnt_make_paused_agent_primary(server, client, environment, agent_factory):
     """
     This test verifies that:
@@ -1094,7 +1083,6 @@ async def test_failover_doesnt_make_paused_agent_primary(server, client, environ
     assert len(agentmanager.tid_endpoint_to_session) == 0
 
 
-@pytest.mark.asyncio
 async def test_add_internal_agent_when_missing_in_agent_map(server, environment, postgresql_client):
     """
     The internal agent should always be present in the autostart_agent_map. If it is not present, it is added when to
@@ -1124,7 +1112,6 @@ async def test_add_internal_agent_when_missing_in_agent_map(server, environment,
     assert "internal" in autostart_agent_map
 
 
-@pytest.mark.asyncio
 async def test_error_handling_agent_fork(server, environment, monkeypatch):
     """
     Verifies resolution of issue: inmanta/inmanta-core#2777

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -136,7 +136,6 @@ def test_module_help(inmanta_config, capsys):
     assert info.value.args[0].startswith("A subcommand is required.")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize_any("add_types", [True, False])
 async def test_export_to_json(tmpvenv_active_inherit: env.VirtualEnv, tmpdir, add_types):
     workspace = tmpdir.mkdir("tmp")
@@ -186,7 +185,6 @@ std::ConfigFile(host=vm1, path="/test", content="")
 @pytest.mark.parametrize_any("push_method", [([]), (["-d"]), (["-d", "--full"])])
 @pytest.mark.parametrize_any("set_server", [True, False])
 @pytest.mark.parametrize_any("set_port", [True, False])
-@pytest.mark.asyncio
 async def test_export(tmpvenv_active_inherit: env.VirtualEnv, tmpdir, server, client, push_method, set_server, set_port):
     server_port = Config.get("client_rest_transport", "port")
     server_host = Config.get("client_rest_transport", "host", "localhost")
@@ -272,7 +270,6 @@ std::ConfigFile(host=vm1, path="/test", content="")
     shutil.rmtree(workspace)
 
 
-@pytest.mark.asyncio
 async def test_export_with_specific_export_plugin(tmpvenv_active_inherit: env.VirtualEnv, tmpdir, client):
     server_port = Config.get("client_rest_transport", "port")
     server_host = Config.get("client_rest_transport", "host", "localhost")
@@ -409,7 +406,6 @@ vm1.name = "other"
 
 
 @pytest.mark.parametrize_any("push_method", [([]), (["-d"]), (["-d", "--full"])])
-@pytest.mark.asyncio
 async def test_export_without_environment(tmpdir, server, client, push_method):
     server_port = Config.get("client_rest_transport", "port")
     server_host = Config.get("client_rest_transport", "host", "localhost")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,6 @@ from inmanta.util import get_compiler_version
 from utils import get_resource, log_contains
 
 
-@pytest.mark.asyncio
 async def test_project(server, client, cli):
     # create a new project
     result = await cli.run("project", "create", "-n", "test_project")
@@ -71,7 +70,6 @@ async def test_project(server, client, cli):
     assert result.exit_code == 0
 
 
-@pytest.mark.asyncio
 async def test_environment(server, client, cli, tmpdir):
     project_name = "test_project"
     result = await client.create_project(project_name)
@@ -121,7 +119,6 @@ async def test_environment(server, client, cli, tmpdir):
         assert f"environment={env_id}" in file_content
 
 
-@pytest.mark.asyncio
 async def test_environment_settings(server, environment, client, cli):
     result = await cli.run("environment", "setting", "list", "-e", environment)
     assert result.exit_code == 0
@@ -144,14 +141,12 @@ async def test_environment_settings(server, environment, client, cli):
     assert result.exit_code == 0
 
 
-@pytest.mark.asyncio
 async def test_agent(server, client, environment, cli):
     result = await cli.run("agent", "list", "-e", environment)
     assert result.exit_code == 0
 
 
 @pytest.mark.parametrize("push_method", [([]), (["-p"]), (["-p", "--full"])])
-@pytest.mark.asyncio
 async def test_version(server, client, clienthelper, environment, cli, push_method):
     version = str(await clienthelper.get_version())
     resources = [
@@ -208,7 +203,6 @@ async def test_version(server, client, clienthelper, environment, cli, push_meth
     assert result.exit_code == 0
 
 
-@pytest.mark.asyncio
 async def test_param(server, client, environment, cli):
     await client.set_setting(environment, data.SERVER_COMPILE, False)
 
@@ -225,7 +219,6 @@ async def test_param(server, client, environment, cli):
     assert "var1" in result.output
 
 
-@pytest.mark.asyncio
 async def test_create_environment(tmpdir, server, client, cli):
     """
     Tests the "inmanta-cli environment create" command
@@ -267,7 +260,6 @@ async def test_create_environment(tmpdir, server, client, cli):
     assert ctime_0 != ctime_2
 
 
-@pytest.mark.asyncio
 async def test_inmanta_cli_http_version(server, client, cli, caplog):
     with caplog.at_level(logging.DEBUG):
         result = await cli.run("project", "create", "-n", "test_project")
@@ -275,7 +267,6 @@ async def test_inmanta_cli_http_version(server, client, cli, caplog):
         log_contains(caplog, "inmanta.protocol.rest.server", logging.DEBUG, "HTTP version of request: HTTP/1.1")
 
 
-@pytest.mark.asyncio
 async def test_pause_agent(server, cli):
     project = data.Project(name="test")
     await project.insert()
@@ -339,7 +330,6 @@ async def test_pause_agent(server, cli):
         assert result.exit_code != 0
 
 
-@pytest.mark.asyncio
 async def test_list_actionlog(server, environment, client, cli, agent, clienthelper):
     """
     Test the `inmanta-cli action-log list` command.
@@ -430,7 +420,6 @@ async def test_list_actionlog(server, environment, client, cli, agent, clienthel
     assert "Invalid value for '--rvid': test" in result.stderr
 
 
-@pytest.mark.asyncio
 async def test_show_messages_actionlog(server, environment, client, cli, agent, clienthelper):
     """
     Test the `inmanta-cli action-log show-messages` command.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,6 @@ import random
 import socket
 
 import netifaces
-import pytest
 from tornado import netutil
 
 import inmanta.agent.config as cfg
@@ -189,7 +188,6 @@ client-id=test456
     assert Config.get("server", "agent-timeout") == 60
 
 
-@pytest.mark.asyncio
 async def test_bind_address_ipv4(async_finalizer):
     """This test case check if the Inmanta server doesn't bind on another interface than 127.0.0.1 when bind-address is equal
     to 127.0.0.1. Procedure:
@@ -240,7 +238,6 @@ async def test_bind_address_ipv4(async_finalizer):
         sock.close()
 
 
-@pytest.mark.asyncio
 async def test_bind_address_ipv6(async_finalizer) -> None:
     @protocol.method(path="/test", operation="POST", client_types=[ClientType.api])
     async def test_endpoint():
@@ -275,7 +272,6 @@ async def test_bind_address_ipv6(async_finalizer) -> None:
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_bind_port(unused_tcp_port, async_finalizer, caplog):
     @protocol.method(path="/test", operation="POST", client_types=[ClientType.api])
     async def test_endpoint():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -32,7 +32,6 @@ from inmanta.const import AgentStatus, LogLevel
 from inmanta.resources import Id, ResourceVersionIdStr
 
 
-@pytest.mark.asyncio
 async def test_connect_too_small_connection_pool(postgres_db, database_name: str, create_db_schema: bool = False):
     pool: Pool = await data.connect(
         postgres_db.host,
@@ -55,7 +54,6 @@ async def test_connect_too_small_connection_pool(postgres_db, database_name: str
         await data.disconnect()
 
 
-@pytest.mark.asyncio
 async def test_connect_default_parameters(postgres_db, database_name: str, create_db_schema: bool = False):
     pool: Pool = await data.connect(
         postgres_db.host, postgres_db.port, database_name, postgres_db.user, postgres_db.password, create_db_schema
@@ -68,7 +66,6 @@ async def test_connect_default_parameters(postgres_db, database_name: str, creat
         await data.disconnect()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("min_size, max_size", [(-1, 1), (2, 1), (-2, -2)])
 async def test_connect_invalid_parameters(postgres_db, min_size, max_size, database_name: str, create_db_schema: bool = False):
     with pytest.raises(ValueError):
@@ -84,14 +81,12 @@ async def test_connect_invalid_parameters(postgres_db, min_size, max_size, datab
         )
 
 
-@pytest.mark.asyncio
 async def test_connection_failure(unused_tcp_port_factory, database_name, clean_reset):
     port = unused_tcp_port_factory()
     with pytest.raises(OSError):
         await data.connect("localhost", port, database_name, "testuser", None)
 
 
-@pytest.mark.asyncio
 async def test_postgres_client(postgresql_client):
     await postgresql_client.execute("CREATE TABLE test(id serial PRIMARY KEY, name VARCHAR (25) NOT NULL)")
     await postgresql_client.execute("INSERT INTO test VALUES(5, 'jef')")
@@ -105,7 +100,6 @@ async def test_postgres_client(postgresql_client):
     assert len(records) == 0
 
 
-@pytest.mark.asyncio
 async def test_project(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -119,7 +113,6 @@ async def test_project(init_dataclasses_and_load_schema):
     assert project.id == other.id
 
 
-@pytest.mark.asyncio
 async def test_project_unique(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -134,7 +127,6 @@ def test_project_no_project_name(init_dataclasses_and_load_schema):
         data.Project()
 
 
-@pytest.mark.asyncio
 async def test_project_cascade_delete(init_dataclasses_and_load_schema):
     async def create_full_environment(project_name, environment_name):
         project = data.Project(name=project_name)
@@ -219,7 +211,6 @@ async def test_project_cascade_delete(init_dataclasses_and_load_schema):
     await assert_project_exists(*full_env_2, exists=True)
 
 
-@pytest.mark.asyncio
 async def test_environment(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -236,7 +227,6 @@ async def test_environment(init_dataclasses_and_load_schema):
     assert len(envs) == 0
 
 
-@pytest.mark.asyncio
 async def test_environment_no_environment_name(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -244,7 +234,6 @@ async def test_environment_no_environment_name(init_dataclasses_and_load_schema)
         data.Environment(project=project.id, repo_url="", repo_branch="")
 
 
-@pytest.mark.asyncio
 async def test_environment_no_project_id(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -252,7 +241,6 @@ async def test_environment_no_project_id(init_dataclasses_and_load_schema):
         data.Environment(name="dev", repo_url="", repo_branch="")
 
 
-@pytest.mark.asyncio
 async def test_environment_cascade_content_only(init_dataclasses_and_load_schema):
     project = data.Project(name="proj")
     await project.insert()
@@ -337,7 +325,6 @@ async def test_environment_cascade_content_only(init_dataclasses_and_load_schema
     assert (await env.get(data.AUTO_DEPLOY)) is True
 
 
-@pytest.mark.asyncio
 async def test_environment_set_setting_parameter(init_dataclasses_and_load_schema):
     project = data.Project(name="proj")
     await project.insert()
@@ -359,7 +346,6 @@ async def test_environment_set_setting_parameter(init_dataclasses_and_load_schem
         await env.set(data.AUTO_DEPLOY, 5)
 
 
-@pytest.mark.asyncio
 async def test_environment_deprecated_setting(init_dataclasses_and_load_schema, caplog):
     project = data.Project(name="proj")
     await project.insert()
@@ -387,7 +373,6 @@ async def test_environment_deprecated_setting(init_dataclasses_and_load_schema, 
         assert "Config option %s is deprecated. Use %s instead." % (deprecated_option, new_option) not in caplog.text
 
 
-@pytest.mark.asyncio
 async def test_agent_process(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -440,7 +425,6 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     assert (await data.AgentInstance.get_by_id(agi2.id)) is None
 
 
-@pytest.mark.asyncio
 async def test_agentprocess_cleanup(init_dataclasses_and_load_schema, postgresql_client):
     project = data.Project(name="test")
     await project.insert()
@@ -505,7 +489,6 @@ async def test_agentprocess_cleanup(init_dataclasses_and_load_schema, postgresql
         assert result[0]["expired"] == datetime.datetime(2020, 1, 1, 3, 0).astimezone()
 
 
-@pytest.mark.asyncio
 async def test_delete_agentinstance_which_is_primary(init_dataclasses_and_load_schema):
     """
     It should be impossible to delete an AgentInstance record which is references
@@ -529,7 +512,6 @@ async def test_delete_agentinstance_which_is_primary(init_dataclasses_and_load_s
         await agent_instance.delete()
 
 
-@pytest.mark.asyncio
 async def test_agent_instance(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -581,7 +563,6 @@ async def test_agent_instance(init_dataclasses_and_load_schema):
     assert current_instances[0].id == agi1.id
 
 
-@pytest.mark.asyncio
 async def test_agent(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -640,7 +621,6 @@ async def test_agent(init_dataclasses_and_load_schema):
     assert primary_process.sid == agent_proc.sid
 
 
-@pytest.mark.asyncio
 async def test_pause_agent_endpoint_set(environment):
     """
     Test the pause() method in the Agent class
@@ -667,7 +647,6 @@ async def test_pause_agent_endpoint_set(environment):
     assert not agent.paused
 
 
-@pytest.mark.asyncio
 async def test_pause_all_agent_in_environment(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -700,7 +679,6 @@ async def test_pause_all_agent_in_environment(init_dataclasses_and_load_schema):
         await assert_paused(env_paused_map={env1.id: False, env2.id: False})
 
 
-@pytest.mark.asyncio
 async def test_config_model(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -722,7 +700,6 @@ async def test_config_model(init_dataclasses_and_load_schema):
     assert "agent1" in agents
 
 
-@pytest.mark.asyncio
 async def test_model_list(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -755,7 +732,6 @@ async def test_model_list(init_dataclasses_and_load_schema):
     assert versions[-1].version == 1
 
 
-@pytest.mark.asyncio
 async def test_model_get_latest_version(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -783,7 +759,6 @@ async def test_model_get_latest_version(init_dataclasses_and_load_schema):
     assert latest_version.version == 4
 
 
-@pytest.mark.asyncio
 async def test_model_set_ready(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -822,7 +797,6 @@ async def test_model_set_ready(init_dataclasses_and_load_schema):
         (const.ResourceState.skipped_for_undefined, True),
     ],
 )
-@pytest.mark.asyncio
 async def test_model_mark_done_if_done(init_dataclasses_and_load_schema, resource_state, should_be_deployed):
     project = data.Project(name="test")
     await project.insert()
@@ -860,7 +834,6 @@ async def test_model_mark_done_if_done(init_dataclasses_and_load_schema, resourc
     assert cm.done == (1 if should_be_deployed else 0)
 
 
-@pytest.mark.asyncio
 async def test_model_get_list(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -904,7 +877,6 @@ async def test_model_get_list(init_dataclasses_and_load_schema):
     assert not cms
 
 
-@pytest.mark.asyncio
 async def test_model_serialization(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -943,7 +915,6 @@ async def test_model_serialization(init_dataclasses_and_load_schema):
     assert dct["status"] == {str(uuid.uuid5(env.id, key)): {"id": key, "status": const.ResourceState.deployed.name}}
 
 
-@pytest.mark.asyncio
 async def test_model_delete_cascade(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -976,7 +947,6 @@ async def test_model_delete_cascade(init_dataclasses_and_load_schema):
     assert (await data.UnknownParameter.get_by_id(unknown_parameter.id)) is None
 
 
-@pytest.mark.asyncio
 async def test_model_get_version_nr_latest_version(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1010,7 +980,6 @@ async def test_model_get_version_nr_latest_version(init_dataclasses_and_load_sch
         (const.ResourceState.skipped, const.VersionState.failed),
     ],
 )
-@pytest.mark.asyncio
 async def test_mark_done(init_dataclasses_and_load_schema, resource_state, version_state):
     project = data.Project(name="test")
     await project.insert()
@@ -1078,7 +1047,6 @@ async def populate_model(env_id, version):
     await res5.insert()
 
 
-@pytest.mark.asyncio
 async def test_resource_purge_on_delete(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1149,7 +1117,6 @@ async def test_resource_purge_on_delete(init_dataclasses_and_load_schema):
     assert to_purge[0].resource_id == "std::File[agent1,path=/etc/motd]"
 
 
-@pytest.mark.asyncio
 async def test_issue_422(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1211,7 +1178,6 @@ async def test_issue_422(init_dataclasses_and_load_schema):
     assert to_purge[0].resource_id == "std::File[agent1,path=/etc/motd]"
 
 
-@pytest.mark.asyncio
 async def test_get_latest_resource(init_dataclasses_and_load_schema, postgresql_client):
     project = data.Project(name="test")
     await project.insert()
@@ -1264,7 +1230,6 @@ async def test_get_latest_resource(init_dataclasses_and_load_schema, postgresql_
     assert res.model == 2
 
 
-@pytest.mark.asyncio
 async def test_order_by_validation(init_dataclasses_and_load_schema):
     """Test the validation of the order by column names and the sort order value. This test case checks that wrong values
     are rejected. Other test cases validate that the parameters work.
@@ -1276,7 +1241,6 @@ async def test_order_by_validation(init_dataclasses_and_load_schema):
         await data.Resource.get_list(order_by_column="resource_id", order="BAD")
 
 
-@pytest.mark.asyncio
 async def test_get_resources(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1318,7 +1282,6 @@ async def test_get_resources(init_dataclasses_and_load_schema):
     assert len(resources) == 0
 
 
-@pytest.mark.asyncio
 async def test_model_get_resources_for_version(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1411,7 +1374,6 @@ async def test_model_get_resources_for_version(init_dataclasses_and_load_schema)
     assert sorted([x.resource_version_id for x in resources]) == sorted([d, s, u, su])
 
 
-@pytest.mark.asyncio
 async def test_get_resources_in_latest_version(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1454,7 +1416,6 @@ async def test_get_resources_in_latest_version(init_dataclasses_and_load_schema)
     assert resource.to_dict() == expected_resource.to_dict()
 
 
-@pytest.mark.asyncio
 async def test_model_get_resources_for_version_optional_args(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1494,7 +1455,6 @@ async def test_model_get_resources_for_version_optional_args(init_dataclasses_an
         assert len(r["attributes"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_escaped_resources(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1530,7 +1490,6 @@ async def test_escaped_resources(init_dataclasses_and_load_schema):
     assert resources[0].attributes["routes"] == routes
 
 
-@pytest.mark.asyncio
 async def test_resource_provides(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1581,7 +1540,6 @@ async def test_resource_provides(init_dataclasses_and_load_schema):
     assert res2.provides == []
 
 
-@pytest.mark.asyncio
 async def test_resource_hash(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1643,7 +1601,6 @@ async def test_resource_hash(init_dataclasses_and_load_schema):
     assert res1.attribute_hash != res3.attribute_hash
 
 
-@pytest.mark.asyncio
 async def test_resources_report(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1759,7 +1716,6 @@ async def test_resources_report(init_dataclasses_and_load_schema):
     assert report_as_map["std::File[agent1,path=/etc/file3]"]["agent"] == "agent1"
 
 
-@pytest.mark.asyncio
 async def test_resource_action(init_dataclasses_and_load_schema):
     """
     Test whether the save() method of a ResourceAction writes its changes, logs and fields
@@ -1830,7 +1786,6 @@ async def test_resource_action(init_dataclasses_and_load_schema):
             assert message == {}
 
 
-@pytest.mark.asyncio
 async def test_resource_action_get_logs(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1912,7 +1867,6 @@ async def test_resource_action_get_logs(init_dataclasses_and_load_schema):
             assert action.action == const.ResourceAction.deploy
 
 
-@pytest.mark.asyncio
 async def test_data_document_recursion(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1938,7 +1892,6 @@ async def test_data_document_recursion(init_dataclasses_and_load_schema):
     await ra.insert()
 
 
-@pytest.mark.asyncio
 async def test_code(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -1996,7 +1949,6 @@ async def test_code(init_dataclasses_and_load_schema):
     assert len(code_list) == 0
 
 
-@pytest.mark.asyncio
 async def test_parameter(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2029,7 +1981,6 @@ async def test_parameter(init_dataclasses_and_load_schema):
     assert (parameters[2].environment, parameters[2].name) in list_of_ids
 
 
-@pytest.mark.asyncio
 async def test_parameter_list_parameters(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2057,7 +2008,6 @@ async def test_parameter_list_parameters(init_dataclasses_and_load_schema):
     assert len(results) == 2
 
 
-@pytest.mark.asyncio
 async def test_dryrun(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2082,7 +2032,6 @@ async def test_dryrun(init_dataclasses_and_load_schema):
     assert dryrun_retrieved.resources[key]["id"] == resource_version_id
 
 
-@pytest.mark.asyncio
 async def test_reports_append(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2102,7 +2051,6 @@ async def test_reports_append(init_dataclasses_and_load_schema):
         compiles.append(compile)
 
 
-@pytest.mark.asyncio
 async def test_compile_get_reports(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2130,7 +2078,6 @@ async def test_compile_get_reports(init_dataclasses_and_load_schema):
     assert report1.errstream == "eeee"
 
 
-@pytest.mark.asyncio
 async def test_compile_get_latest(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2169,7 +2116,6 @@ async def test_compile_get_latest(init_dataclasses_and_load_schema):
     assert sorted([x.id for x in await data.Compile.get_unhandled_compiles()]) == sorted([compile2.id, compile3.id])
 
 
-@pytest.mark.asyncio
 async def test_compile_get_next(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2213,7 +2159,6 @@ async def test_compile_get_next(init_dataclasses_and_load_schema):
     assert env_to_run[env2.id] == compile4.id
 
 
-@pytest.mark.asyncio
 async def test_compile_get_report(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2262,7 +2207,6 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     assert len(reports) == 1
 
 
-@pytest.mark.asyncio
 async def test_match_tables_in_db_against_table_definitions_in_orm(
     postgres_db, database_name, postgresql_client, init_dataclasses_and_load_schema
 ):
@@ -2277,7 +2221,6 @@ async def test_match_tables_in_db_against_table_definitions_in_orm(
         assert item in table_names_in_database
 
 
-@pytest.mark.asyncio
 async def test_purgelog_test(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2336,7 +2279,6 @@ async def test_purgelog_test(init_dataclasses_and_load_schema):
     assert remaining_resource_action.action_id == ra2.action_id
 
 
-@pytest.mark.asyncio
 async def test_insert_many(init_dataclasses_and_load_schema, postgresql_client):
     project1 = data.Project(name="proj1")
     project2 = data.Project(name="proj2")
@@ -2350,7 +2292,6 @@ async def test_insert_many(init_dataclasses_and_load_schema, postgresql_client):
     assert sorted(["proj1", "proj2"]) == sorted(project_names_in_result)
 
 
-@pytest.mark.asyncio
 async def test_resources_json(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2383,7 +2324,6 @@ async def test_resources_json(init_dataclasses_and_load_schema):
     assert res1.attributes == res.attributes
 
 
-@pytest.mark.asyncio
 async def test_update_to_none_value(init_dataclasses_and_load_schema):
     """
     Verify that a field with a default value can be set to None if that field is nullable.
@@ -2404,7 +2344,6 @@ async def test_update_to_none_value(init_dataclasses_and_load_schema):
     assert env.repo_url is None
 
 
-@pytest.mark.asyncio
 async def test_query_resource_actions_simple(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
@@ -2606,7 +2545,6 @@ async def test_query_resource_actions_simple(init_dataclasses_and_load_schema):
     assert resource_actions[0].messages[0]["level"] == "WARNING"
 
 
-@pytest.mark.asyncio
 async def test_query_resource_actions_non_unique_timestamps(init_dataclasses_and_load_schema):
     """
     Test querying resource actions that have non unique timestamps, with pagination, using an explicit start and end time
@@ -2754,7 +2692,6 @@ async def test_query_resource_actions_non_unique_timestamps(init_dataclasses_and
     assert [resource_action.action_id for resource_action in resource_actions] == expected_ids_on_page
 
 
-@pytest.mark.asyncio
 async def test_get_resource_state_for_dependencies(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -50,7 +50,6 @@ def test_deploy(snippetcompiler, tmpdir, postgres_db):
     assert file_name.exists()
 
 
-@pytest.mark.asyncio(timeout=10)
 async def test_fork(server):
     """
     This test should not fail. Some Subprocess'es can make the ioloop hang, this tests fails when that happens.

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -177,7 +177,6 @@ def test_unknown_in_attribute_requires(snippetcompiler, caplog):
     assert len(warning) == 0
 
 
-@pytest.mark.asyncio
 async def test_empty_server_export(snippetcompiler, server, client, environment):
     snippetcompiler.setup_for_snippet(
         """
@@ -191,7 +190,6 @@ async def test_empty_server_export(snippetcompiler, server, client, environment)
     assert len(response.result["versions"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_server_export(snippetcompiler, server, client, environment):
     snippetcompiler.setup_for_snippet(
         """
@@ -207,7 +205,6 @@ async def test_server_export(snippetcompiler, server, client, environment):
     assert result.result["versions"][0]["total"] == 1
 
 
-@pytest.mark.asyncio
 async def test_dict_export_server(snippetcompiler, server, client, environment):
     config.Config.set("config", "environment", environment)
     snippetcompiler.setup_for_snippet(
@@ -226,7 +223,6 @@ a = exp::Test2(mydict={"a":"b"}, mylist=["a","b"])
     assert result.result["versions"][0]["total"] == 1
 
 
-@pytest.mark.asyncio
 async def test_old_compiler(server, client, environment):
     result = await client.put_version(tid=environment, version=123456, resources=[], unknowns=[], version_info={})
     assert result.code == 400

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -157,7 +157,6 @@ def test_end_to_end_2():
     assert "badplugin" not in all
 
 
-@pytest.mark.asyncio
 async def test_startup_failure(async_finalizer, server_config):
     with splice_extension_in("bad_module_path"):
         config.server_enabled_extensions.set("badplugin")
@@ -228,7 +227,6 @@ def test_load_feature_file(tmp_path):
     assert fm.contains(s2, "random")
 
 
-@pytest.mark.asyncio
 async def test_custom_feature_manager(
     tmp_path, inmanta_config, postgres_db, database_name, clean_reset, unused_tcp_port_factory
 ):

--- a/tests/test_influxdbreporting.py
+++ b/tests/test_influxdbreporting.py
@@ -100,7 +100,6 @@ def influxdb(event_loop, free_socket):
     ifl.server.stop()
 
 
-@pytest.mark.asyncio
 async def test_influxdb(influxdb):
     rep = InfluxReporter(port=influxdb.port, tags={"mark": "X"}, autocreate_database=True)
     with timer("test").time():
@@ -126,7 +125,6 @@ async def test_influxdb(influxdb):
         assert "mark=X" in line
 
 
-@pytest.mark.asyncio
 async def test_timing():
     # Attempt to deploy every 0.01 seconds,
     # Deploy hangs on a semaphore, so test case can control progress

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -81,7 +81,6 @@ async def jwks(unused_tcp_port):
     await server.close_all_connections()
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_validate_rs256(jwks, tmp_path):
     """
     Test that inmanta can download a rs256 public key

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -188,7 +188,6 @@ def api_methods_fixture(clean_reset):
         return ""
 
 
-@pytest.mark.asyncio
 async def test_generate_openapi_definition(server: Server, feature_manager: FeatureManager, patch_openapi_spec_validator: None):
     global_url_map = server._transport.get_global_url_map(server.get_slices().values())
     openapi = OpenApiConverter(global_url_map, feature_manager)
@@ -670,7 +669,6 @@ def test_get_operation_partial_documentation(api_methods_fixture):
     assert operation.responses["200"].description == ""
 
 
-@pytest.mark.asyncio
 async def test_openapi_endpoint(client, patch_openapi_spec_validator: None):
     result = await client.get_api_docs("openapi")
     assert result.code == 200
@@ -678,13 +676,11 @@ async def test_openapi_endpoint(client, patch_openapi_spec_validator: None):
     openapi_v3_spec_validator.validate(openapi_spec)
 
 
-@pytest.mark.asyncio
 async def test_swagger_endpoint(client):
     result = await client.get_api_docs()
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_tags(server, feature_manager):
     global_url_map = server._transport.get_global_url_map(server.get_slices().values())
     openapi = OpenApiConverter(global_url_map, feature_manager)

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -18,12 +18,9 @@
 import logging
 import uuid
 
-import pytest
-
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio(timeout=60)
 async def test_param(client, environment):
     """
     Test creating and updating forms

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -31,7 +31,6 @@ from inmanta.server.services.environmentservice import EnvironmentAction, Enviro
 from utils import log_contains
 
 
-@pytest.mark.asyncio
 async def test_project_api_v1(client):
     result = await client.create_project("project-test")
     assert result.code == 200
@@ -81,7 +80,6 @@ async def test_project_api_v1(client):
     assert response.code == 404
 
 
-@pytest.mark.asyncio
 async def test_project_api_v2(client_v2):
     result = await client_v2.project_create("project-test")
     assert result.code == 200
@@ -178,7 +176,6 @@ async def test_project_api_v2(client_v2):
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_modify_environment_project(client_v2):
     """Test modifying the project of an environment"""
 
@@ -224,7 +221,6 @@ async def test_modify_environment_project(client_v2):
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_env_api(client):
     result = await client.create_project("env-test")
     assert result.code == 200
@@ -273,7 +269,6 @@ async def test_env_api(client):
     assert len(result.result["environments"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_project_cascade(client):
     result = await client.create_project("env-test")
     project_id = result.result["project"]["id"]
@@ -288,7 +283,6 @@ async def test_project_cascade(client):
     assert len(result.result["environments"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_create_with_id(client):
     project_id = uuid.uuid4()
     result = await client.create_project(name="test_project", project_id=project_id)
@@ -304,7 +298,6 @@ async def test_create_with_id(client):
     assert result.code == 500
 
 
-@pytest.mark.asyncio
 async def test_environment_listener(server, client_v2, caplog):
     class EnvironmentListenerCounter(EnvironmentListener):
         def __init__(self):
@@ -418,7 +411,6 @@ def environment_icons() -> Dict[str, str]:
     return icon_dict
 
 
-@pytest.mark.asyncio
 async def test_environment_icon_description(client_v2, environment_icons: Dict[str, str]):
     """Test creating an environment with an icon and description"""
 
@@ -533,7 +525,6 @@ async def test_environment_icon_description(client_v2, environment_icons: Dict[s
     assert result.code == 400
 
 
-@pytest.mark.asyncio
 async def test_environment_icon_with_details_only(client_v2, environment_icons: Dict[str, str]):
     """Test that the icon for an environment is only returned when explicitly requested"""
     result = await client_v2.project_create("dev-project")

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -83,7 +83,6 @@ def make_random_file(size=0):
     return (hash, content, body)
 
 
-@pytest.mark.asyncio
 async def test_client_files(client):
     (hash, content, body) = make_random_file()
 
@@ -102,7 +101,6 @@ async def test_client_files(client):
     assert result.result["content"] == body
 
 
-@pytest.mark.asyncio
 async def test_client_files_lost(client):
     (hash, content, body) = make_random_file()
 
@@ -111,7 +109,6 @@ async def test_client_files_lost(client):
     assert result.code == 404
 
 
-@pytest.mark.asyncio
 async def test_sync_client_files(client):
     # work around for https://github.com/pytest-dev/pytest-asyncio/issues/168
     asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
@@ -152,7 +149,6 @@ async def test_sync_client_files(client):
     assert len(done) > 0
 
 
-@pytest.mark.asyncio
 async def test_client_files_stat(client):
 
     file_names = []
@@ -173,7 +169,6 @@ async def test_client_files_stat(client):
     assert len(result.result["files"]) == len(other_files)
 
 
-@pytest.mark.asyncio
 async def test_diff(client):
     ca = "Hello world\n".encode()
     ha = hash_file(ca)
@@ -198,7 +193,6 @@ async def test_diff(client):
     assert len(diff.result["diff"]) == 4
 
 
-@pytest.mark.asyncio
 async def test_client_files_bad(server, client):
     (hash, content, body) = make_random_file()
     # Create the file
@@ -206,7 +200,6 @@ async def test_client_files_bad(server, client):
     assert result.code == 400
 
 
-@pytest.mark.asyncio
 async def test_client_files_corrupt(client):
     (hash, content, body) = make_random_file()
     # Create the file
@@ -237,7 +230,6 @@ async def test_client_files_corrupt(client):
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_gzip_encoding(server):
     """
     Test if the server accepts gzipped encoding and returns gzipped encoding.
@@ -285,7 +277,6 @@ async def app(unused_tcp_port):
     await server.close_all_connections()
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_timeout_error(app):
     """
     Test test verifies that the protocol client can handle requests that timeout. This means it receives a http error
@@ -308,7 +299,6 @@ async def test_timeout_error(app):
     assert "message" in x.result
 
 
-@pytest.mark.asyncio
 async def test_method_properties():
     """
     Test method properties decorator and helper functions
@@ -326,7 +316,6 @@ async def test_method_properties():
     assert props.get_call_url({}) == "/x/v2/test"
 
 
-@pytest.mark.asyncio
 async def test_invalid_client_type():
     """
     Test invalid client ype
@@ -342,7 +331,6 @@ async def test_invalid_client_type():
         assert "Invalid client type invalid specified for function" in str(e)
 
 
-@pytest.mark.asyncio
 async def test_call_arguments_defaults():
     """
     Test processing RPC messages
@@ -369,7 +357,6 @@ def test_create_client():
         protocol.Client("agent", "120")
 
 
-@pytest.mark.asyncio
 async def test_pydantic():
     """
     Test validating pydantic objects
@@ -434,7 +421,6 @@ def test_pydantic_json():
     assert project is not new
 
 
-@pytest.mark.asyncio
 async def test_pydantic_alias(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """
     Round trip test on aliased object
@@ -497,7 +483,6 @@ async def test_pydantic_alias(unused_tcp_port, postgres_db, database_name, async
     await roundtrip(projectt)
 
 
-@pytest.mark.asyncio
 async def test_return_non_warnings(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """
     Test return none but pushing warnings
@@ -535,7 +520,6 @@ async def test_return_non_warnings(unused_tcp_port, postgres_db, database_name, 
     assert "error1" in response.result["metadata"]["warnings"]
 
 
-@pytest.mark.asyncio
 async def test_invalid_handler():
     """
     Handlers should be async
@@ -554,7 +538,6 @@ async def test_invalid_handler():
                 return
 
 
-@pytest.mark.asyncio
 async def test_return_value(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """
     Test the use and validation of methods that use common.ReturnValue
@@ -593,7 +576,6 @@ async def test_return_value(unused_tcp_port, postgres_db, database_name, async_f
     assert "name" in result.result
 
 
-@pytest.mark.asyncio
 async def test_return_model(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """
     Test the use and validation of methods that use common.ReturnValue
@@ -654,7 +636,6 @@ async def test_return_model(unused_tcp_port, postgres_db, database_name, async_f
     assert result.code == 500
 
 
-@pytest.mark.asyncio
 async def test_data_envelope(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """
     Test the use and validation of methods that use common.ReturnValue
@@ -741,7 +722,6 @@ async def test_data_envelope(unused_tcp_port, postgres_db, database_name, async_
     assert "name" in result.result["project"]
 
 
-@pytest.mark.asyncio
 async def test_invalid_paths():
     """
     Test path validation
@@ -763,7 +743,6 @@ async def test_invalid_paths():
     assert str(e.value).startswith("Variable othername in path /test/<othername> is not defined in function")
 
 
-@pytest.mark.asyncio
 async def test_nested_paths(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test overlapping path definition"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -808,7 +787,6 @@ async def test_nested_paths(unused_tcp_port, postgres_db, database_name, async_f
     assert "test_method2" == result.result["data"]["name"]
 
 
-@pytest.mark.asyncio
 async def test_list_basemodel_argument(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test list of basemodel arguments and primitive types"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -842,7 +820,6 @@ async def test_list_basemodel_argument(unused_tcp_port, postgres_db, database_na
     assert "test_method" == result.result["data"]["name"]
 
 
-@pytest.mark.asyncio
 async def test_dict_basemodel_argument(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test dict of basemodel arguments and primitive types"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -876,7 +853,6 @@ async def test_dict_basemodel_argument(unused_tcp_port, postgres_db, database_na
     assert "test_method" == result.result["data"]["name"]
 
 
-@pytest.mark.asyncio
 async def test_dict_with_optional_values(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test dict which may have None as a value"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -932,7 +908,6 @@ async def test_dict_with_optional_values(unused_tcp_port, postgres_db, database_
     assert result.code == 200
 
 
-@pytest.mark.asyncio
 async def test_dict_and_list_return(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test list of basemodel arguments"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -976,7 +951,6 @@ async def test_dict_and_list_return(unused_tcp_port, postgres_db, database_name,
     assert "test_method" == result.result["data"][0]
 
 
-@pytest.mark.asyncio
 async def test_method_definition():
     """
     Test typed methods with wrong annotations
@@ -1048,7 +1022,6 @@ def test_optional():
         """Delete an existing service type."""
 
 
-@pytest.mark.asyncio
 async def test_union_types(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test use of union types"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1107,7 +1080,6 @@ async def test_union_types(unused_tcp_port, postgres_db, database_name, async_fi
     assert 5 == result.result["data"][0]
 
 
-@pytest.mark.asyncio
 async def test_basemodel_validation(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test validation of basemodel arguments and return, and how they are reported"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1154,7 +1126,6 @@ async def test_basemodel_validation(unused_tcp_port, postgres_db, database_name,
     assert "data validation error" in result.result["message"]
 
 
-@pytest.mark.asyncio
 async def test_ACOA_header(server):
     """
     Test if the server accepts gzipped encoding and returns gzipped encoding.
@@ -1174,7 +1145,6 @@ async def test_ACOA_header(server):
     assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
 
-@pytest.mark.asyncio
 async def test_multi_version_method(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test multi version methods"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1253,7 +1223,6 @@ async def test_multi_version_method(unused_tcp_port, postgres_db, database_name,
     assert "data" in response.result
 
 
-@pytest.mark.asyncio
 async def test_multi_version_handler(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test multi version methods"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1297,7 +1266,6 @@ async def test_multi_version_handler(unused_tcp_port, postgres_db, database_name
     assert response.result["data"]["name"] == "v2"
 
 
-@pytest.mark.asyncio
 async def test_simple_return_type(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test methods with simple return types"""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1325,7 +1293,6 @@ async def test_simple_return_type(unused_tcp_port, postgres_db, database_name, a
     assert response.result["data"] == "x"
 
 
-@pytest.mark.asyncio
 async def test_html_content_type(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test whether API endpoints with a text/html content-type work."""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1355,7 +1322,6 @@ async def test_html_content_type(unused_tcp_port, postgres_db, database_name, as
     assert response.result == html_content
 
 
-@pytest.mark.asyncio
 async def test_html_content_type_with_utf8_encoding(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test whether API endpoints with a "text/html; charset=UTF-8" content-type work."""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1386,7 +1352,6 @@ async def test_html_content_type_with_utf8_encoding(unused_tcp_port, postgres_db
     assert response.result == html_content
 
 
-@pytest.mark.asyncio
 async def test_octet_stream_content_type(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test whether API endpoints with an application/octet-stream content-type work."""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1416,7 +1381,6 @@ async def test_octet_stream_content_type(unused_tcp_port, postgres_db, database_
     assert response.result == byte_stream
 
 
-@pytest.mark.asyncio
 async def test_zip_content_type(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """Test whether API endpoints with an application/zip content-type work."""
     configure(unused_tcp_port, database_name, postgres_db.port)
@@ -1471,7 +1435,6 @@ def options_request(unused_tcp_port):
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("auth_enabled, auth_header_allowed", [(True, True), (False, False)])
 async def test_auth_enabled_options_method(
     auth_enabled,
@@ -1496,14 +1459,12 @@ async def test_auth_enabled_options_method(
     assert ("Authorization" in response.headers.get("Access-Control-Allow-Headers")) == auth_header_allowed
 
 
-@pytest.mark.asyncio
 async def test_required_header_not_present(server):
     client = AsyncHTTPClient()
     response = await client.fetch(f"http://localhost:{server_bind_port.get()}/api/v2/environment_settings", raise_error=False)
     assert response.code == 400
 
 
-@pytest.mark.asyncio
 async def test_malformed_json(server):
     """
     Tests sending malformed json to the server
@@ -1521,7 +1482,6 @@ async def test_malformed_json(server):
     )
 
 
-@pytest.mark.asyncio
 async def test_tuple_index_out_of_range(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -1561,7 +1521,6 @@ async def test_tuple_index_out_of_range(unused_tcp_port, postgres_db, database_n
     assert json.loads(response.body)["message"] == "Invalid request: Field 'tid' is required."
 
 
-@pytest.mark.asyncio
 async def test_multiple_path_params(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -1585,7 +1544,6 @@ async def test_multiple_path_params(unused_tcp_port, postgres_db, database_name,
     assert request.url == "/api/v1/test/1/monty?age=42"
 
 
-@pytest.mark.asyncio(timeout=5)
 async def test_2151_method_header_parameter_in_body(async_finalizer) -> None:
     async def _id(x: object, dct: Dict[str, str]) -> object:
         return x
@@ -1636,7 +1594,6 @@ async def test_2151_method_header_parameter_in_body(async_finalizer) -> None:
 
 
 @pytest.mark.parametrize("return_value,valid", [(1, True), (None, True), ("Hello World!", False)])
-@pytest.mark.asyncio
 async def test_2277_typedmethod_return_optional(async_finalizer, return_value: object, valid: bool) -> None:
     @protocol.typedmethod(
         path="/typedtestmethod",
@@ -1679,7 +1636,6 @@ def test_method_strict_exception() -> None:
             pass
 
 
-@pytest.mark.asyncio
 async def test_method_nonstrict_allowed(async_finalizer) -> None:
     @protocol.typedmethod(path="/zipsingle", operation="POST", client_types=[const.ClientType.api], strict_typing=False)
     def merge_dicts(one: Dict[str, Any], other: Dict[str, int], any_arg: Any) -> Dict[str, Any]:
@@ -1744,7 +1700,6 @@ async def test_method_nonstrict_allowed(async_finalizer) -> None:
         (List[str], ["a ", "b", "c", ","], "/api/v1/test/1/monty?filter=a+&filter=b&filter=c&filter=%2C"),
     ],
 )
-@pytest.mark.asyncio
 async def test_dict_list_get_roundtrip(
     unused_tcp_port, postgres_db, database_name, async_finalizer, param_type, param_value, expected_url
 ):
@@ -1777,7 +1732,6 @@ async def test_dict_list_get_roundtrip(
     assert response.result["data"] == param_value
 
 
-@pytest.mark.asyncio
 async def test_dict_get_optional(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -1812,7 +1766,6 @@ async def test_dict_get_optional(unused_tcp_port, postgres_db, database_name, as
     assert response.result["data"] == ""
 
 
-@pytest.mark.asyncio
 async def test_dict_list_nested_get_optional(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -1862,7 +1815,6 @@ async def test_dict_list_nested_get_optional(unused_tcp_port, postgres_db, datab
         (List[List[str]], "lists of dictionaries and lists of lists are not supported for GET requests"),
     ],
 )
-@pytest.mark.asyncio
 async def test_dict_list_get_invalid(
     unused_tcp_port, postgres_db, database_name, async_finalizer, param_type, expected_error_message
 ):
@@ -1882,7 +1834,6 @@ async def test_dict_list_get_invalid(
         assert expected_error_message in str(e)
 
 
-@pytest.mark.asyncio
 async def test_list_get_optional(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -1928,7 +1879,6 @@ async def test_list_get_optional(unused_tcp_port, postgres_db, database_name, as
     assert request.url == f"/api/v1/test_uuid/1?sort={uuids[0]}&sort={uuids[1]}"
 
 
-@pytest.mark.asyncio
 async def test_dicts_multiple_get(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -1962,7 +1912,6 @@ async def test_dicts_multiple_get(unused_tcp_port, postgres_db, database_name, a
     assert response.result["data"] == "a,c,x"
 
 
-@pytest.mark.asyncio
 async def test_dict_list_get_by_url(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 
@@ -2048,7 +1997,6 @@ async def test_dict_list_get_by_url(unused_tcp_port, postgres_db, database_name,
     assert response.code == 200
 
 
-@pytest.mark.asyncio
 async def test_api_datetime_utc(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """
     Test API input and output conversion for timestamps. Objects should be either timezone-aware or implicit UTC.
@@ -2120,7 +2068,6 @@ async def test_api_datetime_utc(unused_tcp_port, postgres_db, database_name, asy
         response = await request(now.replace(tzinfo=None))
 
 
-@pytest.mark.asyncio
 async def test_dict_of_list(unused_tcp_port, postgres_db, database_name, async_finalizer):
     """
     Test API input and output conversion for timestamps. Objects should be either timezone-aware or implicit UTC.
@@ -2153,7 +2100,6 @@ async def test_dict_of_list(unused_tcp_port, postgres_db, database_name, async_f
     assert result.result["data"] == {"test": [{"attr": 1}, {"attr": 5}]}
 
 
-@pytest.mark.asyncio
 async def test_return_value_with_meta(unused_tcp_port, postgres_db, database_name, async_finalizer):
     configure(unused_tcp_port, database_name, postgres_db.port)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -50,7 +50,6 @@ from utils import log_contains, log_doesnt_contain, retry_limited
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio(timeout=60)
 @pytest.mark.slowtest
 async def test_autostart(server, client, environment, caplog):
     """
@@ -103,7 +102,6 @@ async def test_autostart(server, client, environment, caplog):
     log_doesnt_contain(caplog, "inmanta.server.agentmanager", logging.WARNING, "Agent processes did not close in time")
 
 
-@pytest.mark.asyncio(timeout=60)
 @pytest.mark.slowtest
 async def test_autostart_dual_env(client, server):
     """
@@ -143,7 +141,6 @@ async def test_autostart_dual_env(client, server):
     assert len(sessionendpoint._sessions) == 2
 
 
-@pytest.mark.asyncio(timeout=60)
 @pytest.mark.slowtest
 async def test_autostart_batched(client, server, environment):
     """
@@ -183,7 +180,6 @@ async def test_autostart_batched(client, server, environment):
     assert len(sessionendpoint._sessions) == 1
 
 
-@pytest.mark.asyncio(timeout=10)
 async def test_version_removal(client, server):
     """
     Test auto removal of older deploy model versions
@@ -209,7 +205,6 @@ async def test_version_removal(client, server):
         assert versions.result["count"] <= opt.server_version_to_keep.get() + 1
 
 
-@pytest.mark.asyncio(timeout=30)
 @pytest.mark.slowtest
 async def test_get_resource_for_agent(server_multi, client_multi, environment_multi):
     """
@@ -339,7 +334,6 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     await agent.stop()
 
 
-@pytest.mark.asyncio(timeout=10)
 async def test_get_environment(client, clienthelper, server, environment):
     for i in range(10):
         version = await clienthelper.get_version()
@@ -377,7 +371,6 @@ async def test_get_environment(client, clienthelper, server, environment):
     assert len(result.result["environment"]["resources"]) == 9
 
 
-@pytest.mark.asyncio
 async def test_resource_update(postgresql_client, client, clienthelper, server, environment):
     """
     Test updating resources and logging
@@ -478,7 +471,6 @@ async def test_resource_update(postgresql_client, client, clienthelper, server, 
     await agent.stop()
 
 
-@pytest.mark.asyncio
 async def test_clear_environment(client, server, clienthelper, environment):
     """
     Test clearing out an environment
@@ -523,7 +515,6 @@ async def test_clear_environment(client, server, clienthelper, environment):
     assert len(result.result["environment"]["versions"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_tokens(server_multi, client_multi, environment_multi):
     # Test using API tokens
     test_token = client_multi._transport_instance.token
@@ -555,7 +546,6 @@ def make_source(collector, filename, module, source, req):
     return collector
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_code_upload(server, client, agent, environment):
     """Test upload of a single code definition"""
     version = (await client.reserve_version(environment)).result["data"]
@@ -596,7 +586,6 @@ async def test_code_upload(server, client, agent, environment):
     assert res.result["sources"] == sources
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_batched_code_upload(
     server_multi, client_multi, sync_client_multi, environment_multi, agent_multi, snippetcompiler
 ):
@@ -633,7 +622,6 @@ async def test_batched_code_upload(
             assert info.requires == code[3]
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_resource_action_log(server, client, environment):
     version = (await client.reserve_version(environment)).result["data"]
     resources = [
@@ -670,7 +658,6 @@ async def test_resource_action_log(server, client, environment):
         parser.parse(f"{parts[0]} {parts[1]}")
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_invalid_sid(server, client, environment):
     """
     Test the server to manage the updates on a model during agent deploy
@@ -681,7 +668,6 @@ async def test_invalid_sid(server, client, environment):
     assert res.result["message"] == "Invalid request: this is an agent to server call, it should contain an agent session id"
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_get_param(server, client, environment):
     metadata = {"key1": "val1", "key2": "val2"}
     await client.set_param(environment, "param", ParameterSource.user, "val", "", metadata, False)
@@ -703,7 +689,6 @@ async def test_get_param(server, client, environment):
     assert len(parameters) == 2
 
 
-@pytest.mark.asyncio(timeout=30)
 async def test_server_logs_address(server_config, caplog):
     with caplog.at_level(logging.INFO):
         ibl = InmantaBootloader()
@@ -718,7 +703,6 @@ async def test_server_logs_address(server_config, caplog):
         log_contains(caplog, "protocol.rest", logging.INFO, f"Server listening on {address}:")
 
 
-@pytest.mark.asyncio
 async def test_get_resource_actions(postgresql_client, client, clienthelper, server, environment, agent):
     """
     Test querying resource actions via the API
@@ -796,7 +780,6 @@ async def test_get_resource_actions(postgresql_client, client, clienthelper, ser
     assert len(result.result["data"]) == 2
 
 
-@pytest.mark.asyncio
 async def test_resource_action_pagination(postgresql_client, client, clienthelper, server, agent):
     """Test querying resource actions via the API, including the pagination links."""
     project = data.Project(name="test")
@@ -926,7 +909,6 @@ async def test_resource_action_pagination(postgresql_client, client, clienthelpe
 
 
 @pytest.mark.parametrize("endpoint_to_use", ["resource_deploy_start", "resource_action_update"])
-@pytest.mark.asyncio
 async def test_resource_deploy_start(server, client, environment, agent, endpoint_to_use: str):
     """
     Ensure that API endpoint `resource_deploy_start()` does the same as the `resource_action_update()`
@@ -1005,7 +987,6 @@ async def test_resource_deploy_start(server, client, environment, agent, endpoin
     assert resource_action["change"] is None
 
 
-@pytest.mark.asyncio
 async def test_resource_deploy_start_error_handling(server, client, environment, agent):
     """
     Test the error handling of the `resource_deploy_start` API endpoint.
@@ -1026,7 +1007,6 @@ async def test_resource_deploy_start_error_handling(server, client, environment,
     assert f"Environment {environment} doesn't contain a resource with id {resource_id}" in result.result["message"]
 
 
-@pytest.mark.asyncio
 async def test_resource_deploy_start_action_id_conflict(server, client, environment, agent):
     """
     Ensure proper error handling when the same action_id is provided twice to the `resource_deploy_start` API endpoint.
@@ -1068,7 +1048,6 @@ async def test_resource_deploy_start_action_id_conflict(server, client, environm
 
 
 @pytest.mark.parametrize("endpoint_to_use", ["resource_deploy_done", "resource_action_update"])
-@pytest.mark.asyncio
 async def test_resource_deploy_done(server, client, environment, agent, caplog, endpoint_to_use):
     """
     Ensure that the `resource_deploy_done` endpoint behaves in the same way as the `resource_action_update` endpoint
@@ -1234,7 +1213,6 @@ async def test_resource_deploy_done(server, client, environment, agent, caplog, 
     assert result.code == 409, result.result
 
 
-@pytest.mark.asyncio
 async def test_resource_deploy_done_invalid_state(server, client, environment, agent, caplog):
     """
     Ensure proper error handling when a transient state is passed to the `resource_deploy_done` endpoint.
@@ -1276,7 +1254,6 @@ async def test_resource_deploy_done_invalid_state(server, client, environment, a
     assert "No transient state can be used to mark a deployment as done" in result.result["message"]
 
 
-@pytest.mark.asyncio
 async def test_resource_deploy_done_error_handling(server, client, environment, agent):
     env_id = uuid.UUID(environment)
 
@@ -1325,7 +1302,6 @@ async def test_resource_deploy_done_error_handling(server, client, environment, 
     assert result.code == 404, result.result
 
 
-@pytest.mark.asyncio
 async def test_start_location_no_redirect(server):
     """
     Ensure that there is no redirection for the "start" location. (issue #3497)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,7 +29,6 @@ from utils import LogSequence, get_product_meta_data, log_contains, no_error_in_
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_scheduler_remove(caplog):
     sched = util.Scheduler("remove")
 
@@ -50,7 +49,6 @@ async def test_scheduler_remove(caplog):
     no_error_in_logs(caplog)
 
 
-@pytest.mark.asyncio
 async def test_scheduler_stop(caplog):
     sched = util.Scheduler("stop")
 
@@ -77,7 +75,6 @@ async def test_scheduler_stop(caplog):
     assert "Scheduling action 'action', while scheduler is stopped" in caplog.messages
 
 
-@pytest.mark.asyncio
 async def test_scheduler_async_run_fail(caplog):
     sched = util.Scheduler("xxx")
 
@@ -104,7 +101,6 @@ async def test_scheduler_async_run_fail(caplog):
     log_contains(caplog, "inmanta.util", logging.ERROR, "Uncaught exception while executing scheduled action")
 
 
-@pytest.mark.asyncio
 async def test_scheduler_run_async(caplog):
     sched = util.Scheduler("xxx")
 
@@ -126,7 +122,6 @@ async def test_scheduler_run_async(caplog):
     no_error_in_logs(caplog)
 
 
-@pytest.mark.asyncio
 async def test_ensure_future_and_handle_exception(caplog):
     caplog.set_level(logging.INFO)
 


### PR DESCRIPTION
# Description

 Add pytest-asyncio mode to remove deprecation warnings 
https://github.com/pytest-dev/pytest-asyncio#modes

closes #3764 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
