### PR TITLE
Don't re-raise TimeoutError on close connection pool

### DIFF
--- a/changelogs/unreleased/dont-reraise-timeout-close-connection-pool.yml
+++ b/changelogs/unreleased/dont-reraise-timeout-close-connection-pool.yml
@@ -1,0 +1,4 @@
+---
+description: Don't re-raise TimeoutError on close connection pool
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1148,8 +1148,10 @@ class BaseDocument(object, metaclass=DocumentMeta):
             await asyncio.wait_for(cls._connection_pool.close(), config.db_connection_timeout.get())
         except asyncio.TimeoutError:
             cls._connection_pool.terminate()
+            # Don't propagate this exception but just write a log message. This way:
+            #   * A timeout here still makes sure that the other server slices get stopped
+            #   * The tests don't fail when this timeout occurs
             LOGGER.exception("A timeout occurred while closing the connection pool to the database")
-            raise
         except asyncio.CancelledError:
             cls._connection_pool.terminate()
             # Propagate cancel


### PR DESCRIPTION
# Description

The test suite sets the timeout to close the connection pool to the database to 3 seconds. This doesn't seem to be enough for the test cases that run the database migration script. As such, these test cases often fail with a TimeoutError.  I don't think there is reason why we have to re-raise the TimeoutError. All connection are forcefully closed when a timeout occurs, so I think that just writing a log message is enough here. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
