### PR TITLE
Fix obsolete test case on iso5

### DIFF
--- a/changelogs/unreleased/fix-obsolete-test-case.yml
+++ b/changelogs/unreleased/fix-obsolete-test-case.yml
@@ -1,0 +1,4 @@
+description: Remove obsolete test case that was failing now that multiline strings are only supported for triple qutoes
+change-type: patch
+destination-branches: [iso5]
+sections: {}


### PR DESCRIPTION
# Description

Fix obsolete test case on iso5


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
