### PR TITLE
Issue/3832 make mypy diff error "[[ not found"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ MYPY_BASELINE_FILE_NO_LN_NB=$(MYPY_BASELINE_FILE).nolnnb
 # prepare file for diff: remove last 2 lines and filter out line numbers
 MYPY_DIFF_PREPARE=head -n -2 | sed 's/^\(.\+:\)[0-9]\+\(:\)/\1\2/'
 # read old/new line number (format +n for new or -n for old) from stdin and transform to old/new line
-MYPY_DIFF_FETCH_LINES=xargs -I{} sh -c 'sed -n -e "s/^/$(MYPY_SET_COLOUR)$$(echo {} | cut -c 1 -) /" -e "$$(echo {} | cut -c 2- -)p" $(MYPY_SELECT_FILE)'
+MYPY_DIFF_FETCH_LINES=xargs -I{} bash -c 'sed -n -e "s/^/$(MYPY_SET_COLOUR)$$(echo {} | cut -c 1 -) /" -e "$$(echo {} | cut -c 2- -)p" $(MYPY_SELECT_FILE)'
 MYPY_SELECT_FILE=$$(if [[ "{}" == +* ]]; then echo $(MYPY_TMP_FILE); else echo $(MYPY_BASELINE_FILE); fi)
 MYPY_SET_COLOUR=$$(if [[ "{}" == +* ]]; then tput setaf 1; else tput setaf 2; fi)
 # diff line format options

--- a/changelogs/unreleased/fix-build-failure-due-to-pyprojecttoml-module-converter-interaction.yml
+++ b/changelogs/unreleased/fix-build-failure-due-to-pyprojecttoml-module-converter-interaction.yml
@@ -1,0 +1,4 @@
+change-type: patch
+description: fix build failure caused by interaction between pyproject.toml and module converter
+destination-branches: [master, iso5]
+sections: {}

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -70,12 +70,13 @@ def test_issue_3159_conversion_std_module_add_self_to_dependencies(tmpdir):
     doesn't include the std module as a requirement in the setup.cfg file.
     """
     clone_dir = os.path.join(tmpdir, "std")
+    v2_dir = os.path.join(tmpdir, "std_v2")
     subprocess.check_call(["git", "clone", "https://github.com/inmanta/std.git", clone_dir])
     dummyproject = DummyProject()
     module_in = ModuleV1(dummyproject, clone_dir)
-    ModuleConverter(module_in).convert_in_place()
+    ModuleConverter(module_in).convert(v2_dir)
 
-    setup_cfg_file = os.path.join(clone_dir, "setup.cfg")
+    setup_cfg_file = os.path.join(v2_dir, "setup.cfg")
     parser = configparser.ConfigParser()
     parser.read(setup_cfg_file)
     assert parser.has_option("options", "install_requires")


### PR DESCRIPTION
# Description

Explicitly use `bash` instead of relying on `sh` symlinking to it and therefore causing an error for shells where the `[[` keyword is not supported

closes #3832 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
~~- [ ] Type annotations are present~~
- [x] Code is clear and sufficiently documented
-~~ [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
