### PR TITLE
Fix cancellation issue in disconnect from db

### DIFF
--- a/changelogs/unreleased/issue-fix-cancellation-disconnect-from-db.yml
+++ b/changelogs/unreleased/issue-fix-cancellation-disconnect-from-db.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that the disconnect() method of the database layer properly propagates the asyncio.CancelledError exception
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1146,8 +1146,16 @@ class BaseDocument(object, metaclass=DocumentMeta):
             return
         try:
             await asyncio.wait_for(cls._connection_pool.close(), config.db_connection_timeout.get())
-        except (asyncio.TimeoutError, asyncio.CancelledError):
+        except asyncio.TimeoutError:
             cls._connection_pool.terminate()
+            LOGGER.exception("A timeout occurred while closing the connection pool to the database")
+            raise
+        except asyncio.CancelledError:
+            # Propagate cancel
+            raise
+        except Exception:
+            LOGGER.exception("An unexpected exception occurred while closing the connection pool to the database")
+            raise
         finally:
             cls._connection_pool = None
 
@@ -5828,7 +5836,12 @@ def set_connection_pool(pool: asyncpg.pool.Pool) -> None:
 
 async def disconnect() -> None:
     LOGGER.debug("Disconnecting data classes")
-    await asyncio.gather(*[cls.close_connection_pool() for cls in _classes])
+    # Enable `return_exceptions` to make sure we wait until all close_connection_pool() calls are finished
+    # or until the gather itself is cancelled.
+    result = await asyncio.gather(*[cls.close_connection_pool() for cls in _classes], return_exceptions=True)
+    exceptions = [r for r in result if r is not None and isinstance(r, Exception)]
+    if exceptions:
+        raise exceptions[0]
 
 
 PACKAGE_WITH_UPDATE_FILES = inmanta.db.versions

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1151,6 +1151,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
             LOGGER.exception("A timeout occurred while closing the connection pool to the database")
             raise
         except asyncio.CancelledError:
+            cls._connection_pool.terminate()
             # Propagate cancel
             raise
         except Exception:


### PR DESCRIPTION
# Description

From time to time test cases fail in the tear down stage with an error message related to the termination of the database connection pool. I noticed that this also happens on test cases that do not even start the server, which is very strange. After some investigation it seems that the `disconnect()` method of the database layer isn't re-raising the `asyncio.CancelledError`. This way a timeout, while stopping the server in the tear down of the server fixture, doesn't actually cancel the disconnect task. I think this causes the disconnect task to cross the boundary of the test case it belongs to. This PR ensures that the `asyncio.CancelledError` re-raised.

<details>
  <summary>Details about test case failure:</summary>
  
