### PR TITLE
[FIX] explicitly use bash instead of sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ MYPY_BASELINE_FILE_NO_LN_NB=$(MYPY_BASELINE_FILE).nolnnb
 # prepare file for diff: remove last 2 lines and filter out line numbers
 MYPY_DIFF_PREPARE=head -n -2 | sed 's/^\(.\+:\)[0-9]\+\(:\)/\1\2/'
 # read old/new line number (format +n for new or -n for old) from stdin and transform to old/new line
-MYPY_DIFF_FETCH_LINES=xargs -I{} sh -c 'sed -n -e "s/^/$(MYPY_SET_COLOUR)$$(echo {} | cut -c 1 -) /" -e "$$(echo {} | cut -c 2- -)p" $(MYPY_SELECT_FILE)'
+MYPY_DIFF_FETCH_LINES=xargs -I{} bash -c 'sed -n -e "s/^/$(MYPY_SET_COLOUR)$$(echo {} | cut -c 1 -) /" -e "$$(echo {} | cut -c 2- -)p" $(MYPY_SELECT_FILE)'
 MYPY_SELECT_FILE=$$(if [[ "{}" == +* ]]; then echo $(MYPY_TMP_FILE); else echo $(MYPY_BASELINE_FILE); fi)
 MYPY_SET_COLOUR=$$(if [[ "{}" == +* ]]; then tput setaf 1; else tput setaf 2; fi)
 # diff line format options

--- a/changelogs/unreleased/3832-make-mypy-diff-error-double-bracket-not-found.yml
+++ b/changelogs/unreleased/3832-make-mypy-diff-error-double-bracket-not-found.yml
@@ -1,6 +1,6 @@
 description: Explicitly use bash instead of assuming sh symlinking to it to
     prevent errors for shells where the [[ keyword is not supported
 change-type: patch
-destination-branches: [master, iso5]
+destination-branches: [master, iso4, iso5]
 issue-nr: 3832
 sections: {}

--- a/changelogs/unreleased/3832-make-mypy-diff-error-double-bracket-not-found.yml
+++ b/changelogs/unreleased/3832-make-mypy-diff-error-double-bracket-not-found.yml
@@ -1,0 +1,6 @@
+description: Explicitly use bash instead of assuming sh symlinking to it to
+    prevent errors for shells where the [[ keyword is not supported
+change-type: patch
+destination-branches: [master, iso5]
+issue-nr: 3832
+sections: {}


### PR DESCRIPTION
# Description

Explicitly use `bash` instead of relying on `sh` symlinking to it and therefore causing an error for shells where the `[[` keyword is not supported

closes #3832 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
- [x] Code is clear and sufficiently documented
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
