### PR TITLE
Handle unknown and skipped for unknown resources in dryrun diff

### DIFF
--- a/changelogs/unreleased/3919-diff-unknowns.yml
+++ b/changelogs/unreleased/3919-diff-unknowns.yml
@@ -1,0 +1,4 @@
+description: Handle unknown and skipped for unknown resources in dryrun diff
+issue-nr: 3919
+change-type: minor
+destination-branches: [master, iso5]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -472,6 +472,8 @@ class ResourceDiffStatus(str, Enum):
     deleted = "deleted"
     unmodified = "unmodified"
     agent_down = "agent_down"
+    undefined = "undefined"
+    skipped_for_undefined = "skipped_for_undefined"
 
 
 class AttributeDiff(BaseModel):


### PR DESCRIPTION
# Description

closes #3919 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
