### PR TITLE
Issue/4130 v1tov2 does not specify packages sufficiently strict

### DIFF
--- a/changelogs/unreleased/4130-v1tov2-does-not-specify-packages-sufficiently-strict.yml
+++ b/changelogs/unreleased/4130-v1tov2-does-not-specify-packages-sufficiently-strict.yml
@@ -1,6 +1,7 @@
-description: Limit included namespace packages to inmanta_plugins
+description: Limit included namespace packages to inmanta_plugins for v1tov2 module conversion.
 issue-nr: 4130
 change-type: patch
 destination-branches: [iso5, master]
 sections: {
+    bugfix: "{{description}}"
 }

--- a/changelogs/unreleased/4130-v1tov2-does-not-specify-packages-sufficiently-strict.yml
+++ b/changelogs/unreleased/4130-v1tov2-does-not-specify-packages-sufficiently-strict.yml
@@ -1,0 +1,6 @@
+description: Limit included namespace packages to inmanta_plugins
+issue-nr: 4130
+change-type: patch
+destination-branches: [iso5, master]
+sections: {
+}

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1132,5 +1132,6 @@ build-backend = "setuptools.build_meta"
         config["options"]["zip_safe"] = "False"
         config["options"]["include_package_data"] = "True"
         config["options"]["packages"] = "find_namespace:"
+        config["options.packages.find"]["include"] = "inmanta_plugins"
 
         return config

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1119,6 +1119,7 @@ build-backend = "setuptools.build_meta"
         config = self._module.metadata.to_v2().to_config(config_in)
 
         config.add_section("options")
+        config.add_section("options.packages.find")
 
         # add requirements
         module_requirements: List[InmantaModuleRequirement] = self._module.get_all_requires()
@@ -1132,6 +1133,6 @@ build-backend = "setuptools.build_meta"
         config["options"]["zip_safe"] = "False"
         config["options"]["include_package_data"] = "True"
         config["options"]["packages"] = "find_namespace:"
-        config["options.packages.find"]["include"] = "inmanta_plugins"
+        config["options.packages.find"]["include"] = "inmanta_plugins*"
 
         return config

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -93,6 +93,11 @@ def test_module_conversion_in_place_cli(tmpdir, monkeypatch: MonkeyPatch):
     moduletool.ModuleTool().v1tov2(None)
     assert_v2_module(module_name, tmpdir)
 
+    setup_cfg_file = os.path.join(tmpdir, "setup.cfg")
+    parser = configparser.ConfigParser()
+    parser.read(setup_cfg_file)
+    assert parser.has_option("options.packages.find", "include")
+
     with pytest.raises(ModuleVersionException):
         moduletool.ModuleTool().v1tov2(None)
 


### PR DESCRIPTION
# Description

Explicitely limit namespace packages to `inmanta_plugins` 

Part of  #4130 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
