### PR TITLE
Fix parsing issue with MLS with embedded strings

### DIFF
--- a/changelogs/unreleased/fix-mls-regex-lexer.yml
+++ b/changelogs/unreleased/fix-mls-regex-lexer.yml
@@ -1,0 +1,3 @@
+description: Fix the regex used to identify a MLS
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -131,7 +131,7 @@ def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
 
 
 def t_MLS(t: lex.LexToken) -> lex.LexToken:
-    r'"{3}([\s\S]*?)"{3}'
+    r'"{3}(((\"([^"]+)*\")|[\s\S])*?)"{3}'
     value = t.value[3:-3]
     lexer = t.lexer
     match = lexer.lexmatch[0]

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -131,7 +131,7 @@ def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
 
 
 def t_MLS(t: lex.LexToken) -> lex.LexToken:
-    r'"{3}(((\"([^"]+)*\")|[\s\S])*?)"{3}'
+    r'"{3,5}([\s\S]*?)"{3,5}'
     value = t.value[3:-3]
     lexer = t.lexer
     match = lexer.lexmatch[0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1337,6 +1337,66 @@ str1
     assert mls2.value == "\nstr1 with\nsome variations"
 
 
+def test_mls_as_argument():
+    statements = parse_code(
+        """
+std::print(\"""hello\""")
+
+"""
+    )
+    assert len(statements) == 1
+    function_call = statements[0]
+
+    assert isinstance(function_call, FunctionCall)
+    arg = function_call.arguments[0]
+    assert arg.value == "hello"
+
+
+def test_mls_as_argument_2():
+    statements = parse_code(
+        """
+std::print(\"""hello"world"\""")
+
+"""
+    )
+    assert len(statements) == 1
+    function_call = statements[0]
+
+    assert isinstance(function_call, FunctionCall)
+    arg = function_call.arguments[0]
+    assert arg.value == 'hello"world"'
+
+
+def test_mls_as_argument_3():
+    statements = parse_code(
+        """
+std::print("\"""hello"world\""")
+
+"""
+    )
+    assert len(statements) == 1
+    function_call = statements[0]
+
+    assert isinstance(function_call, FunctionCall)
+    arg = function_call.arguments[0]
+    assert arg.value == '"hello"world'
+
+
+def test_mls_as_argument_4():
+    statements = parse_code(
+        """
+std::print("\""aaaa"helloworld"aaaa\""")
+
+"""
+    )
+    assert len(statements) == 1
+    function_call = statements[0]
+
+    assert isinstance(function_call, FunctionCall)
+    arg = function_call.arguments[0]
+    assert arg.value == 'aaaa"helloworld"aaaa'
+
+
 def test_bad():
     with pytest.raises(ParserException):
         parse_code(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1337,6 +1337,57 @@ str1
     assert mls2.value == "\nstr1 with\nsome variations"
 
 
+def test_mls_5():
+    statements = parse_code(
+        """
+\"""This is a mls on one "line"\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+    assert mls.lnr == 2
+    assert mls.elnr == 2
+    assert mls.start == 1
+    assert mls.end == 34
+    assert str(mls.value) == 'This is a mls on one "line"'
+
+
+def test_mls_6():
+    statements = parse_code(
+        """
+\"\"""This" is a mls on one line\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+    assert mls.lnr == 2
+    assert mls.elnr == 2
+    assert mls.start == 1
+    assert mls.end == 34
+    assert str(mls.value) == '"This" is a mls on one line'
+
+
+def test_mls_7():
+    statements = parse_code(
+        """
+\"\"""This" is a "mls" on one "line"\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+    assert mls.lnr == 2
+    assert mls.elnr == 2
+    assert mls.start == 1
+    assert mls.end == 38
+    assert str(mls.value) == '"This" is a "mls" on one "line"'
+
+
 def test_mls_as_argument():
     statements = parse_code(
         """
@@ -1355,7 +1406,7 @@ std::print(\"""hello\""")
 def test_mls_as_argument_2():
     statements = parse_code(
         """
-std::print(\"""hello"world"\""")
+std::print("\""hello"hello"\""")
 
 """
     )
@@ -1364,37 +1415,7 @@ std::print(\"""hello"world"\""")
 
     assert isinstance(function_call, FunctionCall)
     arg = function_call.arguments[0]
-    assert arg.value == 'hello"world"'
-
-
-def test_mls_as_argument_3():
-    statements = parse_code(
-        """
-std::print("\"""hello"world\""")
-
-"""
-    )
-    assert len(statements) == 1
-    function_call = statements[0]
-
-    assert isinstance(function_call, FunctionCall)
-    arg = function_call.arguments[0]
-    assert arg.value == '"hello"world'
-
-
-def test_mls_as_argument_4():
-    statements = parse_code(
-        """
-std::print("\""aaaa"helloworld"aaaa\""")
-
-"""
-    )
-    assert len(statements) == 1
-    function_call = statements[0]
-
-    assert isinstance(function_call, FunctionCall)
-    arg = function_call.arguments[0]
-    assert arg.value == 'aaaa"helloworld"aaaa'
+    assert arg.value == 'hello"hello"'
 
 
 def test_bad():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1403,6 +1403,57 @@ def test_mls_7():
     assert str(mls.value) == '"This" is a "mls" on one "line"'
 
 
+def test_mls_8():
+    statements = parse_code(
+        """
+\"""String: ""\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+    assert mls.lnr == 2
+    assert mls.elnr == 2
+    assert mls.start == 1
+    assert mls.end == 17
+    assert str(mls.value) == 'String: ""'
+
+
+def test_mls_9():
+    statements = parse_code(
+        """
+\"""\"" is a string\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+    assert mls.lnr == 2
+    assert mls.elnr == 2
+    assert mls.start == 1
+    assert mls.end == 21
+    assert str(mls.value) == '"" is a string'
+
+
+def test_mls_10():
+    statements = parse_code(
+        """
+\"""\" start and end with "\"""
+"""
+    )
+    assert len(statements) == 1
+    mls = statements[0]
+
+    assert isinstance(mls, LocatableString)
+    assert mls.lnr == 2
+    assert mls.elnr == 2
+    assert mls.start == 1
+    assert mls.end == 29
+    assert str(mls.value) == '" start and end with "'
+
+
 def test_mls_as_argument():
     statements = parse_code(
         """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1309,12 +1309,21 @@ a = "One big token"
 
 \"""
 str1 with
-some variations\"""
+"some" variations\"""
+
+b = "another big token"
+
+\"""
+str1 with
+some other variations
+\"""
+
 """
     )
-    assert len(statements) == 3
+    assert len(statements) == 5
     mls1 = statements[0]
     mls2 = statements[2]
+    mls3 = statements[4]
 
     assert isinstance(mls1, LocatableString)
     assert isinstance(mls2, Literal)
@@ -1333,8 +1342,14 @@ str1
     assert mls2.location.lnr == 8
     assert mls2.location.end_lnr == 10
     assert mls2.location.start_char == 1
-    assert mls2.location.end_char == 19
-    assert mls2.value == "\nstr1 with\nsome variations"
+    assert mls2.location.end_char == 21
+    assert mls2.value == '\nstr1 with\n"some" variations'
+
+    assert mls3.location.lnr == 14
+    assert mls3.location.end_lnr == 17
+    assert mls3.location.start_char == 1
+    assert mls3.location.end_char == 4
+    assert mls3.value == "\nstr1 with\nsome other variations\n"
 
 
 def test_mls_5():


### PR DESCRIPTION
Currently the parser fails to parse MLSes correctly if there is a string enclosed at the end of it.
(when we have 4 consecutive `"` like in `exec::in_shell("""grep "test"""")`
This commit fixes the regex to accept strings (opened and closed with `"`) in a MLS

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
