### PR TITLE
Issue/3076 fix memory leak introduced by using rlu cache iso4

### DIFF
--- a/changelogs/unreleased/3076-fix-memory-leak-introduced-by-using-rlu-cache-iso4.yml
+++ b/changelogs/unreleased/3076-fix-memory-leak-introduced-by-using-rlu-cache-iso4.yml
@@ -1,0 +1,6 @@
+description: Fix memory leak caused by lru-cache keeping strong references to cached items
+change-type: patch
+destination-branches: [iso4]
+sections: {
+  bugfix: "{{description}}"
+}


### PR DESCRIPTION
# Description

**Problem:** 
lru-cache keeps strong references to cached items.
**Solution:**
Use an attribute as a cache in each instance so that the memory is freed when this instance gets garbage collected.

Part of #3076 [ISO4]

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
