### PR TITLE
Issue/3470 unserializable items in the changes set make the crud handler get stuck in updating

### DIFF
--- a/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
+++ b/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
@@ -1,6 +1,7 @@
-description: Cast sets to string during JSON serialization.
+description: Cast items in the 'changes' set that aren't JSON-serializable to str.
 issue-nr: 3470
 change-type: patch
 destination-branches: [iso5, master]
 sections: {
+  bugfix: "{{description}}"
 }

--- a/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
+++ b/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
@@ -1,7 +1,7 @@
 description: Cast items in the 'changes' set that aren't JSON-serializable to str.
 issue-nr: 3470
 change-type: patch
-destination-branches: [iso5, master]
+destination-branches: [iso4, iso5, master]
 sections: {
   bugfix: "{{description}}"
 }

--- a/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
+++ b/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
@@ -1,0 +1,6 @@
+description: Cast sets to string during JSON serialization.
+issue-nr: 3470
+change-type: patch
+destination-branches: [iso5, master]
+sections: {
+}

--- a/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
+++ b/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
@@ -1,4 +1,4 @@
-description: Cast items in the 'changes' set that aren't JSON-serializable to str.
+description: Fix bug that fails the CRUDHandler when a changed attribute is of type set.
 issue-nr: 3470
 change-type: patch
 destination-branches: [iso4, iso5, master]

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -909,11 +909,13 @@ class CRUDHandler(ResourceHandler):
                     changes["purged"] = dict(desired=desired.purged, current=True)
 
             for field, values in changes.items():
+                current_value = values["current"]
+                desired_value = values["desired"]
                 try:
                     json_encode(values)
                 except TypeError:
-                    current_value = str(values["current"])
-                    desired_value = str(values["desired"])
+                    current_value = str(current_value)
+                    desired_value = str(desired_value)
                     changes[field]["desired"] = desired_value
                     changes[field]["current"] = current_value
                 ctx.add_change(field, desired=desired_value, current=current_value)

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -909,14 +909,6 @@ class CRUDHandler(ResourceHandler):
                     changes["purged"] = dict(desired=desired.purged, current=True)
 
             for field, values in changes.items():
-                for status in ["desired", "current"]:
-                    value = values[status]
-                    try:
-                        json_encode(value)
-                    except TypeError:
-                        value = str(value)
-                        changes[field][status] = value
-
                 ctx.add_change(field, desired=changes[field]["desired"], current=changes[field]["current"])
 
             if not dry_run:

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -909,7 +909,7 @@ class CRUDHandler(ResourceHandler):
                     changes["purged"] = dict(desired=desired.purged, current=True)
 
             for field, values in changes.items():
-                ctx.add_change(field, desired=changes[field]["desired"], current=changes[field]["current"])
+                ctx.add_change(field, desired=values["desired"], current=values["current"])
 
             if not dry_run:
                 if "purged" in changes:
@@ -922,7 +922,7 @@ class CRUDHandler(ResourceHandler):
 
                 elif not desired.purged and len(changes) > 0:
                     ctx.debug("Calling update_resource", changes=ctx.changes)
-                    self.update_resource(ctx, dict(ctx.changes), desired)
+                    self.update_resource(ctx, changes, desired)
 
                 ctx.set_status(const.ResourceState.deployed)
             else:

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -909,16 +909,15 @@ class CRUDHandler(ResourceHandler):
                     changes["purged"] = dict(desired=desired.purged, current=True)
 
             for field, values in changes.items():
-                current_value = values["current"]
-                desired_value = values["desired"]
-                try:
-                    json_encode(values)
-                except TypeError:
-                    current_value = str(current_value)
-                    desired_value = str(desired_value)
-                    changes[field]["desired"] = desired_value
-                    changes[field]["current"] = current_value
-                ctx.add_change(field, desired=desired_value, current=current_value)
+                for status in ["desired", "current"]:
+                    value = values[status]
+                    try:
+                        json_encode(value)
+                    except TypeError:
+                        value = str(value)
+                        changes[field][status] = value
+
+                ctx.add_change(field, desired=changes[field]["desired"], current=changes[field]["current"])
 
             if not dry_run:
                 if "purged" in changes:

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -921,8 +921,8 @@ class CRUDHandler(ResourceHandler):
                         self.delete_resource(ctx, desired)
 
                 elif not desired.purged and len(changes) > 0:
