### PR TITLE
Issue/4019 attributes starting with a capital letter could get better exceptions

### DIFF
--- a/changelogs/unreleased/4019-attributes-starting-with-a-capital-letter-could-get-better-exceptions.yml
+++ b/changelogs/unreleased/4019-attributes-starting-with-a-capital-letter-could-get-better-exceptions.yml
@@ -2,4 +2,5 @@ description: Improve syntax error reporting when defining an attribute starting 
 change-type: patch
 destination-branches: [master, iso5, iso4]
 sections: {
+  bugfix: "{{description}}"
 }

--- a/changelogs/unreleased/4019-attributes-starting-with-a-capital-letter-could-get-better-exceptions.yml
+++ b/changelogs/unreleased/4019-attributes-starting-with-a-capital-letter-could-get-better-exceptions.yml
@@ -1,5 +1,5 @@
 description: Improve syntax error reporting when defining an attribute starting with a capital letter.
 change-type: patch
-destination-branches: [master, iso5]
+destination-branches: [master, iso5, iso4]
 sections: {
 }

--- a/changelogs/unreleased/4019-attributes-starting-with-a-capital-letter-could-get-better-exceptions.yml
+++ b/changelogs/unreleased/4019-attributes-starting-with-a-capital-letter-could-get-better-exceptions.yml
@@ -1,0 +1,5 @@
+description: Improve syntax error reporting when defining an attribute starting with a capital letter.
+change-type: patch
+destination-branches: [master, iso5]
+sections: {
+}

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -349,6 +349,14 @@ def p_attribute_type(p: YaccProduction) -> None:
     p[0] = p[1]
 
 
+def p_attr_err(p: YaccProduction) -> None:
+    """attr : attr_type CID empty
+    | attr_type CID '=' constant
+    | attr_type CID '=' constant_list
+    | attr_type CID '=' UNDEF"""
+    raise ParserException(p[2].location, str(p[2]), "Invalid identifier: Variable names must start with a lower case character")
+
+
 def p_attr(p: YaccProduction) -> None:
     "attr : attr_type ID"
     p[0] = DefineAttribute(p[1], p[2], None)
@@ -366,6 +374,20 @@ def p_attr_undef(p: YaccProduction) -> None:
     "attr : attr_type ID '=' UNDEF"
     p[0] = DefineAttribute(p[1], p[2], None, remove_default=True)
     attach_from_string(p, 2)
+
+
+def p_attr_dict_err(p: YaccProduction) -> None:
+    """attr : DICT CID empty
+    | DICT CID '=' map_def
+    | DICT CID '=' NULL
+    | DICT '?' CID empty
+    | DICT '?'  CID '=' map_def
+    | DICT '?'  CID '=' NULL"""
+    if p[2] == "?":
+        raise ParserException(
+            p[3].location, str(p[3]), "Invalid identifier: Variable names must start with a lower case character"
+        )
+    raise ParserException(p[2].location, str(p[2]), "Invalid identifier: Variable names must start with a lower case character")
 
 
 def p_attr_dict(p: YaccProduction) -> None:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -354,7 +354,9 @@ def p_attr_err(p: YaccProduction) -> None:
     | attr_type CID '=' constant
     | attr_type CID '=' constant_list
     | attr_type CID '=' UNDEF"""
-    raise ParserException(p[2].location, str(p[2]), "Invalid identifier: Variable names must start with a lower case character")
+    raise ParserException(
+        p[2].location, str(p[2]), "Invalid identifier: attribute names must start with a lower case character"
+    )
 
 
 def p_attr(p: YaccProduction) -> None:
@@ -377,17 +379,15 @@ def p_attr_undef(p: YaccProduction) -> None:
 
 
 def p_attr_dict_err(p: YaccProduction) -> None:
-    """attr : DICT CID empty
-    | DICT CID '=' map_def
-    | DICT CID '=' NULL
+    """attr : DICT empty CID empty
+    | DICT empty CID '=' map_def
+    | DICT empty CID '=' NULL
     | DICT '?' CID empty
     | DICT '?'  CID '=' map_def
     | DICT '?'  CID '=' NULL"""
-    if p[2] == "?":
-        raise ParserException(
-            p[3].location, str(p[3]), "Invalid identifier: Variable names must start with a lower case character"
-        )
-    raise ParserException(p[2].location, str(p[2]), "Invalid identifier: Variable names must start with a lower case character")
+    raise ParserException(
+        p[3].location, str(p[3]), "Invalid identifier: attribute names must start with a lower case character"
+    )
 
 
 def p_attr_dict(p: YaccProduction) -> None:

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -331,3 +331,64 @@ value = {expected_value}
     with pytest.raises(DoubleSetException) as excinfo:
         verify_compile(3)
     assert excinfo.value.newvalue == 4
+
+
+@pytest.mark.parametrize(
+    "erroneous_statement,error_at_char",
+    [
+        (
+            "bool CRC18",
+            6,
+        ),
+        (
+            "bool CRC18=false",
+            6,
+        ),
+        (
+            "bool? CRC18",
+            7,
+        ),
+        (
+            "int CRC18=null",
+            5,
+        ),
+        (
+            "dict CRC18",
+            6,
+        ),
+        (
+            "dict CRC18={'invalid':'identifier'}",
+            6,
+        ),
+        (
+            "dict CRC18=null",
+            6,
+        ),
+        (
+            "dict? CRC18",
+            7,
+        ),
+        (
+            "dict? CRC18={'invalid':'identifier'}",
+            7,
+        ),
+        (
+            "dict? CRC18=null",
+            7,
+        ),
+    ],
+)
+def test_attributes_starting_with_capital_letter(snippetcompiler, erroneous_statement, error_at_char):
+    expected_error = (
+        "Syntax error: Invalid identifier: Variable names must start with a lower case character "
+        "({dir}/main.cf:3:"
+        f"{error_at_char})"
+    )
+    snippetcompiler.setup_for_error(
+        f"""
+entity A:
+{erroneous_statement}
+end
+""",
+        expected_error,
+    )

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -400,7 +400,7 @@ value = {expected_value}
 )
 def test_attributes_starting_with_capital_letter(snippetcompiler, erroneous_statement, error_at_char):
     expected_error = (
-        "Syntax error: Invalid identifier: Variable names must start with a lower case character "
+        "Syntax error: Invalid identifier: attribute names must start with a lower case character "
         "({dir}/main.cf:3:"
         f"{error_at_char})"
     )

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -349,6 +349,26 @@ value = {expected_value}
             7,
         ),
         (
+            "bool? CRC18=null",
+            7,
+        ),
+        (
+            "bool[] CRC18",
+            8,
+        ),
+        (
+            "bool[] CRC18=[false]",
+            8,
+        ),
+        (
+            "bool[]? CRC18",
+            9,
+        ),
+        (
+            "bool[]? CRC18=null",
+            9,
+        ),
+        (
             "int CRC18=null",
             5,
         ),


### PR DESCRIPTION
# Description
An exception is now raised when an attribute is defined with a name that starts with a capital letter

closes #4019 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
