### PR TITLE
Add protocol varkw support

### DIFF
--- a/changelogs/unreleased/add-varkw-to-protocol.yml
+++ b/changelogs/unreleased/add-varkw-to-protocol.yml
@@ -1,0 +1,3 @@
+description: Add varkw support to the protocol layer
+change-type: minor
+destination-branches: [master, iso5]

--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -139,6 +139,7 @@ def typedmethod(
     api_prefix: str = "api",
     envelope_key: str = const.ENVELOPE_KEY,
     strict_typing: bool = True,
+    varkw: bool = False,
 ) -> Callable[..., Callable]:
     """
     Decorator to identify a method as a RPC call. The arguments of the decorator are used by each transport to build
@@ -166,6 +167,8 @@ def typedmethod(
     :param strict_typing: If true, does not allow `Any`. Setting this option to False is heavily discouraged except for some
         few very specific cases where the type system does not allow the strict type to be specified, for example in case of
         infinite recursion.
+    :param varkw: If true, additional arguments are allowed and will be dispatched to the handler. The handler is
+                  responsible for the validation.
     """
 
     def wrapper(func: MethodT) -> MethodT:
@@ -187,6 +190,7 @@ def typedmethod(
             True,
             envelope_key,
             strict_typing=strict_typing,
+            varkw=varkw,
         )
         common.MethodProperties.register_method(properties)
         return func

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -231,6 +231,11 @@ class CallArguments(object):
         if self._properties.agent_server and "sid" in all_fields:
             all_fields.remove("sid")
 
+        if self._properties.varkw:
+            # add all other arguments to the call args as well
+            for field in all_fields:
+                self._call_args[field] = self._message[field]
+
         if len(all_fields) > 0 and self._argspec.varkw is None:
             raise exceptions.BadRequest(
                 "request contains fields %s that are not declared in method and no kwargs argument is provided." % all_fields

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2163,7 +2163,7 @@ async def test_kwargs(unused_tcp_port, postgres_db, database_name, async_finaliz
     async_finalizer.add(rs.stop)
 
     client = protocol.Client("client")
-    result = await client.test_method(id="test", **{"name": "test", "value": True})
+    result = await client.test_method(id="test", name="test", value=True)
     assert result.code == 200
     assert result.result["data"]["name"] == "test"
     assert result.result["data"]["value"]


### PR DESCRIPTION
# Description

This PR adds support for **kwargs to collect all "unknown" attributes. This is required for certain APIs where the service attributes are merged at the top-level.

This feature is a bit dangerous because it disables lots of the validation. To limit the risk the following is done:

1. You need to explicitly set varkw in the decorator
2. A **kwargs variable is only allowed when varkw is set to true
3. The type of varkw always needs to be object (you could differ in the handler still) to force the user to validate the data

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