-                    ctx.debug("Calling update_resource", changes=changes)
-                    self.update_resource(ctx, dict(changes), desired)
+                    ctx.debug("Calling update_resource", changes=ctx.changes)
+                    self.update_resource(ctx, dict(ctx.changes), desired)
 
                 ctx.set_status(const.ResourceState.deployed)
             else:

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -912,11 +912,11 @@ class CRUDHandler(ResourceHandler):
                 try:
                     json_encode(values)
                 except TypeError:
-                    current = str(values["current"])
-                    desired = str(values["desired"])
-                    changes[field]["desired"] = desired
-                    changes[field]["current"] = current
-                ctx.add_change(field, desired=desired, current=current)
+                    current_value = str(values["current"])
+                    desired_value = str(values["desired"])
+                    changes[field]["desired"] = desired_value
+                    changes[field]["current"] = current_value
+                ctx.add_change(field, desired=desired_value, current=current_value)
 
             if not dry_run:
                 if "purged" in changes:

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -909,7 +909,14 @@ class CRUDHandler(ResourceHandler):
                     changes["purged"] = dict(desired=desired.purged, current=True)
 
             for field, values in changes.items():
-                ctx.add_change(field, desired=values["desired"], current=values["current"])
+                try:
+                    json_encode(values)
+                except TypeError:
+                    current = str(values["current"])
+                    desired = str(values["desired"])
+                    changes[field]["desired"] = desired
+                    changes[field]["current"] = current
+                ctx.add_change(field, desired=desired, current=current)
 
             if not dry_run:
                 if "purged" in changes:

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -200,6 +200,9 @@ class AttributeStateChange(BaseModel):
 
     @validator("current", "desired")
     def check_serializable(cls, v: Optional[Any]) -> Union[Optional[Any], str]:
+        """
+        Changes that are not json-serializable are cast to str (https://github.com/inmanta/inmanta-core/issues/3470)
+        """
         try:
             protocol.common.json_encode(v)
         except TypeError:

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -27,8 +27,7 @@ from pydantic import validator
 from pydantic.fields import ModelField
 
 import inmanta.ast.export as ast_export
-from inmanta import const
-from inmanta.protocol.common import json_encode
+from inmanta import const, protocol
 from inmanta.stable_api import stable_api
 from inmanta.types import ArgumentTypes, JsonType, SimpleTypes, StrictNonIntBool
 
@@ -199,13 +198,14 @@ class AttributeStateChange(BaseModel):
     current: Optional[Any] = None
     desired: Optional[Any] = None
 
-    @validator('current', 'desired')
-    def check_serializable(cls, v:Optional[Any]) -> Union[Optional[Any], str]:
+    @validator("current", "desired")
+    def check_serializable(cls, v: Optional[Any]) -> Union[Optional[Any], str]:
         try:
-            json_encode(v)
+            protocol.common.json_encode(v)
         except TypeError:
             return str(v)
         return v
+
 
 EnvSettingType = Union[StrictNonIntBool, int, float, str, Dict[str, Union[str, int, StrictNonIntBool]]]
 

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -23,10 +23,12 @@ from typing import Any, ClassVar, Dict, List, NewType, Optional, Union
 
 import pydantic
 import pydantic.schema
+from pydantic import validator
 from pydantic.fields import ModelField
 
 import inmanta.ast.export as ast_export
 from inmanta import const
+from inmanta.protocol.common import json_encode
 from inmanta.stable_api import stable_api
 from inmanta.types import ArgumentTypes, JsonType, SimpleTypes, StrictNonIntBool
 
@@ -197,6 +199,13 @@ class AttributeStateChange(BaseModel):
     current: Optional[Any] = None
     desired: Optional[Any] = None
 
+    @validator('current', 'desired')
+    def check_serializable(cls, v:Optional[Any]) -> Union[Optional[Any], str]:
+        try:
+            json_encode(v)
+        except TypeError:
+            return str(v)
+        return v
 
 EnvSettingType = Union[StrictNonIntBool, int, float, str, Dict[str, Union[str, int, StrictNonIntBool]]]
 

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -310,6 +310,9 @@ def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
         # Logs can push exceptions through RPC. Return a string representation.
         return str(o)
 
