### PR TITLE
Add environment setting to set the auto-recompile-wait time instead of the config option

### DIFF
--- a/changelogs/unreleased/4332-auto-recompile-wait-env-setting.yml
+++ b/changelogs/unreleased/4332-auto-recompile-wait-env-setting.yml
@@ -1,0 +1,7 @@
+description: Add environment setting to set the auto-recompile-wait time instead of the config option
+issue-nr: 4332
+change-type: patch
+destination-branches: [master]
+sections:
+  feature: "{{description}}",
+  deprecation-note: "The auto-recompile-wait option in the server configuration is now deprecated in favor of the environment setting with the same name"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1955,6 +1955,12 @@ def convert_int(value: Union[float, int, str]) -> Union[int, float]:
     return f_value
 
 
+def convert_float(value: Union[float, int, str]) -> float:
+    if isinstance(value, float):
+        return value
+    return float(value)
+
+
 def convert_agent_map(value: Dict[str, str]) -> Dict[str, str]:
     if not isinstance(value, dict):
         raise ValueError("Agent map should be a dict")
@@ -1988,7 +1994,14 @@ def convert_agent_trigger_method(value: object) -> str:
     return value
 
 
-TYPE_MAP = {"int": "integer", "bool": "boolean", "dict": "jsonb", "str": "varchar", "enum": "varchar"}
+TYPE_MAP = {
+    "int": "integer",
+    "bool": "boolean",
+    "dict": "jsonb",
+    "str": "varchar",
+    "enum": "varchar",
+    "float": "double precision",
+}
 
 AUTO_DEPLOY = "auto_deploy"
 PUSH_ON_AUTO_DEPLOY = "push_on_auto_deploy"
@@ -2009,6 +2022,7 @@ PURGE_ON_DELETE = "purge_on_delete"
 PROTECTED_ENVIRONMENT = "protected_environment"
 NOTIFICATION_RETENTION = "notification_retention"
 AVAILABLE_VERSIONS_TO_KEEP = "available_versions_to_keep"
+AUTO_RECOMPILE_WAIT = "auto_recompile_wait"
 
 
 class Setting(object):
@@ -2260,6 +2274,14 @@ class Environment(BaseDocument):
             typ="int",
             validator=convert_int,
             doc="The number of days to retain notifications for",
+        ),
+        AUTO_RECOMPILE_WAIT: Setting(
+            name=AUTO_RECOMPILE_WAIT,
+            default=0.1,
+            typ="float",
+            validator=convert_float,
+            doc="""The number of seconds to wait before the server may attempt to do a new recompile.
+                    Recompiles are triggered after facts updates for example.""",
         ),
     }
 

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -198,7 +198,7 @@ class AttributeStateChange(BaseModel):
     desired: Optional[Any] = None
 
 
-EnvSettingType = Union[StrictNonIntBool, int, str, Dict[str, Union[str, int, StrictNonIntBool]]]
+EnvSettingType = Union[StrictNonIntBool, int, float, str, Dict[str, Union[str, int, StrictNonIntBool]]]
 
 
 class Environment(BaseModel):

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -175,15 +175,6 @@ server_fact_resource_block = Option(
     "server", "fact-resource-block", 60, "Minimal time between subsequent requests for the same fact", is_time
 )
 
