### PR TITLE
Improved batching for code loading

### DIFF
--- a/changelogs/unreleased/4217-batched-code-loading.yml
+++ b/changelogs/unreleased/4217-batched-code-loading.yml
@@ -4,4 +4,4 @@ issue-nr: 4217
 change-type: patch
 destination-branches: [master, iso5]
 sections:
-  minor: "{{description}}"
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/4217-batched-code-loading.yml
+++ b/changelogs/unreleased/4217-batched-code-loading.yml
@@ -1,0 +1,7 @@
+---
+description: Improve batching of code loading in the agent
+issue-nr: 4217
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  minor: "{{description}}"

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1194,7 +1194,7 @@ class Agent(SessionEndpoint):
                 # stop if the last successful load was this one
                 # The combination of the lock and this check causes the reloads to naturally 'batch up'
                 if self._last_loaded[rt] == version:
-                    LOGGER.debug("Code already present for %s %d", rt, version)
+                    LOGGER.debug("Code already present for %s version=%d", rt, version)
                     continue
                 # clear cache, for retry on failure
                 self._last_loaded[rt] = -1
@@ -1202,7 +1202,7 @@ class Agent(SessionEndpoint):
                 result: protocol.Result = await self._client.get_code(environment, version, rt)
                 if result.code == 200 and result.result is not None:
                     try:
-                        LOGGER.debug("Installing handler %s %d", rt, version)
+                        LOGGER.debug("Installing handler %s version=%d", rt, version)
                         await self._install(
                             [
                                 (ModuleSource(name, content, hash_value), requires)
@@ -1212,7 +1212,7 @@ class Agent(SessionEndpoint):
                         LOGGER.debug("Installed handler %s %d", rt, version)
                         self._last_loaded[rt] = version
                     except Exception:
-                        LOGGER.exception("Failed to install handler %s %d", rt, version)
+                        LOGGER.exception("Failed to install handler %s version=%d", rt, version)
                         failed_to_load.add(rt)
 
         return failed_to_load

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -26,7 +26,6 @@ import uuid
 from asyncio import Lock
 from collections import defaultdict
 from concurrent.futures.thread import ThreadPoolExecutor
-from dataclasses import dataclass
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, cast
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1209,7 +1209,7 @@ class Agent(SessionEndpoint):
                                 for hash_value, (path, name, content, requires) in result.result["sources"].items()
                             ]
                         )
-                        LOGGER.debug("Installed handler %s %d", rt, version)
+                        LOGGER.debug("Installed handler %s version=%d", rt, version)
                         self._last_loaded[rt] = version
                     except Exception:
                         LOGGER.exception("Failed to install handler %s version=%d", rt, version)

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -23,7 +23,10 @@ import os
 import random
 import time
 import uuid
+from asyncio import Lock
+from collections import defaultdict
 from concurrent.futures.thread import ThreadPoolExecutor
+from dataclasses import dataclass
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, cast
 
@@ -43,7 +46,7 @@ from inmanta.loader import CodeLoader, ModuleSource
 from inmanta.protocol import SessionEndpoint, methods, methods_v2
 from inmanta.resources import Id, Resource
 from inmanta.types import Apireturn, JsonType
-from inmanta.util import add_future
+from inmanta.util import NamedLock, add_future
 
 LOGGER = logging.getLogger(__name__)
 GET_RESOURCE_BACKOFF = 5
@@ -65,6 +68,20 @@ if TYPE_CHECKING:
     ResourceActionResultFuture = asyncio.Future[ResourceActionResult]
 else:
     ResourceActionResultFuture = asyncio.Future
+
+
+@dataclass
+class PerModuleLock:
+    """A data structure to help managing the fine-grained locks for module loading
+
+    :param resource_name: name of the resource being loaded
+    :param current_hash: current file hash baing loaded
+    :param lock: future representing completion
+    """
+
+    resource_name: str
+    resource_verion: str
+    result: Future = Future()
 
 
 class ResourceActionBase(abc.ABC):
@@ -988,6 +1005,12 @@ class Agent(SessionEndpoint):
             self._env = env.VirtualEnv(self._storage["env"])
             self._env.use_virtual_env()
             self._loader = CodeLoader(self._storage["code"])
