### PR TITLE
Issue/3927 inmanta deploy cmd iso4

### DIFF
--- a/changelogs/unreleased/3927-ensure-config-isolation-inmanta-deploy-cmd.yml
+++ b/changelogs/unreleased/3927-ensure-config-isolation-inmanta-deploy-cmd.yml
@@ -2,6 +2,6 @@
 description: Fixed bug that makes the `inmanta deploy` command fail when the database and server sections of the inmanta configuration files contain non-default values.
 issue-nr: 3927
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso4]
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/3927-ensure-config-isolation-inmanta-deploy-cmd.yml
+++ b/changelogs/unreleased/3927-ensure-config-isolation-inmanta-deploy-cmd.yml
@@ -1,0 +1,7 @@
+---
+description: Fixed bug that makes the `inmanta deploy` command fail when the database and server sections of the inmanta configuration files contain non-default values.
+issue-nr: 3927
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -416,8 +416,7 @@ def deploy(options: argparse.Namespace) -> None:
     run = deploy_module.Deploy(options)
     try:
         if not run.setup():
-            LOGGER.error("Failed to setup the orchestrator.")
-            return
+            raise Exception("Failed to setup an embedded Inmanta orchestrator.")
         run.run()
     finally:
         run.stop()

--- a/src/inmanta/deploy.py
+++ b/src/inmanta/deploy.py
@@ -102,6 +102,8 @@ class Deploy(object):
 [database]
 name=postgres
 port=%(postgres_port)s
+host=localhost
+username=postgres
 
 [config]
 state-dir=%(state_dir)s
@@ -109,18 +111,23 @@ log-dir=%(log_dir)s
 
 [server]
 bind-port=%(server_port)s
+bind-address=127.0.0.1
 
 [agent_rest_transport]
 port=%(server_port)s
+host=localhost
 
 [compiler_rest_transport]
 port=%(server_port)s
+host=localhost
 
 [client_rest_transport]
 port=%(server_port)s
+host=localhost
 
 [cmdline_rest_transport]
 port=%(server_port)s
+host=localhost
 """
             % vars_in_configfile
         )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2017 Inmanta
+    Copyright 2022 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 """
 import collections
 import os
+import subprocess
+import sys
 
 import pytest
 from tornado import process
@@ -40,13 +42,53 @@ def test_deploy(snippetcompiler, tmpdir, postgres_db):
     Options = collections.namedtuple("Options", ["dryrun", "dashboard"])
     options = Options(dryrun=False, dashboard=False)
 
+    assert not file_name.exists()
+
     run = deploy.Deploy(options, postgresport=postgres_db.port)
     try:
-        run.setup()
+        if not run.setup():
+            raise Exception("Failed to setup server")
         run.run()
     finally:
         run.stop()
 
+    assert file_name.exists()
+
+
+@pytest.mark.slowtest
+def test_deploy_with_non_default_config(snippetcompiler, tmpdir) -> None:
+    """
+    Ensure that configuration options set in one of the inmanta configuration
+    files cannot make the `inmanta deploy` fail.
+    """
+    file_name = tmpdir.join("test_file")
+    snippetcompiler.setup_for_snippet(
+        """
+    host = std::Host(name="internal", os=std::linux)
+    file = std::Symlink(host=host, source="/dev/null", target="%s")
+    """
+        % file_name
+    )
+
+    path_dot_inmanta_file = os.path.join(snippetcompiler.project_dir, ".inmanta")
+    with open(path_dot_inmanta_file, "w") as fh:
+        fh.write(
+            """
+[database]
+name=non-default-username
+host=non-default-value
+port=9999
+username=non-default-value
+password=non-default-value
+
+[server]
+bind-port=7777
+bind-address=192.168.100.100
+        """
+        )
+
+    assert not file_name.exists()
+    subprocess.check_call([sys.executable, "-m", "inmanta.app", "deploy"], cwd=snippetcompiler.project_dir)
     assert file_name.exists()
 
 


### PR DESCRIPTION
**Same PR as #3942 but scoped to iso4 only due to a merge conflict.**

# Description

This PR fixes a bug that makes the `inmanta deploy` command fail when the `database` and `server` sections of the inmanta configuration files contain non-default values.

This PR doesn't resolve all the issues of its kind. The following problems can still occor:

* An Inmanta configuration file enables SSL/TLS by setting the `ssl-cert-file` and `ssl-key-file` options
* The `*_rest_transport` section defines the token config optio

The above-mentioned issues require the capability to unset a config option via a configuration file. That feature is currently not supported.

closes #3927

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
