### PR TITLE
[FIX] Remove pytest.ini and move its content to pyproject.toml

### DIFF
--- a/changelogs/unreleased/1071-deprecation-warning-regarding-asyncio-mode-in-module-set-tests.yml
+++ b/changelogs/unreleased/1071-deprecation-warning-regarding-asyncio-mode-in-module-set-tests.yml
@@ -1,5 +1,6 @@
 description: Remove pytest.ini and move its content to pyproject.toml
 issue-nr: 1071
+issue-repo: irt
 change-type: patch
 destination-branches: [iso5, master]
 sections: {

--- a/changelogs/unreleased/1071-deprecation-warning-regarding-asyncio-mode-in-module-set-tests.yml
+++ b/changelogs/unreleased/1071-deprecation-warning-regarding-asyncio-mode-in-module-set-tests.yml
@@ -1,0 +1,6 @@
+description: Remove pytest.ini and move its content to pyproject.toml
+issue-nr: 1071
+change-type: patch
+destination-branches: [iso5, master]
+sections: {
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,12 @@ directory = "tests_common"
 
 [tool.irt.publish.python]
 public = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = [
+    "slowtest",
+    "link_check",
+    "parametrize_any: only execute one of the parameterized cases when in fast mode (see documentation in conftest.py)",
+    "db_restore_dump(dump): mark the db dump to restore. To be used in conjunction with the `migrate_db_from` fixture."
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-asyncio_mode = auto
-markers =
-    slowtest
-    link_check
-    parametrize_any: only execute one of the parameterized cases when in fast mode (see documentation in conftest.py)
-    db_restore_dump(dump): mark the db dump to restore. To be used in conjunction with the `migrate_db_from` fixture.


### PR DESCRIPTION
# Description

Remove pytest.ini and move its content to pyproject.toml

Part of inmanta/irt#1071

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