05:02:12 home/user/code/tests/test_config.py::test_environment_deprecated_options PASSED [ 37%]
05:02:12 home/user/code/tests/test_config.py::test_options PASSED                 [ 37%]
05:02:12 home/user/code/tests/test_config.py::test_bind_port PASSED               [ 37%]
05:02:27 home/user/code/tests/test_config.py::test_bind_port ERROR                [ 37%]
05:02:27 _____________________ ERROR at teardown of test_bind_port ______________________
05:02:27 
05:02:27 cls = <class 'inmanta.data.Project'>
05:02:27 
05:02:27     @classmethod
05:02:27     async def close_connection_pool(cls) -> None:
05:02:27         if not cls._connection_pool:
05:02:27             return
05:02:27         try:
05:02:27 >           await asyncio.wait_for(cls._connection_pool.close(), config.db_connection_timeout.get())
05:02:27 
05:02:27 opt/inmanta/lib64/python3.10/site-packages/inmanta/data/__init__.py:921: 
05:02:27 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:02:27 
05:02:27 fut = <Task cancelled name='Task-112051' coro=<Pool.close() done, defined at /opt/inmanta/lib64/python3.10/site-packages/asyncpg/pool.py:869>>
05:02:27 timeout = 60.0
05:02:27 
05:02:27     async def wait_for(fut, timeout):
05:02:27         """Wait for the single Future or coroutine to complete, with timeout.
05:02:27     
05:02:27         Coroutine will be wrapped in Task.
05:02:27     
05:02:27         Returns result of the Future or coroutine.  When a timeout occurs,
05:02:27         it cancels the task and raises TimeoutError.  To avoid the task
05:02:27         cancellation, wrap it in shield().
05:02:27     
05:02:27         If the wait is cancelled, the task is also cancelled.
05:02:27     
05:02:27         This function is a coroutine.
05:02:27         """
05:02:27         loop = events.get_running_loop()
05:02:27     
05:02:27         if timeout is None:
05:02:27             return await fut
05:02:27     
05:02:27         if timeout <= 0:
05:02:27             fut = ensure_future(fut, loop=loop)
05:02:27     
05:02:27             if fut.done():
05:02:27                 return fut.result()
05:02:27     
05:02:27             await _cancel_and_wait(fut, loop=loop)
05:02:27             try:
05:02:27                 return fut.result()
05:02:27             except exceptions.CancelledError as exc:
05:02:27                 raise exceptions.TimeoutError() from exc
05:02:27     
05:02:27         waiter = loop.create_future()
05:02:27         timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
05:02:27         cb = functools.partial(_release_waiter, waiter)
05:02:27     
05:02:27         fut = ensure_future(fut, loop=loop)
05:02:27         fut.add_done_callback(cb)
05:02:27     
05:02:27         try:
05:02:27             # wait until the future completes or the timeout
05:02:27             try:
05:02:27 >               await waiter
05:02:27 E               asyncio.exceptions.CancelledError
05:02:27 
05:02:27 usr/lib64/python3.10/asyncio/tasks.py:432: CancelledError
05:02:27 
05:02:27 During handling of the above exception, another exception occurred:
05:02:27 
05:02:27 self = <inmanta.server.bootloader.InmantaBootloader object at 0x7fe5bdd81f00>
05:02:27 
05:02:27     async def stop(self) -> None:
05:02:27 >       await self.restserver.stop()
05:02:27 
05:02:27 opt/inmanta/lib64/python3.10/site-packages/inmanta/server/bootloader.py:86: 
05:02:27 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:02:27 
05:02:27 self = <inmanta.server.protocol.Server object at 0x7fe5bdd81a50>
05:02:27 
05:02:27     async def stop(self) -> None:
05:02:27         """
05:02:27         Stop the transport.
05:02:27     
05:02:27         The order in which the endpoint are stopped, is reverse compared to the starting order.
05:02:27         This prevents database connection from being closed too early. This order in which the endpoint
05:02:27         are started, is hardcoded in the get_server_slices() method in server/bootloader.py
05:02:27         """
05:02:27         if not self.running:
05:02:27             return
05:02:27         self.running = False
05:02:27     
05:02:27         await super(Server, self).stop()
05:02:27     
05:02:27         order = list(reversed(self._get_slice_sequence()))
05:02:27     
05:02:27         for endpoint in order:
05:02:27             LOGGER.debug("Pre Stopping %s", endpoint.name)
05:02:27             await endpoint.prestop()
05:02:27     
05:02:27         for endpoint in order:
05:02:27             LOGGER.debug("Stopping %s", endpoint.name)
05:02:27 >           await endpoint.stop()
05:02:27 
05:02:27 opt/inmanta/lib64/python3.10/site-packages/inmanta/server/protocol.py:201: 
05:02:27 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:02:27 
05:02:27 self = <inmanta.server.services.databaseservice.DatabaseService object at 0x7fe5bdd809d0>
05:02:27 
05:02:27     async def stop(self) -> None:
05:02:27 >       await self.disconnect_database()
05:02:27 
05:02:27 opt/inmanta/lib64/python3.10/site-packages/inmanta/server/services/databaseservice.py:48: 
05:02:27 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:02:27 
05:02:27 self = <inmanta.server.services.databaseservice.DatabaseService object at 0x7fe5bdd809d0>
05:02:27 
05:02:27     async def disconnect_database(self) -> None:
05:02:27         """Disconnect the database"""
05:02:27 >       await data.disconnect()
05:02:27 
05:02:27 opt/inmanta/lib64/python3.10/site-packages/inmanta/server/services/databaseservice.py:79: 
05:02:27 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:02:27 
05:02:27     async def disconnect() -> None:
05:02:27         LOGGER.debug("Disconnecting data classes")
05:02:27 >       await asyncio.gather(*[cls.close_connection_pool() for cls in _classes])
05:02:27 E       asyncio.exceptions.CancelledError
05:02:27 
05:02:27 opt/inmanta/lib64/python3.10/site-packages/inmanta/data/__init__.py:5351: CancelledError
05:02:27 
05:02:27 During handling of the above exception, another exception occurred:
05:02:27 
05:02:27 fut = <Task cancelled name='Task-112036' coro=<InmantaBootloader.stop() done, defined at /opt/inmanta/lib64/python3.10/site-packages/inmanta/server/bootloader.py:85>>
05:02:27 timeout = 15
05:02:27 
05:02:27     async def wait_for(fut, timeout):
05:02:27         """Wait for the single Future or coroutine to complete, with timeout.
05:02:27     
05:02:27         Coroutine will be wrapped in Task.
05:02:27     
05:02:27         Returns result of the Future or coroutine.  When a timeout occurs,
05:02:27         it cancels the task and raises TimeoutError.  To avoid the task
05:02:27         cancellation, wrap it in shield().
05:02:27     
05:02:27         If the wait is cancelled, the task is also cancelled.
05:02:27     
05:02:27         This function is a coroutine.
05:02:27         """
05:02:27         loop = events.get_running_loop()
05:02:27     
05:02:27         if timeout is None:
05:02:27             return await fut
05:02:27     
05:02:27         if timeout <= 0:
05:02:27             fut = ensure_future(fut, loop=loop)
05:02:27     
05:02:27             if fut.done():
05:02:27                 return fut.result()
05:02:27     
05:02:27             await _cancel_and_wait(fut, loop=loop)
05:02:27             try:
05:02:27                 return fut.result()
05:02:27             except exceptions.CancelledError as exc:
05:02:27                 raise exceptions.TimeoutError() from exc
05:02:27     
05:02:27         waiter = loop.create_future()
05:02:27         timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
05:02:27         cb = functools.partial(_release_waiter, waiter)
05:02:27     
05:02:27         fut = ensure_future(fut, loop=loop)
05:02:27         fut.add_done_callback(cb)
05:02:27     
05:02:27         try:
05:02:27             # wait until the future completes or the timeout
05:02:27             try:
05:02:27                 await waiter
05:02:27             except exceptions.CancelledError:
05:02:27                 if fut.done():
05:02:27                     return fut.result()
05:02:27                 else:
05:02:27                     fut.remove_done_callback(cb)
05:02:27                     # We must ensure that the task is not running
05:02:27                     # after wait_for() returns.
05:02:27                     # See https://bugs.python.org/issue32751
05:02:27                     await _cancel_and_wait(fut, loop=loop)
05:02:27                     raise
05:02:27     
05:02:27             if fut.done():
05:02:27                 return fut.result()
05:02:27             else:
05:02:27                 fut.remove_done_callback(cb)
05:02:27                 # We must ensure that the task is not running
05:02:27                 # after wait_for() returns.
05:02:27                 # See https://bugs.python.org/issue32751
05:02:27                 await _cancel_and_wait(fut, loop=loop)
05:02:27                 # In case task cancellation failed with some
05:02:27                 # exception, we should re-raise it
05:02:27                 # See https://bugs.python.org/issue40607
05:02:27                 try:
05:02:27 >                   return fut.result()
05:02:27 E                   asyncio.exceptions.CancelledError
05:02:27 
05:02:27 usr/lib64/python3.10/asyncio/tasks.py:456: CancelledError
05:02:27 
05:02:27 The above exception was the direct cause of the following exception:
05:02:27 
05:02:27     def finalizer():
05:02:27         """Yield again, to finalize."""
05:02:27     
05:02:27         async def async_finalizer():
05:02:27             try:
05:02:27                 await gen_obj.__anext__()
05:02:27             except StopAsyncIteration:
05:02:27                 pass
05:02:27             else:
05:02:27                 msg = "Async generator fixture didn't stop."
05:02:27                 msg += "Yield only once."
05:02:27                 raise ValueError(msg)
05:02:27     
05:02:27 >       loop.run_until_complete(async_finalizer())
05:02:27 
05:02:27 opt/inmanta/lib64/python3.10/site-packages/pytest_asyncio/plugin.py:362: 
05:02:27 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:02:27 usr/lib64/python3.10/asyncio/base_events.py:646: in run_until_complete
05:02:27     return future.result()
05:02:27 opt/inmanta/lib64/python3.10/site-packages/pytest_asyncio/plugin.py:354: in async_finalizer
05:02:27     await gen_obj.__anext__()
05:02:27 home/user/code/tests/conftest.py:676: in server
05:02:27     await asyncio.wait_for(ibl.stop(), 15)
05:02:27 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:02:27 
05:02:27 fut = <Task cancelled name='Task-112036' coro=<InmantaBootloader.stop() done, defined at /opt/inmanta/lib64/python3.10/site-packages/inmanta/server/bootloader.py:85>>
05:02:27 timeout = 15
05:02:27 
05:02:27     async def wait_for(fut, timeout):
05:02:27         """Wait for the single Future or coroutine to complete, with timeout.
05:02:27     
05:02:27         Coroutine will be wrapped in Task.
05:02:27     
05:02:27         Returns result of the Future or coroutine.  When a timeout occurs,
05:02:27         it cancels the task and raises TimeoutError.  To avoid the task
05:02:27         cancellation, wrap it in shield().
05:02:27     
05:02:27         If the wait is cancelled, the task is also cancelled.
05:02:27     
05:02:27         This function is a coroutine.
05:02:27         """
05:02:27         loop = events.get_running_loop()
05:02:27     
05:02:27         if timeout is None:
05:02:27             return await fut
05:02:27     
05:02:27         if timeout <= 0:
05:02:27             fut = ensure_future(fut, loop=loop)
05:02:27     
05:02:27             if fut.done():
05:02:27                 return fut.result()
05:02:27     
05:02:27             await _cancel_and_wait(fut, loop=loop)
05:02:27             try:
05:02:27                 return fut.result()
05:02:27             except exceptions.CancelledError as exc:
05:02:27                 raise exceptions.TimeoutError() from exc
05:02:27     
05:02:27         waiter = loop.create_future()
05:02:27         timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
05:02:27         cb = functools.partial(_release_waiter, waiter)
05:02:27     
05:02:27         fut = ensure_future(fut, loop=loop)
05:02:27         fut.add_done_callback(cb)
05:02:27     
05:02:27         try:
05:02:27             # wait until the future completes or the timeout
05:02:27             try:
05:02:27                 await waiter
05:02:27             except exceptions.CancelledError:
05:02:27                 if fut.done():
05:02:27                     return fut.result()
05:02:27                 else:
05:02:27                     fut.remove_done_callback(cb)
05:02:27                     # We must ensure that the task is not running
05:02:27                     # after wait_for() returns.
05:02:27                     # See https://bugs.python.org/issue32751
05:02:27                     await _cancel_and_wait(fut, loop=loop)
05:02:27                     raise
05:02:27     
05:02:27             if fut.done():
05:02:27                 return fut.result()
05:02:27             else:
05:02:27                 fut.remove_done_callback(cb)
05:02:27                 # We must ensure that the task is not running
05:02:27                 # after wait_for() returns.
05:02:27                 # See https://bugs.python.org/issue32751
05:02:27                 await _cancel_and_wait(fut, loop=loop)
05:02:27                 # In case task cancellation failed with some
05:02:27                 # exception, we should re-raise it
05:02:27                 # See https://bugs.python.org/issue40607
05:02:27                 try:
05:02:27                     return fut.result()
05:02:27                 except exceptions.CancelledError as exc:
05:02:27 >                   raise exceptions.TimeoutError() from exc
05:02:27 E                   asyncio.exceptions.TimeoutError
05:02:27 
05:02:27 usr/lib64/python3.10/asyncio/tasks.py:458: TimeoutError
05:02:27 ------------------------------ Captured log setup ------------------------------
05:02:27 WARNING  inmanta.config:config.py:179 Config name token not defined in section server_rest_transport
05:02:27 ------------------------------ Captured log call -------------------------------
05:02:27 WARNING  inmanta.config:config.py:179 Config name token not defined in section server_rest_transport
05:02:27 WARNING  py.warnings:warnings.py:109 /opt/inmanta/lib64/python3.10/site-packages/inmanta/server/config.py:116: DeprecationWarning: The server_rest_transport.port config option is deprecated in favour of the server.bind-port option.
05:02:27   warnings.warn(
05:02:27 
05:02:27 WARNING  py.warnings:warnings.py:109 /opt/inmanta/lib64/python3.10/site-packages/inmanta/protocol/endpoints.py:384: RuntimeWarning: coroutine 'test_bind_port.<locals>.test_endpoint' was never awaited
05:02:27   method.function(*args, **kwargs)
05:02:27 
05:02:27 WARNING  inmanta.config:config.py:179 Config name token not defined in section server_rest_transport
05:02:27 WARNING  py.warnings:warnings.py:109 /opt/inmanta/lib64/python3.10/site-packages/inmanta/server/config.py:108: DeprecationWarning: Ignoring the server_rest_transport.port config option since the new config options server.bind-port/server.bind-address are used.
05:02:27   warnings.warn(
05:02:27 
05:02:27 WARNING  inmanta.config:config.py:179 Config name token not defined in section server_rest_transport
05:02:27 ---------------------------- Captured log teardown -----------------------------
05:02:27 ERROR    inmanta.server.services.compilerservice:compilerservice.py:513 The following exception occurred while cleaning up old compiler reports
05:02:27 Traceback (most recent call last):
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/inmanta/server/services/compilerservice.py", line 508, in _cleanup
05:02:27     await data.Compile.delete_older_than(oldest_retained_date)
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/inmanta/data/__init__.py", line 3100, in delete_older_than
05:02:27     await cls._execute_query(query, oldest_retained_date, connection=connection)
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/inmanta/data/__init__.py", line 1024, in _execute_query
05:02:27     return await con.execute(query, *values)
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/asyncpg/connection.py", line 320, in execute
05:02:27     _, status, _ = await self._execute(
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/asyncpg/connection.py", line 1659, in _execute
05:02:27     result, _ = await self.__execute(
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/asyncpg/connection.py", line 1684, in __execute
05:02:27     return await self._do_execute(
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/asyncpg/connection.py", line 1711, in _do_execute
05:02:27     stmt = await self._get_statement(
05:02:27   File "/opt/inmanta/lib64/python3.10/site-packages/asyncpg/connection.py", line 398, in _get_statement
05:02:27     statement = await self._protocol.prepare(
05:02:27   File "asyncpg/protocol/protocol.pyx", line 168, in prepare
05:02:27   File "asyncpg/protocol/protocol.pyx", line 865, in asyncpg.protocol.protocol.BaseProtocol._dispatch_result
05:02:27 asyncpg.exceptions._base.InternalClientError: got result for unknown protocol state 3
</details>

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
