### PR TITLE
Treat expressions as statements

### DIFF
--- a/changelogs/unreleased/3367-expressions-as-statements.yml
+++ b/changelogs/unreleased/3367-expressions-as-statements.yml
@@ -1,0 +1,6 @@
+description: Expressions are now treated as statements
+change-type: minor
+destination-branches: [master, iso5]
+issue-nr: 3367
+sections:
+    feature: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -491,7 +491,7 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
     def get_inmanta_module_name(cls, python_package_name: str) -> str:
         if not python_package_name.startswith(ModuleV2.PKG_NAME_PREFIX):
             raise ValueError(f"Invalid python package name: should start with {ModuleV2.PKG_NAME_PREFIX}")
-        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX):].replace("-", "_")
+        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX) :].replace("-", "_")
         if not result:
             raise ValueError("Invalid python package name: empty module name part.")
         return result
@@ -2282,7 +2282,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
         files = self._get_model_files(self.model_dir)
 
         for f in files:
-            name = f[len(self.model_dir) + 1: -3]
+            name = f[len(self.model_dir) + 1 : -3]
             parts = name.split("/")
             if parts[-1] == "_init":
                 parts = parts[:-1]
@@ -2668,7 +2668,7 @@ class ModuleV2(Module[ModuleV2Metadata]):
 
     @classmethod
     def get_name_from_metadata(cls, metadata: ModuleV2Metadata) -> str:
-        return metadata.name[len(cls.PKG_NAME_PREFIX):].replace("-", "_")
+        return metadata.name[len(cls.PKG_NAME_PREFIX) :].replace("-", "_")
 
     @classmethod
     def get_metadata_file_schema_type(cls) -> Type[ModuleV2Metadata]:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -491,7 +491,7 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
     def get_inmanta_module_name(cls, python_package_name: str) -> str:
         if not python_package_name.startswith(ModuleV2.PKG_NAME_PREFIX):
             raise ValueError(f"Invalid python package name: should start with {ModuleV2.PKG_NAME_PREFIX}")
-        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX) :].replace("-", "_")
+        result: str = python_package_name[len(ModuleV2.PKG_NAME_PREFIX):].replace("-", "_")
         if not result:
             raise ValueError("Invalid python package name: empty module name part.")
         return result
@@ -2282,7 +2282,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
         files = self._get_model_files(self.model_dir)
 
         for f in files:
-            name = f[len(self.model_dir) + 1 : -3]
+            name = f[len(self.model_dir) + 1: -3]
             parts = name.split("/")
             if parts[-1] == "_init":
                 parts = parts[:-1]
@@ -2668,7 +2668,7 @@ class ModuleV2(Module[ModuleV2Metadata]):
 
     @classmethod
     def get_name_from_metadata(cls, metadata: ModuleV2Metadata) -> str:
-        return metadata.name[len(cls.PKG_NAME_PREFIX) :].replace("-", "_")
+        return metadata.name[len(cls.PKG_NAME_PREFIX):].replace("-", "_")
 
     @classmethod
     def get_metadata_file_schema_type(cls) -> Type[ModuleV2Metadata]:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -116,15 +116,14 @@ def make_none(p: YaccProduction, token: int) -> Literal:
 
 def p_main(p: YaccProduction) -> None:
     "main : head body"
-    if p[1]:
-        p[0] = (p[1], p[2])
-    else:
-        p[0] = p[2]
+    v = p[2]
+    v.insert(0, p[1])
+    p[0] = v
 
 
 def p_main_head(p: YaccProduction) -> None:
     "head :"
-    p[0] = None
+    p[0] = []
 
 
 def p_main_head_doc(p: YaccProduction) -> None:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -67,9 +67,8 @@ precedence = (
     ("left", "CMP_OP"),
     ("nonassoc", "NOT"),
     ("left", "IN"),
-    ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY", "NS_REF", "VAR_REF", "MAP_LOOKUP"),
+    ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
     ("left", "CID", "ID"),
-    ("left", "(", "["),
     ("left", "MLS"),
 )
 
@@ -116,15 +115,21 @@ def make_none(p: YaccProduction, token: int) -> Literal:
 
 
 def p_main(p: YaccProduction) -> None:
