### PR TITLE
fixed use of wrong Python interpreter in test case

### DIFF
--- a/changelogs/unreleased/fix-test-python-interpreter.yml
+++ b/changelogs/unreleased/fix-test-python-interpreter.yml
@@ -1,0 +1,4 @@
+description: Fixed use of incorrect Python interpreter in determinism test
+change-type: patch
+destination-branches:
+  - iso4

--- a/tests/compiler/test_determinism.py
+++ b/tests/compiler/test_determinism.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import subprocess
+import sys
 
 import pytest
 
@@ -51,4 +52,4 @@ test = a.optional
         """
     )
     # fork new Python interpreter to force new Python hash seed, which is a source for nondeterminism
-    subprocess.check_output(["python", "-m", "inmanta.app", "compile"], cwd=Project.get()._path)
+    subprocess.check_output([sys.executable, "-m", "inmanta.app", "compile"], cwd=Project.get()._path)


### PR DESCRIPTION
Should fix [failing build](https://jenkins.inmanta.com/job/integration-tests/job/pytest/1813/branch=master,os=ubuntu-latest/console).