+            # Lock to ensure only one actual install runs at a time
+            self._loader_lock = Lock()
+            # Cache to prevent re-loading the same resource-version
+            self._last_loaded: Dict[str, int] = defaultdict(lambda: -1)
+            # Per-resource lock to serialize all actions per resource
+            self._resource_loader_lock = NamedLock()
 
         self.agent_map: Optional[Dict[str, str]] = agent_map
 
@@ -1181,21 +1204,31 @@ class Agent(SessionEndpoint):
             return failed_to_load
 
         for rt in set(resource_types):
-            result: protocol.Result = await self._client.get_code(environment, version, rt)
+            # only one logical thread can load a particular resource type at any time
+            async with self._resource_loader_lock.get(rt):
+                # stop if the last successful load was this one
+                # The combination of the lock and this check causes the reloads to naturally 'batch up'
+                if self._last_loaded[rt] == version:
+                    LOGGER.debug("Code already present for %s %d", rt, version)
+                    continue
+                # clear cache, for retry on failure
+                self._last_loaded[rt] = -1
 
-            if result.code == 200 and result.result is not None:
-                try:
-                    LOGGER.debug("Installing handler %s", rt)
-                    await self._install(
-                        [
-                            (ModuleSource(name, content, hash_value), requires)
-                            for hash_value, (path, name, content, requires) in result.result["sources"].items()
-                        ]
-                    )
-                    LOGGER.debug("Installed handler %s", rt)
-                except Exception:
-                    LOGGER.exception("Failed to install handler %s", rt)
-                    failed_to_load.add(rt)
+                result: protocol.Result = await self._client.get_code(environment, version, rt)
+                if result.code == 200 and result.result is not None:
+                    try:
+                        LOGGER.debug("Installing handler %s %d", rt, version)
+                        await self._install(
+                            [
+                                (ModuleSource(name, content, hash_value), requires)
+                                for hash_value, (path, name, content, requires) in result.result["sources"].items()
+                            ]
+                        )
+                        LOGGER.debug("Installed handler %s %d", rt, version)
+                        self._last_loaded[rt] = version
+                    except Exception:
+                        LOGGER.exception("Failed to install handler %s %d", rt, version)
+                        failed_to_load.add(rt)
 
         return failed_to_load
 
@@ -1203,10 +1236,11 @@ class Agent(SessionEndpoint):
         if self._env is None or self._loader is None:
             raise Exception("Unable to load code when agent is started with code loading disabled.")
 
-        loop = asyncio.get_event_loop()
-        for module, module_requires in modules:
-            await loop.run_in_executor(self.thread_pool, self._env.install_from_list, module_requires)
-        await loop.run_in_executor(self.thread_pool, self._loader.deploy_version, (source for source, _ in modules))
+        async with self._loader_lock:
+            loop = asyncio.get_event_loop()
+            for module, module_requires in modules:
+                await loop.run_in_executor(self.thread_pool, self._env.install_from_list, module_requires)
+            await loop.run_in_executor(self.thread_pool, self._loader.deploy_version, (source for source, _ in modules))
 
     @protocol.handle(methods.trigger, env="tid", agent="id")
     async def trigger_update(self, env: uuid.UUID, agent: str, incremental_deploy: bool) -> Apireturn:

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -70,20 +70,6 @@ else:
     ResourceActionResultFuture = asyncio.Future
 
 
-@dataclass
-class PerModuleLock:
-    """A data structure to help managing the fine-grained locks for module loading
-
-    :param resource_name: name of the resource being loaded
-    :param current_hash: current file hash baing loaded
-    :param lock: future representing completion
-    """
-
-    resource_name: str
-    resource_verion: str
-    result: Future = Future()
-
-
 class ResourceActionBase(abc.ABC):
     """Base class for Local and Remote resource actions"""
 

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -257,13 +257,13 @@ class CodeLoader(object):
             return False
 
     def deploy_version(self, module_sources: Iterable[ModuleSource]) -> None:
