### PR TITLE
constrained click to known compatible range

### DIFF
--- a/changelogs/unreleased/constrain-pip.yml
+++ b/changelogs/unreleased/constrain-pip.yml
@@ -1,0 +1,6 @@
+description: Constrained click dependency to known compatible range because of backwards incompatible minor
+change-type: patch
+sections:
+  bugfix: "{{description}}"
+destination-branches:
+  - iso4

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from os import path
 requires = [
     "asyncpg",
     "click-plugins",
-    "click",
+    # click has been known to publish non-backwards compatible minors in the past (removed deprecated code in 8.1.0)
+    "click~=8.0.0",
     "colorlog",
     "cookiecutter",
     "cryptography",


### PR DESCRIPTION
# Description

See #4111 for motivation (probably best to review that one first). Does this warrant a patch release?

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
