### PR TITLE
Fix order of stages in compile report details

### DIFF
--- a/changelogs/unreleased/compile-report-stage-order.yml
+++ b/changelogs/unreleased/compile-report-stage-order.yml
@@ -3,3 +3,5 @@ issue-nr: 3082
 issue-repo: web-console
 change-type: patch
 destination-branches: [master, iso5, iso4]
+sections:
+    bugfix: "{{description}}"

--- a/changelogs/unreleased/compile-report-stage-order.yml
+++ b/changelogs/unreleased/compile-report-stage-order.yml
@@ -1,0 +1,5 @@
+description: Fix order of stages in compile report details
+issue-nr: 3082
+issue-repo: web-console
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3322,7 +3322,7 @@ class Compile(BaseDocument):
                     {cls.table_name()} comp
                     INNER JOIN compiledetails cd ON cd.substitute_compile_id = comp.id
                     LEFT JOIN public.report rep on comp.id = rep.compile
-        ) SELECT * FROM compiledetails;
+        ) SELECT * FROM compiledetails ORDER BY report_started ASC;
         """
         values = [cls._get_value(environment), cls._get_value(id)]
         result = await cls.select_query(query, values, no_obj=True)

--- a/tests/server/test_compile_details.py
+++ b/tests/server/test_compile_details.py
@@ -22,6 +22,7 @@ import pytest
 
 from inmanta import data
 from inmanta.data import Report
+from utils import parse_datetime_to_utc
 
 
 def compile_ids(compile_objects):
@@ -83,10 +84,6 @@ async def env_with_compiles(client, environment):
     ).insert()
 
     return environment, ids, compile_requested_timestamps
-
-
-def parse_datetime_to_utc(time: str) -> datetime.datetime:
-    return datetime.datetime.strptime(time, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=datetime.timezone.utc)
 
 
 async def test_compile_details(server, client, env_with_compiles):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,7 @@
 """
 import asyncio
 import configparser
+import datetime
 import inspect
 import json
 import logging
@@ -566,3 +567,7 @@ def v1_module_from_template(
             )
     with open(config_file, "r") as fd:
         return module.ModuleV1Metadata.parse(fd)
+
+
+def parse_datetime_to_utc(time: str) -> datetime.datetime:
+    return datetime.datetime.strptime(time, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
# Description

closes inmanta/web-console#3082

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
