### PR TITLE
An error message is now shown if a wrong repo path is used (PR #3897)

### DIFF
--- a/changelogs/unreleased/3826-error-msg-wrong-repo.yml
+++ b/changelogs/unreleased/3826-error-msg-wrong-repo.yml
@@ -1,0 +1,4 @@
+description: An error message is now shown if a wrong repo path is used
+change-type: patch
+destination-branches: [iso4]
+sections: { bugfix: "{{description}}" }

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -275,11 +275,12 @@ class RemoteRepo(ModuleRepo):
         self.baseurl = baseurl
 
     def clone(self, name: str, dest: str) -> bool:
+        url, nbr_substitutions = re.subn(r"{}", name, self.baseurl)
+        if nbr_substitutions > 1:
+            raise InvalidMetadata(msg=f"Wrong repo path at {self.baseurl} : should only contain at most one {{}} pair")
+        elif nbr_substitutions == 0:
+            url = self.baseurl + name
         try:
-            url = self.baseurl.format(name)
-            if url == self.baseurl:
-                url = self.baseurl + name
-
             gitprovider.clone(url, os.path.join(dest, name))
             return True
         except Exception:

--- a/tests/moduletool/test_repos.py
+++ b/tests/moduletool/test_repos.py
@@ -17,7 +17,9 @@
 """
 import os
 
-from inmanta.module import LocalFileRepo, RemoteRepo, gitprovider
+import pytest
+
+from inmanta.module import InvalidMetadata, LocalFileRepo, RemoteRepo, gitprovider
 
 
 def test_file_co(modules_dir, modules_repo):
@@ -29,24 +31,42 @@ version: '3.2'
     assert result == module_yaml
 
 
-def test_local_repo_good(modules_dir, modules_repo):
+def test_local_repo_good(tmpdir, modules_repo):
     repo = LocalFileRepo(modules_repo)
-    coroot = os.path.join(modules_dir, "clone_local_good")
+    coroot = os.path.join(tmpdir, "clone_local_good")
     result = repo.clone("mod1", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "mod1", "module.yml"))
 
 
-def test_remote_repo_good(modules_dir, modules_repo):
+def test_remote_repo_good(tmpdir, modules_repo):
     repo = RemoteRepo("https://github.com/rmccue/")
-    coroot = os.path.join(modules_dir, "clone_remote_good")
+    coroot = os.path.join(tmpdir, "clone_remote_good")
     result = repo.clone("test-repository", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
 
 
-def test_local_repo_bad(modules_dir, modules_repo):
+def test_remote_repo_good2(tmpdir, modules_repo):
+    repo = RemoteRepo("https://github.com/rmccue/{}")
+    coroot = os.path.join(tmpdir, "clone_remote_good")
+    result = repo.clone("test-repository", coroot)
+    assert result
+    assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
+
+
+def test_remote_repo_bad(tmpdir, modules_repo):
+    repo = RemoteRepo("https://github.com/{}/{}")
+    coroot = os.path.join(tmpdir, "clone_remote_good")
+    with pytest.raises(InvalidMetadata) as e:
+        result = repo.clone("test-repository", coroot)
+        assert not result
+    msg = e.value.msg
+    assert msg == "Wrong repo path at https://github.com/{}/{} : should only contain at most one {} pair"
+
+
+def test_local_repo_bad(tmpdir, modules_repo):
     repo = LocalFileRepo(modules_repo)
-    coroot = os.path.join(modules_dir, "clone_local_good")
+    coroot = os.path.join(tmpdir, "clone_local_good")
     result = repo.clone("thatotherthing", coroot)
     assert not result


### PR DESCRIPTION
When including more than one {} in a repo path we get an unclear error.
This commit logs a more readable error message.

closes #3826

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
