### PR TITLE
Fix issue with get_resources_in_latest_version call not taking into account versions without resources (#4234)

### DIFF
--- a/changelogs/unreleased/fix-resources-in-latest-version.yml
+++ b/changelogs/unreleased/fix-resources-in-latest-version.yml
@@ -1,0 +1,7 @@
+description: Fix issue with get_resources_in_latest_version call not taking into account versions without resources
+issue-nr: 739
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3639,9 +3639,9 @@ class Resource(BaseDocument):
         query = f"""
             SELECT *
             FROM {Resource.table_name()} AS r1
-            WHERE r1.environment=$1 AND r1.model=(SELECT MAX(r2.model)
-                                                  FROM {Resource.table_name()} AS r2
-                                                  WHERE r2.environment=$1)
+            WHERE r1.environment=$1 AND r1.model=(SELECT MAX(cm.version)
+                                                  FROM {ConfigurationModel.table_name()} AS cm
+                                                  WHERE cm.environment=$1)
         """
         if resource_type:
             query += " AND r1.resource_type=$2"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1451,6 +1451,21 @@ async def test_get_resources_in_latest_version(init_dataclasses_and_load_schema)
     )
     assert resource.to_dict() == expected_resource.to_dict()
 
+    cm = data.ConfigurationModel(
+        environment=env.id,
+        version=3,
+        date=datetime.datetime.now(),
+        total=2,
+        version_info={},
+        released=True,
+        deployed=True,
+    )
+    await cm.insert()
+    resources = await data.Resource.get_resources_in_latest_version(
+        env.id, "std::File", {"path": "/etc/motd1", "purge_on_delete": True}
+    )
+    assert len(resources) == 0
+
 
 @pytest.mark.asyncio
 async def test_model_get_resources_for_version_optional_args(init_dataclasses_and_load_schema):


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4234