### PR TITLE
Improve UX of the inmanta project/module update command

### DIFF
--- a/changelogs/unreleased/3911-improve-ux-module-project-update-cmd.yml
+++ b/changelogs/unreleased/3911-improve-ux-module-project-update-cmd.yml
@@ -1,0 +1,8 @@
+---
+description: "Improve the UX of the `inmanta project update` and the `inmanta module update` command."
+issue-nr: 3911
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "Fix bug where the user is suggested to run the `inmanta module update` command when the execution of the same command failed."
+  upgrade-note: "The default log level of the `inmanta` commandline tool was changed from ERROR to WARNING"

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -617,7 +617,7 @@ def cmd_parser() -> argparse.ArgumentParser:
         "-v",
         "--verbose",
         action="count",
-        default=0,
+        default=1,
         help="Log level for messages going to the console. Default is only errors,"
         "-v warning, -vv info and -vvv debug and -vvvv trace",
     )

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -617,9 +617,9 @@ def cmd_parser() -> argparse.ArgumentParser:
         "-v",
         "--verbose",
         action="count",
-        default=1,
-        help="Log level for messages going to the console. Default is only errors,"
-        "-v warning, -vv info and -vvv debug and -vvvv trace",
+        default=0,
+        help="Log level for messages going to the console. Default is warnings,"
+        "-v warning, -vv info, -vvv debug and -vvvv trace",
     )
     parser.add_argument(
         "--warnings",
@@ -701,6 +701,14 @@ def _convert_to_log_level(level: int) -> int:
     return log_levels[level]
 
 
+def _convert_cli_log_level(level: int) -> int:
+    if level < 1:
+        # The minimal log level on the CLI is always WARNING
+        return logging.WARNING
+    else:
+        return _convert_to_log_level(level)
+
+
 def _get_log_formatter_for_stream_handler(timed: bool) -> logging.Formatter:
     log_format = "%(asctime)s " if timed else ""
     if _is_on_tty():
@@ -742,7 +750,7 @@ def app() -> None:
         if options.timed:
             formatter = _get_log_formatter_for_stream_handler(timed=True)
             stream_handler.setFormatter(formatter)
-        log_level = _convert_to_log_level(options.verbose)
+        log_level = _convert_cli_log_level(options.verbose)
         stream_handler.setLevel(log_level)
 
     logging.captureWarnings(True)

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1977,8 +1977,8 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
             if self.metadata.install_mode == InstallMode.master:
                 exc_message += (
                     "\nThe release type of the project is set to 'master'. Set it to a value that is "
-                    "appropriate for the version constraint or remove the version constraint to resolve "
-                    "this issue."
+                    "appropriate for the version constraint or remove the version constraint. After that, "
+                    "run `inmanta project update` to resolve this issue."
                 )
             else:
                 exc_message += "\nRun `inmanta project update` to resolve this."

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1952,7 +1952,7 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
 
     def verify_module_version_compatibility(self) -> None:
         if not self._module_versions_compatible():
-            raise CompilerException("Not all module dependencies have been met. Run `inmanta modules update` to resolve this.")
+            raise CompilerException("Not all module dependencies have been met. Run `inmanta project update` to resolve this.")
 
     def verify_python_requires(self) -> None:
         """

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -199,7 +199,7 @@ class ProjectTool(ModuleLikeTool):
 Install all modules required for this project.
 
 This command installs missing modules in the development venv, but doesn't update already installed modules if that's not
-required to satisfy the module version constraints. Use `inmanta modules update` instead if the already installed modules need
+required to satisfy the module version constraints. Use `inmanta project update` instead if the already installed modules need
 to be updated to the latest compatible version.
 
 This command might reinstall Python packages in the development venv if the currently installed versions are not compatible

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -225,10 +225,7 @@ compatible with the dependencies specified by the updated modules.
         """
         !!! Big Side-effect !!! sets yaml parser to be order preserving
         """
-        try:
-            project = self.get_project(load=True)
-        except Exception:
-            raise CLIException("Could not load project", exitcode=1)
+        project = self.get_project(load=True)
 
         if recursive is None:
             recursive = project.freeze_recursive
@@ -320,7 +317,7 @@ compatible with the dependencies specified by the updated modules.
 
         attempt = 0
         done = False
-        last_failure = None
+        last_failure: Optional[CompilerException] = None
 
         while not done and attempt < MAX_UPDATE_ATTEMPT:
             LOGGER.info("Performing update attempt %d of %d", attempt + 1, MAX_UPDATE_ATTEMPT)
@@ -348,9 +345,7 @@ compatible with the dependencies specified by the updated modules.
             except CompilerException as e:
                 last_failure = e
                 # model is corrupt
-                LOGGER.info(
-                    "The model is not currently in an executable state, performing intermediate updates", stack_info=True
-                )
+                LOGGER.info("The model is not currently in an executable state, performing intermediate updates")
                 # get all specs from all already loaded modules
                 specs = my_project.collect_requirements()
 

--- a/tests/moduletool/test_freeze.py
+++ b/tests/moduletool/test_freeze.py
@@ -21,7 +21,7 @@ import sys
 
 import pytest
 
-from inmanta.command import CLIException
+from inmanta.ast import CompilerException
 from inmanta.moduletool import ModuleTool
 from moduletool.common import install_project
 from test_app_cli import app
@@ -72,17 +72,10 @@ def test_project_freeze_basic(git_modules_dir, modules_repo):
 def test_project_freeze_bad(git_modules_dir, modules_repo, capsys, caplog):
     coroot = install_project(git_modules_dir, "baddep", config=False)
 
-    with pytest.raises(CLIException) as e:
+    with pytest.raises(CompilerException) as e:
         app(["project", "freeze"])
 
-    assert e.value.exitcode == 1
-    assert str(e.value) == "Could not load project"
-
-    out, err = capsys.readouterr()
-
-    assert len(err) == 0, err
-    assert len(out) == 0, out
-    assert "requirement mod2<2016 on module mod2 not fulfilled, now at version 2016.1" in caplog.text
+    assert "requirement mod2<2016 on module mod2 not fulfilled, now at version 2016.1" in str(e.value)
 
     assert os.path.getsize(os.path.join(coroot, "project.yml")) != 0
 

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -23,7 +23,7 @@ import shutil
 import subprocess
 from importlib.abc import Loader
 from itertools import chain
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 import py
 import pytest
@@ -33,7 +33,7 @@ from pkg_resources import Requirement
 from inmanta import const, env, loader, module
 from inmanta.ast import CompilerException
 from inmanta.config import Config
-from inmanta.module import InstallMode, ModuleLoadingException
+from inmanta.module import InmantaModuleRequirement, InstallMode, ModuleLoadingException
 from inmanta.moduletool import DummyProject, ModuleConverter, ModuleTool, ProjectTool
 from moduletool.common import BadModProvider, install_project
 from packaging import version
@@ -172,7 +172,7 @@ def test_bad_dep_checkout(git_modules_dir, modules_repo):
     os.chdir(coroot)
     Config.load_config()
 
-    with pytest.raises(CompilerException, match="Not all module dependencies have been met"):
+    with pytest.raises(CompilerException, match="requirement mod2<2016 on module mod2 not fulfilled, now at version 2016.1"):
         ProjectTool().execute("install", [])
 
 
@@ -636,17 +636,17 @@ def test_project_install_incompatible_versions(
 
     # install project
     os.chdir(module.Project.get().path)
-    with pytest.raises(
-        CompilerException, match="Not all module dependencies have been met. Run `inmanta project update` to resolve this."
-    ):
+    with pytest.raises(CompilerException) as excinfo:
         ProjectTool().execute("install", [])
 
-    log_messages: Set[str] = {rec.message for rec in caplog.records}
-    expected: Set[str] = {
-        f"requirement {req_v1_on_v1} on module v1mod1 not fulfilled, now at version {current_version}",
-        f"requirement {req_v1_on_v2} on module {v2_mod_name} not fulfilled, now at version {current_version}",
-    }
-    assert expected.issubset(log_messages)
+    assert f"""
+The following requirements were not satisfied:
+\t* requirement {req_v1_on_v2} on module {v2_mod_name} not fulfilled, now at version {current_version}.
+\t* requirement {req_v1_on_v1} on module v1mod1 not fulfilled, now at version {current_version}.
+Run `inmanta project update` to resolve this.
+    """.strip() in str(
+        excinfo.value
+    )
 
 
 @pytest.mark.slowtest
@@ -865,4 +865,33 @@ import custom_mod_two
 | std            | v1   | yes      | 2.1.10         | 2.1.10         | yes     |
 +----------------+------+----------+----------------+----------------+---------+
     """.strip()
+    )
+
+
+def test_install_project_with_install_mode_master(tmpdir: py.path.local, snippetcompiler, modules_repo, capsys) -> None:
+    """
+    Ensure that an appropriate exception message is returned when a module installed in a project is not in-line with
+    the version constraint on the project and the install_mode of the project is set to master.
+    """
+    mod_with_multiple_version = os.path.join(modules_repo, "mod11")
+    mod_with_multiple_version_copy = os.path.join(tmpdir, "mod11")
+    shutil.copytree(mod_with_multiple_version, mod_with_multiple_version_copy)
+    snippetcompiler.setup_for_snippet(
+        snippet="import mod11",
+        autostd=False,
+        install_project=False,
+        add_to_module_path=[str(tmpdir)],
+        project_requires=[InmantaModuleRequirement(Requirement.parse("mod11==3.2.1"))],
+        install_mode=InstallMode.master,
+    )
+
+    with pytest.raises(CompilerException) as excinfo:
+        ProjectTool().execute("update", [])
+
+    assert """
+The following requirements were not satisfied:
+\t* requirement mod11==3.2.1 on module mod11 not fulfilled, now at version 4.2.0.
+The release type of the project is set to 'master'. Set it to a value that is appropriate for the version constraint
+    """.strip() in str(
+        excinfo.value
     )

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -637,7 +637,7 @@ def test_project_install_incompatible_versions(
     # install project
     os.chdir(module.Project.get().path)
     with pytest.raises(
-        CompilerException, match="Not all module dependencies have been met. Run `inmanta modules update` to resolve this."
+        CompilerException, match="Not all module dependencies have been met. Run `inmanta project update` to resolve this."
     ):
         ProjectTool().execute("install", [])
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -397,8 +397,7 @@ caused by:
 
     def exec(*cmd):
         process = do_run([sys.executable, "-m", "inmanta.app"] + list(cmd), cwd=snippetcompiler.project_dir)
-        out, err = process.communicate(timeout=30)
-        assert out.decode() == ""
+        _, err = process.communicate(timeout=30)
         assert err.decode() == output
 
     no_cache_option = [] if cache_cf_files else ["--no-cache"]
@@ -425,7 +424,6 @@ end
 
     process = do_run([sys.executable, "-m", "inmanta.app"] + cmd, cwd=snippetcompiler.project_dir)
     out, err = process.communicate(timeout=30)
-    assert out.decode() == ""
     if "-X" in cmd:
         assert "inmanta.ast.TypeNotFoundException: could not find type nuber in namespace" in str(err)
     else:


### PR DESCRIPTION
# Description

* This PR improves the UX of the `inmanta module update` and the `inmanta project update` command by printing a descriptive message to stderr when the command fails.
* The default log level of the `inmanta` commandline tool was changed from ERROR to WARNING.

closes #3911 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