-    "main : body"
+    "main : head body"
+    if p[1]:
+        p[0] = (p[1], p[2])
+    else:
+        p[0] = p[2]
+
+
+def p_main_head(p: YaccProduction) -> None:
+    "head :"
+    p[0] = None
+
+
+def p_main_head_doc(p: YaccProduction) -> None:
+    "head : MLS"
     p[0] = p[1]
-
-
-def p_main_comment(p: YaccProduction) -> None:
-    "main : MLS body"
-    v = p[2]
-    v.insert(0, p[1])
-    p[0] = v
 
 
 def p_body_collect(p: YaccProduction) -> None:
@@ -619,11 +624,11 @@ def p_expression(p: YaccProduction) -> None:
     """expression : boolean_expression
     | constant
     | function_call
-    | var_ref %prec VAR_REF
+    | var_ref
     | constructor
     | list_def
     | map_def
-    | map_lookup %prec MAP_LOOKUP
+    | map_lookup
     | index_lookup
     | conditional_expression"""
     p[0] = p[1]
@@ -998,7 +1003,7 @@ def p_operand_list_term_2(p: YaccProduction) -> None:
 
 
 def p_var_ref(p: YaccProduction) -> None:
-    "var_ref : attr_ref %prec VAR_REF"
+    "var_ref : attr_ref"
     p[0] = p[1]
 
 
@@ -1015,7 +1020,7 @@ def p_attr_ref(p: YaccProduction) -> None:
 
 
 def p_var_ref_2(p: YaccProduction) -> None:
-    "var_ref : ns_ref %prec NS_REF"
+    "var_ref : ns_ref"
     p[0] = Reference(p[1])
     attach_from_string(p, 1)
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -122,17 +122,16 @@ def p_main(p: YaccProduction) -> None:
 
 def p_main_comment(p: YaccProduction) -> None:
     "main : MLS body"
-    p[0] = (p[1], p[2])
+    v = p[2]
+    v.insert(0, p[1])
+    p[0] = v
 
 
 def p_body_collect(p: YaccProduction) -> None:
     "body : top_stmt body"
-    if(p[2]):
-        v = p[2]
-        v.insert(0, p[1])
-        p[0] = v
-    else:
-        p[0] = p[1]
+    v = p[2]
+    v.insert(0, p[1])
+    p[0] = v
 
 
 def p_body_term(p: YaccProduction) -> None:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -1015,12 +1015,6 @@ def p_attr_ref(p: YaccProduction) -> None:
     attach_lnr(p, 2)
 
 
-# def p_local_var(p: YaccProduction) -> None:
-#     "local_var : ns_ref"
-#     p[0] = Reference(p[1])
-#     attach_from_string(p, 1)
-
-
 def p_var_ref_2(p: YaccProduction) -> None:
     "var_ref : ns_ref %prec NS_REF"
     p[0] = Reference(p[1])

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -67,8 +67,9 @@ precedence = (
     ("left", "CMP_OP"),
     ("nonassoc", "NOT"),
     ("left", "IN"),
-    ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
+    ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY", "NS_REF", "VAR_REF", "MAP_LOOKUP"),
     ("left", "CID", "ID"),
+    ("left", "(", "["),
     ("left", "MLS"),
 )
 
@@ -601,11 +602,11 @@ def p_expression(p: YaccProduction) -> None:
     """expression : boolean_expression
     | constant
     | function_call
-    | var_ref
+    | var_ref %prec VAR_REF
     | constructor
     | list_def
     | map_def
-    | map_lookup
+    | map_lookup %prec MAP_LOOKUP
     | index_lookup
     | conditional_expression"""
     p[0] = p[1]
@@ -980,7 +981,7 @@ def p_operand_list_term_2(p: YaccProduction) -> None:
 
 
 def p_var_ref(p: YaccProduction) -> None:
-    "var_ref : attr_ref"
+    "var_ref : attr_ref %prec VAR_REF"
     p[0] = p[1]
 
 
@@ -997,7 +998,7 @@ def p_attr_ref(p: YaccProduction) -> None:
 
 
 def p_var_ref_2(p: YaccProduction) -> None:
