### PR TITLE
[FEAT] override inmanta_state_dir fixture

### DIFF
--- a/changelogs/unreleased/189-add-support-for-changing-state-dir-to-a-writable-location-by-the-current-user.yml
+++ b/changelogs/unreleased/189-add-support-for-changing-state-dir-to-a-writable-location-by-the-current-user.yml
@@ -1,0 +1,7 @@
+description: Add support for changing the Inmanta state directory to a writable location by the current user.
+issue-nr: 189
+issue-repo: pytest-inmanta
+change-type: patch
+destination-branches: [iso5, master]
+sections: {
+}


### PR DESCRIPTION
# Description

Add support for changing the Inmanta state directory to a writable location by the current user.

part of [#189](https://github.com/inmanta/pytest-inmanta/issues/189)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