-        to_reload: Set[ModuleSource] = set()
+        to_reload: List[ModuleSource] = []
 
         sources = set(module_sources)
         for module_source in sources:
             is_changed = self.install_source(module_source)
             if is_changed:
-                to_reload.add(module_source)
+                to_reload.append(module_source)
 
         if len(to_reload) > 0:
             importlib.invalidate_caches()

--- a/src/inmanta/server/services/codeservice.py
+++ b/src/inmanta/server/services/codeservice.py
@@ -120,7 +120,7 @@ class CodeService(protocol.ServerSlice):
     async def get_code(self, env: data.Environment, code_id: int, resource: str) -> Apireturn:
         code = await data.Code.get_version(environment=env.id, version=code_id, resource=resource)
         if code is None:
-            raise NotFound("The version of the code does not exist.")
+            raise NotFound(f"The version of the code does not exist. {resource}, {code_id}")
 
         sources = {}
         if code.source_refs is not None:

--- a/tests/agent_server/test_agent_code_loading.py
+++ b/tests/agent_server/test_agent_code_loading.py
@@ -90,15 +90,15 @@ def xx():
     await gather(r1, r2, r3)
 
     # Test 1 is deployed once, as seen by the agent
-    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test 5").contains(
-        "inmanta.agent.agent", DEBUG, "Installed handler test::Test 5"
-    ).contains("inmanta.agent.agent", DEBUG, "Code already present for test::Test 5").assert_not(
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test version=5").contains(
+        "inmanta.agent.agent", DEBUG, "Installed handler test::Test version=5"
+    ).contains("inmanta.agent.agent", DEBUG, "Code already present for test::Test version=5").assert_not(
         "inmanta", DEBUG, "test::Test "
     )
 
     # Test 2 is deployed twice, as seen by the agent
-    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test2 5")
-    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test2 6")
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test2 version=5")
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test2 version=6")
 
     # Loader only loads source1 once
     LogSequence(caplog).contains("inmanta.loader", INFO, f"Deploying code (hv={hv1}, module=inmanta_plugins.test)").assert_not(
@@ -111,5 +111,5 @@ def xx():
     )
 
     # Test 3 is deployed twice, as seen by the agent and the loader
-    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test3 5")
-    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test3 6")
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test3 version=5")
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test3 version=6")

