### PR TITLE
Use the recompile_backoff in the tests instead of the auto-recompile-wait setting

### DIFF
--- a/changelogs/unreleased/dont-set-auto-recompile-wait-setting.yml
+++ b/changelogs/unreleased/dont-set-auto-recompile-wait-setting.yml
@@ -1,0 +1,5 @@
+---
+description: Don't set the auto-recompile-wait setting in the test suite, but use the recompile_backoff environment setting instead.
+issue-nr: 4332
+change-type: patch
+destination-branches: [master]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -861,11 +861,7 @@ async def create_environment(client, use_custom_env_settings: bool) -> str:
         await env_obj.set(data.AUTO_DEPLOY, False)
         await env_obj.set(data.PUSH_ON_AUTO_DEPLOY, False)
         await env_obj.set(data.AGENT_TRIGGER_METHOD_ON_AUTO_DEPLOY, const.AgentTriggerMethod.push_full_deploy)
-
-    # Set the RECOMPILE_BACKOFF setting to 0, to ensure backwards compatibility. The previous implementation
-    # of the test suite set the auto-recompile-wait setting in the server fixture(s) to zero.
-    result = await client.set_setting(tid=env_id, id=data.RECOMPILE_BACKOFF, value=0)
-    assert result.code == 200
+        await env_obj.set(data.RECOMPILE_BACKOFF, 0)
 
     return env_id
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -688,7 +688,6 @@ async def server_config(event_loop, inmanta_config, postgres_db, database_name, 
     config.Config.set("server", "agent-process-purge-interval", "0")
     config.Config.set("config", "executable", os.path.abspath(inmanta.app.__file__))
     config.Config.set("server", "agent-timeout", "2")
-    config.Config.set("server", "auto-recompile-wait", "0")
     config.Config.set("agent", "agent-repair-interval", "0")
     yield config
     shutil.rmtree(state_dir)
@@ -787,7 +786,6 @@ async def server_multi(
     config.Config.set("config", "executable", os.path.abspath(inmanta.app.__file__))
     config.Config.set("server", "agent-timeout", "2")
     config.Config.set("agent", "agent-repair-interval", "0")
-    config.Config.set("server", "auto-recompile-wait", "0")
 
     ibl = InmantaBootloader()
 
@@ -863,6 +861,11 @@ async def create_environment(client, use_custom_env_settings: bool) -> str:
         await env_obj.set(data.AUTO_DEPLOY, False)
         await env_obj.set(data.PUSH_ON_AUTO_DEPLOY, False)
         await env_obj.set(data.AGENT_TRIGGER_METHOD_ON_AUTO_DEPLOY, const.AgentTriggerMethod.push_full_deploy)
+
+    # Set the RECOMPILE_BACKOFF setting to 0, to ensure backwards compatibility. The previous implementation
+    # of the test suite set the auto-recompile-wait setting in the server fixture(s) to zero.
+    result = await client.set_setting(tid=env_id, id=data.RECOMPILE_BACKOFF, value=0)
+    assert result.code == 200
 
     return env_id
 


### PR DESCRIPTION
# Description

Don't set the auto-recompile-wait setting in the test suite, but use the recompile_backoff environment setting instead.

Part of #4332

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
