### PR TITLE
Issue/4361 the set setting endpoint return status code 500 on invalid value

### DIFF
--- a/changelogs/unreleased/4361-the-set-setting-endpoint-return-status-code-500-on-invalid-value.yml
+++ b/changelogs/unreleased/4361-the-set-setting-endpoint-return-status-code-500-on-invalid-value.yml
@@ -1,0 +1,5 @@
+description: The set_setting endpoint now correctly returns a 400 status code when an invalid value is provided.
+change-type: patch
+destination-branches: [master, iso4, iso5]
+issue-nr: 4361
+sections: {}

--- a/changelogs/unreleased/4361-the-set-setting-endpoint-return-status-code-500-on-invalid-value.yml
+++ b/changelogs/unreleased/4361-the-set-setting-endpoint-return-status-code-500-on-invalid-value.yml
@@ -2,4 +2,5 @@ description: The set_setting endpoint now correctly returns a 400 status code wh
 change-type: patch
 destination-branches: [master, iso4, iso5]
 issue-nr: 4361
-sections: {}
+sections:
+    bugfix: "{{description}}"

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -276,7 +276,7 @@ class EnvironmentService(protocol.ServerSlice):
         except KeyError:
             raise NotFound()
         except ValueError as e:
-            raise ServerError(f"Invalid value. {e}")
+            raise BadRequest(f"Invalid value. {e}")
 
     @handle(methods.get_setting, env="tid", key="id")
     async def get_setting(self, env: data.Environment, key: str) -> Apireturn:

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -33,7 +33,7 @@ async def test_environment_settings(client, server, environment_default):
 
     # set invalid value
     result = await client.set_setting(tid=environment_default, id="auto_deploy", value="test")
-    assert result.code == 500
+    assert result.code == 400
 
     # set non existing setting
     result = await client.set_setting(tid=environment_default, id="auto_deploy_non", value=False)
@@ -94,7 +94,7 @@ async def test_environment_settings(client, server, environment_default):
 
     # Internal agent is missing
     result = await client.set_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP, value={"agent1": ""})
-    assert result.code == 500
+    assert result.code == 400
     assert "The internal agent must be present in the autostart_agent_map" in result.result["message"]
     # Assert agent_map didn't change
     result = await client.get_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP)
@@ -102,7 +102,7 @@ async def test_environment_settings(client, server, environment_default):
     assert result.result["value"] == agent_map
 
     result = await client.set_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP, value="")
-    assert result.code == 500
+    assert result.code == 400
     assert "Agent map should be a dict" in result.result["message"]
     # Assert agent_map didn't change
     result = await client.get_setting(tid=environment_default, id=data.AUTOSTART_AGENT_MAP)


### PR DESCRIPTION
# Description

Invalid values passed to set_setting() now correctly return status code 400 (previously was 500).

closes #4361 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
