### PR TITLE
change wrapping of location for set attribute

### DIFF
--- a/changelogs/unreleased/3000-accurate-errors-on-gradual-exucution.yml
+++ b/changelogs/unreleased/3000-accurate-errors-on-gradual-exucution.yml
@@ -1,0 +1,4 @@
+description: Accurate error reporting on gradual execution
+issue-nr: 3000
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -244,10 +244,10 @@ class GradualSetAttributeHelper(ResultCollector[T]):
     are attributed to the correct statement
     """
 
-    __slots__ = ("owner", "next", "instance", "attribute_name")
+    __slots__ = ("stmt", "next", "instance", "attribute_name")
 
-    def __init__(self, owner: "Statement", instance: "Instance", attribute_name: str, next: ResultCollector[T]) -> None:
-        self.owner = owner
+    def __init__(self, stmt: "Statement", instance: "Instance", attribute_name: str, next: ResultCollector[T]) -> None:
+        self.stmt = stmt
         self.instance = instance
         self.next = next
         self.attribute_name = attribute_name
@@ -259,8 +259,8 @@ class GradualSetAttributeHelper(ResultCollector[T]):
             e.set_statement(self.stmt, False)
             raise
         except RuntimeException as e:
-            e.set_statement(self.owner, False)
-            raise AttributeException(self.owner, self.instance, self.attribute_name, e)
+            e.set_statement(self.stmt, False)
+            raise AttributeException(self.stmt, self.instance, self.attribute_name, e)
 
 
 class SetAttributeHelper(ExecutionUnit):

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -29,6 +29,7 @@ from inmanta.ast import (
     HyphenDeprecationWarning,
     KeyException,
     LocatableString,
+    Location,
     RuntimeException,
     TypeReferenceAnchor,
     TypingException,
@@ -51,7 +52,7 @@ from inmanta.execute.util import Unknown
 from . import ReferenceStatement
 
 try:
-    from typing import TYPE_CHECKING, Dict, Optional
+    from typing import TYPE_CHECKING, Dict, Optional, TypeVar
 except ImportError:
     TYPE_CHECKING = False
 
@@ -59,6 +60,8 @@ except ImportError:
 if TYPE_CHECKING:
     from inmanta.ast.statements.generator import WrappedKwargs  # noqa: F401
     from inmanta.ast.variables import Reference  # noqa: F401
+
+T = TypeVar("T")
 
 
 class CreateList(ReferenceStatement):
@@ -220,7 +223,7 @@ class SetAttribute(AssignStatement, Resumer):
             # gradual only for multi
             # to preserve order on lists used in attributes
             # while allowing gradual execution on relations
-            reqs = self.value.requires_emit_gradual(resolver, queue, var)
+            reqs = self.value.requires_emit_gradual(resolver, queue, ResultCollectorExceptionWrapper(self, var))
         else:
             reqs = self.value.requires_emit(resolver, queue)
 
@@ -233,7 +236,31 @@ class SetAttribute(AssignStatement, Resumer):
         return "%s.%s = %s" % (str(self.instance), self.attribute_name, str(self.value))
 
 
+class ResultCollectorExceptionWrapper(ResultCollector[T]):
+    """
+    A result collector wrapper that ensures that exceptions that happen during assignment are attributed to the correct statement
+    """
+
+    __slots__ = ("owner", "next")
+
+    def __init__(self, owner: "SetAttribute", next: ResultCollector[T]) -> None:
+        self.owner = owner
+        self.next = next
+
+    def receive_result(self, value: T, location: Location) -> None:
+        try:
+            self.next.receive_result(value, location)
+        except AttributeException:
+            raise
+        except RuntimeException as e:
+            e.set_statement(self.owner, False)
+            raise AttributeException(self.owner, self.owner.instance, self.owner.attribute_name, e)
+
+
 class SetAttributeHelper(ExecutionUnit):
+
+    __slots__ = ("stmt", "instance", "attribute_name")
+
     def __init__(
         self,
         queue_scheduler: QueueScheduler,
@@ -253,6 +280,8 @@ class SetAttributeHelper(ExecutionUnit):
     def execute(self) -> None:
         try:
             ExecutionUnit._unsafe_execute(self)
+        except AttributeException:
+            raise
         except RuntimeException as e:
             e.set_statement(self.stmt, False)
             raise AttributeException(self.stmt, self.instance, self.attribute_name, e)

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -251,7 +251,8 @@ class ResultCollectorExceptionWrapper(ResultCollector[T]):
     def receive_result(self, value: T, location: Location) -> None:
         try:
             self.next.receive_result(value, location)
-        except AttributeException:
+        except AttributeException as e:
+            e.set_statement(self.stmt, False)
             raise
         except RuntimeException as e:
             e.set_statement(self.owner, False)
@@ -281,7 +282,8 @@ class SetAttributeHelper(ExecutionUnit):
     def execute(self) -> None:
         try:
             ExecutionUnit._unsafe_execute(self)
-        except AttributeException:
+        except AttributeException as e:
+            e.set_statement(self.stmt, False)
             raise
         except RuntimeException as e:
             e.set_statement(self.stmt, False)

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -37,7 +37,7 @@ from inmanta.ast import (
 )
 from inmanta.ast.blocks import BasicBlock
 from inmanta.ast.statements import DynamicStatement, ExpressionStatement, RawResumer
-from inmanta.ast.statements.assign import SetAttributeHelper
+from inmanta.ast.statements.assign import GradualSetAttributeHelper, SetAttributeHelper
 from inmanta.const import LOG_LEVEL_TRACE
 from inmanta.execute.dataflow import DataflowGraph
 from inmanta.execute.runtime import (
@@ -572,7 +572,9 @@ class Constructor(ExpressionStatement):
                 # gradual only for multi
                 # to preserve order on lists used in attributes
                 # while allowing gradual execution on relations
-                reqs = valueexpression.requires_emit_gradual(resolver, queue, var)
+                reqs = valueexpression.requires_emit_gradual(
+                    resolver, queue, GradualSetAttributeHelper(self, object_instance, attributename, var)
+                )
             else:
                 reqs = valueexpression.requires_emit(resolver, queue)
             SetAttributeHelper(queue, resolver, var, reqs, valueexpression, self, object_instance, attributename)

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -198,3 +198,32 @@ SUBTREE for __config__::A instance:
                 dir=snippetcompiler.project_dir
             )
         )
+
+
+def test_assignment_failed_on_gradual(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+c1 = C()
+c1.bs += c1.ac
+c1.ac = A()
+
+entity A:
+end
+
+entity B extends A:
+end
+
+entity C:
+end
+
+C.ac [0:] -- A
+C.bs [0:] -- B
+
+implement A using std::none
+implement B using std::none
+implement C using std::none
+        """,
+        """Could not set attribute `bs` on instance `c1` (reported in c1.bs = c1.ac ({dir}/main.cf:3))
+caused by:
+  Invalid class type for __config__::A (instantiated at {dir}/main.cf:4), should be __config__::B (reported in c1.bs = c1.ac ({dir}/main.cf:3))""",
+    )

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -225,5 +225,33 @@ implement C using std::none
         """,
         """Could not set attribute `bs` on instance `c1` (reported in c1.bs = c1.ac ({dir}/main.cf:3))
 caused by:
