### PR TITLE
Add support to cancel background tasks when the server is stopped

### DIFF
--- a/changelogs/unreleased/add-support-to-cancel-background-tasks.yml
+++ b/changelogs/unreleased/add-support-to-cancel-background-tasks.yml
@@ -1,0 +1,4 @@
+---
+description: Add support to cancel background tasks when the scheduler is stopped
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -21,7 +21,7 @@ import socket
 import time
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, Coroutine, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import importlib_metadata
 from tornado import gen, queues, routing, web
@@ -36,7 +36,7 @@ from inmanta.protocol.rest import server
 from inmanta.server import SLICE_SESSION_MANAGER, SLICE_TRANSPORT
 from inmanta.server import config as opt
 from inmanta.types import ArgumentTypes, JsonType
-from inmanta.util import CycleException, Scheduler, TaskHandler, stable_depth_first
+from inmanta.util import CycleException, Scheduler, TaskHandler, TaskMethod, stable_depth_first
 
 if TYPE_CHECKING:
     from inmanta.server.extensions import Feature, FeatureManager
@@ -295,7 +295,7 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler):
         return self._handlers
 
     # utility methods for extensions developers
-    def schedule(self, call: Union[Callable, Coroutine], interval: int = 60, initial_delay: Optional[float] = None) -> None:
+    def schedule(self, call: TaskMethod, interval: int = 60, initial_delay: Optional[float] = None) -> None:
         self._sched.add_action(call, interval, initial_delay)
 
     def add_static_handler(self, location: str, path: str, default_filename: Optional[str] = None, start: bool = False) -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import asyncio
+import dataclasses
 import datetime
 import logging
 import uuid
@@ -46,6 +47,7 @@ async def test_scheduler_remove(caplog):
     length = len(i)
     await asyncio.sleep(0.1)
     assert len(i) == length
+    assert not sched._in_flight_tasks[action]
     no_error_in_logs(caplog)
 
 
@@ -73,6 +75,7 @@ async def test_scheduler_stop(caplog):
     caplog.clear()
     sched.add_action(action, 0.05, 0)
     assert "Scheduling action 'action', while scheduler is stopped" in caplog.messages
+    assert not sched._in_flight_tasks[action]
 
 
 async def test_scheduler_async_run_fail(caplog):
@@ -95,6 +98,7 @@ async def test_scheduler_async_run_fail(caplog):
     length = len(i)
     await asyncio.sleep(0.1)
     assert len(i) == length
+    assert not sched._in_flight_tasks[action]
 
     print(caplog.messages)
 
@@ -119,7 +123,39 @@ async def test_scheduler_run_async(caplog):
     length = len(i)
     await asyncio.sleep(0.1)
     assert len(i) == length
+    assert not sched._in_flight_tasks[action]
     no_error_in_logs(caplog)
+
+
+async def test_scheduler_cancel_in_flight_task() -> None:
+    """
+    Verify that in-flight tasks are cancelled when the scheduler is stopped.
+    """
+
+    @dataclasses.dataclass
+    class TaskStatus:
+        task_is_executing: bool = False
+        task_was_cancelled: bool = False
+
+    task_status = TaskStatus()
+
+    async def action():
+        task_status.task_is_executing = True
+        try:
+            await asyncio.sleep(1000)
+        except asyncio.CancelledError:
+            task_status.task_was_cancelled = True
+            raise
+
+    sched = util.Scheduler("xxx")
+    sched.add_action(action, interval=1000, initial_delay=0)
+    await util.retry_limited(lambda: task_status.task_is_executing, timeout=10)
+    assert task_status.task_is_executing
+    assert not task_status.task_was_cancelled
+    assert sched._in_flight_tasks[action]
+    sched.stop()
+    await util.retry_limited(lambda: task_status.task_was_cancelled, timeout=10)
+    assert not sched._in_flight_tasks[action]
 
 
 async def test_ensure_future_and_handle_exception(caplog):
@@ -132,8 +168,8 @@ async def test_ensure_future_and_handle_exception(caplog):
         LOGGER.info("Fail")
         raise Exception("message F")
 
-    ensure_future_and_handle_exception(LOGGER, "marker 1", success())
-    ensure_future_and_handle_exception(LOGGER, "marker 2", fail())
+    ensure_future_and_handle_exception(LOGGER, "marker 1", success(), notify_done_callback=lambda x: None)
+    ensure_future_and_handle_exception(LOGGER, "marker 2", fail(), notify_done_callback=lambda x: None)
 
     await asyncio.sleep(0.2)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -47,7 +47,7 @@ async def test_scheduler_remove(caplog):
     length = len(i)
     await asyncio.sleep(0.1)
     assert len(i) == length
-    assert not sched._in_flight_tasks[action]
+    assert not sched._executing_tasks[action]
     no_error_in_logs(caplog)
 
 
@@ -75,7 +75,7 @@ async def test_scheduler_stop(caplog):
     caplog.clear()
     sched.add_action(action, 0.05, 0)
     assert "Scheduling action 'action', while scheduler is stopped" in caplog.messages
-    assert not sched._in_flight_tasks[action]
+    assert not sched._executing_tasks[action]
 
 
 async def test_scheduler_async_run_fail(caplog):
