### PR TITLE
Added upgrade not regarding recompile on upgrade

### DIFF
--- a/changelogs/unreleased/note-recompile-on-upgrade.yml
+++ b/changelogs/unreleased/note-recompile-on-upgrade.yml
@@ -1,0 +1,6 @@
+---
+description: Each project present on the Inmanta server should be recompiled after an upgrade of the server.
+change-type: patch
+destination-branches: [iso5]
+sections:
+  upgrade-note: "{{description}}"


### PR DESCRIPTION
# Description

Add an upgrade note saying that a recompile is require after an upgrade of the Inmanta server. This is required because the `processing_events` resource state was removed in #3020. As such, the upgrade server cannot handle resources with a resource state set to `processing_events`.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
