### PR TITLE
Fix order of stages in compile report details

### DIFF
--- a/changelogs/unreleased/compile-report-stage-order.yml
+++ b/changelogs/unreleased/compile-report-stage-order.yml
@@ -1,0 +1,7 @@
+description: Fix order of stages in compile report details
+issue-nr: 3082
+issue-repo: web-console
+change-type: patch
+destination-branches: [iso4]
+sections:
+    bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3038,7 +3038,7 @@ class Compile(BaseDocument):
                     {cls.table_name()} comp
                     INNER JOIN compiledetails cd ON cd.substitute_compile_id = comp.id
                     LEFT JOIN public.report rep on comp.id = rep.compile
-        ) SELECT * FROM compiledetails;
+        ) SELECT * FROM compiledetails ORDER BY report_started ASC;
         """
         values = [cls._get_value(environment), cls._get_value(id)]
         result = await cls.select_query(query, values, no_obj=True)

--- a/tests/server/test_compile_details.py
+++ b/tests/server/test_compile_details.py
@@ -17,12 +17,12 @@
 """
 import datetime
 import uuid
-from operator import itemgetter
 
 import pytest
 
 from inmanta import data
 from inmanta.data import Report
+from utils import parse_datetime_to_utc
 
 
 def compile_ids(compile_objects):
@@ -95,17 +95,18 @@ async def test_compile_details(server, client, env_with_compiles):
     assert result.code == 200
     reports = result.result["data"]["reports"]
     assert len(reports) == 2
+    assert parse_datetime_to_utc(reports[0]["started"]) < parse_datetime_to_utc(reports[1]["started"])
     assert uuid.UUID(result.result["data"]["id"]) == ids[0]
-    assert datetime.datetime.strptime(result.result["data"]["requested"], "%Y-%m-%dT%H:%M:%S.%f").replace(
-        tzinfo=datetime.timezone.utc
-    ) == compile_requested_timestamps[0].astimezone(datetime.timezone.utc)
+    assert parse_datetime_to_utc(result.result["data"]["requested"]) == compile_requested_timestamps[0].astimezone(
+        datetime.timezone.utc
+    )
 
     # A compile that is 2 levels deep in substitutions: id2 -> id1 -> id0
     result = await client.compile_details(environment, ids[2])
     assert result.code == 200
     substituted_reports = result.result["data"]["reports"]
     assert len(substituted_reports) == 2
-    assert sorted(substituted_reports, key=itemgetter("name")) == sorted(reports, key=itemgetter("name"))
+    assert substituted_reports == reports
     assert uuid.UUID(result.result["data"]["id"]) == ids[2]
     assert datetime.datetime.strptime(result.result["data"]["requested"], "%Y-%m-%dT%H:%M:%S.%f").replace(
         tzinfo=datetime.timezone.utc

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import asyncio
+import datetime
 import inspect
 import json
 import logging
@@ -324,3 +325,6 @@ def mark_only_for_version_higher_than(version: str) -> "MarkDecorator":
         product_version_lower_or_equal_than(version),
         reason=f"This test is only intended for version larger than {version} currently at {current}",
     )
+
+def parse_datetime_to_utc(time: str) -> datetime.datetime:
+    return datetime.datetime.strptime(time, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
# Description

inmanta/webconsole#3082 for the iso4 branch

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
