### PR TITLE
issue3826/ Wrong repo path leads to unclear error

### DIFF
--- a/changelogs/unreleased/3826-error-msg-wrong-repo.yml
+++ b/changelogs/unreleased/3826-error-msg-wrong-repo.yml
@@ -1,0 +1,3 @@
+description: An error message is now shown if a wrong repo path is used
+change-type: patch
+destination-branches: [master, iso4, iso5]

--- a/changelogs/unreleased/3826-error-msg-wrong-repo.yml
+++ b/changelogs/unreleased/3826-error-msg-wrong-repo.yml
@@ -1,3 +1,4 @@
 description: An error message is now shown if a wrong repo path is used
 change-type: patch
 destination-branches: [master, iso4, iso5]
+sections: { bugfix: "{{description}}" }

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -491,7 +491,7 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
     def get_inmanta_module_name(cls, python_package_name: str) -> str:
         if not python_package_name.startswith(ModuleV2.PKG_NAME_PREFIX):
             raise ValueError(f"Invalid python package name: should start with {ModuleV2.PKG_NAME_PREFIX}")
-        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX) :].replace("-", "_")
+        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX):].replace("-", "_")
         if not result:
             raise ValueError("Invalid python package name: empty module name part.")
         return result
@@ -697,13 +697,14 @@ class RemoteRepo(ModuleRepo):
         self.baseurl = baseurl
 
     def clone(self, name: str, dest: str) -> bool:
+        url, nbr_substitutions = re.subn(r"{}", name, self.baseurl)
+        if nbr_substitutions > 1:
+            LOGGER.debug("Wrong repo url: %s. can only contain one occurrence of '{}'" % self.baseurl, exc_info=True)
+            return False
+        elif nbr_substitutions == 0:
+            url = self.baseurl + name
         try:
-            url, nbr_substitutions = re.subn(r"{}", name, self.baseurl)
-            if nbr_substitutions == 0:
-                url = self.baseurl + name
-            elif nbr_substitutions > 1:
-                LOGGER.debug("Wrong repo url: %s. can only contain one occurrence of '{}'" % self.baseurl, exc_info=True)
-                return False
+            print(url)
             gitprovider.clone(url, os.path.join(dest, name))
             return True
         except Exception:
@@ -2283,7 +2284,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
         files = self._get_model_files(self.model_dir)
 
         for f in files:
-            name = f[len(self.model_dir) + 1 : -3]
+            name = f[len(self.model_dir) + 1: -3]
             parts = name.split("/")
             if parts[-1] == "_init":
                 parts = parts[:-1]
@@ -2669,7 +2670,7 @@ class ModuleV2(Module[ModuleV2Metadata]):
 
     @classmethod
     def get_name_from_metadata(cls, metadata: ModuleV2Metadata) -> str:
-        return metadata.name[len(cls.PKG_NAME_PREFIX) :].replace("-", "_")
+        return metadata.name[len(cls.PKG_NAME_PREFIX):].replace("-", "_")
 
     @classmethod
     def get_metadata_file_schema_type(cls) -> Type[ModuleV2Metadata]:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -698,10 +698,12 @@ class RemoteRepo(ModuleRepo):
 
     def clone(self, name: str, dest: str) -> bool:
         try:
-            url = self.baseurl.format(name)
-            if url == self.baseurl:
+            url, nbr_substitutions = re.subn(r"{}", name, self.baseurl)
+            if nbr_substitutions == 0:
                 url = self.baseurl + name
-
+            elif nbr_substitutions > 1:
+                LOGGER.debug("Wrong repo url: %s. can only contain one occurrence of '{}'" % self.baseurl, exc_info=True)
+                return False
             gitprovider.clone(url, os.path.join(dest, name))
             return True
         except Exception:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -491,7 +491,7 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
     def get_inmanta_module_name(cls, python_package_name: str) -> str:
         if not python_package_name.startswith(ModuleV2.PKG_NAME_PREFIX):
             raise ValueError(f"Invalid python package name: should start with {ModuleV2.PKG_NAME_PREFIX}")
