### PR TITLE
Fix issue where updating the modules always spawns a pip sub-process

### DIFF
--- a/changelogs/unreleased/4055-fix-bug-compiler-performance-decreased.yml
+++ b/changelogs/unreleased/4055-fix-bug-compiler-performance-decreased.yml
@@ -1,0 +1,7 @@
+---
+description: Fix bug where `inmanta project install` and `inmanta project update` always invokes pip, even when all dependencies are already met.
+issue-nr: 4055
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -381,7 +381,13 @@ class ActiveEnv(PythonEnvironment):
             return True
         reqs_as_requirements: Sequence[Requirement] = self._get_as_requirements_type(requirements)
         installed_packages: Dict[str, version.Version] = PythonWorkingSet.get_packages_in_working_set()
-        return all(r.key in installed_packages and str(installed_packages[r.key]) in r for r in reqs_as_requirements)
+        for r in reqs_as_requirements:
+            if r.marker and not r.marker.evaluate():
+                # The marker of the requirement doesn't apply on this environment
+                continue
+            if r.key not in installed_packages or str(installed_packages[r.key]) not in r:
+                return False
+        return True
 
     def install_from_index(
         self,


### PR DESCRIPTION
# Description

The `are_installed()` method in `env.py`, that checks whether a requirement is installed in the active Python environment, didn't take into account the markers set on a requirement. As such, the method would always evaluate to `False` when a marker was set that wasn't applicable for the active environment. This caused degraded performance on all test suites that ran using python >=3.7 and used the `project` fixture, because the requirements.txt file of the std module has the following requirement set:

```
dataclasses~=0.7;python_version<'3.7'
```

Each time the `are_installed()` method evaluates to False, a pip sub-process is spawned. This slowed down the tests a lot. This patch increases the runtime of the `lsm` test suite by 2.2x

closes #4055 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
