### PR TITLE
Issue/4274 auto full export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ click-plugins==1.1.1
 click==8.1.3
 colorlog==6.6.0
 cookiecutter==2.1.1
+croniter==1.3.5
 cryptography==37.0.2
 docstring-parser==0.14.1
 email-validator==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ requires = [
     "click>=8.0,<8.2",
     "colorlog~=6.0",
     "cookiecutter>=1,<3",
+    "croniter~=1.3",
     "cryptography>=36,<38",
     # docstring-parser has been known to publish non-backwards compatible minors in the past
     "docstring-parser>=0.10,<0.15",

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -43,7 +43,7 @@ from inmanta.loader import CodeLoader, ModuleSource
 from inmanta.protocol import SessionEndpoint, methods, methods_v2
 from inmanta.resources import Id, Resource
 from inmanta.types import Apireturn, JsonType
-from inmanta.util import add_future
+from inmanta.util import add_future, IntervalSchedule
 
 LOGGER = logging.getLogger(__name__)
 GET_RESOURCE_BACKOFF = 5
@@ -637,7 +637,7 @@ class AgentInstance(object):
             self._enable_time_trigger(repair_action, self._repair_interval, self._repair_splay_value)
 
     def _enable_time_trigger(self, action: Callable[[], Awaitable[None]], interval: int, splay: int) -> None:
-        self.process._sched.add_action(action, interval, splay)
+        self.process._sched.add_action(action, IntervalSchedule(interval=float(interval), initial_delay=float(splay)))
         self._time_triggered_actions.add(action)
 
     def _disable_time_triggers(self) -> None:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2255,10 +2255,6 @@ class Environment(BaseDocument):
             validator=convert_boolean,
             doc="Allow the server to compile the configuration model.",
         ),
