### PR TITLE
issue3787/UnsetExceptions should not be wrapped

### DIFF
--- a/changelogs/unreleased/fix-unwrap-unset-exception.yml
+++ b/changelogs/unreleased/fix-unwrap-unset-exception.yml
@@ -1,0 +1,4 @@
+description: Unset exceptions should not be wrapped as they are needed by the compiler
+change-type: patch
+issue-nr: 2443
+destination-branches: [master, iso4, iso5]

--- a/changelogs/unreleased/fix-unwrap-unset-exception.yml
+++ b/changelogs/unreleased/fix-unwrap-unset-exception.yml
@@ -1,4 +1,4 @@
 description: Unset exceptions should not be wrapped as they are needed by the compiler
 change-type: patch
-issue-nr: 2443
+issue-nr: 3787
 destination-branches: [master, iso4, iso5]

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -38,13 +38,7 @@ from typing import (
 
 import inmanta.util
 from inmanta import plugins
-from inmanta.ast import (
-    CompilerException,
-    ExplicitPluginException,
-    ExternalException,
-    RuntimeException,
-    WrappingRuntimeException,
-)
+from inmanta.ast import CompilerException, ExplicitPluginException, ExternalException
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.execute import proxy, runtime, util
 from inmanta.stable_api import stable_api

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -316,6 +316,8 @@ class Resource(metaclass=ResourceMeta):
                 # passing along the serialized version would break the resource apis
                 json.dumps(value, default=inmanta.util.api_boundary_json_encoder)
                 return value
+            except IgnoreResourceException:
+                raise  # will be handled in _load_resources of export.py
             except proxy.UnknownException as e:
                 return e.unknown
             except plugins.PluginException as e:

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -38,7 +38,13 @@ from typing import (
 
 import inmanta.util
 from inmanta import plugins
-from inmanta.ast import ExplicitPluginException, ExternalException, RuntimeException, WrappingRuntimeException
+from inmanta.ast import (
+    CompilerException,
+    ExplicitPluginException,
+    ExternalException,
+    RuntimeException,
+    WrappingRuntimeException,
+)
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.execute import proxy, runtime, util
 from inmanta.stable_api import stable_api
@@ -310,14 +316,14 @@ class Resource(metaclass=ResourceMeta):
                 # passing along the serialized version would break the resource apis
                 json.dumps(value, default=inmanta.util.api_boundary_json_encoder)
                 return value
-            except IgnoreResourceException:
-                raise  # will be handled in _load_resources of export.py
             except proxy.UnknownException as e:
                 return e.unknown
-            except RuntimeException as e:
-                raise WrappingRuntimeException(None, f"Failed to get attribute '{field_name}' for export on '{entity_name}'", e)
             except plugins.PluginException as e:
                 raise ExplicitPluginException(None, f"Failed to get attribute '{field_name}' for export on '{entity_name}'", e)
+            except CompilerException:
+                # Internal exceptions (like UnsetException) should be propagated without being wrapped
+                # as they are used later on and wrapping them would break the compiler
+                raise
             except Exception as e:
                 raise ExternalException(None, f"Failed to get attribute '{field_name}' for export on '{entity_name}'", e)
 


### PR DESCRIPTION
# Description

https://github.com/inmanta/inmanta-core/pull/3859/files changed how exceptions are wrapped and handled. 
The unsetException should never be wrapped as it is used by the compiler. This PR fixes the introduced error.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
