### PR TITLE
Issue/4408 cache invalidation

### DIFF
--- a/changelogs/unreleased/4408-cache-invalidation.yml
+++ b/changelogs/unreleased/4408-cache-invalidation.yml
@@ -1,0 +1,7 @@
+description: More precise cache invalidation for the compiler cache
+issue-nr: 4408
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  minor-improvement: "{{description}}"
+

--- a/src/inmanta/parser/cache.py
+++ b/src/inmanta/parser/cache.py
@@ -28,9 +28,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class CacheEnvelope:
-    """Every cached file gets the exact modification to of the file it is caching, to have cheap, accurate invalidation"""
+    """Every cached file gets the exact modification time of the file it is caching, to have cheap, accurate invalidation"""
 
-    def __init__(self, timestamp: float, statements: List[Statement]):
+    def __init__(self, timestamp: float, statements: List[Statement]) -> None:
         self.timestamp = timestamp
         self.statements = statements
 

--- a/src/inmanta/parser/cache.py
+++ b/src/inmanta/parser/cache.py
@@ -27,7 +27,9 @@ from inmanta.util import get_compiler_version
 LOGGER = logging.getLogger(__name__)
 
 
-class CacheEnveloppe:
+class CacheEnvelope:
+    """Every cached file gets the exact modification to of the file it is caching, to have cheap, accurate invalidation"""
+
     def __init__(self, timestamp: float, statements: List[Statement]):
         self.timestamp = timestamp
         self.statements = statements
@@ -86,7 +88,7 @@ class CacheManager:
                 return None
             with open(cache_filename, "rb") as fh:
                 result = ASTUnpickler(fh, namespace).load()
-                if not isinstance(result, CacheEnveloppe):
+                if not isinstance(result, CacheEnvelope):
                     # old cache format
                     self.misses += 1
                     return None
@@ -109,7 +111,7 @@ class CacheManager:
         try:
             cache_filename = self.get_file_name(filename)
             mtime = os.path.getmtime(filename)
-            cache_entry = CacheEnveloppe(mtime, statements)
+            cache_entry = CacheEnvelope(mtime, statements)
             with open(cache_filename, "wb") as fh:
                 ASTPickler(fh, protocol=4).dump(cache_entry)
         except Exception:

--- a/tests/compiler/test_cache.py
+++ b/tests/compiler/test_cache.py
@@ -1,0 +1,43 @@
+"""
+    Copyright 2018 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+import inmanta.parser.plyInmantaParser as parser
+from inmanta import compiler
+from inmanta.parser.cache import CacheManager
+
+
+def test_caching(snippetcompiler):
+    # reset counts
+    parser.cache_manager = CacheManager()
+    snippetcompiler.setup_for_snippet(
+        """
+a=1
+"""
+    )
+    # don't know hit count, may very on previous testcases
+    assert parser.cache_manager.misses > 1
+    assert parser.cache_manager.failures == 0
+
+    # reset counts
+    parser.cache_manager = CacheManager()
+    # reset project ast cache
+    snippetcompiler._load_project(autostd=True, install_project=True)
+
+    assert parser.cache_manager.misses == 0
+    assert parser.cache_manager.failures == 0
+    assert parser.cache_manager.hits == 2  # main.cf and std::init

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -20,11 +20,10 @@ from pathlib import Path
 from time import sleep
 
 import inmanta.parser.plyInmantaParser as parser
-from conftest import SnippetCompilationTest
 from inmanta.parser.cache import CacheManager
 
 
-def test_caching(snippetcompiler: SnippetCompilationTest):
+def test_caching(snippetcompiler):
     # reset counts
     parser.cache_manager = CacheManager()
     snippetcompiler.setup_for_snippet(

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -32,7 +32,7 @@ a=1
 """
     )
     # don't know hit count, may vary on previous testcases
-    assert parser.cache_manager.misses > 1
+    assert parser.cache_manager.misses >= 1
     assert parser.cache_manager.failures == 0
 
     # reset counts

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2018 Inmanta
+    Copyright 2022 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ def test_caching(snippetcompiler):
 a=1
 """
     )
-    # don't know hit count, may very on previous testcases
+    # don't know hit count, may vary on previous testcases
     assert parser.cache_manager.misses > 1
     assert parser.cache_manager.failures == 0
 


### PR DESCRIPTION
# Description

More precise  invalidation for the compiler cache
closes #4408 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design

