### PR TITLE
[FEAT] Add environment setting to set the number of stored versions a…

### DIFF
--- a/changelogs/unreleased/3505-increase-the-number-of-stored-versions-in-the-database.yml
+++ b/changelogs/unreleased/3505-increase-the-number-of-stored-versions-in-the-database.yml
@@ -4,5 +4,5 @@ change-type: patch
 destination-branches: [iso4, iso5, master]
 sections: {
   feature: "{{description}}",
-  deprecation-note: "The server_version_to_keep option in the server configuration file is now deprecated in favor of the environment setting"
+  deprecation-note: "The available-versions-to-keep option in the server configuration file is now deprecated in favor of the environment setting"
 }

--- a/changelogs/unreleased/3505-increase-the-number-of-stored-versions-in-the-database.yml
+++ b/changelogs/unreleased/3505-increase-the-number-of-stored-versions-in-the-database.yml
@@ -1,7 +1,7 @@
 description: Add environment setting to set the number of stored versions.
 issue-nr: 3505
 change-type: patch
-destination-branches: [iso4, iso5, master]
+destination-branches: [iso5, master]
 sections: {
   feature: "{{description}}",
   deprecation-note: "The available-versions-to-keep option in the server configuration file is now deprecated in favor of the environment setting"

--- a/changelogs/unreleased/3505-increase-the-number-of-stored-versions-in-the-database.yml
+++ b/changelogs/unreleased/3505-increase-the-number-of-stored-versions-in-the-database.yml
@@ -1,0 +1,8 @@
+description: Add environment setting to set the number of stored versions.
+issue-nr: 3505
+change-type: patch
+destination-branches: [iso4, iso5, master]
+sections: {
+  feature: "{{description}}",
+  deprecation-note: "The server_version_to_keep option in the server configuration file is now deprecated in favor of the environment setting"
+}

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1999,6 +1999,7 @@ RESOURCE_ACTION_LOGS_RETENTION = "resource_action_logs_retention"
 PURGE_ON_DELETE = "purge_on_delete"
 PROTECTED_ENVIRONMENT = "protected_environment"
 NOTIFICATION_RETENTION = "notification_retention"
+AVAILABLE_VERSIONS_TO_KEEP = "available_versions_to_keep"
 
 
 class Setting(object):
@@ -2221,6 +2222,13 @@ class Environment(BaseDocument):
             typ="int",
             validator=convert_int,
             doc="The number of days to retain resource-action logs",
+        ),
+        AVAILABLE_VERSIONS_TO_KEEP: Setting(
+            name=AVAILABLE_VERSIONS_TO_KEEP,
+            default=10,
+            typ="int",
+            validator=convert_int,
+            doc="The number of versions to keep stored in the database",
         ),
         PURGE_ON_DELETE: Setting(
             name=PURGE_ON_DELETE,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2225,7 +2225,7 @@ class Environment(BaseDocument):
         ),
         AVAILABLE_VERSIONS_TO_KEEP: Setting(
             name=AVAILABLE_VERSIONS_TO_KEEP,
-            default=10,
+            default=100,
             typ="int",
             validator=convert_int,
             doc="The number of versions to keep stored in the database",

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -197,8 +197,9 @@ server_version_to_keep = Option(
     "server",
     "available-versions-to-keep",
     10,
-    """On boot and at regular intervals the server will purge older versions.
-                                   This is the number of most recent versions to keep available.""",
+    """[DEPRECATED: use AVAILABLE_VERSIONS_TO_KEEP environment setting]
+                                On boot and at regular intervals the server will purge older versions.
+                                This is the number of most recent versions to keep available.""",
     is_int,
 )
 

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -27,6 +27,7 @@ import asyncpg
 from inmanta import const, data
 from inmanta.data import (
     APILIMIT,
+    AVAILABLE_VERSIONS_TO_KEEP,
     ENVIRONMENT_AGENT_TRIGGER_METHOD,
     PURGE_ON_DELETE,
     DesiredStateVersionOrder,
@@ -93,7 +94,7 @@ class OrchestrationService(protocol.ServerSlice):
         envs = await data.Environment.get_list()
         for env_item in envs:
             # get available versions
-            n_versions = opt.server_version_to_keep.get()
+            n_versions = await env_item.get(AVAILABLE_VERSIONS_TO_KEEP)
             versions = await data.ConfigurationModel.get_list(environment=env_item.id)
             if len(versions) > n_versions:
                 LOGGER.info("Removing %s available versions from environment %s", len(versions) - n_versions, env_item.id)


### PR DESCRIPTION
…nd deprecate old config option

# Description
- Add an environment setting to set the number of stored version
- Deprecate the option in the config file
 
closes #3505 
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
- [x] Code is clear and sufficiently documented
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
