### PR TITLE
issue3952/Syntax highlighting elif

### DIFF
--- a/changelogs/unreleased/3952-syntax-highlight-elif-vim.yml
+++ b/changelogs/unreleased/3952-syntax-highlight-elif-vim.yml
@@ -1,5 +1,3 @@
 description: Add highlighting for the elif keyword for vim
 change-type: minor
 destination-branches: [master, iso5]
-sections:
-    feature: "{{description}}"

--- a/changelogs/unreleased/3952-syntax-highlight-elif-vim.yml
+++ b/changelogs/unreleased/3952-syntax-highlight-elif-vim.yml
@@ -1,0 +1,5 @@
+description: Add highlighting for the elif keyword for vim
+change-type: minor
+destination-branches: [master, iso5]
+sections:
+    feature: "{{description}}"

--- a/misc/inmanta.vim
+++ b/misc/inmanta.vim
@@ -25,7 +25,7 @@ syn keyword Boolean true false
 syn keyword Identifier self
 
 " Statement
-syn keyword Conditional if else when
+syn keyword Conditional if else when elif
 syn keyword Repeat for
 syn keyword Operator in not or and matching is defined
 syn keyword Keyword entity implementation end using implement extends as index parents


### PR DESCRIPTION
# Description

Add highlighting for the elif keyword for vim

closes #3952

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
