### PR TITLE
bumped compiler version

### DIFF
--- a/changelogs/unreleased/bump-compiler-version-2022-3.yml
+++ b/changelogs/unreleased/bump-compiler-version-2022-3.yml
@@ -1,0 +1,5 @@
+description: "bumped compiler version to allow lsm module to depend on current dev version"
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -16,4 +16,4 @@
     Contact: code@inmanta.com
 """
 
-COMPILER_VERSION = "2022.2"
+COMPILER_VERSION = "2022.3"


### PR DESCRIPTION
# Description

The latest versions of the lsm module require compiler version 2022.3, but core was still on 2022.2. This caused the module set tests for iso-master to still use the old lsm module rather than the latest.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
