### PR TITLE
[WIP] remove Shift/reduce conflicts

### DIFF
--- a/changelogs/unreleased/remove-shift-reduce-conflicts.yml
+++ b/changelogs/unreleased/remove-shift-reduce-conflicts.yml
@@ -1,0 +1,3 @@
+description: Remove shift/reduce conflicts by enforcing precedence rules
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -69,7 +69,7 @@ precedence = (
     ("left", "IN"),
     ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
     ("left", "CID", "ID"),
-    ("left", "MLS"),
+    ("right", "MLS"),
     ("left", "MLS_END"),
 )
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -67,7 +67,7 @@ precedence = (
     ("left", "CMP_OP"),
     ("nonassoc", "NOT"),
     ("left", "IN"),
-    ("left", "RELATION_DEF", "TYPEDEF_INNER", "EMPTY"),
+    ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
     ("left", "CID", "ID"),
     ("left", "MLS"),
     ("left", "MLS_END")
@@ -979,7 +979,7 @@ def p_operand_list_term(p: YaccProduction) -> None:
 
 
 def p_operand_list_term_2(p: YaccProduction) -> None:
-    "operand_list :"
+    "operand_list : %prec OPERAND_LIST"
     p[0] = []
 
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -67,8 +67,10 @@ precedence = (
     ("left", "CMP_OP"),
     ("nonassoc", "NOT"),
     ("left", "IN"),
-    ("right", "MLS"),
-    ("right", "MLS_END"),
+    ("left", "RELATION_DEF", "TYPEDEF_INNER"),
+    ("left", "CID", "ID"),
+    ("left", "MLS"),
+    ("left", "MLS_END")
 )
 
 
@@ -508,7 +510,7 @@ def p_relation_outer_comment(p: YaccProduction) -> None:
 
 
 def p_relation_outer(p: YaccProduction) -> None:
-    "relation : relation_def"
+    "relation : relation_def %prec RELATION_DEF"
     p[0] = p[1]
 
 
@@ -560,7 +562,7 @@ def p_multi_4(p: YaccProduction) -> None:
 
 
 def p_typedef_outer(p: YaccProduction) -> None:
-    """typedef : typedef_inner"""
+    """typedef : typedef_inner %prec TYPEDEF_INNER"""
     p[0] = p[1]
 
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -70,7 +70,7 @@ precedence = (
     ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
     ("left", "CID", "ID"),
     ("left", "MLS"),
-    ("left", "MLS_END")
+    ("left", "MLS_END"),
 )
 
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -67,7 +67,7 @@ precedence = (
     ("left", "CMP_OP"),
     ("nonassoc", "NOT"),
     ("left", "IN"),
-    ("left", "RELATION_DEF", "TYPEDEF_INNER"),
+    ("left", "RELATION_DEF", "TYPEDEF_INNER", "EMPTY"),
     ("left", "CID", "ID"),
     ("left", "MLS"),
     ("left", "MLS_END")
@@ -141,7 +141,7 @@ def p_top_stmt(p: YaccProduction) -> None:
 
 
 def p_empty(p: YaccProduction) -> None:
-    "empty :"
+    "empty : %prec EMPTY"
     pass
 
 


### PR DESCRIPTION
# Description
This Commit removes all the warnings of shift/reduce conflicts by enforcing a shift.
By default if no precedence rules are found, a shift is performed and a warning issued.
By adding the precedence rules to perform a shift when there are conflict the same behavior
should be kept without the warnings. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
