### PR TITLE
Issue/3851 update classifiers in setup py

### DIFF
--- a/changelogs/unreleased/3817-extras-and-constraints-are-deprecated-in-pip.yml
+++ b/changelogs/unreleased/3817-extras-and-constraints-are-deprecated-in-pip.yml
@@ -1,7 +1,0 @@
-description: 
-issue-nr: 3817
-change-type: patch
-destination-branches: [master]
-sections: {
-  bugfix: "{{description}}"
-}

--- a/changelogs/unreleased/3817-extras-and-constraints-are-deprecated-in-pip.yml
+++ b/changelogs/unreleased/3817-extras-and-constraints-are-deprecated-in-pip.yml
@@ -1,0 +1,7 @@
+description: 
+issue-nr: 3817
+change-type: patch
+destination-branches: [master]
+sections: {
+  bugfix: "{{description}}"
+}

--- a/changelogs/unreleased/3851-update-classifiers-in-setup-py.yml
+++ b/changelogs/unreleased/3851-update-classifiers-in-setup-py.yml
@@ -1,6 +1,6 @@
 change-type: patch
 issue-nr: 3851
 description: Update python versions in the setup.py classifiers
-destination-branches: [master]
-sections:
-    upgrade-note: "{{description}}"
+destination-branches: [master, iso5]
+sections: {}
+

--- a/changelogs/unreleased/3851-update-classifiers-in-setup-py.yml
+++ b/changelogs/unreleased/3851-update-classifiers-in-setup-py.yml
@@ -1,0 +1,6 @@
+change-type: patch
+issue-nr: 3851
+description: Update python versions in the setup.py classifiers
+destination-branches: [master]
+sections:
+    upgrade-note: "{{description}}"

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     keywords="orchestrator orchestration configurationmanagement",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
# Description

Update python versions in the setup.py classifiers

closes #3851 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