-    "var_ref : ns_ref"
+    "var_ref : ns_ref %prec NS_REF"
     p[0] = Reference(p[1])
     attach_from_string(p, 1)
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -115,15 +115,28 @@ def make_none(p: YaccProduction, token: int) -> Literal:
     return none
 
 
-def p_main_collect(p: YaccProduction) -> None:
-    "main : top_stmt main"
-    v = p[2]
-    v.insert(0, p[1])
-    p[0] = v
+def p_main(p: YaccProduction) -> None:
+    "main : body"
+    p[0] = p[1]
 
 
-def p_main_term(p: YaccProduction) -> None:
-    "main : empty"
+def p_main_comment(p: YaccProduction) -> None:
+    "main : MLS body"
+    p[0] = (p[1], p[2])
+
+
+def p_body_collect(p: YaccProduction) -> None:
+    "body : top_stmt body"
+    if(p[2]):
+        v = p[2]
+        v.insert(0, p[1])
+        p[0] = v
+    else:
+        p[0] = p[1]
+
+
+def p_body_term(p: YaccProduction) -> None:
+    "body : empty"
     p[0] = []
 
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -69,7 +69,7 @@ precedence = (
     ("left", "IN"),
     ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
     ("left", "CID", "ID"),
-    ("right", "MLS"),
+    ("left", "MLS"),
 )
 
 
@@ -127,8 +127,7 @@ def p_main_term(p: YaccProduction) -> None:
 
 
 def p_top_stmt(p: YaccProduction) -> None:
-    """top_stmt : MLS
-    | entity_def
+    """top_stmt : entity_def
     | implement_def
     | implementation_def
     | relation
@@ -168,10 +167,9 @@ def p_import_1(p: YaccProduction) -> None:
 
 def p_stmt(p: YaccProduction) -> None:
     """statement : assign
-    | constructor
-    | function_call
     | for
-    | if"""
+    | if
+    | expression"""
     p[0] = p[1]
 
 
@@ -654,8 +652,7 @@ def p_operand(p: YaccProduction) -> None:
 
 
 def p_map_lookup(p: YaccProduction) -> None:
-    """map_lookup : attr_ref '[' operand ']'
-    | local_var '[' operand ']'
+    """map_lookup : var_ref '[' operand ']'
     | map_lookup '[' operand ']'"""
     p[0] = MapLookup(p[1], p[3])
 
@@ -993,10 +990,10 @@ def p_attr_ref(p: YaccProduction) -> None:
     attach_lnr(p, 2)
 
 
-def p_local_var(p: YaccProduction) -> None:
-    "local_var : ns_ref"
-    p[0] = Reference(p[1])
-    attach_from_string(p, 1)
+# def p_local_var(p: YaccProduction) -> None:
+#     "local_var : ns_ref"
+#     p[0] = Reference(p[1])
+#     attach_from_string(p, 1)
 
 
 def p_var_ref_2(p: YaccProduction) -> None:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -675,7 +675,8 @@ def p_operand(p: YaccProduction) -> None:
 
 
 def p_map_lookup(p: YaccProduction) -> None:
-    """map_lookup : var_ref '[' operand ']'
+    """map_lookup : attr_ref '[' operand ']'
+    | var_ref '[' operand ']'
     | map_lookup '[' operand ']'"""
     p[0] = MapLookup(p[1], p[3])
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -117,7 +117,7 @@ def make_none(p: YaccProduction, token: int) -> Literal:
 def p_main(p: YaccProduction) -> None:
     "main : head body"
     v = p[2]
-    if(p[1]):
+    if p[1]:
         v.insert(0, p[1])
     p[0] = v
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -67,8 +67,9 @@ precedence = (
     ("left", "CMP_OP"),
     ("nonassoc", "NOT"),
     ("left", "IN"),
-    ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY"),
+    ("left", "RELATION_DEF", "TYPEDEF_INNER", "OPERAND_LIST", "EMPTY", "NS_REF", "VAR_REF", "MAP_LOOKUP"),
     ("left", "CID", "ID"),
+    ("left", "(", "["),
     ("left", "MLS"),
 )
 
@@ -123,7 +124,7 @@ def p_main(p: YaccProduction) -> None:
 
 
 def p_main_head(p: YaccProduction) -> None:
-    "head :"
+    "head : %prec EMPTY"
     p[0] = None
 
 
@@ -624,11 +625,11 @@ def p_expression(p: YaccProduction) -> None:
     """expression : boolean_expression
     | constant
     | function_call
