### PR TITLE
Set timeout on server stop

### DIFF
--- a/changelogs/unreleased/set-timeout-on-stop-server.yml
+++ b/changelogs/unreleased/set-timeout-on-stop-server.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that the test suite uses a timeout when stopping the Inmanta server
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -86,11 +86,13 @@ class InmantaBootloader(object):
     async def stop(self, timeout: Optional[int] = None) -> None:
         """
         :param timeout: Raises TimeoutError when the server hasn't finished stopping after
-                        this amount of seconds.
+                        this amount of seconds. This argument should only be used by test
+                        cases.
         """
         if not timeout:
             await self._stop()
-        await asyncio.wait_for(self._stop(), timeout=timeout)
+        else:
+            await asyncio.wait_for(self._stop(), timeout=timeout)
 
     async def _stop(self) -> None:
         await self.restserver.stop()

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import asyncio
 import importlib
 import logging
 import pkgutil
@@ -82,7 +83,16 @@ class InmantaBootloader(object):
         await self.restserver.start()
         self.started = True
 
-    async def stop(self) -> None:
+    async def stop(self, timeout: Optional[int] = None) -> None:
+        """
+        :param timeout: Raises TimeoutError when the server hasn't finished stopping after
+                        this amount of seconds.
+        """
+        if not timeout:
+            await self._stop()
+        await asyncio.wait_for(self._stop(), timeout=timeout)
+
+    async def _stop(self) -> None:
         await self.restserver.stop()
         if self.feature_manager is not None:
             self.feature_manager.stop()

--- a/tests/agent_server/test_agent_timeout.py
+++ b/tests/agent_server/test_agent_timeout.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import asyncio
 import logging
 
 from agent_server.conftest import get_agent
