### PR TITLE
added missing option to setup.cfg in modules v2 docs

### DIFF
--- a/changelogs/unreleased/docs-modules-v2-setupcfg-missing-option.yml
+++ b/changelogs/unreleased/docs-modules-v2-setupcfg-missing-option.yml
@@ -1,0 +1,4 @@
+description: added missing option to setup.cfg in modules v2 docs
+change-type: patch
+destination-branches:
+  - master

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -85,6 +85,9 @@ The ``setup.cfg`` file defines metadata about the module. The following code sni
     include_package_data=True
     packages=find_namespace:
 
+    [options.packages.find]
+    include = inmanta_plugins*
+
 
 * The ``metadata`` section defines the following fields:
 


### PR DESCRIPTION
# Description

Updated docs after #4130

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
