### PR TITLE
Fix race condition in the test_wait test case

### DIFF
--- a/changelogs/unreleased/fix-race-in-test-wait-test-case.yml
+++ b/changelogs/unreleased/fix-race-in-test-wait-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: Fix a race condition in the test_wait test case.
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -930,6 +930,8 @@ async def test_wait(resource_container, client, clienthelper, environment, serve
 
     await wait_for_n_deployed_resources(client, env_id, version1, n=2)
 
+    generation_version1 = agent._instances["agent1"]._nq.generation
+
     result = await client.get_version(environment, version1)
     assert result.code == 200
     assert result.result["model"]["done"] == 2
@@ -950,6 +952,10 @@ async def test_wait(resource_container, client, clienthelper, environment, serve
 
     logger.info("second version released")
 
+    # Wait until the agent is deploying version2. Otherwise the call to `wait_for_done_with_waiters()`
+    # might notify a test::Wait resource of version1, instead of the resources of version2. This could
+    # cause problem when the resource states of version1 are checked later on in this test case.
+    await retry_limited(lambda: agent._instances["agent1"]._nq.generation != generation_version1, timeout=10)
     await resource_container.wait_for_done_with_waiters(client, env_id, version2)
 
     logger.info("second version complete")


### PR DESCRIPTION
# Description

Fix race condition in the `test_wait` test case.

This PR should fix the following failure in the future:

```
06:32:59     @pytest.mark.asyncio(timeout=15)
06:32:59     async def test_wait(resource_container, client, clienthelper, environment, server, no_agent_backoff, async_finalizer):
06:32:59         """
06:32:59         If this test fail due to timeout,
06:32:59         this is probably due to the mechanism in the agent that prevents pulling resources in very rapid succession.
06:32:59     
06:32:59         If the test server is slow, a get_resources call takes a long time,
06:32:59         this makes the back-off longer
06:32:59     
06:32:59         this test deploys two models in rapid successions, if the server is slow, this may fail due to the back-off
06:32:59         """
06:32:59         resource_container.Provider.reset()
06:32:59     
06:32:59         env_id = environment
06:32:59     
06:32:59         # setup agent
06:32:59         agent = Agent(hostname="node1", environment=env_id, agent_map={"agent1": "localhost"}, code_loader=False, poolsize=10)
06:32:59         await agent.add_end_point_name("agent1")
06:32:59         await agent.start()
06:32:59         async_finalizer(agent.stop)
06:32:59     
06:32:59         # wait for agent
06:32:59         await retry_limited(lambda: len(server.get_slice(SLICE_SESSION_MANAGER)._sessions) == 1, 10)
06:32:59     
06:32:59         # set the deploy environment
06:32:59         resource_container.Provider.set("agent1", "key", "value")
06:32:59     
06:32:59         async def make_version():
06:32:59             version = await clienthelper.get_version()
06:32:59     
06:32:59             resources = [
06:32:59                 {
06:32:59                     "key": "key",
06:32:59                     "value": "value",
06:32:59                     "id": "test::Wait[agent1,key=key],v=%d" % version,
06:32:59                     "requires": [],
06:32:59                     "purged": False,
06:32:59                     "send_event": False,
06:32:59                 },
06:32:59                 {
06:32:59                     "key": "key2",
06:32:59                     "value": "value",
06:32:59                     "id": "test::Resource[agent1,key=key2],v=%d" % version,
06:32:59                     "requires": ["test::Wait[agent1,key=key],v=%d" % version],
06:32:59                     "purged": False,
06:32:59                     "send_event": False,
06:32:59                 },
06:32:59                 {
06:32:59                     "key": "key3",
06:32:59                     "value": "value",
06:32:59                     "id": "test::Resource[agent1,key=key3],v=%d" % version,
06:32:59                     "requires": [],
06:32:59                     "purged": False,
06:32:59                     "send_event": False,
06:32:59                 },
06:32:59                 {
06:32:59                     "key": "key4",
06:32:59                     "value": "value",
06:32:59                     "id": "test::Resource[agent1,key=key4],v=%d" % version,
06:32:59                     "requires": ["test::Resource[agent1,key=key3],v=%d" % version],
06:32:59                     "purged": False,
06:32:59                     "send_event": False,
06:32:59                 },
06:32:59                 {
06:32:59                     "key": "key5",
06:32:59                     "value": "value",
06:32:59                     "id": "test::Resource[agent1,key=key5],v=%d" % version,
06:32:59                     "requires": ["test::Resource[agent1,key=key4],v=%d" % version, "test::Wait[agent1,key=key],v=%d" % version],
06:32:59                     "purged": False,
06:32:59                     "send_event": False,
06:32:59                 },
06:32:59             ]
06:32:59             return version, resources
06:32:59     
06:32:59         logger.info("setup done")
06:32:59     
06:32:59         version1, resources = await make_version()
06:32:59         result = await client.put_version(
06:32:59             tid=env_id, version=version1, resources=resources, unknowns=[], version_info={}, compiler_version=get_compiler_version()
06:32:59         )
06:32:59         assert result.code == 200
06:32:59     
06:32:59         logger.info("first version pushed")
06:32:59     
06:32:59         # deploy and wait until one is ready
06:32:59         result = await client.release_version(env_id, version1, True, const.AgentTriggerMethod.push_full_deploy)
06:32:59         assert result.code == 200
06:32:59     
06:32:59         logger.info("first version released")
06:32:59     
06:32:59         await wait_for_n_deployed_resources(client, env_id, version1, n=2)
06:32:59     
06:32:59         result = await client.get_version(environment, version1)
06:32:59         assert result.code == 200
06:32:59         assert result.result["model"]["done"] == 2
06:32:59     
06:32:59         logger.info("first version, 2 resources deployed")
06:32:59     
06:32:59         version2, resources = await make_version()
06:32:59         result = await client.put_version(
06:32:59             tid=env_id, version=version2, resources=resources, unknowns=[], version_info={}, compiler_version=get_compiler_version()
06:32:59         )
06:32:59         assert result.code == 200
06:32:59     
06:32:59         logger.info("second version pushed %f", time.time())
06:32:59     
06:32:59         # deploy and wait until done
06:32:59         result = await client.release_version(env_id, version2, True, const.AgentTriggerMethod.push_full_deploy)
06:32:59         assert result.code == 200
06:32:59     
06:32:59         logger.info("second version released")
06:32:59     
06:32:59         await resource_container.wait_for_done_with_waiters(client, env_id, version2)
06:32:59     
06:32:59         logger.info("second version complete")
06:32:59     
06:32:59         result = await client.get_version(env_id, version2)
06:32:59         assert result.code == 200
06:32:59         for x in result.result["resources"]:
06:32:59             assert x["status"] == const.ResourceState.deployed.name
06:32:59     
06:32:59         result = await client.get_version(env_id, version1)
06:32:59         assert result.code == 200
06:32:59         states = {x["id"]: x["status"] for x in result.result["resources"]}
06:32:59     
06:32:59         assert states["test::Wait[agent1,key=key],v=%d" % version1] == const.ResourceState.deployed.name
06:32:59 >       assert states["test::Resource[agent1,key=key2],v=%d" % version1] == const.ResourceState.available.name
06:32:59 E       AssertionError: assert 'deployed' == 'available'
06:32:59 E         - available
06:32:59 E         + deployed
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
