### PR TITLE
Make sure the appropriate error message is returned when creating a token while authentication is disabled

### DIFF
--- a/changelogs/unreleased/3900-auth-disabled-token-fix.yml
+++ b/changelogs/unreleased/3900-auth-disabled-token-fix.yml
@@ -1,4 +1,4 @@
 description: Make sure the appropriate error message is returned when creating a token while authentication is disabled
 issue-nr: 3900
 change-type: patch
-destination-branches: [iso5, master]
+destination-branches: [iso5, master, iso4]

--- a/changelogs/unreleased/3900-auth-disabled-token-fix.yml
+++ b/changelogs/unreleased/3900-auth-disabled-token-fix.yml
@@ -1,0 +1,4 @@
+description: Make sure the appropriate error message is returned when creating a token while authentication is disabled
+issue-nr: 3900
+change-type: patch
+destination-branches: [iso5, master]

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -132,6 +132,8 @@ section expects the following keys:
 * audience: The audience for tokens, as per RFC this should match or the token is rejected.
 * jwks_uri: The uri to the public key information. This is required for algorithm RS256. The keys are loaded the first time
   a token needs to be verified after a server restart. There is not key refresh mechanism.
+* jwks_request_timeout: The timeout for the request to the 'jwks_uri', in seconds. If not provided,
+  the default value of 30 seconds will be used.
 
 An example configuration is:
 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -587,9 +587,9 @@ class AuthJWTConfig(object):
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
-
+        jwks_timeout = self._config.getfloat("jwks_request_timeout", 30.0)
         try:
-            with request.urlopen(self.jwks_uri, context=ctx) as response:
+            with request.urlopen(self.jwks_uri, timeout=jwks_timeout, context=ctx) as response:
                 key_data = json.loads(response.read().decode("utf-8"))
         except error.URLError as e:
             # HTTPError is raised for non-200 responses; the response

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -29,7 +29,7 @@ from typing import Dict, List, Optional, Pattern, Set, cast
 
 from asyncpg import StringDataRightTruncationError
 
-from inmanta import data
+from inmanta import config, data
 from inmanta.data import model
 from inmanta.protocol import encode_token, handle, methods, methods_v2
 from inmanta.protocol.common import ReturnValue, attach_warnings
@@ -472,6 +472,8 @@ class EnvironmentService(protocol.ServerSlice):
         """
         Create a new auth token for this environment
         """
+        if not config.Config.getboolean("server", "auth", False):
+            raise BadRequest("Authentication is disabled, generating a token is not allowed")
         return encode_token(client_types, str(env.id), idempotent)
 
     @handle(methods_v2.environment_settings_list, env="tid")

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -114,6 +114,7 @@ validate_cert=false
         )
 
     from inmanta.config import AuthJWTConfig, Config
+
     # Make sure the config starts from a clean slate
     AuthJWTConfig.sections = {}
     AuthJWTConfig.issuers = {}
@@ -165,6 +166,7 @@ validate_cert=false
         )
 
     from inmanta.config import AuthJWTConfig, Config
+
     # Make sure the config starts from a clean slate
     AuthJWTConfig.sections = {}
     AuthJWTConfig.issuers = {}

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -141,7 +141,7 @@ async def slow_jwks(unused_tcp_port):
 
 async def test_rs256_invalid_config_timeout(tmp_path, slow_jwks):
     """
-    Test that the timeout to download the rs256 public key is taken into account
+    Test that an error is raised when the timeout to download the rs256 public key is exceeded
     """
     port = str(list(slow_jwks._sockets.values())[0].getsockname()[1])
     config_file = os.path.join(tmp_path, "auth.cfg")

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -114,7 +114,9 @@ validate_cert=false
         )
 
     from inmanta.config import AuthJWTConfig, Config
-
+    # Make sure the config starts from a clean slate
+    AuthJWTConfig.sections = {}
+    AuthJWTConfig.issuers = {}
     Config.load_config(config_file)
 
     cfg_list = await asyncio.get_event_loop().run_in_executor(None, AuthJWTConfig.list)
@@ -163,7 +165,9 @@ validate_cert=false
         )
 
     from inmanta.config import AuthJWTConfig, Config
-
+    # Make sure the config starts from a clean slate
+    AuthJWTConfig.sections = {}
+    AuthJWTConfig.issuers = {}
     Config.load_config(config_file)
     with pytest.raises(ValueError):
         await asyncio.get_event_loop().run_in_executor(None, partial(AuthJWTConfig.get, "auth_jwt_keycloak"))


### PR DESCRIPTION
# Description

closes #3900

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