-  Invalid class type for __config__::A (instantiated at {dir}/main.cf:4), should be __config__::B (reported in c1.bs = c1.ac ({dir}/main.cf:3))""",
+  Invalid class type for __config__::A (instantiated at {dir}/main.cf:4), should be __config__::B (reported in c1.bs = c1.ac ({dir}/main.cf:3))""",  # noqa: E501
+    )
+
+
+def test_assignment_failed_on_gradual_ctor(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+c1 = C(bs = c1.ac)
+c1.ac = A()
+
+entity A:
+end
+
+entity B extends A:
+end
+
+entity C:
+end
+
+C.ac [0:] -- A
+C.bs [0:] -- B
+
+implement A using std::none
+implement B using std::none
+implement C using std::none
+        """,
+        """Could not set attribute `bs` on instance `__config__::C (instantiated at {dir}/main.cf:2)` (reported in Construct(C) ({dir}/main.cf:2))
+caused by:
+  Invalid class type for __config__::A (instantiated at {dir}/main.cf:3), should be __config__::B (reported in Construct(C) ({dir}/main.cf:2))""",  # noqa: E501
     )

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -223,7 +223,7 @@ implement A using std::none
 implement B using std::none
 implement C using std::none
         """,
-        """Could not set attribute `bs` on instance `c1` (reported in c1.bs = c1.ac ({dir}/main.cf:3))
+        """Could not set attribute `bs` on instance `__config__::C (instantiated at {dir}/main.cf:2)` (reported in c1.bs = c1.ac ({dir}/main.cf:3))
 caused by:
   Invalid class type for __config__::A (instantiated at {dir}/main.cf:4), should be __config__::B (reported in c1.bs = c1.ac ({dir}/main.cf:3))""",  # noqa: E501
     )

--- a/tests/compiler/test_slots.py
+++ b/tests/compiler/test_slots.py
@@ -19,7 +19,7 @@ from inmanta.ast import Location, Range
 from inmanta.ast.attribute import RelationAttribute
 from inmanta.ast.entity import Entity, Namespace
 from inmanta.ast.statements import Literal, Resumer, Statement
-from inmanta.ast.statements.assign import ResultCollectorExceptionWrapper, SetAttribute, SetAttributeHelper
+from inmanta.ast.statements.assign import GradualSetAttributeHelper, SetAttribute, SetAttributeHelper
 from inmanta.ast.statements.call import FunctionUnit
 from inmanta.ast.variables import Reference
 from inmanta.execute.dataflow import (
@@ -83,7 +83,7 @@ def test_slots_rt():
     assert_slotted(FunctionUnit(qs, rs, ResultVariable(), {}, None))
 
     assert_slotted(i)
-    assert_slotted(ResultCollectorExceptionWrapper(sa, ResultVariable()))
+    assert_slotted(GradualSetAttributeHelper(sa, ResultVariable()))
     assert_slotted(SetAttributeHelper(qs, rs, ResultVariable(), {}, Literal("A"), sa, i, "A"))
 
 

--- a/tests/compiler/test_slots.py
+++ b/tests/compiler/test_slots.py
@@ -19,7 +19,9 @@ from inmanta.ast import Location, Range
 from inmanta.ast.attribute import RelationAttribute
 from inmanta.ast.entity import Entity, Namespace
 from inmanta.ast.statements import Literal, Resumer, Statement
+from inmanta.ast.statements.assign import ResultCollectorExceptionWrapper, SetAttribute, SetAttributeHelper
 from inmanta.ast.statements.call import FunctionUnit
+from inmanta.ast.variables import Reference
 from inmanta.execute.dataflow import (
     AssignableNode,
     Assignment,
@@ -61,6 +63,7 @@ def test_slots_rt():
     qs = QueueScheduler(None, [], [], None, set())
     r = RelationAttribute(e, None, "xx", Location("", 1))
     i = Instance(e, rs, qs)
+    sa = SetAttribute(Reference("a"), "a", Literal("a"))
 
     assert_slotted(ResultVariable())
     assert_slotted(AttributeVariable(None, None))
@@ -80,6 +83,8 @@ def test_slots_rt():
     assert_slotted(FunctionUnit(qs, rs, ResultVariable(), {}, None))
 
     assert_slotted(i)
+    assert_slotted(ResultCollectorExceptionWrapper(sa, ResultVariable()))
+    assert_slotted(SetAttributeHelper(qs, rs, ResultVariable(), {}, Literal("A"), sa, i, "A"))
 
 
 def test_slots_ast():

--- a/tests/compiler/test_slots.py
+++ b/tests/compiler/test_slots.py
@@ -83,7 +83,7 @@ def test_slots_rt():
     assert_slotted(FunctionUnit(qs, rs, ResultVariable(), {}, None))
 
     assert_slotted(i)
-    assert_slotted(GradualSetAttributeHelper(sa, ResultVariable()))
+    assert_slotted(GradualSetAttributeHelper(sa, i, "A", ResultVariable()))
     assert_slotted(SetAttributeHelper(qs, rs, ResultVariable(), {}, Literal("A"), sa, i, "A"))
 
 


### PR DESCRIPTION
# Description

Changed wrapping of exceptions for setattribute calls to correctly report type exceptions on gradual executions of set attributes

closes #3000 

- adds slots to setattribute helper  (we seem to have missed that one before)
- wraps exception wrapping in the gradual path similar to the normal path
- prevent double wrapping of AttributeExceptions

I applied the solution in both places where we use SetAttributeHelper, which should cover the issue I think. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

