### PR TITLE
Fix issue where rate limiter causes high resource deployment times

### DIFF
--- a/changelogs/unreleased/send-resource-events-in-background.yml
+++ b/changelogs/unreleased/send-resource-events-in-background.yml
@@ -1,5 +1,6 @@
 ---
 description: Fix issue where the deployment of resources takes a long time, due a high rate limiter backoff.
+issue-nr: 4084
 change-type: patch
 destination-branches: [master, iso5, iso4]
 sections:

--- a/changelogs/unreleased/send-resource-events-in-background.yml
+++ b/changelogs/unreleased/send-resource-events-in-background.yml
@@ -1,0 +1,6 @@
+---
+description: Fix issue where the deployment of resources takes a long time, due a high rate limiter backoff.
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -706,7 +706,9 @@ class ResourceService(protocol.ServerSlice):
                 if aclient is not None:
                     if change is None:
                         change = const.Change.nochange
-                    await aclient.resource_event(env.id, agent, resource_id, send_events, status, change, changes)
+                    self.add_background_task(
+                        aclient.resource_event(env.id, agent, resource_id, send_events, status, change, changes)
+                    )
 
         return 200
 


### PR DESCRIPTION
# Description

Ensure that the `resurce_action_update` method executes the `aclient.resource_event()` call in the background to prevent the `get_resources_for_agent()` from taking a very long time.

closes #4084
closes #4059

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
