### PR TITLE
Type cast docs

### DIFF
--- a/changelogs/unreleased/type-cast-docs.yml
+++ b/changelogs/unreleased/type-cast-docs.yml
@@ -2,6 +2,7 @@ description: Added documentation for primitive type casts to the language refere
 change-type: patch
 sections:
   feature: "{{description}}"
+  bugfix: "Fixed type cast behavior for `null` and unknown values"
 destination-branches:
   - master
   - iso5

--- a/changelogs/unreleased/type-cast-docs.yml
+++ b/changelogs/unreleased/type-cast-docs.yml
@@ -1,0 +1,8 @@
+description: Added documentation for primitive type casts to the language reference
+change-type: patch
+sections:
+  feature: "{{description}}"
+destination-branches:
+  - master
+  - iso5
+  - iso4

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -136,6 +136,10 @@ The basic primitive types are ``string``, ``number``, ``int`` or ``bool``. These
     assert = bool(1.2) == true
     assert = bool(0) == false
     assert = bool(null) == false
+    assert = bool("x") == true
+    # like in Python, only empty strings are considered false
+    assert = bool("false") == true
+    assert = bool("") == false
     assert = string(true) == "true"
 
 Constrained primitive types can be derived from the basic primitive type with a typedef statement.

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -135,6 +135,7 @@ The basic primitive types are ``string``, ``number``, ``int`` or ``bool``. These
     assert = number(true) == 1
     assert = bool(1.2) == true
     assert = bool(0) == false
+    assert = bool(null) == false
     assert = string(true) == "true"
 
 Constrained primitive types can be derived from the basic primitive type with a typedef statement.

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -125,7 +125,17 @@ Literal values can be assigned to variables
 Primitive types
 ==============================
 
-The basic primitive types are ``string``, ``number``, ``int`` or ``bool``.
+The basic primitive types are ``string``, ``number``, ``int`` or ``bool``. These basic types also support type casts:
+
+.. code-block:: inmanta
+
+    assert = true
+    assert = int("1") == 1
+    assert = number("1.2") == 1.2
+    assert = number(true) == 1
+    assert = bool(1.2) == true
+    assert = bool(0) == false
+    assert = string(true) == "true"
 
 Constrained primitive types can be derived from the basic primitive type with a typedef statement.
 Constrained primitive types add additional constraints to the basic primitive type with either a Python regex or a logical

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -32,7 +32,7 @@ from inmanta.ast import (
     RuntimeException,
     TypeNotFoundException,
 )
-from inmanta.execute.util import AnyType, NoneValue
+from inmanta.execute.util import AnyType, NoneValue, Unknown
 from inmanta.stable_api import stable_api
 
 try:
@@ -201,6 +201,10 @@ class Primitive(Type):
         Cast a value to this type. If the value can not be cast, raises a :py:class:`inmanta.ast.RuntimeException`.
         """
         exception: RuntimeException = RuntimeException(None, "Failed to cast '%s' to %s" % (value, self))
+
+        if isinstance(value, Unknown):
+            # propagate unknowns
+            return value
 
         for cast in self.try_cast_functions:
             try:

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -301,6 +301,9 @@ class Bool(Primitive):
             return True
         raise RuntimeException(None, "Invalid value '%s', expected Bool" % value)
 
+    def cast(self, value: Optional[object]) -> object:
+        return super().cast(value if not isinstance(value, NoneValue) else None)
+
     def type_string(self) -> str:
         return "bool"
 

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -152,6 +152,7 @@ w = int(tests::unknown())
     assert Integer().validate(z)
     assert isinstance(w, Unknown)
 
+
 def test_cast_to_string(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -188,6 +188,12 @@ v = bool("false")
 v = true
 w = bool("")
 w = false
+p = bool(null)
+p = false
+q = bool([])
+q = false
+r = bool([1])
+r = true
         """,
     )
     (_, scopes) = compiler.do_compile()
@@ -198,12 +204,18 @@ w = false
     u = root.lookup("u").get_value()
     v = root.lookup("v").get_value()
     w = root.lookup("w").get_value()
+    p = root.lookup("p").get_value()
+    q = root.lookup("q").get_value()
+    r = root.lookup("r").get_value()
     assert Bool().validate(x)
     assert Bool().validate(y)
     assert Bool().validate(z)
     assert Bool().validate(u)
     assert Bool().validate(v)
     assert Bool().validate(w)
+    assert Bool().validate(p)
+    assert Bool().validate(q)
+    assert Bool().validate(r)
 
 
 def test_cast_exception_kwargs(snippetcompiler):

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -26,6 +26,7 @@ from inmanta.ast import AttributeException, Namespace, TypingException
 from inmanta.ast.attribute import Attribute
 from inmanta.ast.entity import Entity
 from inmanta.ast.type import Bool, Integer, Number, String
+from inmanta.execute.util import Unknown
 
 
 def test_lnr_on_double_is_defined(snippetcompiler):
@@ -136,6 +137,8 @@ y = int(true)
 y = 1
 z = int(false)
 z = 0
+import tests
+w = int(tests::unknown())
         """,
     )
     (_, scopes) = compiler.do_compile()
@@ -143,10 +146,11 @@ z = 0
     x = root.lookup("x").get_value()
     y = root.lookup("y").get_value()
     z = root.lookup("z").get_value()
+    w = root.lookup("w").get_value()
     assert Integer().validate(x)
     assert Integer().validate(y)
     assert Integer().validate(z)
-
+    assert isinstance(w, Unknown)
 
 def test_cast_to_string(snippetcompiler):
     snippetcompiler.setup_for_snippet(


### PR DESCRIPTION
# Description

Added documentation for primitive type casts to the language reference

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
