### PR TITLE
Issue/4200 module install change requirements (dummy)

### DIFF
--- a/changelogs/unreleased/4200-module-install-change-requirements.yml
+++ b/changelogs/unreleased/4200-module-install-change-requirements.yml
@@ -1,0 +1,4 @@
+description: Dummy change entry for a change made in master/iso5 that was finally not ported to iso4
+issue-nr: 3986
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/changelogs/unreleased/4200-module-install-change-requirements.yml
+++ b/changelogs/unreleased/4200-module-install-change-requirements.yml
@@ -1,4 +1,4 @@
 description: Dummy change entry for a change made in master/iso5 that was finally not ported to iso4
-issue-nr: 3986
+issue-nr: 4200
 change-type: patch
 destination-branches: [iso4]

--- a/changelogs/unreleased/4200-module-install-change-requirements.yml
+++ b/changelogs/unreleased/4200-module-install-change-requirements.yml
@@ -1,4 +1,4 @@
 description: Dummy change entry for a change made in master/iso5 that was finally not ported to iso4
 issue-nr: 3986
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso4]


### PR DESCRIPTION
# Description

This commit just adds a dummy changelog file so that the project invariant check won't fail anymore. 
the PR #4209 was merged into master and iso5 but should not have target iso4.

closes https://github.com/inmanta/inmanta-core/issues/4200