+    if isinstance(o, set):
+        return str(o)
+
     from inmanta.data.model import BaseModel
 
     if isinstance(o, BaseModel):

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -310,9 +310,6 @@ def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
         # Logs can push exceptions through RPC. Return a string representation.
         return str(o)
 
-    if isinstance(o, set):
-        return str(o)
-
     from inmanta.data.model import BaseModel
 
     if isinstance(o, BaseModel):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -95,10 +95,13 @@ def test_CRUD_handler_with_unserializable_items(caplog):
 
     class DummyCrud(CRUDHandler):
         def __init__(self):
-            pass
+            self.updated = False
 
         def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
             resource.value = "a"
+
+        def update_resource(self, ctx: HandlerContext, changes: dict, resource: resources.PurgeableResource) -> None:
+            self.updated = True
 
     @resource("aa::Aa", "aa", "aa")
     class TestResource(PurgeableResource):
@@ -108,10 +111,11 @@ def test_CRUD_handler_with_unserializable_items(caplog):
 
     # Sets are not JSON serializable
     res.value = {"a", "b"}
+    res.purged = False
 
     ctx = HandlerContext(res, False)
 
     handler = DummyCrud()
     handler.execute(ctx, res, False)
 
-    no_error_in_logs(caplog)
+    assert handler.updated

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -87,9 +87,10 @@ def test_CRUD_handler_purged_response(purged_desired, purged_actual, excn, creat
     log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")
 
 
-def test_CRUD_handler_with_unserializable_items(caplog):
+def test_3470_CRUD_handler_with_unserializable_items(caplog):
     """
-    This test case checks that sets are correctly turned into strings during JSON serialization
+    This test case checks that unserializable items in the 'changes' set not longer make
+    the CRUD handler hang.
     """
     caplog.set_level(logging.DEBUG)
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import logging
+from typing import Dict, Any
 
 import pytest
 
@@ -100,7 +101,7 @@ def test_3470_CRUD_handler_with_unserializable_items():
         def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
             resource.value = "a"
 
-        def update_resource(self, ctx: HandlerContext, changes: dict, resource: resources.PurgeableResource) -> None:
+        def update_resource(self, ctx: HandlerContext, changes: Dict[str, Dict[str, Any]], resource: resources.PurgeableResource) -> None:
             self.updated = True
 
     @resource(name="aa::Aa", id_attribute="aa", agent="aa")

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -87,12 +87,11 @@ def test_CRUD_handler_purged_response(purged_desired, purged_actual, excn, creat
     log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")
 
 
-def test_3470_CRUD_handler_with_unserializable_items(caplog):
+def test_3470_CRUD_handler_with_unserializable_items():
     """
     This test case checks that unserializable items in the 'changes' set not longer make
     the CRUD handler hang.
     """
-    caplog.set_level(logging.DEBUG)
 
     class DummyCrud(CRUDHandler):
         def __init__(self):
@@ -104,19 +103,19 @@ def test_3470_CRUD_handler_with_unserializable_items(caplog):
         def update_resource(self, ctx: HandlerContext, changes: dict, resource: resources.PurgeableResource) -> None:
             self.updated = True
 
-    @resource("aa::Aa", "aa", "aa")
+    @resource(name="aa::Aa", id_attribute="aa", agent="aa")
     class TestResource(PurgeableResource):
         fields = ("value",)
 
-    res = TestResource(Id("aa::Aa", "aa", "aa", "aa", 1))
+    res = TestResource(Id(entity_type="aa::Aa", agent_name="aa", attribute="aa", attribute_value="aa", version=1))
 
     # Sets are not JSON serializable
     res.value = {"a", "b"}
     res.purged = False
 
-    ctx = HandlerContext(res, False)
+    ctx = HandlerContext(res, dry_run=False)
 
     handler = DummyCrud()
-    handler.execute(ctx, res, False)
+    handler.execute(ctx, res, dry_run=False)
 
     assert handler.updated


### PR DESCRIPTION
# Description

Cast sets to string during JSON serialization

Part of #3470 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
