### PR TITLE
Fix bug that makes every inmanta warning end with an empty line

### DIFF
--- a/changelogs/unreleased/3951-remove-newline-in-warnings.yml
+++ b/changelogs/unreleased/3951-remove-newline-in-warnings.yml
@@ -1,0 +1,7 @@
+---
+description: Fix bug that makes every inmanta warning end with an empty line.
+issue-nr: 3951
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/warnings.py
+++ b/src/inmanta/warnings.py
@@ -160,7 +160,8 @@ class WarningsManager:
             logger = logging.getLogger("py.warnings")
         if file is not None:
             try:
-                file.write(text)
+                # This code path is currently not used in our code base
+                file.write(f"{text}\n")
             except OSError:
                 pass
         else:

--- a/src/inmanta/warnings.py
+++ b/src/inmanta/warnings.py
@@ -146,7 +146,7 @@ class WarningsManager:
         text: str
         logger: logging.Logger
         if issubclass(category, InmantaWarning):
-            text = "%s: %s\n" % (category.__name__, message)
+            text = "%s: %s" % (category.__name__, message)
             logger = logging.getLogger("inmanta.warnings")
         else:
             text = warnings.formatwarning(

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -69,7 +69,7 @@ def test_warning_format(caplog, warning: Union[str, Warning], category: Type[War
     warnings.filterwarnings("default", category=Warning)
     warnings.warn_explicit(warning, category, filename, lineno)
     if isinstance(warning, InmantaWarning):
-        assert caplog.record_tuples == [("inmanta.warnings", logging.WARNING, "%s: %s\n" % (category.__name__, warning))]
+        assert caplog.record_tuples == [("inmanta.warnings", logging.WARNING, "%s: %s" % (category.__name__, warning))]
     else:
         assert caplog.record_tuples == [
             (


### PR DESCRIPTION
# Description

Fix bug that makes every inmanta warning end with an empty line.

closes #3951 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
