### PR TITLE
constrained click to known compatible range

### DIFF
--- a/changelogs/unreleased/constrain-pip.yml
+++ b/changelogs/unreleased/constrain-pip.yml
@@ -1,0 +1,7 @@
+description: Constrained click dependency to known compatible range because of backwards incompatible minor
+change-type: patch
+sections:
+  bugfix: "{{description}}"
+destination-branches:
+  - master
+  - iso5

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from os import path
 requires = [
     "asyncpg",
     "click-plugins",
-    "click",
+    # click has been known to publish non-backwards compatible minors in the past (removed deprecated code in 8.1.0)
+    "click>=8.0,<8.2",
     "colorlog",
     "cookiecutter",
     "cryptography",


### PR DESCRIPTION
# Description

Short term resolution for the click incompatibility. Click has released a backwards incompatible [minor](https://click.palletsprojects.com/en/8.1.x/changes/#version-8-1-0). This breaks the current stable release (see #4093). This is a short-term response to that incompatibility. I'll cherry-pick this to the iso5 RC.

@wouterdb to respond to your earlier question, dependabot does track this. `docstring-parser` was constrained to `~=0.10.0` for similar reasons 9 months ago. It is now at `>=0.10,<0.14` (see [its history](https://github.com/inmanta/inmanta-core/blame/98cfd5223ae6bea3a5c38070fb94266974d97f90/setup.py#L12)).

Should we create a ticket to document how a build master should respond to backwards incompatibilities? We don't have a standard procedure now but I believe it would be good to have a documented procedure that includes managing the `setup.py` file so that its constraints give a measure of confidence as to stability of our releases.

I'll open a similar pull request for iso4, but constrain it more heavily there because we didn't fix the code there. Does this warrant a patch release for iso4 (RPM install is fine, pip install is probably broken)? What about OSS?

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
