### PR TITLE
Improve error message regarding index attribute missing in constructor

### DIFF
--- a/changelogs/unreleased/3902-index-attr-missing-in-constructor.yml
+++ b/changelogs/unreleased/3902-index-attr-missing-in-constructor.yml
@@ -1,0 +1,7 @@
+---
+description: Improve the compiler error message when an index attribute is missing in the constructor
+issue-nr: 3902
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/3902-index-attr-missing-in-constructor.yml
+++ b/changelogs/unreleased/3902-index-attr-missing-in-constructor.yml
@@ -1,5 +1,5 @@
 ---
-description: Improve the compiler error message when an index attribute is missing in the constructor
+description: Improve the compiler error message that is given when an index attribute is missing in the constructor call.
 issue-nr: 3902
 change-type: patch
 destination-branches: [master, iso5, iso4]

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -261,7 +261,7 @@ class Entity(EntityLike, NamedType):
         else:
             raise DuplicateException(self._attributes[attribute.name], attribute, "attribute already exists")
 
-    def get_attribute(self, name: str) -> "Attribute":
+    def get_attribute(self, name: str) -> Optional["Attribute"]:
         """
         Get the attribute with the given name
         """

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -696,6 +696,7 @@ class DefineIndex(DefinitionStatement):
                 )
             else:
                 rattribute = entity_type.get_attribute(attribute)