-        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX):].replace("-", "_")
+        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX) :].replace("-", "_")
         if not result:
             raise ValueError("Invalid python package name: empty module name part.")
         return result
@@ -699,12 +699,10 @@ class RemoteRepo(ModuleRepo):
     def clone(self, name: str, dest: str) -> bool:
         url, nbr_substitutions = re.subn(r"{}", name, self.baseurl)
         if nbr_substitutions > 1:
-            LOGGER.debug("Wrong repo url: %s. can only contain one occurrence of '{}'" % self.baseurl, exc_info=True)
-            return False
+            raise InvalidMetadata(msg=f"Wrong repo path at {self.baseurl} : should only contain at most one {{}} pair")
         elif nbr_substitutions == 0:
             url = self.baseurl + name
         try:
-            print(url)
             gitprovider.clone(url, os.path.join(dest, name))
             return True
         except Exception:
@@ -2284,7 +2282,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
         files = self._get_model_files(self.model_dir)
 
         for f in files:
-            name = f[len(self.model_dir) + 1: -3]
+            name = f[len(self.model_dir) + 1 : -3]
             parts = name.split("/")
             if parts[-1] == "_init":
                 parts = parts[:-1]
@@ -2670,7 +2668,7 @@ class ModuleV2(Module[ModuleV2Metadata]):
 
     @classmethod
     def get_name_from_metadata(cls, metadata: ModuleV2Metadata) -> str:
-        return metadata.name[len(cls.PKG_NAME_PREFIX):].replace("-", "_")
+        return metadata.name[len(cls.PKG_NAME_PREFIX) :].replace("-", "_")
 
     @classmethod
     def get_metadata_file_schema_type(cls) -> Type[ModuleV2Metadata]:

--- a/tests/moduletool/test_repos.py
+++ b/tests/moduletool/test_repos.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import os
+import shutil
 
 from inmanta.module import InvalidMetadata, LocalFileRepo, RemoteRepo, gitprovider
 