-    | var_ref
+    | var_ref %prec VAR_REF
     | constructor
     | list_def
     | map_def
-    | map_lookup
+    | map_lookup %prec MAP_LOOKUP
     | index_lookup
     | conditional_expression"""
     p[0] = p[1]
@@ -1004,7 +1005,7 @@ def p_operand_list_term_2(p: YaccProduction) -> None:
 
 
 def p_var_ref(p: YaccProduction) -> None:
-    "var_ref : attr_ref"
+    "var_ref : attr_ref %prec VAR_REF"
     p[0] = p[1]
 
 
@@ -1021,7 +1022,7 @@ def p_attr_ref(p: YaccProduction) -> None:
 
 
 def p_var_ref_2(p: YaccProduction) -> None:
-    "var_ref : ns_ref"
+    "var_ref : ns_ref %prec NS_REF"
     p[0] = Reference(p[1])
     attach_from_string(p, 1)
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -117,13 +117,14 @@ def make_none(p: YaccProduction, token: int) -> Literal:
 def p_main(p: YaccProduction) -> None:
     "main : head body"
     v = p[2]
-    v.insert(0, p[1])
+    if(p[1]):
+        v.insert(0, p[1])
     p[0] = v
 
 
 def p_main_head(p: YaccProduction) -> None:
     "head :"
-    p[0] = []
+    p[0] = None
 
 
 def p_main_head_doc(p: YaccProduction) -> None:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -435,13 +435,18 @@ def p_implementation_def(p: YaccProduction) -> None:
 
 
 def p_implementation(p: YaccProduction) -> None:
-    "implementation : ':' MLS block"
-    p[0] = (p[2], p[3])
+    "implementation : implementation_head block"
+    p[0] = (p[1], p[2])
 
 
-def p_implementation_1(p: YaccProduction) -> None:
-    "implementation : ':' block"
-    p[0] = (None, p[2])
+def p_implementation_head(p: YaccProduction) -> None:
+    "implementation_head : ':'"
+    p[0] = None
+
+
+def p_implementation_head_doc(p: YaccProduction) -> None:
+    "implementation_head : ':' MLS"
+    p[0] = p[2]
 
 
 def p_block(p: YaccProduction) -> None:

--- a/tests/compiler/test_compile_export.py
+++ b/tests/compiler/test_compile_export.py
@@ -102,7 +102,7 @@ x = 1
             "1 = 1",
             ParserException,
             ast_export.ErrorCategory.parser,
-            "Syntax error at token 1",
+            "Syntax error at token =",
             "inmanta.parser.ParserException",
         ),
         (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1263,8 +1263,6 @@ mls
     )
     assert len(statements) == 1
     mls = statements[0]
-    import pudb
-    pu.db
     assert isinstance(mls, LocatableString)
 
     assert mls.lnr == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1355,17 +1355,6 @@ a=|
         )
 
 
-def test_error_on_relation():
-    with pytest.raises(ParserException) as e:
-        parse_code(
-            """
-Host.provider [1] -- Provider test"""
-        )
-    assert e.value.location.file == "test"
-    assert e.value.location.lnr == 3
-    assert e.value.location.start_char == 2
-
-
 def test_doc_string_on_new_relation():
     statements = parse_code(
         """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1874,17 +1874,6 @@ def test_1766_empty_model_multiple_newline():
     assert len(statements) == 0
 
 
-def test_1707_out_of_place_regex():
-    with pytest.raises(ParserException) as pytest_e:
-        parse_code(
-            """
-/some_out_of_place_regex/
-            """,
-        )
-    exc: ParserException = pytest_e.value
-    assert exc.msg == "Syntax error at token /some_out_of_place_regex/"
-
-
 def test_multiline_string_interpolation():
     statements = parse_code(
         """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1263,6 +1263,8 @@ mls
     )
     assert len(statements) == 1
     mls = statements[0]
+    import pudb
+    pu.db
     assert isinstance(mls, LocatableString)
 
     assert mls.lnr == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2161,9 +2161,10 @@ File(host = 5, path = "Jos")
 { "a":"b", "b":1}
 File[host = 5, path = "Jos"]
 y > 0 ? y : y < 0 ? -1 : 0
+/some_out_of_place_regex/
     """
     )
