### PR TITLE
Issue/2582 different escaping rules for single and triple quotes

### DIFF
--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -132,7 +132,7 @@ def t_JCOMMENT(t: lex.LexToken) -> None:  # noqa: N802
 
 def t_MLS(t: lex.LexToken) -> lex.LexToken:
     r'"{3,5}([\s\S]*?)"{3,5}'
-    value = t.value[3:-3]
+    value = bytes(t.value[3:-3], "utf-8").decode("unicode_escape")
     lexer = t.lexer
     match = lexer.lexmatch[0]
     lines = match.split("\n")

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -135,3 +135,16 @@ std::print(test_string_11)
 '''
     )
     compiler.do_compile()
+
+
+def test_escaping_rules_single_vs_triple_quotes(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        r'''
+test_string_1 = """trippel hello\nworld"""
+test_string_2 = "single hello\nworld"
+std::print(test_string_1)
+std::print(test_string_2)
+'''
+    )
+    compiler.do_compile()
+


### PR DESCRIPTION
# Description

Use the same escaping rules for multi-line strings as for regular strings

closes #2582 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
~~- [ ] Type annotations are present~~
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
