### PR TITLE
Issue/3829 unclear error when compiler venv has incompatible python version

### DIFF
--- a/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
+++ b/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
@@ -1,7 +1,7 @@
 description: An exception is now raised when there is a mismatch between the python versions of the compiler venv and the active process
 issue-nr: 3829
 change-type: patch
-destination-branches: [master]
+destination-branches: [iso4, iso5, master]
 sections: {
   bugfix: "{{description}}"
 }

--- a/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
+++ b/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
@@ -1,4 +1,5 @@
 description: An exception is now raised when there is a mismatch between the python versions of the compiler venv and the active process
+issue-nr: 3829
 change-type: patch
 destination-branches: [master]
 sections: {

--- a/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
+++ b/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
@@ -1,4 +1,4 @@
-description: An exception is now raised when there is a mismatch between the python versions of the compiler venv and the active process
+description: An exception is now raised when there is a mismatch between the python version of the compiler venv and the python version of the active process
 issue-nr: 3829
 change-type: patch
 destination-branches: [iso4, iso5, master]

--- a/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
+++ b/changelogs/unreleased/3829-unclear-error-when-compiler-venv-has-incompatible-python-version.yml
@@ -1,0 +1,6 @@
+description: An exception is now raised when there is a mismatch between the python versions of the compiler venv and the active process
+change-type: patch
+destination-branches: [master]
+sections: {
+  bugfix: "{{description}}"
+}

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -842,8 +842,8 @@ class VenvCreationFailedError(Exception):
         super().__init__(msg)
         self.msg = msg
 
+
 class VenvActivationFailedError(Exception):
     def __init__(self, msg: str) -> None:
         super().__init__(msg)
         self.msg = msg
-

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -706,7 +706,9 @@ class VirtualEnv(ActiveEnv):
                     )
             else:
                 # get version as a (major, minor) tuple for the venv and the running process
-                venv_python_version = subprocess.check_output([self.python_path, "--version"]).decode("utf-8").strip().split()[1]
+                venv_python_version = (
+                    subprocess.check_output([self.python_path, "--version"]).decode("utf-8").strip().split()[1]
+                )
                 venv_python_version = tuple(map(int, venv_python_version.split(".")))[:2]
 
                 running_process_python_version = sys.version_info[:2]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -699,7 +699,7 @@ class VirtualEnv(ActiveEnv):
             if not os.path.exists(self.site_packages_dir):
                 # the venv hosts a different python version than the running process
                 raise VenvCreationFailedError(
-                    msg=f"Unable to create new virtualenv at {self.env_path} due to python version mismatch"
+                    msg=f"Unable to use virtualenv at {self.env_path} due to python version mismatch"
                 )
 
             # Venv was created using an older version of Inmanta -> Update pip binary and set sitecustomize.py file

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -705,7 +705,7 @@ class VirtualEnv(ActiveEnv):
                     )
             else:
                 python_subprocess = subprocess.Popen([self.python_path, "--version"], stdout=subprocess.PIPE, encoding="utf-8")
-                venv_python_version = tuple(map(int,python_subprocess.stdout.readline().strip().split()[1].split(".")))
+                venv_python_version = tuple(map(int, python_subprocess.stdout.readline().strip().split()[1].split(".")))
                 LOGGER.debug(f"virtual env python version: {venv_python_version}")
                 running_process_python_version = sys.version_info[:3]
                 LOGGER.debug(f"running_process_python_version: {running_process_python_version}")
@@ -714,7 +714,6 @@ class VirtualEnv(ActiveEnv):
                     raise VenvActivationFailedError(
                         msg=f"Unable to use virtualenv at {self.env_path} due to python version mismatch"
                     )
-
 
             # Venv was created using an older version of Inmanta -> Update pip binary and set sitecustomize.py file
             self._write_pip_binary()

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -701,19 +701,19 @@ class VirtualEnv(ActiveEnv):
                 # on UNIX based systems, the python version is in the path to the site packages dir:
                 if not os.path.exists(self.site_packages_dir):
                     raise VenvActivationFailedError(
-                        msg=f"Unable to use virtualenv at {self.env_path} because its Python version"
+                        msg=f"Unable to use virtualenv at {self.env_path} because its Python version "
                         "is different from the Python version of this process."
                     )
             else:
                 # get version as a (major, minor) tuple for the venv and the running process