-    assert len(statements) == 8
+    assert len(statements) == 9
     boolean_expression = statements[0]
     constant = statements[1]
     function_call = statements[2]
@@ -2172,6 +2173,7 @@ y > 0 ? y : y < 0 ? -1 : 0
     map_def = statements[5]
     index_lookup = statements[6]
     conditional_expression = statements[7]
+    regex = statements[8]
     assert isinstance(boolean_expression, Equals)
     assert isinstance(constant, Literal)
     assert isinstance(function_call, FunctionCall)
@@ -2180,3 +2182,4 @@ y > 0 ? y : y < 0 ? -1 : 0
     assert isinstance(map_def, CreateDict)
     assert isinstance(index_lookup, IndexLookup)
     assert isinstance(conditional_expression, ConditionalExpression)
+    assert isinstance(regex, Regex)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1316,7 +1316,7 @@ some variations\"""
     mls2 = statements[2]
 
     assert isinstance(mls1, LocatableString)
-    assert isinstance(mls2, LocatableString)
+    assert isinstance(mls2, Literal)
 
     assert mls1.lnr == 2
     assert mls1.elnr == 4
@@ -1329,16 +1329,11 @@ str1
 """
     )
 
-    assert mls2.lnr == 8
-    assert mls2.elnr == 10
-    assert mls2.start == 1
-    assert mls2.end == 19
-    assert (
-        str(mls2)
-        == """
-str1 with
-some variations"""
-    )
+    assert mls2.location.lnr == 8
+    assert mls2.location.end_lnr == 10
+    assert mls2.location.start_char == 1
+    assert mls2.location.end_char == 19
+    assert mls2.value == "\nstr1 with\nsome variations"
 
 
 def test_bad():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1263,7 +1263,8 @@ mls
     )
     assert len(statements) == 1
     mls = statements[0]
-
+    import pudb
+    pu.db
     assert isinstance(mls, LocatableString)
 
     assert mls.lnr == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1263,6 +1263,7 @@ mls
     )
     assert len(statements) == 1
     mls = statements[0]
+
     assert isinstance(mls, LocatableString)
 
     assert mls.lnr == 2
@@ -2149,7 +2150,7 @@ x.n
     assert instance1.locatable_name.location == Range("test", 5, 1, 5, 2)
 
 
-def test_espression_as_statements():
+def test_expression_as_statements():
     statements = parse_code(
         """
 1 == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2175,3 +2175,35 @@ x.n
     assert instance1.name == "x"
     assert str(instance1.locatable_name) == "x"
     assert instance1.locatable_name.location == Range("test", 5, 1, 5, 2)
+
+
+def test_espression_as_statements():
+    statements = parse_code(
+        """
+1 == 2
+"hello"
+file(b)
+File(host = 5, path = "Jos")
+[1,2]
+{ "a":"b", "b":1}
+File[host = 5, path = "Jos"]
+y > 0 ? y : y < 0 ? -1 : 0
+    """
+    )
+    assert len(statements) == 8
+    boolean_expression = statements[0]
+    constant = statements[1]
+    function_call = statements[2]
+    constructor = statements[3]
+    list_def = statements[4]
+    map_def = statements[5]
+    index_lookup = statements[6]
+    conditional_expression = statements[7]
+    assert isinstance(boolean_expression, Equals)
+    assert isinstance(constant, Literal)
+    assert isinstance(function_call, FunctionCall)
+    assert isinstance(constructor, Constructor)
+    assert isinstance(list_def, CreateList)
+    assert isinstance(map_def, CreateDict)
+    assert isinstance(index_lookup, IndexLookup)
+    assert isinstance(conditional_expression, ConditionalExpression)


### PR DESCRIPTION
# Description

This commit makes it so that all expressions are now treated as statements.
Some changes where made to MLS as well as it can now occur as a "statement string" or a multi-line comment,
where previously a standalone MLS was always a comment. To be a string it needed to be part of  an assignment.
If the MLS is at the top of a file it will be considered as a comment, otherwise as a Literal.

closes #3367

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
