### PR TITLE
Fix race condition in test case test_compile_details

### DIFF
--- a/changelogs/unreleased/fix-race-condition-in-test-compile-details.yml
+++ b/changelogs/unreleased/fix-race-condition-in-test-compile-details.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in the `test_compile_details()` test case. The background task that removes old compile reports was removing the compile reports created by the `env_with_compiles` fixture.
+change-type: patch
+destination-branches: [master, iso5]

--- a/changelogs/unreleased/fix-race-condition-in-test-compile-details.yml
+++ b/changelogs/unreleased/fix-race-condition-in-test-compile-details.yml
@@ -1,4 +1,4 @@
 ---
 description: Fix race condition in the `test_compile_details()` test case. The background task that removes old compile reports was removing the compile reports created by the `env_with_compiles` fixture.
 change-type: patch
-destination-branches: [master, iso5]
+destination-branches: [master, iso5, iso4]

--- a/tests/server/test_compile_details.py
+++ b/tests/server/test_compile_details.py
@@ -33,16 +33,17 @@ def compile_ids(compile_objects):
 async def env_with_compiles(client, environment):
     compile_requested_timestamps = []
     compiles = []
+    now = datetime.datetime.now()
     for i in range(4):
-        requested = datetime.datetime.strptime(f"2021-09-09T11:{i}:00.0", "%Y-%m-%dT%H:%M:%S.%f")
+        requested = now + datetime.timedelta(minutes=i)
         compile_requested_timestamps.append(requested)
         compile = data.Compile(
             id=uuid.uuid4(),
             remote_id=uuid.uuid4(),
             environment=uuid.UUID(environment),
             requested=requested,
-            started=requested.replace(second=20),
-            completed=requested.replace(second=40),
+            started=requested + datetime.timedelta(seconds=20),
+            completed=requested + datetime.timedelta(seconds=40),
             do_export=True,
             force_update=False,
             metadata={"meta": 42} if i % 2 else None,

--- a/tests/server/test_compile_details.py
+++ b/tests/server/test_compile_details.py
@@ -33,6 +33,8 @@ def compile_ids(compile_objects):
 async def env_with_compiles(client, environment):
     compile_requested_timestamps = []
     compiles = []
+    # Make sure that timestamp is never older than 7 days,
+    # as such that the cleanup service doesn't delete them.
     now = datetime.datetime.now()
     for i in range(4):
         requested = now + datetime.timedelta(minutes=i)


### PR DESCRIPTION
# Description

This PR fixes a race condition in the `test_compile_details()` test case. The background task that removes old compile reports was removing the compile reports created by the `env_with_compiles` fixture, causing the test case to fail with the following exception:

```
_____________________________ test_compile_details _____________________________

server = <inmanta.server.protocol.Server object at 0x7f8b8c0eed60>
client = <inmanta.protocol.endpoints.Client object at 0x7f8b726bda00>
env_with_compiles = ('5565bfc6-df9d-4517-914c-5b352d6b4565', [UUID('f36a91ab-3df5-42a7-942b-2f1b78a1e716'), UUID('73a916f6-8d60-4f88-ba52-... 0), datetime.datetime(2021, 9, 9, 11, 1), datetime.datetime(2021, 9, 9, 11, 2), datetime.datetime(2021, 9, 9, 11, 3)])

    async def test_compile_details(server, client, env_with_compiles):
        environment, ids, compile_requested_timestamps = env_with_compiles
    
        # A compile that has no substitute_compile_id, and has reports
        result = await client.compile_details(environment, ids[0])
>       assert result.code == 200
E       assert 404 == 200
E         +404
E         -200
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
