### PR TITLE
Remove yaml loading order hack

### DIFF
--- a/changelogs/unreleased/3884-remove-yaml-loading-order.yml
+++ b/changelogs/unreleased/3884-remove-yaml-loading-order.yml
@@ -1,0 +1,6 @@
+description: Remove yaml loading order hack
+issue-nr: 3884
+change-type: patch
+destination-branches:
+    - master
+    - iso5

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -28,7 +28,6 @@ import tempfile
 import time
 import zipfile
 from argparse import ArgumentParser
-from collections import OrderedDict
 from configparser import ConfigParser
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Sequence, Set
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -74,28 +74,6 @@ else:
 LOGGER = logging.getLogger(__name__)
 
 
-def set_yaml_order_preserving() -> None:
-    """
-    Set yaml modules to be order preserving.
-
-    !!! Big Side-effect !!!
-
-    Library is not OO, unavoidable
-
-    Will no longer be needed in python3.7
-    """
-    _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
-
-    def dict_representer(dumper, data):
-        return dumper.represent_dict(data.items())
-
-    def dict_constructor(loader, node):
-        return OrderedDict(loader.construct_pairs(node))
-
-    yaml.add_representer(OrderedDict, dict_representer)
-    yaml.add_constructor(_mapping_tag, dict_constructor)
-
-
 class ModuleVersionException(CLIException):
     def __init__(self, msg: str) -> None:
         super().__init__(msg, exitcode=5)
@@ -260,8 +238,6 @@ compatible with the dependencies specified by the updated modules.
             operator = project.freeze_operator
 
         freeze = project.get_freeze(mode=operator, recursive=recursive)
-
-        set_yaml_order_preserving()
 
         with open(project.get_metadata_file_path(), "r", encoding="utf-8") as fd:
             newconfig = yaml.safe_load(fd)
@@ -882,8 +858,6 @@ version: 0.0.1dev0"""
 
         for submodule in module_obj.get_all_submodules():
             freeze.update(module_obj.get_freeze(submodule=submodule, mode=operator, recursive=recursive))
-
-        set_yaml_order_preserving()
 
         with open(module_obj.get_metadata_file_path(), "r", encoding="utf-8") as fd:
             newconfig = yaml.safe_load(fd)


### PR DESCRIPTION
# Description

There is a hack in the code to make yaml perserve the order. This has the note that it can be removed from 3.7 and on

closes #3884 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
