### PR TITLE
(iso4) Make sure the appropriate error message is returned when creating a token while authentication is disabled 

### DIFF
--- a/changelogs/unreleased/3900-auth-disabled-token-fix.yml
+++ b/changelogs/unreleased/3900-auth-disabled-token-fix.yml
@@ -1,4 +1,4 @@
 description: Make sure the appropriate error message is returned when creating a token while authentication is disabled
 issue-nr: 3900
 change-type: patch
-destination-branches: [iso5, master, iso4]
+destination-branches: [iso4]

--- a/changelogs/unreleased/3900-auth-disabled-token-fix.yml
+++ b/changelogs/unreleased/3900-auth-disabled-token-fix.yml
@@ -1,0 +1,4 @@
+description: Make sure the appropriate error message is returned when creating a token while authentication is disabled
+issue-nr: 3900
+change-type: patch
+destination-branches: [iso5, master, iso4]

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -131,6 +131,8 @@ section expects the following keys:
 * audience: The audience for tokens, as per RFC this should match or the token is rejected.
 * jwks_uri: The uri to the public key information. This is required for algorithm RS256. The keys are loaded the first time
   a token needs to be verified after a server restart. There is not key refresh mechanism.
+* jwks_request_timeout: The timeout for the request to the 'jwks_uri', in seconds. If not provided,
+  the default value of 30 seconds will be used.
 
 An example configuration is:
 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -587,9 +587,9 @@ class AuthJWTConfig(object):
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
-
+        jwks_timeout = self._config.getfloat("jwks_request_timeout", 30.0)
         try:
-            with request.urlopen(self.jwks_uri, context=ctx) as response:
+            with request.urlopen(self.jwks_uri, timeout=jwks_timeout, context=ctx) as response:
                 key_data = json.loads(response.read().decode("utf-8"))
         except error.URLError as e:
             # HTTPError is raised for non-200 responses; the response

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -29,7 +29,7 @@ from typing import Dict, List, Optional, Pattern, Set, cast
 
 from asyncpg import StringDataRightTruncationError
 
-from inmanta import data
+from inmanta import config, data
 from inmanta.data import model
 from inmanta.protocol import encode_token, handle, methods, methods_v2
 from inmanta.protocol.common import ReturnValue, attach_warnings
@@ -472,6 +472,8 @@ class EnvironmentService(protocol.ServerSlice):
         """
         Create a new auth token for this environment
         """
+        if not config.Config.getboolean("server", "auth", False):
+            raise BadRequest("Authentication is disabled, generating a token is not allowed")
         return encode_token(client_types, str(env.id), idempotent)
 
     @handle(methods_v2.environment_settings_list, env="tid")

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -19,6 +19,7 @@ import asyncio
 import json
 import os
 import time
+from functools import partial
 
 import pytest
 import tornado
@@ -115,7 +116,61 @@ validate_cert=false
 
     from inmanta.config import AuthJWTConfig, Config
 
+    # Make sure the config starts from a clean slate
+    AuthJWTConfig.sections = {}
+    AuthJWTConfig.issuers = {}
     Config.load_config(config_file)
 
     cfg_list = await asyncio.get_event_loop().run_in_executor(None, AuthJWTConfig.list)
     assert len(cfg_list) == 2
+
+
+class SlowHandler(web.RequestHandler):
+    async def get(self):
+        await asyncio.sleep(5)
+        self.write(json.dumps({"keys": "not only slow, but also invalid"}))
+
+
+@pytest.fixture(scope="function")
+async def slow_jwks(unused_tcp_port):
+    http_app = web.Application([(r"/auth/realms/inmanta/protocol/openid-connect/certs", SlowHandler)])
+    server = tornado.httpserver.HTTPServer(http_app)
+    server.bind(unused_tcp_port)
+    server.start()
+    yield server
+
+    server.stop()
+    await server.close_all_connections()
+
+
+async def test_rs256_invalid_config_timeout(tmp_path, slow_jwks):
+    """
+    Test that an error is raised when the timeout to download the rs256 public key is exceeded
+    """
+    port = str(list(slow_jwks._sockets.values())[0].getsockname()[1])
+    config_file = os.path.join(tmp_path, "auth.cfg")
+    with open(config_file, "w+", encoding="utf-8") as fd:
+        fd.write(
+            """
+[auth_jwt_keycloak]
+algorithm=RS256
+sign=false
+client_types=api
+issuer=https://localhost:{0}/auth/realms/inmanta
+audience=sodev
+jwks_uri=http://localhost:{0}/auth/realms/inmanta/protocol/openid-connect/certs
+jwks_request_timeout=0.1
+validate_cert=false
+""".format(
+                port
+            )
+        )
+
+    from inmanta.config import AuthJWTConfig, Config
+
+    # Make sure the config starts from a clean slate
+    AuthJWTConfig.sections = {}
+    AuthJWTConfig.issuers = {}
+    Config.load_config(config_file)
+    with pytest.raises(ValueError):
+        await asyncio.get_event_loop().run_in_executor(None, partial(AuthJWTConfig.get, "auth_jwt_keycloak"))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -523,8 +523,14 @@ async def test_clear_environment(client, server, clienthelper, environment):
 
 
 @pytest.mark.asyncio
-async def test_tokens(server_multi, client_multi, environment_multi):
+async def test_tokens(server_multi, client_multi, environment_multi, request):
     # Test using API tokens
+
+    # Check the parameters of the 'server_multi' fixture
+    if request.node.callspec.id in ["SSL", "Normal"]:
+        # Generating tokens is not allowed if auth is not enabled
+        return
+
     test_token = client_multi._transport_instance.token
     token = await client_multi.create_token(environment_multi, ["api"], idempotent=True)
     jot = token.result["token"]
@@ -546,6 +552,12 @@ async def test_tokens(server_multi, client_multi, environment_multi):
     client_multi._transport_instance.token = agent_jot
     result = await client_multi.list_versions(environment_multi)
     assert result.code == 401
+
+
+async def test_token_without_auth(server, client, environment):
+    """Generating a token when auth is not enabled is not allowed"""
+    token = await client.create_token(environment, ["api"], idempotent=True)
+    assert token.code == 400
 
 
 def make_source(collector, filename, module, source, req):


### PR DESCRIPTION
# Description

 #3900 for the iso4 branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
