### PR TITLE
Fix test_autostart_mapping test case

### DIFF
--- a/changelogs/unreleased/fix-test-autostart-mapping-test-case.yml
+++ b/changelogs/unreleased/fix-test-autostart-mapping-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that the test_autostart_mapping test case only takes into account the inmanta agent processes.
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -1383,7 +1383,7 @@ async def test_autostart_mapping(server, client, clienthelper, resource_containe
     env_uuid = uuid.UUID(environment)
     agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
     current_process = psutil.Process()
-    children_pre = current_process.children(recursive=True)
+    agent_processes_pre: List[psutil.Process] = _get_inmanta_agent_child_processes(current_process)
     resource_container.Provider.reset()
     env = await data.Environment.get_by_id(env_uuid)
     await env.set(data.AUTOSTART_AGENT_MAP, {"internal": "", "agent1": ""})
@@ -1484,12 +1484,10 @@ async def test_autostart_mapping(server, client, clienthelper, resource_containe
     # Stop server
     await asyncio.wait_for(server.stop(), timeout=15)
 
-    current_process = psutil.Process()
-    children = current_process.children(recursive=True)
+    agent_processes: List[psutil.Process] = _get_inmanta_agent_child_processes(current_process)
+    new_agent_processes = set(agent_processes) - set(agent_processes_pre)
 
-    newchildren = set(children) - set(children_pre)
-
-    assert len(newchildren) == 0, newchildren
+    assert len(new_agent_processes) == 0, new_agent_processes
 
 
 async def test_autostart_mapping_update_uri(server, client, environment, async_finalizer, caplog):


### PR DESCRIPTION
# Description

Ensure that the test_autostart_mapping test case only takes into account the inmanta agent processes. For some reason, this test case fails regularly on the presence of a postgresql processs. This is probably pytest-postgresql spawning an additional process for some reason. Since the postgresql processes are not relevant for the test case, this PR ignores them.

Snippet from Jenkins output:

```
04:04:09 >       assert len(newchildren) == 0, newchildren
04:04:09 E       AssertionError: {psutil.Process(pid=2370, name='postgres', status='zombie', started='02:04:07')}
04:04:09 E       assert 1 == 0
04:04:09 E         +1
04:04:09 E         -0
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