-                venv_python_version = subprocess.check_output([self.python_path, "--version"]).decode("utf-8").split()[1]
+                venv_python_version = subprocess.check_output([self.python_path, "--version"]).decode("utf-8").strip().split()[1]
                 venv_python_version = tuple(map(int, venv_python_version.split(".")))[:2]
 
                 running_process_python_version = sys.version_info[:2]
 
                 if venv_python_version != running_process_python_version:
                     raise VenvActivationFailedError(
-                        msg=f"Unable to use virtualenv at {self.env_path} because its Python version"
+                        msg=f"Unable to use virtualenv at {self.env_path} because its Python version "
                         "is different from the Python version of this process."
                     )
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -675,10 +675,6 @@ class VirtualEnv(ActiveEnv):
         """
         self._parent_python = sys.executable
 
-        if not os.path.exists(self.site_packages_dir):
-            # the venv hosts a different python version than the running process
-            raise VenvCreationFailedError(msg=f"Unable to create new virtualenv at {self.env_path}")
-
         # check if the virtual env exists
         if not os.path.exists(self.python_path):
             # venv requires some care when the .env folder already exists
@@ -700,6 +696,10 @@ class VirtualEnv(ActiveEnv):
                 raise VenvCreationFailedError(msg=f"Unable to create new virtualenv at {self.env_path}")
             LOGGER.debug("Created a new virtualenv at %s", self.env_path)
         elif not os.path.exists(self._path_pth_file):
+            if not os.path.exists(self.site_packages_dir):
+            # the venv hosts a different python version than the running process
+                raise VenvCreationFailedError(msg=f"Unable to create new virtualenv at {self.env_path} due to python version mismatch")
+
             # Venv was created using an older version of Inmanta -> Update pip binary and set sitecustomize.py file
             self._write_pip_binary()
             self._write_pth_file()

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -698,7 +698,7 @@ class VirtualEnv(ActiveEnv):
         elif not os.path.exists(self._path_pth_file):
             if not os.path.exists(self.site_packages_dir):
                 # the venv hosts a different python version than the running process
-                raise VenvCreationFailedError(
+                raise VenvActivationFailedError(
                     msg=f"Unable to use virtualenv at {self.env_path} due to python version mismatch"
                 )
 
@@ -841,3 +841,9 @@ class VenvCreationFailedError(Exception):
     def __init__(self, msg: str) -> None:
         super().__init__(msg)
         self.msg = msg
+
+class VenvActivationFailedError(Exception):
+    def __init__(self, msg: str) -> None:
+        super().__init__(msg)
+        self.msg = msg
+

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -675,6 +675,10 @@ class VirtualEnv(ActiveEnv):
         """
         self._parent_python = sys.executable
 
+        if not os.path.exists(self.site_packages_dir):
+            # the venv hosts a different python version than the running process
+            raise VenvCreationFailedError(msg=f"Unable to create new virtualenv at {self.env_path}")
+
         # check if the virtual env exists
         if not os.path.exists(self.python_path):
             # venv requires some care when the .env folder already exists

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -701,7 +701,8 @@ class VirtualEnv(ActiveEnv):
                 # on UNIX based systems, the python version is in the path to the site packages dir:
                 if not os.path.exists(self.site_packages_dir):
                     raise VenvActivationFailedError(
-                        msg=f"Unable to use virtualenv at {self.env_path} due to python version mismatch"
+                        msg=f"Unable to use virtualenv at {self.env_path} because its Python version"
+                        "is different from the Python version of this process."
                     )
             else:
                 # get version as a (major, minor) tuple for the venv and the running process
@@ -712,7 +713,8 @@ class VirtualEnv(ActiveEnv):
 
                 if venv_python_version != running_process_python_version:
                     raise VenvActivationFailedError(
-                        msg=f"Unable to use virtualenv at {self.env_path} due to python version mismatch ({'.'.join(map(str,venv_python_version))} vs {'.'.join(map(str,running_process_python_version))})"  # NOQA E501
+                        msg=f"Unable to use virtualenv at {self.env_path} because its Python version"
+                        "is different from the Python version of this process."
                     )
 
             # Venv was created using an older version of Inmanta -> Update pip binary and set sitecustomize.py file

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -697,8 +697,10 @@ class VirtualEnv(ActiveEnv):
             LOGGER.debug("Created a new virtualenv at %s", self.env_path)
         elif not os.path.exists(self._path_pth_file):
             if not os.path.exists(self.site_packages_dir):
-            # the venv hosts a different python version than the running process
-                raise VenvCreationFailedError(msg=f"Unable to create new virtualenv at {self.env_path} due to python version mismatch")
+                # the venv hosts a different python version than the running process
+                raise VenvCreationFailedError(
+                    msg=f"Unable to create new virtualenv at {self.env_path} due to python version mismatch"
+                )
 
             # Venv was created using an older version of Inmanta -> Update pip binary and set sitecustomize.py file
             self._write_pip_binary()


### PR DESCRIPTION
# Description
Raise an exception when the compiler venv has a different python version from the running process.

closes #3829 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
- [x] Code is clear and sufficiently documented
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
