### PR TITLE
Fix backwards compatibility issue in Compile

### DIFF
--- a/changelogs/unreleased/fix-backwards-compatibility-data.yml
+++ b/changelogs/unreleased/fix-backwards-compatibility-data.yml
@@ -1,4 +1,4 @@
-description: add default None value to version in Compile class to keep backwards compatibility
+description: add default 'None' value to 'version' field in 'Compile' class to keep backward compatibility
 change-type: patch
 destination-branches:
     - iso5

--- a/changelogs/unreleased/fix-backwards-compatibility-data.yml
+++ b/changelogs/unreleased/fix-backwards-compatibility-data.yml
@@ -1,0 +1,5 @@
+description: add default None value to version in Compile class to keep backwards compatibility
+change-type: patch
+destination-branches:
+    - iso5
+    - master

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3285,7 +3285,7 @@ class Compile(BaseDocument):
 
     success: Optional[bool]
     handled: bool = False
-    version: Optional[int]
+    version: Optional[int] = None
 
     # Compile queue might be collapsed if it contains similar compile requests.
     # In that case, substitute_compile_id will reference the actually compiled request.


### PR DESCRIPTION
# Description

To keep things backward compatible the optional 'version' field in the Compile class needs 'None' as default value. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
