### PR TITLE
Don't protect the inmanta-dev-dependencies package (iso5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ tests/.coverage
 .tox
 junit*.xml
 .pytest_cache
+coverage.xml
 
 # Generated
 src/*/parser/parser.out

--- a/changelogs/unreleased/4249-dont-protect-inmanta-dev-dependencies-pkg.yml
+++ b/changelogs/unreleased/4249-dont-protect-inmanta-dev-dependencies-pkg.yml
@@ -1,0 +1,7 @@
+---
+description: Make sure that the `inmanta project install` command doesn't protect the inmanta-dev-dependencies package
+issue-nr: 4249
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/4249-dont-protect-inmanta-dev-dependencies-pkg.yml
+++ b/changelogs/unreleased/4249-dont-protect-inmanta-dev-dependencies-pkg.yml
@@ -2,6 +2,6 @@
 description: Make sure that the `inmanta project install` command doesn't protect the inmanta-dev-dependencies package
 issue-nr: 4249
 change-type: patch
-destination-branches: [master, iso5]
+destination-branches: [iso5]
 sections:
   bugfix: "{{description}}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,6 +443,9 @@ def deactive_venv():
     old_os_venv: Optional[str] = os.environ.get("VIRTUAL_ENV", None)
     old_process_env: str = env.process_env.python_path
     old_working_set = pkg_resources.working_set
+    old_available_extensions = (
+        dict(InmantaBootloader.AVAILABLE_EXTENSIONS) if InmantaBootloader.AVAILABLE_EXTENSIONS is not None else None
+    )
 
     yield
 
@@ -462,6 +465,7 @@ def deactive_venv():
         del os.environ["VIRTUAL_ENV"]
     env.mock_process_env(python_path=old_process_env)
     loader.PluginModuleFinder.reset()
+    InmantaBootloader.AVAILABLE_EXTENSIONS = old_available_extensions
 
 
 def reset_metrics():
@@ -490,6 +494,7 @@ def reset_all_objects():
     handler.Commander.reset()
     Project._project = None
     unknown_parameters.clear()
+    InmantaBootloader.AVAILABLE_EXTENSIONS = None
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -27,7 +27,7 @@ from pkg_resources import Requirement
 
 from inmanta import plugins
 from inmanta.compiler.config import feature_compiler_cache
-from inmanta.env import LocalPackagePath
+from inmanta.env import LocalPackagePath, process_env
 from inmanta.module import (
     DummyProject,
     InmantaModuleRequirement,
@@ -541,6 +541,14 @@ def test_project_requirements_dont_overwrite_core_requirements_source(
     but with another version. The requirements of core should not be
     overwritten. The module gets installed from source
     """
+    if "inmanta-core" in process_env.get_installed_packages(only_editable=True):
+        pytest.skip(
+            "This test would fail if it runs against an inmanta-core installed in editable mode, because the build tag "
+            "on the development branch is set to .dev0. The inmanta package protection feature would make pip "
+            "install a non-editable version of the same package. But no version with build tag .dev0 exists on the python "
+            "package repository."
+        )
+
     # Create the module
     module_name: str = "minimalv2module"
     module_path: str = str(tmpdir.join(module_name))
@@ -572,6 +580,13 @@ def test_project_requirements_dont_overwrite_core_requirements_index(
     but with another version. The requirements of core should not be
     overwritten. The module gets installed from index.
     """
+    if "inmanta-core" in process_env.get_installed_packages(only_editable=True):
+        pytest.skip(
+            "This test would fail if it runs against an inmanta-core installed in editable mode, because the build tag "
+            "on the development branch is set to .dev0. The inmanta package protection feature would make pip "
+            "install a non-editable version of the same package. But no version with build tag .dev0 exists on the python "
+            "package repository."
+        )
     # Create the module
     module_name: str = "minimalv2module"
     module_path: str = str(tmpdir.join(module_name))


### PR DESCRIPTION
# Description

**Same PR as  #4314 but scoped to the ISO5 branch only due to a merge conflict.**

Make sure that the `inmanta project install` command doesn't protect the `inmanta-dev-dependencies` package.

closes #4249 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