--- a/tests/agent_server/test_agent_code_loading.py
+++ b/tests/agent_server/test_agent_code_loading.py
@@ -1,0 +1,115 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import hashlib
+from asyncio import gather
+from logging import DEBUG, INFO
+
+from inmanta.agent import Agent
+from utils import LogSequence
+
+
+async def test_agent_code_loading(caplog, server, agent_factory, client, environment):
+    """
+    Test goals:
+    1. ensure the agent doesn't re-load the same code if not required
+       1a. because the resource-version is exactly the same
+       1b. because the underlying code is the same
+    even when loading is done in very short succession
+    """
+
+    caplog.set_level(DEBUG)
+
+    def make_source_structure(into, file, module, source):
+        sha1sum = hashlib.new("sha1")
+        sha1sum.update(source.encode())
+        hv: str = sha1sum.hexdigest()
+        into[hv] = [file, module, source, []]
+        return hv
+
+    codea = """
+def test():
+    return 10
+    """
+
+    codeb = """
+def test():
+    return 10
+def xx():
+    pass
+    """
+
+    sources = {}
+    sources2 = {}
+    hv1 = make_source_structure(sources, "inmanta_plugins/test/__init__.py", "inmanta_plugins.test", codea)
+    hv2 = make_source_structure(sources2, "inmanta_plugins/tests/__init__.py", "inmanta_plugins.tests", codeb)
+
+    res = await client.upload_code(tid=environment, id=5, resource="test::Test", sources=sources)
+    assert res.code == 200
+
+    # 2 identical versions
+    res = await client.upload_code(tid=environment, id=5, resource="test::Test2", sources=sources)
+    assert res.code == 200
+    res = await client.upload_code(tid=environment, id=6, resource="test::Test2", sources=sources)
+    assert res.code == 200
+
+    # two distinct versions
+    res = await client.upload_code(tid=environment, id=5, resource="test::Test3", sources=sources)
+    assert res.code == 200
+    res = await client.upload_code(tid=environment, id=6, resource="test::Test3", sources=sources2)
+    assert res.code == 200
+
+    agent: Agent = await agent_factory(
+        environment=environment, agent_map={"agent1": "localhost"}, hostname="host", agent_names=["agent1"], code_loader=True
+    )
+
+    r1 = agent.ensure_code(
+        environment=environment,
+        version=5,
+        resource_types=["test::Test", "test::Test2", "test::Test3"],
+    )
+
+    r2 = agent.ensure_code(environment=environment, version=5, resource_types=["test::Test", "test::Test2"])
+
+    r3 = agent.ensure_code(environment=environment, version=6, resource_types=["test::Test2", "test::Test3"])
+
+    await gather(r1, r2, r3)
+
+    # Test 1 is deployed once, as seen by the agent
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test 5").contains(
+        "inmanta.agent.agent", DEBUG, "Installed handler test::Test 5"
+    ).contains("inmanta.agent.agent", DEBUG, "Code already present for test::Test 5").assert_not(
+        "inmanta", DEBUG, "test::Test "
+    )
+
+    # Test 2 is deployed twice, as seen by the agent
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test2 5")
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test2 6")
+
+    # Loader only loads source1 once
+    LogSequence(caplog).contains("inmanta.loader", INFO, f"Deploying code (hv={hv1}, module=inmanta_plugins.test)").assert_not(
+        "inmanta.loader", INFO, f"Deploying code (hv={hv1}, module=inmanta_plugins.test)"
+    )
+
+    # Loader only loads source1 once
+    LogSequence(caplog).contains("inmanta.loader", INFO, f"Deploying code (hv={hv2}, module=inmanta_plugins.tests)").assert_not(
+        "inmanta.loader", INFO, f"Deploying code (hv={hv2}, module=inmanta_plugins.tests)"
+    )
+
+    # Test 3 is deployed twice, as seen by the agent and the loader
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test3 5")
+    LogSequence(caplog).contains("inmanta.agent.agent", DEBUG, "Installing handler test::Test3 6")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,7 +24,7 @@ import uuid
 import pytest
 
 from inmanta import util
-from inmanta.util import CycleException, ensure_future_and_handle_exception, stable_depth_first
+from inmanta.util import CycleException, NamedLock, ensure_future_and_handle_exception, stable_depth_first
 from utils import LogSequence, get_product_meta_data, log_contains, no_error_in_logs
 
 LOGGER = logging.getLogger(__name__)
@@ -274,3 +274,17 @@ def test_is_sub_dict():
 def test_get_product_meta_data():
     """Basic smoke test for testing utils"""
     assert get_product_meta_data() is not None
+
+
+async def test_named_lock():
+    lock = NamedLock()
+    await lock.acquire("a")
+    await lock.acquire("b")
+    await lock.release("b")
+    fut = asyncio.create_task(lock.acquire("a"))
+    assert not fut.done()
+    await lock.release("a")
+    await fut
+    await lock.release("a")
+    # Don't leak
+    assert not lock._named_locks

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -207,7 +207,7 @@ class LogSequence(object):
             # first error is later
             idxe = self._find("", logging.ERROR, "", self.index)
             assert idxe == -1 or idxe >= index
-        assert index >= 0
+        assert index >= 0, "could not find " + msg
         return LogSequence(self.caplog, index + 1, self.allow_errors, self.ignore)
 
     def assert_not(self, loggerpart, level, msg):


### PR DESCRIPTION
# Description

Improved batching for the agent.

- The basic idea is to serialize similar requests behind a lock and drop subsequent identical requests (a cache with size 1)
- This is applied both at the level of the resource type and of the actual code loading. 
- The first level is quite course grained, because it only works within a version (which is still a common case, when many agents do the same type of resource). This level also cuts out the downloading from the server.
- The second level is at the file level, much finer, but it only happens after downloading the code from the server
- I think this a reasonable strategy, because we don't want to (and probably can't) reload multiple modules in parallel

closes #4217 

Personal note: I'm a bit under the weather, so review critically. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [ x Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )


