### PR TITLE
Issue/fix build failure due to pyprojecttoml module converter interaction

### DIFF
--- a/changelogs/unreleased/fix-build-failure-due-to-pyprojecttoml-module-converter-interaction.yml
+++ b/changelogs/unreleased/fix-build-failure-due-to-pyprojecttoml-module-converter-interaction.yml
@@ -1,0 +1,4 @@
+change-type: patch
+description: fix build failure caused by interaction between pyproject.toml and module converter
+destination-branches: [master, iso5]
+sections: {}

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -70,12 +70,13 @@ def test_issue_3159_conversion_std_module_add_self_to_dependencies(tmpdir):
     doesn't include the std module as a requirement in the setup.cfg file.
     """
     clone_dir = os.path.join(tmpdir, "std")
+    v2_dir = os.path.join(tmpdir, "std_v2")
     subprocess.check_call(["git", "clone", "https://github.com/inmanta/std.git", clone_dir])
     dummyproject = DummyProject()
     module_in = ModuleV1(dummyproject, clone_dir)
-    ModuleConverter(module_in).convert_in_place()
+    ModuleConverter(module_in).convert(v2_dir)
 
-    setup_cfg_file = os.path.join(clone_dir, "setup.cfg")
+    setup_cfg_file = os.path.join(v2_dir, "setup.cfg")
     parser = configparser.ConfigParser()
     parser.read(setup_cfg_file)
     assert parser.has_option("options", "install_requires")


### PR DESCRIPTION
# Description

Fix a testcase that was failing since we added a pyproject.toml file to all modules.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
~~- [ ] Type annotations are present~~
- [x] Code is clear and sufficiently documented
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
