### PR TITLE
Remove module name warning when running in pytest

### DIFF
--- a/changelogs/unreleased/remove-test-warning.yml
+++ b/changelogs/unreleased/remove-test-warning.yml
@@ -1,0 +1,3 @@
+description: Remove module name warning when running in pytest
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -2464,7 +2464,9 @@ class ModuleV1(Module[ModuleV1Metadata], ModuleLikeWithYmlMetadataFile):
                 )
             raise
 
-        if self.name != os.path.basename(self._path):
+        # Only show the warning when we are not running tests. Especially on jenkins the directory of the module often does not
+        # have the correct name.
+        if self.name != os.path.basename(self._path) and "PYTEST_CURRENT_TEST" not in os.environ:
             LOGGER.warning(
                 "The name in the module file (%s) does not match the directory name (%s)",
                 self.name,


### PR DESCRIPTION
# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
