### PR TITLE
Issue/3470 add global variable

### DIFF
--- a/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
+++ b/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
@@ -1,0 +1,7 @@
+description: Fix bug that fails the CRUDHandler when a changed attribute is of type set.
+issue-nr: 3470
+change-type: patch
+destination-branches: [iso4, iso5, master]
+sections: {
+  bugfix: "{{description}}"
+}

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -19,7 +19,7 @@
 COMPILER_VERSION = "2022.3"
 RUNNING_TESTS = False
 """
-    This is enabled/disabled by the test suite when tests are ran.
+    This is enabled/disabled by the test suite when tests are run.
     This variable is used to disable certain features that shouldn't run during tests.
 """
 

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -17,6 +17,11 @@
 """
 
 COMPILER_VERSION = "2022.3"
+RUNNING_TESTS = False
+"""
+    This is enabled/disabled by the test suite when tests are ran.
+    This variable is used to disable certain features that shouldn't run during tests.
+"""
 
 if __name__ == "__main__":
     import inmanta.app

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -370,7 +370,7 @@ class HandlerContext(object):
             except TypeError:
                 if inmanta.RUNNING_TESTS:
                     # Fail the test when the value is not serializable
-                    raise Exception(f"Fail to serialize argument for log message {k}={v}")
+                    raise Exception(f"Failed to serialize argument for log message {k}={v}")
                 else:
                     # In production, try to cast the non-serializable value to str to prevent the handler from failing.
                     kwargs[k] = str(v)

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -28,7 +28,8 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, T
 
 from tornado import concurrent
 
-from inmanta import RUNNING_TESTS, const, data, protocol, resources
+import inmanta
+from inmanta import const, data, protocol, resources
 from inmanta.agent import io
 from inmanta.agent.cache import AgentCache
 from inmanta.const import ParameterSource, ResourceState
@@ -367,7 +368,7 @@ class HandlerContext(object):
             try:
                 json_encode(v)
             except TypeError:
-                if RUNNING_TESTS:
+                if inmanta.RUNNING_TESTS:
                     # Fail the test when the value is not serializable
                     raise Exception(f"Fail to serialize argument for log message {k}={v}")
                 else:

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -210,7 +210,7 @@ class AttributeStateChange(BaseModel):
         except TypeError:
             if inmanta.RUNNING_TESTS:
                 # Fail the test when the value is not serializable
-                raise Exception(f"Fail to serialize attribute {v}")
+                raise Exception(f"Failed to serialize attribute {v}")
             else:
                 # In production, try to cast the non-serializable value to str to prevent the handler from failing.
                 return str(v)

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -23,10 +23,12 @@ from typing import Any, ClassVar, Dict, List, NewType, Optional, Union
 
 import pydantic
 import pydantic.schema
+from pydantic import validator
 from pydantic.fields import ModelField
 
+import inmanta
 import inmanta.ast.export as ast_export
-from inmanta import const
+from inmanta import const, protocol
 from inmanta.stable_api import stable_api
 from inmanta.types import ArgumentTypes, JsonType, SimpleTypes, StrictNonIntBool
 
@@ -196,6 +198,23 @@ class AttributeStateChange(BaseModel):
 
     current: Optional[Any] = None
     desired: Optional[Any] = None
+
+    @validator("current", "desired")
+    @classmethod
+    def check_serializable(cls, v: Optional[Any]) -> Optional[Any]:
+        """
+        Verify whether the value is serializable (https://github.com/inmanta/inmanta-core/issues/3470)
+        """
+        try:
+            protocol.common.json_encode(v)
+        except TypeError:
+            if inmanta.RUNNING_TESTS:
+                # Fail the test when the value is not serializable
+                raise Exception(f"Fail to serialize attribute {v}")
+            else:
+                # In production, try to cast the non-serializable value to str to prevent the handler from failing.
+                return str(v)
+        return v
 
 
 EnvSettingType = Union[StrictNonIntBool, int, float, str, Dict[str, Union[str, int, StrictNonIntBool]]]

--- a/tests/agent_server/test_resource_handler.py
+++ b/tests/agent_server/test_resource_handler.py
@@ -112,7 +112,7 @@ async def test_logging_error(resource_container, environment, client, agent, cli
     assert result.code == 200
     assert result.result["status"] == "failed"
 
-    log_contains(caplog, "inmanta.agent", logging.ERROR, "Fail to serialize argument for log message")
+    log_contains(caplog, "inmanta.agent", logging.ERROR, "Failed to serialize argument for log message")
 
 
 @pytest.mark.parametrize(

--- a/tests/agent_server/test_resource_handler.py
+++ b/tests/agent_server/test_resource_handler.py
@@ -112,7 +112,7 @@ async def test_logging_error(resource_container, environment, client, agent, cli
     assert result.code == 200
     assert result.result["status"] == "failed"
 
-    log_contains(caplog, "inmanta.agent", logging.ERROR, "Exception during serializing log message arguments")
+    log_contains(caplog, "inmanta.agent", logging.ERROR, "Fail to serialize argument for log message")
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,7 @@ from tornado import netutil
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
 import build.env
+import inmanta
 import inmanta.agent
 import inmanta.app
 import inmanta.compiler as compiler
@@ -1513,3 +1514,11 @@ def guard_testing_venv():
             venv_was_altered = True
             error_message += f"\t* {pkg}: initial version={version_before_tests} --> after tests={version_after_tests}\n"
     assert not venv_was_altered, error_message
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def set_running_tests():
+    """
+    Ensure the RUNNING_TESTS variable is True when running tests
+    """
+    inmanta.RUNNING_TESTS = True

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -145,9 +145,7 @@ def test_3470_CRUD_handler_with_unserializable_changes(running_test: bool, monke
 
 @pytest.mark.parametrize(
     "running_test",
-    [
-        (True, False),
-    ],
+    [True, False],
 )
 def test_3470_CRUD_handler_with_unserializable_items_log_message(running_test: bool, monkeypatch, caplog):
     """
@@ -166,7 +164,7 @@ def test_3470_CRUD_handler_with_unserializable_items_log_message(running_test: b
         def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
             resource.value = "b"
             unserializable_set = {"b"}
-            ctx.debug(msg="Unserializable kwargs: ", kwargs={"unserializable", unserializable_set})
+            ctx.debug(msg="Unserializable kwargs: ", kwargs={"unserializable": unserializable_set})
 
         def update_resource(
             self, ctx: HandlerContext, changes: Dict[str, Dict[str, Any]], resource: resources.PurgeableResource
@@ -188,9 +186,8 @@ def test_3470_CRUD_handler_with_unserializable_items_log_message(running_test: b
 
     if running_test:
         handler.execute(ctx, res, dry_run=False)
-        assert ctx.status is ResourceState.failed
         error_message = "Fail to serialize argument for log message"
-
+        assert ctx.status is ResourceState.failed
         assert error_message in caplog.text
 
     else:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -16,11 +16,13 @@
     Contact: code@inmanta.com
 """
 import logging
+from typing import Any, Dict
 
 import pytest
 
 from inmanta import resources
 from inmanta.agent.handler import CRUDHandler, HandlerContext, ResourcePurged
+from inmanta.const import ResourceState
 from inmanta.resources import Id, PurgeableResource, resource
 from utils import log_contains, no_error_in_logs
 
@@ -85,3 +87,112 @@ def test_CRUD_handler_purged_response(purged_desired, purged_actual, excn, creat
     assert handler.deleted == delete
     no_error_in_logs(caplog)
     log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")
+
+    log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")
+
+
+@pytest.mark.parametrize(
+    "running_test",
+    [True, False],
+)
+def test_3470_CRUD_handler_with_unserializable_changes(running_test: bool, monkeypatch, caplog):
+    """
+    This test case checks that unserializable items in the 'changes' set not longer make
+    the CRUD handler hang in production and that an exception is raised when the
+    RUNNING_TEST variable is set to True.
+    """
+    import inmanta
+
+    monkeypatch.setattr(inmanta, "RUNNING_TESTS", running_test)
+
+    class DummyCrud(CRUDHandler):
+        def __init__(self):
+            self.updated = False
+
+        def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
+            resource.value = "b"
+
+        def update_resource(
+            self, ctx: HandlerContext, changes: Dict[str, Dict[str, Any]], resource: resources.PurgeableResource
+        ) -> None:
+            self.updated = True
+
+    @resource(name="aa::Aa", id_attribute="aa", agent="aa")
+    class TestResource(PurgeableResource):
+        fields = ("value",)
+
+    res = TestResource(Id(entity_type="aa::Aa", agent_name="aa", attribute="aa", attribute_value="aa", version=1))
+
+    # Sets are not JSON serializable
+    res.value = {"a"}
+    res.purged = False
+
+    ctx = HandlerContext(res, dry_run=False)
+
+    handler = DummyCrud()
+
+    if running_test:
+        handler.execute(ctx, res, dry_run=False)
+        assert ctx.status is ResourceState.failed
+        error_message = "Fail to serialize attribute {'a'}"
+
+        assert error_message in caplog.text
+
+    else:
+        handler.execute(ctx, res, dry_run=False)
+        assert handler.updated
+
+
+@pytest.mark.parametrize(
+    "running_test",
+    [
+        (True, False),
+    ],
+)
+def test_3470_CRUD_handler_with_unserializable_items_log_message(running_test: bool, monkeypatch, caplog):
+    """
+    This test case checks that unserializable log messages no longer make
+    the CRUD handler hang in production and that an exception is raised when the
+    RUNNING_TEST variable is set to True.
+    """
+    import inmanta
+
+    monkeypatch.setattr(inmanta, "RUNNING_TESTS", running_test)
+
+    class DummyCrud(CRUDHandler):
+        def __init__(self):
+            self.updated = False
+
+        def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
+            resource.value = "b"
+            unserializable_set = {"b"}
+            ctx.debug(msg="Unserializable kwargs: ", kwargs={"unserializable", unserializable_set})
+
+        def update_resource(
+            self, ctx: HandlerContext, changes: Dict[str, Dict[str, Any]], resource: resources.PurgeableResource
+        ) -> None:
+            self.updated = True
+
+    @resource(name="aa::Aa", id_attribute="aa", agent="aa")
+    class TestResource(PurgeableResource):
+        fields = ("value",)
+
+    res = TestResource(Id(entity_type="aa::Aa", agent_name="aa", attribute="aa", attribute_value="aa", version=1))
+
+    res.value = "a"
+    res.purged = False
+
+    ctx = HandlerContext(res, dry_run=False)
+
+    handler = DummyCrud()
+
+    if running_test:
+        handler.execute(ctx, res, dry_run=False)
+        assert ctx.status is ResourceState.failed
+        error_message = "Fail to serialize argument for log message"
+
+        assert error_message in caplog.text
+
+    else:
+        handler.execute(ctx, res, dry_run=False)
+        assert handler.updated

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -88,8 +88,6 @@ def test_CRUD_handler_purged_response(purged_desired, purged_actual, excn, creat
     no_error_in_logs(caplog)
     log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")
 
-    log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")
-
 
 @pytest.mark.parametrize(
     "running_test",
@@ -134,12 +132,13 @@ def test_3470_CRUD_handler_with_unserializable_changes(running_test: bool, monke
     if running_test:
         handler.execute(ctx, res, dry_run=False)
         assert ctx.status is ResourceState.failed
-        error_message = "Fail to serialize attribute {'a'}"
+        error_message = "Failed to serialize attribute {'a'}"
 
         assert error_message in caplog.text
 
     else:
         handler.execute(ctx, res, dry_run=False)
+        assert ctx.status is ResourceState.deployed
         assert handler.updated
 
 
@@ -186,10 +185,11 @@ def test_3470_CRUD_handler_with_unserializable_items_log_message(running_test: b
 
     if running_test:
         handler.execute(ctx, res, dry_run=False)
-        error_message = "Fail to serialize argument for log message"
+        error_message = "Failed to serialize argument for log message"
         assert ctx.status is ResourceState.failed
         assert error_message in caplog.text
 
     else:
         handler.execute(ctx, res, dry_run=False)
+        assert ctx.status is ResourceState.deployed
         assert handler.updated

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,6 +23,7 @@ import uuid
 
 import pytest
 
+import inmanta
 from inmanta import util
 from inmanta.util import CycleException, NamedLock, ensure_future_and_handle_exception, stable_depth_first
 from utils import LogSequence, get_product_meta_data, log_contains, no_error_in_logs
@@ -288,3 +289,10 @@ async def test_named_lock():
     await lock.release("a")
     # Don't leak
     assert not lock._named_locks
+
+
+def test_running_test_fixture():
+    """
+    Assert that the RUNNING_TESTS variable is set to True when we run the tests
+    """
+    assert inmanta.RUNNING_TESTS


### PR DESCRIPTION
# Description

add global variable RUNNING_TESTS to allow the following behavior:
- in production: cast unserializable items to str
- during tests: raise an exception

closes #3470 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
