### PR TITLE
Validate resource sets argument of the put_version endpoint

### DIFF
--- a/changelogs/unreleased/4328-resource-set-input-validation.yml
+++ b/changelogs/unreleased/4328-resource-set-input-validation.yml
@@ -1,0 +1,4 @@
+description: Validate resource sets argument of the put_version endpoint
+issue-nr: 4328
+change-type: minor
+destination-branches: [master, iso5]

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -280,7 +280,7 @@ class OrchestrationService(protocol.ServerSlice):
         superfluous_ids = set(resource_sets.keys()) - resource_ids
         if superfluous_ids:
             raise BadRequest(
-                f"The following resource ids provided in the resource_set parameter are not present "
+                f"The following resource ids provided in the resource_sets parameter are not present "
                 f"in the resources list: {', '.join(superfluous_ids)}"
             )
 

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -276,6 +276,13 @@ class OrchestrationService(protocol.ServerSlice):
                     if rid.get_agent_name() != agent:
                         # it is a CAD
                         cross_agent_dep.append((res_obj, rid))
+        resource_ids = {res.resource_id for res in resource_objects}
+        superfluous_ids = set(resource_sets.keys()) - resource_ids
+        if superfluous_ids:
+            raise BadRequest(
+                f"The following resource ids provided in the resource_set parameter are not present "
+                f"in the resources list: {', '.join(superfluous_ids)}"
+            )
 
         # hook up all CADs
         for f, t in cross_agent_dep:

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -24,6 +24,20 @@ from inmanta.util import get_compiler_version
 async def test_resource_sets_via_put_version(server, client, environment, clienthelper):
     version = await clienthelper.get_version()
 
+    result = await client.put_version(
+        tid=environment,
+        version=version,
+        resources=[],
+        resource_state={},
+        unknowns=[],
+        version_info={},
+        compiler_version=get_compiler_version(),
+        resource_sets={
+            "test::Resource[agent1,key=key1]": "set-a",
+        },
+    )
+    assert result.code == 400
+
     resources = [
         {
             "key": "key1",


### PR DESCRIPTION
# Description

closes #4328 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