+                assert rattribute is not None  # Make mypy happy
                 if rattribute.is_optional():
                     raise IndexException(
                         self,

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -399,7 +399,7 @@ class IndexAttributeMissingInConstructorException(TypingException):
             attribute_kind = "relation" if isinstance(attribute, RelationAttribute) else "attribute"
             exc_message += (
                 f"\n\t* Missing {attribute_kind} '{attribute.name}'. "
-                f"The relation {entity.get_full_name()}.{attribute.name} is part of an index."
+                f"The {attribute_kind} {entity.get_full_name()}.{attribute.name} is part of an index."
             )
         return exc_message
 

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -532,7 +532,7 @@ class Constructor(ExpressionStatement):
 
         missing_attrs: List[str] = [attr for attr in self.required_kwargs if attr not in kwarg_attrs]
         if missing_attrs:
-            raise IndexAttributeMissingInConstructorException(self, self.type.get_entity(), missing_attrs)
+            raise IndexAttributeMissingInConstructorException(self, type_class, missing_attrs)
 
         # Schedule all direct attributes for direct execution. The kwarg keys and the direct_attributes keys are disjoint
         # because a RuntimeException is raised above when they are not.

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -35,6 +35,7 @@ from inmanta.ast import (
     TypeReferenceAnchor,
     TypingException,
 )
+from inmanta.ast.attribute import Attribute, RelationAttribute
 from inmanta.ast.blocks import BasicBlock
 from inmanta.ast.statements import DynamicStatement, ExpressionStatement, RawResumer
 from inmanta.ast.statements.assign import GradualSetAttributeHelper, SetAttributeHelper
@@ -378,6 +379,28 @@ class ConditionalExpressionResumer(RawResumer):
             self.result.set_value(value, self.location)
 
 
+class IndexAttributeMissingInConstructorException(TypingException):
+    """
+    Raised when an index attribute was not set in the constructor call for an entity.
+    """
+
+    def __init__(self, stmt: "Optional[Locatable]", entity: "Entity", unset_attributes: List[str]):
+        if not unset_attributes:
+            raise Exception("Argument `unset_attributes` should contain at least one element")
+        error_message = self._get_error_message(entity, unset_attributes)
+        super(IndexAttributeMissingInConstructorException, self).__init__(stmt, error_message)
+
+    def _get_error_message(self, entity: "Entity", unset_attributes: List[str]) -> str:
+        exc_message = "Invalid Constructor call:"
+        for attribute_name in unset_attributes:
+            attribute: Optional[Attribute] = entity.get_attribute(attribute_name)
+            assert attribute is not None  # Make mypy happy
+            attribute_kind = "relation" if isinstance(attribute, RelationAttribute) else "attribute"
+            exc_message += f"\n\t* Missing {attribute_kind} '{attribute.name}'. " \
+                           f"The relation {entity.get_full_name()}.{attribute.name} is part of an index."
+        return exc_message
+
+
 class Constructor(ExpressionStatement):
     """
     This class represents the usage of a constructor to create a new object.
@@ -444,10 +467,7 @@ class Constructor(ExpressionStatement):
                     continue
                 inindex.add(attr)
         if self.required_kwargs and not self.wrapped_kwargs:
-            raise TypingException(
-                self,
-                "attributes %s are part of an index and should be set in the constructor." % ",".join(self.required_kwargs),
-            )
+            raise IndexAttributeMissingInConstructorException(self, self.type.get_entity(), self.required_kwargs)
 
         for (k, v) in all_attributes.items():
             attribute = self.type.get_entity().get_attribute(k)
@@ -509,9 +529,7 @@ class Constructor(ExpressionStatement):
 
         missing_attrs: List[str] = [attr for attr in self.required_kwargs if attr not in kwarg_attrs]
         if missing_attrs:
-            raise TypingException(
-                self, "attributes %s are part of an index and should be set in the constructor." % ",".join(missing_attrs)
-            )
+            raise IndexAttributeMissingInConstructorException(self, self.type.get_entity(), missing_attrs)
 
         # Schedule all direct attributes for direct execution. The kwarg keys and the direct_attributes keys are disjoint
         # because a RuntimeException is raised above when they are not.

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -27,6 +27,7 @@ import inmanta.execute.dataflow as dataflow
 from inmanta.ast import (
     AttributeReferenceAnchor,
     DuplicateException,
+    Locatable,
     LocatableString,
     Location,
     Namespace,
@@ -384,7 +385,7 @@ class IndexAttributeMissingInConstructorException(TypingException):
     Raised when an index attribute was not set in the constructor call for an entity.
     """
 
-    def __init__(self, stmt: "Optional[Locatable]", entity: "Entity", unset_attributes: List[str]):
+    def __init__(self, stmt: Optional[Locatable], entity: "Entity", unset_attributes: List[str]):
         if not unset_attributes:
             raise Exception("Argument `unset_attributes` should contain at least one element")
         error_message = self._get_error_message(entity, unset_attributes)
@@ -396,8 +397,10 @@ class IndexAttributeMissingInConstructorException(TypingException):
             attribute: Optional[Attribute] = entity.get_attribute(attribute_name)
             assert attribute is not None  # Make mypy happy
             attribute_kind = "relation" if isinstance(attribute, RelationAttribute) else "attribute"
-            exc_message += f"\n\t* Missing {attribute_kind} '{attribute.name}'. " \
-                           f"The relation {entity.get_full_name()}.{attribute.name} is part of an index."
+            exc_message += (
+                f"\n\t* Missing {attribute_kind} '{attribute.name}'. "
+                f"The relation {entity.get_full_name()}.{attribute.name} is part of an index."
+            )
         return exc_message
 
 

--- a/src/inmanta/execute/dataflow/__init__.py
+++ b/src/inmanta/execute/dataflow/__init__.py
@@ -973,7 +973,7 @@ class InstanceNode(Node):
             return self.get_self().assign_other_direction(attribute, node_ref, responsible, context)
         if self.entity is None:
             return
-        ast_attribute: "Attribute" = self.entity.get_attribute(attribute)
+        ast_attribute: Optional["Attribute"] = self.entity.get_attribute(attribute)
         if ast_attribute is None:
             return
         if ast_attribute.end is not None:

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -945,7 +945,9 @@ class Instance(ExecutionContext):
                 # prune duplicates because get_new_result_variable() has side effects
                 # don't use set for pruning because side effects drive control flow and set iteration is nondeterministic
                 continue
-            self.slots[attr_name] = mytype.get_attribute(attr_name).get_new_result_variable(self, queue)
+            attribute = mytype.get_attribute(attr_name)
+            assert attribute is not None  # Make mypy happy
+            self.slots[attr_name] = attribute.get_new_result_variable(self, queue)
         # TODO: this is somewhat ugly. Is there a cleaner way to enforce this constraint
         assert (resolver.dataflow_graph is None) == (node is None)
         self.dataflow_graph: Optional[DataflowGraph] = None
@@ -1012,6 +1014,7 @@ class Instance(ExecutionContext):
                     v.freeze()
                 else:
                     attr = self.type.get_attribute(k)
+                    assert attr is not None  # Make mypy happy
                     if attr.is_multi():
                         low = attr.low
                         # none for list attributes

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -549,5 +549,5 @@ Test_A()
         """,
         re.escape(
             "Invalid Constructor call:\n\t* Missing attribute 'name'. The relation __config__::Test_A.name is part of an index."
-        )
+        ),
     )

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -534,10 +534,14 @@ index TestA(name)
     )
 
 
-def test_index_attribute_missing_in_constructor_call(snippetcompiler) -> None:
-    snippetcompiler.setup_for_error_re(
-        """
+@pytest.mark.parametrize("use_wrapped_kwargs", [True, False])
+def test_index_attribute_missing_in_constructor_call(snippetcompiler, use_wrapped_kwargs: bool) -> None:
+    """
+    Assert correct error message when index attribute is not set in the constructor call.
+    """
+    model = f"""
 entity Test_A:
+    number id
     string name
 end
 
@@ -545,8 +549,11 @@ index Test_A(name)
 
 implement Test_A using std::none
 
-Test_A()
-        """,
+Test_A({'id=1' if not use_wrapped_kwargs else '**{"id": 1}'})
+    """
+
+    snippetcompiler.setup_for_error_re(
+        model,
         re.escape(
             "Invalid Constructor call:\n\t* Missing attribute 'name'. The relation __config__::Test_A.name is part of an index."
         ),

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -555,6 +555,7 @@ Test_A({'id=1' if not use_wrapped_kwargs else '**{"id": 1}'})
     snippetcompiler.setup_for_error_re(
         model,
         re.escape(
-            "Invalid Constructor call:\n\t* Missing attribute 'name'. The relation __config__::Test_A.name is part of an index."
+            "Invalid Constructor call:\n\t* Missing attribute 'name'. "
+            "The attribute __config__::Test_A.name is part of an index."
         ),
     )

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -532,3 +532,22 @@ index TestA(name)
         """,
         "could not find type TestA in namespace __config__ ({dir}/main.cf:6:7)",
     )
+
+
+def test_index_attribute_missing_in_constructor_call(snippetcompiler) -> None:
+    snippetcompiler.setup_for_error_re(
+        """
+entity Test_A:
+    string name
+end
+
+index Test_A(name)
+
+implement Test_A using std::none
+
+Test_A()
+        """,
+        re.escape(
+            "Invalid Constructor call:\n\t* Missing attribute 'name'. The relation __config__::Test_A.name is part of an index."
+        )
+    )


### PR DESCRIPTION
# Description

* Improve the compiler error message that is given when an index attribute is missing in the constructor call.
* Fix the typing of the `Entity.get_attribute()` method.

closes #3902 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