-        # TODO: take into account:
-        #   auto-recompile-wait: https://docs.inmanta.com/inmanta-service-orchestrator-dev/6/reference/config.html#server.auto-recompile-wait
-        #   recompile_backoff: https://docs.inmanta.com/inmanta-service-orchestrator-dev/6/reference/environmentsettings.html#recompile_backoff
-        # TODO: make sure this can only be enabled if server_compile is True or mention only relevant in that case
         AUTO_FULL_COMPILE: Setting(
             name=AUTO_FULL_COMPILE,
             default="",
@@ -2266,7 +2262,9 @@ class Environment(BaseDocument):
             validator=validate_cron,
             doc=(
                 "Periodically run a full compile following a cron-like time-to-run specification"
-                " (`min hour dom month dow` or macros). Mostly relevant when partial compiles are enabled."
+                " (`min hour dom month dow` or macros). A compile will be requested at the scheduled time. The actual"
+                " compilation may have to wait in the compile queue for some time, depending on the size of the queue and the"
+                " RECOMPILE_BACKOFF environment variable. This setting has no effect when server_compile is disabled."
             ),
         ),
         RESOURCE_ACTION_LOGS_RETENTION: Setting(

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -17,7 +17,6 @@
 """
 import asyncio
 import copy
-import croniter
 import datetime
 import enum
 import hashlib
@@ -57,6 +56,7 @@ import pydantic
 import pydantic.tools
 import typing_inspect
 from asyncpg.protocol import Record
+from croniter import croniter
 
 import inmanta.db.versions
 from inmanta import const, resources, util
@@ -2237,6 +2237,9 @@ class Environment(BaseDocument):
             validator=convert_boolean,
             doc="Allow the server to compile the configuration model.",
         ),
+        # TODO: take into account:
+        #   auto-recompile-wait: https://docs.inmanta.com/inmanta-service-orchestrator-dev/6/reference/config.html#server.auto-recompile-wait
+        #   recompile_backoff: https://docs.inmanta.com/inmanta-service-orchestrator-dev/6/reference/environmentsettings.html#recompile_backoff
         # TODO: make sure this can only be enabled if server_compile is True or mention only relevant in that case
         AUTO_FULL_COMPILE: Setting(
             name=AUTO_FULL_COMPILE,

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2019 Inmanta
+    Copyright 2022 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ from inmanta.protocol.rest import server
 from inmanta.server import SLICE_SESSION_MANAGER, SLICE_TRANSPORT
 from inmanta.server import config as opt
 from inmanta.types import ArgumentTypes, JsonType
-from inmanta.util import CycleException, Scheduler, TaskHandler, TaskMethod, stable_depth_first
+from inmanta.util import CronSchedule, CycleException, Scheduler, TaskHandler, TaskMethod, stable_depth_first, IntervalSchedule
 
 if TYPE_CHECKING:
     from inmanta.server.extensions import Feature, FeatureManager
@@ -296,7 +296,21 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler):
 
     # utility methods for extensions developers
     def schedule(self, call: TaskMethod, interval: int = 60, initial_delay: Optional[float] = None) -> None:
-        self._sched.add_action(call, interval, initial_delay)
+        """
+        Schedule a task repeatedly with a given interval.
+
+        :param interval: The interval between executions of the task.
+        :param initial_delay: The delay to execute the task for the first time. If not set, interval is used.
+        """
+        self._sched.add_action(call, IntervalSchedule(interval, initial_delay))
+
+    def schedule_cron(self, call: TaskMethod, cron: str) -> None:
+        """
+        Schedule a task according to a cron specifier.
+
+        :param cron: The cron specifier to schedule the task by.
+        """
+        self._sched.add_action(call, CronSchedule(cron))
 
     def add_static_handler(self, location: str, path: str, default_filename: Optional[str] = None, start: bool = False) -> None:
         """

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -265,6 +265,7 @@ class EnvironmentService(protocol.ServerSlice):
     async def list_settings(self, env: data.Environment) -> Apireturn:
         return 200, {"settings": env.settings, "metadata": data.Environment._settings}
 
+    # TODO: update cron when setting changes
     @handle(methods.set_setting, env="tid", key="id")
     async def set_setting(self, env: data.Environment, key: str, value: model.EnvSettingType) -> Apireturn:
         try:

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -145,7 +145,7 @@ class TaskSchedule(ABC):
 
 
 @dataclass
-class IntervalSchedule(TaskSchedule)
+class IntervalSchedule(TaskSchedule):
     """
     Simple interval schedule for tasks.
 
@@ -160,7 +160,7 @@ class IntervalSchedule(TaskSchedule)
         return self.initial_delay if self.initial_delay is not None else self.interval
 
     def get_next_delay(self) -> float:
-        return self.next_delay
+        return self.interval
 
     def log(self, action: TaskMethod) -> None:
         LOGGER.debug(
@@ -168,7 +168,7 @@ class IntervalSchedule(TaskSchedule)
         )
 
 
-class CronSchedule(TaskSchedule)
+class CronSchedule(TaskSchedule):
     """
     Current-time based scheduler: interval is calculated dynamically based on cron specifier and current time.
     """
@@ -243,7 +243,6 @@ class Scheduler(object):
             return
 
         schedule.log(action)
-        LOGGER.debug("Scheduling action %s every %d seconds with initial delay %d", action, interval, initial_delay)
 
         def action_function() -> None:
             LOGGER.info("Calling %s" % action)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,7 +24,7 @@ import uuid
 import pytest
 
 from inmanta import util
-from inmanta.util import CycleException, ensure_future_and_handle_exception, stable_depth_first
+from inmanta.util import CycleException, ensure_future_and_handle_exception, stable_depth_first, IntervalSchedule
 from utils import LogSequence, get_product_meta_data, log_contains, no_error_in_logs
 
 LOGGER = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ async def test_scheduler_remove(caplog):
     async def action():
         i.append(0)
 
-    sched.add_action(action, 0.05, 0)
+    sched.add_action(action, IntervalSchedule(0.05, 0))
 
     while len(i) == 0:
         await asyncio.sleep(0.01)
@@ -60,7 +60,7 @@ async def test_scheduler_stop(caplog):
         i.append(0)
         return "A"
 
-    sched.add_action(action, 0.05, 0)
+    sched.add_action(action, IntervalSchedule(0.05, 0))
 
     while len(i) == 0:
         await asyncio.sleep(0.01)
@@ -73,7 +73,7 @@ async def test_scheduler_stop(caplog):
     no_error_in_logs(caplog)
 
     caplog.clear()
-    sched.add_action(action, 0.05, 0)
+    sched.add_action(action, IntervalSchedule(0.05, 0))
     assert "Scheduling action 'action', while scheduler is stopped" in caplog.messages
     assert not sched._executing_tasks[action]
 
@@ -88,7 +88,7 @@ async def test_scheduler_async_run_fail(caplog):
         await asyncio.sleep(0)
         raise Exception("Marker")
 
-    sched.add_action(action, 0.05, 0)
+    sched.add_action(action, IntervalSchedule(0.05, 0))
 
     while len(i) == 0:
         await asyncio.sleep(0.01)
@@ -113,7 +113,7 @@ async def test_scheduler_run_async(caplog):
     async def action():
         i.append(0)
 
-    sched.add_action(action, 0.05, 0)
+    sched.add_action(action, IntervalSchedule(0.05, 0))
 
     while len(i) == 0:
         await asyncio.sleep(0.01)
@@ -148,7 +148,7 @@ async def test_scheduler_cancel_executing_tasks() -> None:
             raise
 
     sched = util.Scheduler("xxx")
-    sched.add_action(action, interval=1000, initial_delay=0)
+    sched.add_action(action, IntervalSchedule(interval=1000, initial_delay=0))
     await util.retry_limited(lambda: task_status.task_is_executing, timeout=10)
     assert task_status.task_is_executing
     assert not task_status.task_was_cancelled


### PR DESCRIPTION
# Description

Still in draft

# Questions
Did I pick an appropriate cron library? If anyone prefers another one for some reason it should be relatively simple at this point to swap it. The ones I considered are the following:
- [crontab](https://pypi.org/project/crontab/): 286 stars, simple interface to get the number of seconds till next time point (exactly what we need), well documented which subset is supported, latest commit 1+ year old
- [croniter](https://pypi.org/project/croniter/): 83 stars, objects are generators (a bit more advanced than what we use it for), documentation OK, actively maintained (latest release last month), seems to use SemVer
- [python-crontab](https://pypi.org/project/python-crontab/): 73 stars, cool icon, doesn't seem to support parsing just the time-part of a cron expression

I went for `croniter` mostly because it seems sufficiently stable and is actively maintained for sure. I'm not sure if we should worry about the latter though, perhaps `crontab` just didn't receive updates because it is so stable?

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