@@ -43,6 +44,7 @@ def test_remote_repo_good(git_modules_dir, modules_repo):
     result = repo.clone("test-repository", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
+    shutil.rmtree(os.path.join(coroot, "test-repository"))
 
 
 def test_remote_repo_good2(git_modules_dir, modules_repo):
@@ -51,6 +53,7 @@ def test_remote_repo_good2(git_modules_dir, modules_repo):
     result = repo.clone("test-repository", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
+    shutil.rmtree(os.path.join(coroot, "test-repository"))
 
 
 def test_remote_repo_bad(git_modules_dir, modules_repo):

--- a/tests/moduletool/test_repos.py
+++ b/tests/moduletool/test_repos.py
@@ -17,7 +17,7 @@
 """
 import os
 
-from inmanta.module import LocalFileRepo, RemoteRepo, gitprovider
+from inmanta.module import InvalidMetadata, LocalFileRepo, RemoteRepo, gitprovider
 
 
 def test_file_co(git_modules_dir, modules_repo):
@@ -43,6 +43,21 @@ def test_remote_repo_good(git_modules_dir, modules_repo):
     result = repo.clone("test-repository", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
+
+
+def test_remote_repo_good2(git_modules_dir, modules_repo):
+    repo = RemoteRepo("https://github.com/rmccue/{}")
+    coroot = os.path.join(git_modules_dir, "clone_remote_good")
+    result = repo.clone("test-repository", coroot)
+    assert result
+    assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
+
+
+def test_remote_repo_bad(git_modules_dir, modules_repo):
+    repo = RemoteRepo("https://github.com/{}/{}")
+    coroot = os.path.join(git_modules_dir, "clone_remote_good")
+    result = repo.clone("test-repository", coroot)
+    assert not result
 
 
 def test_local_repo_bad(git_modules_dir, modules_repo):

--- a/tests/moduletool/test_repos.py
+++ b/tests/moduletool/test_repos.py
@@ -16,7 +16,6 @@
     Contact: code@inmanta.com
 """
 import os
-import shutil
 
 import pytest
 
@@ -32,35 +31,33 @@ version: '3.2'
     assert result == module_yaml
 
 
-def test_local_repo_good(git_modules_dir, modules_repo):
+def test_local_repo_good(tmpdir, modules_repo):
     repo = LocalFileRepo(modules_repo)
-    coroot = os.path.join(git_modules_dir, "clone_local_good")
+    coroot = os.path.join(tmpdir, "clone_local_good")
     result = repo.clone("mod1", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "mod1", "module.yml"))
 
 
-def test_remote_repo_good(git_modules_dir, modules_repo):
+def test_remote_repo_good(tmpdir, modules_repo):
     repo = RemoteRepo("https://github.com/rmccue/")
-    coroot = os.path.join(git_modules_dir, "clone_remote_good")
+    coroot = os.path.join(tmpdir, "clone_remote_good")
     result = repo.clone("test-repository", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
-    shutil.rmtree(os.path.join(coroot, "test-repository"))
 
 
-def test_remote_repo_good2(git_modules_dir, modules_repo):
+def test_remote_repo_good2(tmpdir, modules_repo):
     repo = RemoteRepo("https://github.com/rmccue/{}")
-    coroot = os.path.join(git_modules_dir, "clone_remote_good")
+    coroot = os.path.join(tmpdir, "clone_remote_good")
     result = repo.clone("test-repository", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
-    shutil.rmtree(os.path.join(coroot, "test-repository"))
 
 
-def test_remote_repo_bad(git_modules_dir, modules_repo):
+def test_remote_repo_bad(tmpdir, modules_repo):
     repo = RemoteRepo("https://github.com/{}/{}")
-    coroot = os.path.join(git_modules_dir, "clone_remote_good")
+    coroot = os.path.join(tmpdir, "clone_remote_good")
     with pytest.raises(InvalidMetadata) as e:
         result = repo.clone("test-repository", coroot)
         assert not result
@@ -68,8 +65,8 @@ def test_remote_repo_bad(git_modules_dir, modules_repo):
     assert msg == "Wrong repo path at https://github.com/{}/{} : should only contain at most one {} pair"
 
 
-def test_local_repo_bad(git_modules_dir, modules_repo):
+def test_local_repo_bad(tmpdir, modules_repo):
     repo = LocalFileRepo(modules_repo)
-    coroot = os.path.join(git_modules_dir, "clone_local_good")
+    coroot = os.path.join(tmpdir, "clone_local_good")
     result = repo.clone("thatotherthing", coroot)
     assert not result

--- a/tests/moduletool/test_repos.py
+++ b/tests/moduletool/test_repos.py
@@ -18,6 +18,8 @@
 import os
 import shutil
 
+import pytest
+
 from inmanta.module import InvalidMetadata, LocalFileRepo, RemoteRepo, gitprovider
 
 
@@ -59,8 +61,11 @@ def test_remote_repo_good2(git_modules_dir, modules_repo):
 def test_remote_repo_bad(git_modules_dir, modules_repo):
     repo = RemoteRepo("https://github.com/{}/{}")
     coroot = os.path.join(git_modules_dir, "clone_remote_good")
-    result = repo.clone("test-repository", coroot)
-    assert not result
+    with pytest.raises(InvalidMetadata) as e:
+        result = repo.clone("test-repository", coroot)
+        assert not result
+    msg = e.value.msg
+    assert msg == "Wrong repo path at https://github.com/{}/{} : should only contain at most one {} pair"
 
 
 def test_local_repo_bad(git_modules_dir, modules_repo):


### PR DESCRIPTION
# Description

When including more than one {} in a repo path we get an unclear error.
This commit logs a more readable error message.

closes #3826 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
