### PR TITLE
Handle psutil exceptions when processes are gone (PR #4315)

### DIFF
--- a/changelogs/unreleased/unstable-test-psutil.yml
+++ b/changelogs/unreleased/unstable-test-psutil.yml
@@ -1,0 +1,3 @@
+description: Handle psutil exceptions when processes are gone
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -1717,7 +1717,15 @@ async def setup_environment_with_agent(client, project_name):
 
 
 def _get_inmanta_agent_child_processes(parent_process: psutil.Process) -> List[psutil.Process]:
-    return [p for p in parent_process.children(recursive=True) if "inmanta.app" in p.cmdline() and "agent" in p.cmdline()]
+    def try_get_cmd(p: psutil.Process) -> str:
+        try:
+            return p.cmdline()
+        except Exception:
+            logger.warning("A child process is gone! pid=%d", p.pid)
+            """If a child process is gone, p.cmdline() raises an exception"""
+            return ""
+
+    return [p for p in parent_process.children(recursive=True) if "inmanta.app" in try_get_cmd(p) and "agent" in try_get_cmd(p)]
 
 
 @pytest.mark.asyncio(timeout=15)


### PR DESCRIPTION
# Description

**Cherry pick this change onto the stable branch to fix broken tests.**

We are getting regular failures in the nightly builds due to this.

This is a first attempt to get to the bottom of it.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
