### PR TITLE
issue/4388-deprecation-warning-setuptool

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include LICENSE
-graft docs
 include tox.ini
 include setup.py
 include setup.cfg
@@ -7,13 +6,7 @@ include src/inmanta/py.typed
 include src/inmanta/parser/parser.out
 
 recursive-include src *.j2
-recursive-include docs *
-recursive-include misc *
-recursive-include tests *
 
 global-exclude *.pyc
 global-exclude */__pycache__/*
 global-exclude **/.env/**
-exclude docs/**
-exclude tests/**
-exclude misc/**

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,4 +14,6 @@ recursive-include tests *
 global-exclude *.pyc
 global-exclude */__pycache__/*
 global-exclude **/.env/**
-exclude docs/build/**
+exclude docs/**
+exclude tests/**
+exclude misc/**

--- a/changelogs/unreleased/4388-fix-deprecation-warning-setuptools.yml
+++ b/changelogs/unreleased/4388-fix-deprecation-warning-setuptools.yml
@@ -1,4 +1,4 @@
 description: "fix deprecation warning for setuptools"
 change-type: patch
-destination-branches: [iso4, iso5]
+destination-branches: [iso4, iso5, master]
 issue-nr: 4388

--- a/changelogs/unreleased/4388-fix-deprecation-warning-setuptools.yml
+++ b/changelogs/unreleased/4388-fix-deprecation-warning-setuptools.yml
@@ -1,0 +1,4 @@
+description: "fix deprecation warning for setuptools"
+change-type: patch
+destination-branches: [iso4, iso5]
+issue-nr: 4388

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from os import path
 
 requires = [
@@ -70,7 +70,7 @@ setup(
     },
     # Packaging
     package_dir={"": "src"},
-    packages=find_packages("src") + namespace_packages,
+    packages=find_namespace_packages(where="src") + namespace_packages,
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information
     package_data={"": ["misc/*", "docs/*"], "inmanta": ["py.typed"]},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ requires = [
     "typing_inspect",
 ]
 
-# Package a dummy extensions so that the namespace package for extensions is not empty
-namespace_packages = ["inmanta_ext.core"]
 
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     },
     # Packaging
     package_dir={"": "src"},
-    packages=find_namespace_packages(where="src") + namespace_packages,
+    packages=find_namespace_packages(where="src"),
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information
     package_data={"": ["misc/*", "docs/*"], "inmanta": ["py.typed"]},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,11 @@ setup(
     },
     # Packaging
     package_dir={"": "src"},
+    # find_namespace_packages scans all directories for packages and namespace_packages,
+    # even those without an __init__.py file where find_packages will not consider directories without
+    # the __init__.py file
     packages=find_namespace_packages(where="src"),
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information
-    package_data={"": ["misc/*", "docs/*"], "inmanta": ["py.typed"]},
     zip_safe=False,
     include_package_data=True,
     install_requires=requires,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_packages
 from os import path
 
 requires = [
@@ -70,7 +70,7 @@ setup(
     },
     # Packaging
     package_dir={"": "src"},
-    packages=find_namespace_packages(where='src') + namespace_packages,
+    packages=find_packages("src") + namespace_packages,
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information
     package_data={"": ["misc/*", "docs/*"], "inmanta": ["py.typed"]},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,7 @@ setup(
     },
     # Packaging
     package_dir={"": "src"},
-    # find_namespace_packages scans all directories for packages and namespace_packages,
-    # even those without an __init__.py file where find_packages will not consider directories without
-    # the __init__.py file. All data should be treated as namespace package according to
+    # All data files should be treated as namespace package according to
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files
     packages=find_namespace_packages(where="src"),
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,8 @@ setup(
     package_dir={"": "src"},
     # find_namespace_packages scans all directories for packages and namespace_packages,
     # even those without an __init__.py file where find_packages will not consider directories without
-    # the __init__.py file
+    # the __init__.py file. All data should be treated as namespace package according to
+    # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files
     packages=find_namespace_packages(where="src"),
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from os import path
 
 requires = [
@@ -70,7 +70,7 @@ setup(
     },
     # Packaging
     package_dir={"": "src"},
-    packages=find_packages("src") + namespace_packages,
+    packages=find_namespace_packages(where='src') + namespace_packages,
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information
     package_data={"": ["misc/*", "docs/*"], "inmanta": ["py.typed"]},
     zip_safe=False,

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -64,6 +64,9 @@ setup(
     project_urls={"Bug Tracker": "https://github.com/inmanta/inmanta-core/issues"},
     # Packaging
     package_dir={"": "src"},
+    # find_namespace_packages scans all directories for packages and namespace_packages,
+    # even those without an __init__.py file where find_packages will not consider directories without
+    # the __init__.py file
     packages=find_namespace_packages(where="src"),
     include_package_data=True,
     install_requires=requires,

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -64,9 +64,7 @@ setup(
     project_urls={"Bug Tracker": "https://github.com/inmanta/inmanta-core/issues"},
     # Packaging
     package_dir={"": "src"},
-    # find_namespace_packages scans all directories for packages and namespace_packages,
-    # even those without an __init__.py file where find_packages will not consider directories without
-    # the __init__.py file. All data should be treated as namespace package according to
+    # All data files should be treated as namespace package according to
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files
     packages=find_namespace_packages(where="src"),
     include_package_data=True,

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -17,7 +17,7 @@
 """
 from os import path
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 version = "4.4.4"
 
@@ -64,7 +64,7 @@ setup(
     project_urls={"Bug Tracker": "https://github.com/inmanta/inmanta-core/issues"},
     # Packaging
     package_dir={"": "src"},
-    packages=find_packages("src"),
+    packages=find_namespace_packages(where='src'),
     include_package_data=True,
     install_requires=requires,
     entry_points={"pytest11": ["pytest-inmanta-tests = inmanta_tests.plugin"]},

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -66,7 +66,8 @@ setup(
     package_dir={"": "src"},
     # find_namespace_packages scans all directories for packages and namespace_packages,
     # even those without an __init__.py file where find_packages will not consider directories without
-    # the __init__.py file
+    # the __init__.py file. All data should be treated as namespace package according to
+    # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files
     packages=find_namespace_packages(where="src"),
     include_package_data=True,
     install_requires=requires,

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -64,7 +64,7 @@ setup(
     project_urls={"Bug Tracker": "https://github.com/inmanta/inmanta-core/issues"},
     # Packaging
     package_dir={"": "src"},
-    packages=find_namespace_packages(where='src'),
+    packages=find_namespace_packages(where="src"),
     include_package_data=True,
     install_requires=requires,
     entry_points={"pytest11": ["pytest-inmanta-tests = inmanta_tests.plugin"]},


### PR DESCRIPTION
# Description

Fixes a deprecation warning related to setuptools. The error is the following one and has occurrences in both inmanta-core and 
test_common

```
/tmp/tmpas1m3135/env/lib64/python3.9/site-packages/setuptools/command/build_py.py:153: SetuptoolsDeprecationWarning:     Installing 'inmanta_tests.data' as data is deprecated, please list it in `packages`.
    !!


    ############################
    # Package would be ignored #
    ############################
    Python recognizes 'inmanta_tests.data' as an importable package,
    but it is not listed in the `packages` configuration of setuptools.

    'inmanta_tests.data' has been automatically added to the distribution only
    because it may contain data files, but this behavior is likely to change
    in future versions of setuptools (and therefore is considered deprecated).

    Please make sure that 'inmanta_tests.data' is included as a package by using
    the `packages` configuration field or the proper discovery methods
    (for example by using `find_namespace_packages(...)`/`find_namespace:`
    instead of `find_packages(...)`/`find:`).

    You can read more about "package discovery" and "data files" on setuptools
    documentation page.


!!
```

closes #4388

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