@@ -38,7 +39,7 @@ async def test_agent_disconnect(resource_container, environment, server, client,
     agent = await get_agent(server, environment, "agent1")
     async_finalizer.add(agent.stop)
 
-    await server.stop()
+    await asyncio.wait_for(server.stop(), timeout=15)
 
     def disconnected():
         return not agent._instances["agent1"]._enabled

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -19,9 +19,9 @@ import asyncio
 import logging
 import time
 import uuid
+from functools import partial
 from itertools import groupby
 from typing import Any, Dict, List, Optional, Tuple
-from functools import partial
 
 import psutil
 import pytest

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -21,6 +21,7 @@ import time
 import uuid
 from itertools import groupby
 from typing import Any, Dict, List, Optional, Tuple
+from functools import partial
 
 import psutil
 import pytest
@@ -217,7 +218,7 @@ async def test_deploy_with_undefined(server, client, resource_container, async_f
 
 
 async def test_server_restart(
-    resource_container, server, agent, environment, clienthelper, postgres_db, client, no_agent_backoff
+    resource_container, server, agent, environment, clienthelper, postgres_db, client, no_agent_backoff, async_finalizer
 ):
     """
     Test if agent reconnects correctly after server restart
@@ -226,9 +227,11 @@ async def test_server_restart(
     resource_container.Provider.set("agent1", "key2", "incorrect_value")
     resource_container.Provider.set("agent1", "key3", "value")
 
-    await server.stop()
+    await asyncio.wait_for(server.stop(), timeout=15)
     ibl = InmantaBootloader()
     server = ibl.restserver
+    async_finalizer.add(agent.stop)
+    async_finalizer.add(partial(ibl.stop, timeout=15))
     await ibl.start()
 
     env_id = environment
@@ -287,9 +290,6 @@ async def test_server_restart(
     assert resource_container.Provider.get("agent1", "key1") == "value1"
     assert resource_container.Provider.get("agent1", "key2") == "value2"
     assert not resource_container.Provider.isset("agent1", "key3")
-
-    await agent.stop()
-    await ibl.stop()
 
 
 async def test_spontaneous_deploy(
@@ -1476,7 +1476,7 @@ async def test_autostart_mapping(server, client, clienthelper, resource_containe
     await assert_session_state({"agent1": AgentStatus.up, "agent2": AgentStatus.down}, ["agent1", "agent2"])
 
     # Stop server
-    await server.stop()
+    await asyncio.wait_for(server.stop(), timeout=15)
 
     current_process = psutil.Process()
     children = current_process.children(recursive=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -700,7 +700,7 @@ async def server(server_pre_start):
     yield ibl.restserver
 
     try:
-        await asyncio.wait_for(ibl.stop(), 15)
+        await ibl.stop(timeout=15)
     except concurrent.futures.TimeoutError:
         logger.exception("Timeout during stop of the server in teardown")
 
@@ -785,7 +785,7 @@ async def server_multi(
 
     yield ibl.restserver
     try:
-        await asyncio.wait_for(ibl.stop(), 15)
+        await ibl.stop(timeout=15)
     except concurrent.futures.TimeoutError:
         logger.exception("Timeout during stop of the server in teardown")
 
@@ -1475,7 +1475,7 @@ async def migrate_db_from(
 
     yield migrate
 
-    await bootloader.stop()
+    await bootloader.stop(timeout=15)
 
 
 @pytest.fixture(scope="session", autouse=not PYTEST_PLUGIN_MODE)

--- a/tests/db/test_v17_to_v202105170.py
+++ b/tests/db/test_v17_to_v202105170.py
@@ -47,7 +47,7 @@ async def migrate_v17_to_v202105170(
 
     # When the bootloader is started, it also executes the migration to v202105170
     yield ibl.start
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_timestamp_timezones(

--- a/tests/db/test_v202105170_to_v202106080.py
+++ b/tests/db/test_v202105170_to_v202106080.py
@@ -41,7 +41,7 @@ async def migrate_v202105170_to_v202106080(
 
     # When the bootloader is started, it also executes the migration to v202105170
     yield ibl.start
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_timestamp_timezones(

--- a/tests/db/test_v202106080_to_v202106210.py
+++ b/tests/db/test_v202106080_to_v202106210.py
@@ -41,7 +41,7 @@ async def migrate_v202106080_to_v202106210(
 
     # When the bootloader is started, it also executes the migration to v202105170
     yield ibl.start
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_add_value_to_resource_table(

--- a/tests/db/test_v202106210_to_v202109100.py
+++ b/tests/db/test_v202106210_to_v202109100.py
@@ -43,7 +43,7 @@ async def migrate_v202106210_to_v202109100(
 
     # When the bootloader is started, it also executes the migration to v202105170
     yield ibl.start
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_valid_loglevels(migrate_v202106210_to_v202109100: Callable[[], Awaitable[None]]) -> None:

--- a/tests/db/test_v202109100_to_v202111260.py
+++ b/tests/db/test_v202109100_to_v202111260.py
@@ -41,7 +41,7 @@ async def migrate_v202109100_to_v202111260(
 
     # When the bootloader is started, it also executes the migration to v202111260
     yield ibl.start
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_added_environment_columns(

--- a/tests/db/test_v202111260_to_v202203140.py
+++ b/tests/db/test_v202111260_to_v202203140.py
@@ -40,7 +40,7 @@ async def migrate_v202111260_to_v202203140(
 
     # When the bootloader is started, it also executes the migration to v202203140
     yield ibl.start
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_added_notification_table(

--- a/tests/db/test_v2_to_v3.py
+++ b/tests/db/test_v2_to_v3.py
@@ -37,7 +37,7 @@ async def migrate_v2_to_v3(hard_clean_db, hard_clean_db_post, postgresql_client:
 
     await ibl.start()
     yield
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 @pytest.mark.slowtest

--- a/tests/db/test_v3_to_v4.py
+++ b/tests/db/test_v3_to_v4.py
@@ -48,7 +48,7 @@ async def migrate_v3_to_v4(hard_clean_db, hard_clean_db_post, postgresql_client:
     # When the bootloader is started, it also executes the migration to v4
     await ibl.start()
     yield resource_version_id_dict
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_db_migration(migrate_v3_to_v4, postgresql_client: Connection):

--- a/tests/db/test_v4_to_v5.py
+++ b/tests/db/test_v4_to_v5.py
@@ -40,7 +40,7 @@ async def migrate_v4_to_v5(
     await ibl.start()
     # When the bootloader is started, it also executes the migration to v5
     yield
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_db_migration_compile_data(migrate_v4_to_v5, postgresql_client: Connection) -> None:

--- a/tests/db/test_v5_to_v6.py
+++ b/tests/db/test_v5_to_v6.py
@@ -40,7 +40,7 @@ async def migrate_v5_to_v6(
     await ibl.start()
     # When the bootloader is started, it also executes the migration to v6
     yield
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_add_on_delete_cascade_constraint(migrate_v5_to_v6, postgresql_client: Connection) -> None:

--- a/tests/db/test_v6_to_v7.py
+++ b/tests/db/test_v6_to_v7.py
@@ -44,7 +44,7 @@ async def migrate_v6_to_v7(
     await ibl.start()
     # When the bootloader is started, it also executes the migration to v7
     yield
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_unique_agent_instances(migrate_v6_to_v7: None, postgresql_client: Connection) -> None:

--- a/tests/db/test_v7_to_v17.py
+++ b/tests/db/test_v7_to_v17.py
@@ -46,7 +46,7 @@ async def migrate_v7_to_v17(
     await ibl.start()
     # When the bootloader is started, it also executes the migration to v18
     yield
-    await ibl.stop()
+    await ibl.stop(timeout=15)
 
 
 async def test_foreign_key_agent_to_agentinstance(migrate_v7_to_v17: None, postgresql_client: Connection) -> None:

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -770,7 +770,7 @@ async def server_with_frequent_cleanups(server_pre_start, server_config, async_f
     ibl = InmantaBootloader()
     await ibl.start()
     yield ibl.restserver
-    await asyncio.wait_for(ibl.stop(), 15)
+    await ibl.stop(timeout=15)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -108,7 +108,7 @@ async def startable_server(server_config):
     bootloader = InmantaBootloader()
     yield bootloader
     try:
-        await asyncio.wait_for(bootloader.stop(), 15)
+        await bootloader.stop(timeout=15)
     except concurrent.futures.TimeoutError:
         logger.exception("Timeout during stop of the server in teardown")
 

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sys
 from contextlib import contextmanager
+from functools import partial
 from typing import Any, Generator
 
 import pytest
@@ -41,7 +42,6 @@ from inmanta.server.bootloader import InmantaBootloader, PluginLoadFailed
 from inmanta.server.extensions import BoolFeature, FeatureManager, InvalidFeature, InvalidSliceNameException, StringListFeature
 from inmanta.server.protocol import Server, ServerSlice
 from utils import log_contains
-from functools import partial
 
 
 @contextmanager

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -41,6 +41,7 @@ from inmanta.server.bootloader import InmantaBootloader, PluginLoadFailed
 from inmanta.server.extensions import BoolFeature, FeatureManager, InvalidFeature, InvalidSliceNameException, StringListFeature
 from inmanta.server.protocol import Server, ServerSlice
 from utils import log_contains
+from functools import partial
 
 
 @contextmanager
@@ -162,7 +163,7 @@ async def test_startup_failure(async_finalizer, server_config):
         config.server_enabled_extensions.set("badplugin")
 
         ibl = InmantaBootloader()
-        async_finalizer.add(ibl.stop)
+        async_finalizer.add(partial(ibl.stop, timeout=15))
         with pytest.raises(Exception) as e:
             await ibl.start()
 
@@ -228,7 +229,7 @@ def test_load_feature_file(tmp_path):
 
 
 async def test_custom_feature_manager(
-    tmp_path, inmanta_config, postgres_db, database_name, clean_reset, unused_tcp_port_factory
+    tmp_path, inmanta_config, postgres_db, database_name, clean_reset, unused_tcp_port_factory, async_finalizer
 ):
     with splice_extension_in("test_module_path"):
         state_dir = str(tmp_path)
@@ -250,6 +251,7 @@ async def test_custom_feature_manager(
         config.server_enabled_extensions.set("testfm")
 
         ibl = InmantaBootloader()
+        async_finalizer.add(partial(ibl.stop, timeout=15))
         await ibl.start()
         server = ibl.restserver
 
@@ -257,5 +259,3 @@ async def test_custom_feature_manager(
 
         assert not fm.enabled(None)
         assert not fm.enabled("a")
-
-        await ibl.stop()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,6 +22,7 @@ import logging
 import os
 import uuid
 from datetime import datetime, timedelta
+from functools import partial
 
 import pytest
 from dateutil import parser
@@ -689,9 +690,10 @@ async def test_get_param(server, client, environment):
     assert len(parameters) == 2
 
 
-async def test_server_logs_address(server_config, caplog):
+async def test_server_logs_address(server_config, caplog, async_finalizer):
     with caplog.at_level(logging.INFO):
         ibl = InmantaBootloader()
+        async_finalizer.add(partial(ibl.stop, timeout=15))
         await ibl.start()
 
         client = Client("client")
@@ -699,7 +701,6 @@ async def test_server_logs_address(server_config, caplog):
         assert result.code == 200
         address = "127.0.0.1"
 
-        await ibl.stop()
         log_contains(caplog, "protocol.rest", logging.INFO, f"Server listening on {address}:")
 
 


### PR DESCRIPTION
# Description

Make sure that the tests cases set a timeout on the action of stopping the server. The goal is to:

* Prevent that the test suite hangs indefinitely.
* Improve the ability to investigate why the test suite is hanging.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
