### PR TITLE
Issue/2600 missing self. location attribute

### DIFF
--- a/changelogs/unreleased/2600-missing_self_location_attribute.yml
+++ b/changelogs/unreleased/2600-missing_self_location_attribute.yml
@@ -1,0 +1,5 @@
+description: Add test to check if exception is correctly raised when unpacking a null dictionary
+change-type: patch
+destination-branches: [master, iso5]
+sections: {
+}

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -412,3 +412,19 @@ end
 """,
         expected_error,
     )
+
+
+def test_unpack_null_dictionary(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+
+hello_world = "Hello World!"
+dct = null
+hi_world = std::replace(hello_world, **dct)
+std::print(hi_world)
+""",
+        (
+            "The ** operator can only be applied to dictionaries (reported in "
+            "std::replace(hello_world,**dct) ({dir}/main.cf:5))"
+        ),
+    )

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -424,6 +424,6 @@ std::print(hi_world)
 """,
         (
             "The ** operator can only be applied to dictionaries (reported in "
-            "std::replace(hello_world,**dct) ({dir}/main.cf:5))"
+            "std::replace(hello_world,**dct) ({dir}/main.cf:4))"
         ),
     )

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -417,7 +417,6 @@ end
 def test_unpack_null_dictionary(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
-
 hello_world = "Hello World!"
 dct = null
 hi_world = std::replace(hello_world, **dct)


### PR DESCRIPTION
# Description

Add a test case to make sure that an exception is correctly raised when trying to unpack a `null` dictionary.

closes #2600 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