-server_autrecompile_wait = Option(
-    "server",
-    "auto-recompile-wait",
-    10,
-    """The number of seconds to wait before the server may attempt to do a new recompile.
-                                     Recompiles are triggered after facts updates for example.""",
-    is_time,
-)
-
 server_purge_version_interval = Option(
     "server",
     "purge-versions-interval",

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -638,7 +638,8 @@ class CompilerService(ServerSlice):
         return wait
 
     async def _auto_recompile_wait(self, compile: data.Compile) -> None:
-        wait_time = opt.server_autrecompile_wait.get()
+        env = await data.Environment.get_by_id(compile.environment)
+        wait_time = await env.get(data.AUTO_RECOMPILE_WAIT)
         last_run = await data.Compile.get_last_run(compile.environment)
         if not last_run:
             wait: float = 0
@@ -649,7 +650,7 @@ class CompilerService(ServerSlice):
             )
         if wait > 0:
             LOGGER.info(
-                "server-auto-recompile-wait is enabled and set to %s seconds, "
+                "auto_recompile_wait is enabled and set to %s seconds, "
                 "waiting for %.2f seconds before running a new compile",
                 wait_time,
                 wait,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -688,7 +688,6 @@ async def server_config(event_loop, inmanta_config, postgres_db, database_name, 
     config.Config.set("server", "agent-process-purge-interval", "0")
     config.Config.set("config", "executable", os.path.abspath(inmanta.app.__file__))
     config.Config.set("server", "agent-timeout", "2")
-    config.Config.set("server", "auto-recompile-wait", "0")
     config.Config.set("agent", "agent-repair-interval", "0")
     yield config
     shutil.rmtree(state_dir)
@@ -787,7 +786,6 @@ async def server_multi(
     config.Config.set("config", "executable", os.path.abspath(inmanta.app.__file__))
     config.Config.set("server", "agent-timeout", "2")
     config.Config.set("agent", "agent-repair-interval", "0")
-    config.Config.set("server", "auto-recompile-wait", "0")
 
     ibl = InmantaBootloader()
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -529,7 +529,8 @@ async def test_server_recompile(server, client, environment, monkeypatch):
     """
     Test a recompile on the server and verify recompile triggers
     """
-    config.Config.set("server", "auto-recompile-wait", "0")
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.set(data.AUTO_RECOMPILE_WAIT, 0)
 
     project_dir = os.path.join(server.get_slice(SLICE_SERVER)._server_storage["environments"], str(environment))
     project_source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "data", "project")
@@ -642,7 +643,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     correct value in this test.
     """
     env = await data.Environment.get_by_id(environment)
-    config.Config.set("server", "auto-recompile-wait", "0")
+    await env.set(data.AUTO_RECOMPILE_WAIT, 0)
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
 
     result = await client.get_compile_queue(environment)
@@ -738,7 +739,8 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
 
 
 async def test_compilerservice_halt(mocked_compiler_service_block, server, client, environment: uuid.UUID) -> None:
-    config.Config.set("server", "auto-recompile-wait", "0")
+    env = await data.Environment.get_by_id(environment)
+    await env.set(data.AUTO_RECOMPILE_WAIT, 0)
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
 
     result = await client.get_compile_queue(environment)
@@ -951,7 +953,7 @@ async def test_compileservice_auto_recompile_wait(mocked_compiler_service_block,
     """
     with caplog.at_level(logging.DEBUG):
         env = await data.Environment.get_by_id(environment)
-        config.Config.set("server", "auto-recompile-wait", "2")
+        await env.set(data.AUTO_RECOMPILE_WAIT, "2.1")
         compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
 
         # request compiles in rapid succession
@@ -982,7 +984,7 @@ async def test_compileservice_auto_recompile_wait(mocked_compiler_service_block,
         ).contains(
             "inmanta.server.services.compilerservice",
             logging.INFO,
-            "server-auto-recompile-wait is enabled and set to 2 seconds",
+            "auto_recompile_wait is enabled and set to 2.1 seconds",
         ).contains(
             "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
         )
@@ -990,10 +992,9 @@ async def test_compileservice_auto_recompile_wait(mocked_compiler_service_block,
 
 async def test_compileservice_calculate_auto_recompile_wait(mocked_compiler_service_block, server):
     """
-    Test the recompile waiting time calculation when auto-recompile-wait configuration option is enabled
+    Test the recompile waiting time calculation when auto-recompile-wait environment setting is enabled
     """
     auto_recompile_wait = 2
-    config.Config.set("server", "auto-recompile-wait", str(auto_recompile_wait))
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
 
     now = datetime.datetime.now()


### PR DESCRIPTION
# Description

closes #4332 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