@@ -98,7 +98,7 @@ async def test_scheduler_async_run_fail(caplog):
     length = len(i)
     await asyncio.sleep(0.1)
     assert len(i) == length
-    assert not sched._in_flight_tasks[action]
+    assert not sched._executing_tasks[action]
 
     print(caplog.messages)
 
@@ -123,13 +123,13 @@ async def test_scheduler_run_async(caplog):
     length = len(i)
     await asyncio.sleep(0.1)
     assert len(i) == length
-    assert not sched._in_flight_tasks[action]
+    assert not sched._executing_tasks[action]
     no_error_in_logs(caplog)
 
 
-async def test_scheduler_cancel_in_flight_task() -> None:
+async def test_scheduler_cancel_executing_tasks() -> None:
     """
-    Verify that in-flight tasks are cancelled when the scheduler is stopped.
+    Verify that executing tasks are cancelled when the scheduler is stopped.
     """
 
     @dataclasses.dataclass
@@ -152,10 +152,10 @@ async def test_scheduler_cancel_in_flight_task() -> None:
     await util.retry_limited(lambda: task_status.task_is_executing, timeout=10)
     assert task_status.task_is_executing
     assert not task_status.task_was_cancelled
-    assert sched._in_flight_tasks[action]
+    assert sched._executing_tasks[action]
     sched.stop()
     await util.retry_limited(lambda: task_status.task_was_cancelled, timeout=10)
-    assert not sched._in_flight_tasks[action]
+    assert not sched._executing_tasks[action]
 
 
 async def test_ensure_future_and_handle_exception(caplog):


### PR DESCRIPTION
# Description

The scheduler, which schedules background tasks, didn't have support to cancel tasks that are executing. It only has support to stop tasks that were scheduled to run, but are not yet executing. This caused tests to fail in the following scenario:

* The scheduler starts executing a background task that requires interaction with the database
* The stop method of the server is called
* The stop method of the scheduler is called, but that doesn't cancel the task that is already executing
* The stop method of the database slice is called, which stops the connection pool to the database
* The executing background tasks fails, because it cannot connect to the database.

This PR adds support to the scheduler to cancel all background tasks that are executing when the stop method of the server is called.

Relevant section from the teardown log of the failing test case:

```
DEBUG    inmanta.data:__init__.py:5590 Disconnecting data classes
ERROR    inmanta.util:util.py:114 Uncaught exception while executing scheduled action
Traceback (most recent call last):
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 1663, in perform_query
    async for record in con.cursor(query, *values):
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib64/python3.9/site-packages/asyncpg/cursor.py", line 214, in __anext__
    self._state = await self._connection._get_statement(
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib64/python3.9/site-packages/asyncpg/connection.py", line 398, in _get_statement
    statement = await self._protocol.prepare(
  File "asyncpg/protocol/protocol.pyx", line 168, in prepare
  File "asyncpg/protocol/protocol.pyx", line 865, in asyncpg.protocol.protocol.BaseProtocol._dispatch_result
asyncpg.exceptions._base.InternalClientError: got result for unknown protocol state 3

**During handling of the above exception, another exception occurred:**

Traceback (most recent call last):
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/server/services/notificationservice.py", line 64, in _cleanup
    await data.Notification.clean_up_notifications()
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 5540, in clean_up_notifications
    environments = await Environment.get_list()
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 2166, in get_list
    return await super().get_list(
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 1193, in get_list
    return await cls.get_list_with_columns(
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 1238, in get_list_with_columns
    result = await cls.select_query(sql_query, values, no_obj=no_obj, connection=connection)
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 1672, in select_query
    return await perform_query(con)
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 1668, in perform_query
    return result
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib64/python3.9/site-packages/asyncpg/transaction.py", line 66, in __aexit__
    self._check_conn_validity('__aexit__')
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib64/python3.9/site-packages/asyncpg/connresource.py", line 41, in _check_conn_validity
    raise exceptions.InterfaceError(
asyncpg.exceptions._base.InterfaceError: cannot call Transaction.__aexit__(): the underlying connection is closed
ERROR    inmanta.server.services.compilerservice:compilerservice.py:513 The following exception occurred while cleaning up old compiler reports
Traceback (most recent call last):
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/server/services/compilerservice.py", line 508, in _cleanup
    await data.Compile.delete_older_than(oldest_retained_date)
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 3179, in delete_older_than
    await cls._execute_query(query, oldest_retained_date, connection=connection)
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib/python3.9/site-packages/inmanta/data/__init__.py", line 1049, in _execute_query
    return await con.execute(query, *values)
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib64/python3.9/site-packages/asyncpg/pool.py", line 993, in __aexit__
    await self.pool.release(con)
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib64/python3.9/site-packages/asyncpg/pool.py", line 855, in release
    self._check_init()
  File "/home/jenkins/workspace/core/inmanta-core-test-coverage/.tox/py39/lib64/python3.9/site-packages/asyncpg/pool.py", line 948, in _check_init
    raise exceptions.InterfaceError('pool is closed')
asyncpg.exceptions._base.InterfaceError: pool is closed
DEBUG    asyncio:selector_events.py:59 Using selector: EpollSelector
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
