### PR TITLE
Simplify MLS in compiler

### DIFF
--- a/changelogs/unreleased/simplify-mls-compiler.yml
+++ b/changelogs/unreleased/simplify-mls-compiler.yml
@@ -1,0 +1,3 @@
+description: Simplify MLS and MLS_END to just need MLS in the parser.
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -131,7 +131,7 @@ def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
 
 
 def t_MLS(t: lex.LexToken) -> lex.LexToken:
-    r'["]{3}.*["]{3}'
+    r'"{3}([\s\S]*?)"{3}'
     t.value = bytes(t.value[3:-3], "utf-8").decode("unicode_escape")
     lexer = t.lexer
 

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -24,8 +24,6 @@ from inmanta.ast.constraint.expression import Regex
 from inmanta.ast.variables import Reference
 from inmanta.parser import ParserException
 
-states = (("mls", "exclusive"),)
-
 keyworldlist = [
     "typedef",
     "as",
@@ -60,7 +58,7 @@ literals = [":", "[", "]", "(", ")", "=", ",", ".", "{", "}", "?", "*"]
 reserved = {k: k.upper() for k in keyworldlist}
 
 # List of token names.   This is always required
-tokens = ["INT", "FLOAT", "ID", "CID", "SEP", "STRING", "MLS", "MLS_END", "CMP_OP", "REGEX", "REL", "PEQ", "RSTRING"] + sorted(
+tokens = ["INT", "FLOAT", "ID", "CID", "SEP", "STRING", "MLS", "CMP_OP", "REGEX", "REL", "PEQ", "RSTRING"] + sorted(
     list(reserved.values())
 )
 
@@ -132,28 +130,9 @@ def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
     pass
 
 
-def t_begin_mls(t: lex.LexToken) -> lex.LexToken:
-    r'["]{3}'
-    t.lexer.begin("mls")
-    t.type = "MLS"
-
-    lexer = t.lexer
-
-    end = lexer.lexpos - lexer.linestart + 1
-    (s, e) = lexer.lexmatch.span()
-    start = end - (e - s)
-
-    t.value = LocatableString("", Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace)
-
-    return t
-
-
-def t_mls_end(t: lex.LexToken) -> lex.LexToken:
-    r'.*["]{3}'
-    t.lexer.begin("INITIAL")
-    t.type = "MLS_END"
-    value = t.value[:-3]
-
+def t_MLS(t: lex.LexToken) -> lex.LexToken:
+    r'["]{3}.*["]{3}'
+    t.value = bytes(t.value[3:-3], "utf-8").decode("unicode_escape")
     lexer = t.lexer
 
     end = lexer.lexpos - lexer.linestart + 1
@@ -161,14 +140,9 @@ def t_mls_end(t: lex.LexToken) -> lex.LexToken:
     start = end - (e - s)
 
     t.value = LocatableString(
-        value, Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace
+        t.value, Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace
     )
 
-    return t
-
-
-def t_mls_MLS(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r".+"
     return t
 
 
@@ -223,18 +197,8 @@ def t_newline(t: lex.LexToken) -> None:  # noqa: N802
     t.lexer.linestart = t.lexer.lexpos
 
 
-def t_mls_newline(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"\n+"
-    t.lexer.lineno += len(t.value)
-    t.lexer.linestart = t.lexer.lexpos
-    t.type = "MLS"
-    return t
-
-
 # A string containing ignored characters (spaces and tabs)
 t_ignore = " \t"
-t_mls_ignore = ""
-
 # Error handling rule
 
 

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -132,7 +132,7 @@ def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
 
 def t_MLS(t: lex.LexToken) -> lex.LexToken:
     r'"{3}([\s\S]*?)"{3}'
-    t.value = bytes(t.value[3:-3], "utf-8").decode("unicode_escape")
+    value = t.value[3:-3]
     lexer = t.lexer
     match = lexer.lexmatch[0]
     lines = match.split("\n")
@@ -143,7 +143,7 @@ def t_MLS(t: lex.LexToken) -> lex.LexToken:
     start = lexer.lexpos - lexer.linestart - (e - s) + 1
     end = len(lines[-1]) + 1
 
-    t.value = LocatableString(t.value, Range(lexer.inmfile, start_line, start, end_line, end), lexer.lexpos, lexer.namespace)
+    t.value = LocatableString(value, Range(lexer.inmfile, start_line, start, end_line, end), lexer.lexpos, lexer.namespace)
 
     return t
 

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -134,14 +134,16 @@ def t_MLS(t: lex.LexToken) -> lex.LexToken:
     r'"{3}([\s\S]*?)"{3}'
     t.value = bytes(t.value[3:-3], "utf-8").decode("unicode_escape")
     lexer = t.lexer
-
-    end = lexer.lexpos - lexer.linestart + 1
+    match = lexer.lexmatch[0]
+    lines = match.split("\n")
+    start_line = lexer.lineno
+    end_line = lexer.lineno + len(lines) - 1
+    t.lexer.lineno = end_line
     (s, e) = lexer.lexmatch.span()
-    start = end - (e - s)
+    start = lexer.lexpos - lexer.linestart - (e - s) + 1
+    end = len(lines[-1]) + 1
 
-    t.value = LocatableString(
-        t.value, Range(lexer.inmfile, lexer.lineno, start, lexer.lineno, end), lexer.lexpos, lexer.namespace
-    )
+    t.value = LocatableString(t.value, Range(lexer.inmfile, start_line, start, end_line, end), lexer.lexpos, lexer.namespace)
 
     return t
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -69,7 +69,8 @@ precedence = (
     ("left", "IN"),
     ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
     ("left", "CID", "ID"),
-    ("right", "MLS"),)
+    ("right", "MLS"),
+)
 
 
 def attach_lnr(p: YaccProduction, token: int = 1) -> None:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -69,9 +69,7 @@ precedence = (
     ("left", "IN"),
     ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
     ("left", "CID", "ID"),
-    ("right", "MLS"),
-    ("left", "MLS_END"),
-)
+    ("right", "MLS"),)
 
 
 def attach_lnr(p: YaccProduction, token: int = 1) -> None:
@@ -128,7 +126,7 @@ def p_main_term(p: YaccProduction) -> None:
 
 
 def p_top_stmt(p: YaccProduction) -> None:
-    """top_stmt : mls
+    """top_stmt : MLS
     | entity_def
     | implement_def
     | implementation_def
@@ -278,7 +276,7 @@ def p_entity_extends_err(p: YaccProduction) -> None:
 
 
 def p_entity_body_outer(p: YaccProduction) -> None:
-    """entity_body_outer : mls entity_body END"""
+    """entity_body_outer : MLS entity_body END"""
     p[0] = (p[1], p[2])
 
 
@@ -293,7 +291,7 @@ def p_entity_body_outer_none(p: YaccProduction) -> None:
 
 
 def p_entity_body_outer_4(p: YaccProduction) -> None:
-    """entity_body_outer : mls END"""
+    """entity_body_outer : MLS END"""
     p[0] = (p[1], [])
 
 
@@ -406,7 +404,7 @@ def p_implement_ns_list_collect(p: YaccProduction) -> None:
 
 def p_implement(p: YaccProduction) -> None:
     """implement_def : IMPLEMENT class_ref USING implement_ns_list empty
-    | IMPLEMENT class_ref USING implement_ns_list mls"""
+    | IMPLEMENT class_ref USING implement_ns_list MLS"""
     (inherit, implementations) = p[4]
     p[0] = DefineImplement(p[2], implementations, Literal(True), inherit=inherit, comment=p[5])
     attach_lnr(p)
@@ -414,7 +412,7 @@ def p_implement(p: YaccProduction) -> None:
 
 def p_implement_when(p: YaccProduction) -> None:
     """implement_def : IMPLEMENT class_ref USING implement_ns_list WHEN expression empty
-    | IMPLEMENT class_ref USING implement_ns_list WHEN expression mls"""
+    | IMPLEMENT class_ref USING implement_ns_list WHEN expression MLS"""
     (inherit, implementations) = p[4]
     p[0] = DefineImplement(p[2], implementations, p[6], inherit=inherit, comment=p[7])
     attach_lnr(p)
@@ -437,7 +435,7 @@ def p_implementation_def(p: YaccProduction) -> None:
 
 
 def p_implementation(p: YaccProduction) -> None:
-    "implementation : ':' mls block"
+    "implementation : ':' MLS block"
     p[0] = (p[2], p[3])
 
 
@@ -464,7 +462,7 @@ def p_relation_deprecated(p: YaccProduction) -> None:
 
 
 def p_relation_deprecated_comment(p: YaccProduction) -> None:
-    "relation : class_ref ID multi REL multi class_ref ID mls"
+    "relation : class_ref ID multi REL multi class_ref ID MLS"
     if not (p[4] == "--"):
         LOGGER.warning(
             "DEPRECATION: use of %s in relation definition is deprecated, use -- (in %s)" % (p[4], Location(file, p.lineno(4)))
@@ -503,7 +501,7 @@ def deprecated_relation_warning(p: YaccProduction) -> None:
 
 
 def p_relation_outer_comment(p: YaccProduction) -> None:
-    "relation : relation_def mls"
+    "relation : relation_def MLS"
     rel = p[1]
     rel.comment = str(p[2])
     p[0] = rel
@@ -567,7 +565,7 @@ def p_typedef_outer(p: YaccProduction) -> None:
 
 
 def p_typedef_outer_comment(p: YaccProduction) -> None:
-    """typedef : typedef_inner mls"""
+    """typedef : typedef_inner MLS"""
     tdef = p[1]
     tdef.comment = str(p[2])
     p[0] = tdef
@@ -789,7 +787,7 @@ def p_constant_rstring(p: YaccProduction) -> None:
 
 
 def p_constant_mls(p: YaccProduction) -> None:
-    "constant : mls"
+    "constant : MLS"
     p[0] = get_string_ast_node(p[1], True)
     attach_from_string(p)
 
@@ -1071,17 +1069,6 @@ def p_id_list_collect(p: YaccProduction) -> None:
 def p_id_list_term(p: YaccProduction) -> None:
     "id_list : ID"
     p[0] = [p[1]]
-
-
-def p_mls_term(p: YaccProduction) -> None:
-    "mls : MLS_END"
-    p[0] = p[1]
-
-
-def p_mls_collect(p: YaccProduction) -> None:
-    "mls : MLS mls"
-    p[0] = "%s%s" % (p[1], p[2])
-    merge_lnr_to_string(p, 1, 2)
 
 
 # Error rule for syntax errors

--- a/tests/compiler/test_import.py
+++ b/tests/compiler/test_import.py
@@ -37,7 +37,6 @@ def test_1480_1767_invalid_repo(snippetcompiler_clean):
     snippetcompiler_clean.repo = "some_invalid_url"
     snippetcompiler_clean.setup_for_error(
         """
-
         """,
         "Failed to load module std (reported in import std (__internal__:1:1))"
         "\ncaused by:"

--- a/tests/compiler/test_import.py
+++ b/tests/compiler/test_import.py
@@ -37,6 +37,7 @@ def test_1480_1767_invalid_repo(snippetcompiler_clean):
     snippetcompiler_clean.repo = "some_invalid_url"
     snippetcompiler_clean.setup_for_error(
         """
+
         """,
         "Failed to load module std (reported in import std (__internal__:1:1))"
         "\ncaused by:"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1231,8 +1231,6 @@ end
 
     mls = stmt.comment
 
-    print(mls)
-
     assert (
         str(mls)
         == """
@@ -1249,6 +1247,98 @@ end
 
         More test
     """
+    )
+
+
+def test_mls_2():
+    statements = parse_code(
+        """
+\"""
+This
+is
+a
+mls
+\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+
+    assert mls.lnr == 2
+    assert mls.elnr == 7
+    assert mls.start == 1
+    assert mls.end == 4
+    assert (
+        str(mls.value)
+        == """
+This
+is
+a
+mls
+"""
+    )
+
+
+def test_mls_3():
+    statements = parse_code(
+        """
+\"""This is a mls on one line\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+    assert mls.lnr == 2
+    assert mls.elnr == 2
+    assert mls.start == 1
+    assert mls.end == 32
+    assert str(mls.value) == "This is a mls on one line"
+
+
+def test_mls_4():
+    statements = parse_code(
+        """
+\"""
+str1
+\"""
+
+a = "One big token"
+
+\"""
+str1 with
+some variations\"""
+"""
+    )
+    assert len(statements) == 3
+    mls1 = statements[0]
+    mls2 = statements[2]
+
+    assert isinstance(mls1, LocatableString)
+    assert isinstance(mls2, LocatableString)
+
+    assert mls1.lnr == 2
+    assert mls1.elnr == 4
+    assert mls1.start == 1
+    assert mls1.end == 4
+    assert (
+        str(mls1)
+        == """
+str1
+"""
+    )
+
+    assert mls2.lnr == 8
+    assert mls2.elnr == 10
+    assert mls2.start == 1
+    assert mls2.end == 19
+    assert (
+        str(mls2)
+        == """
+str1 with
+some variations"""
     )
 
 


### PR DESCRIPTION
# Description

Previously the Lexer would produces 2 tokens to identify multi line strings. 
First matching on `"""` and create `MLS`, then matching on `.*"""` and produce `MLS_END`. 
The parser did then need to rebuild the multi line string using grammar rules.
whit this commit the MLS token will match the entire multi line string directly 
and removes the burden of using grammar rules. 


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
