### PR TITLE
Issue/3470 unserializable items in the changes set make the crud handler get stuck in updating iso4

### DIFF
--- a/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
+++ b/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
@@ -1,0 +1,7 @@
+description: Fix bug that fails the CRUDHandler when a changed attribute is of type set.
+issue-nr: 3470
+change-type: patch
+destination-branches: [iso4, iso5, master]
+sections: {
+  bugfix: "{{description}}"
+}

--- a/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
+++ b/changelogs/unreleased/3470-unserializable-items-in-the-changes-set-make-the-CRUD-handler-get-stuck-in-updating.yml
@@ -1,7 +1,7 @@
 description: Fix bug that fails the CRUDHandler when a changed attribute is of type set.
 issue-nr: 3470
 change-type: patch
-destination-branches: [iso4, iso5, master]
+destination-branches: [iso4]
 sections: {
   bugfix: "{{description}}"
 }

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -17,3 +17,8 @@
 """
 
 COMPILER_VERSION = "2020.7.1"
+RUNNING_TESTS = False
+"""
+    This is enabled/disabled by the test suite when tests are run.
+    This variable is used to disable certain features that shouldn't run during tests.
+"""

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, T
 
 from tornado import concurrent
 
+import inmanta
 from inmanta import const, data, protocol, resources
 from inmanta.agent import io
 from inmanta.agent.cache import AgentCache
@@ -362,10 +363,20 @@ class HandlerContext(object):
             kwargs["traceback"] = traceback.format_exc()
         else:
             exc_info = False
-        try:
-            json_encode(kwargs)
-        except Exception as e:
-            raise Exception("Exception during serializing log message arguments") from e
+
+        for k, v in dict(kwargs).items():
+            try:
+                json_encode(v)
+            except TypeError:
+                if inmanta.RUNNING_TESTS:
+                    # Fail the test when the value is not serializable
+                    raise Exception(f"Failed to serialize argument for log message {k}={v}")
+                else:
+                    # In production, try to cast the non-serializable value to str to prevent the handler from failing.
+                    kwargs[k] = str(v)
+
+            except Exception as e:
+                raise Exception("Exception during serializing log message arguments") from e
         log = data.LogLine.log(level, msg, **kwargs)
         self.logger.log(level, "resource %s: %s", self._resource.id.resource_version_str(), log._data["msg"], exc_info=exc_info)
         self._logs.append(log)

--- a/tests/agent_server/test_resource_handler.py
+++ b/tests/agent_server/test_resource_handler.py
@@ -113,7 +113,7 @@ async def test_logging_error(resource_container, environment, client, agent, cli
     assert result.code == 200
     assert result.result["status"] == "failed"
 
-    log_contains(caplog, "inmanta.agent", logging.ERROR, "Exception during serializing log message arguments")
+    log_contains(caplog, "inmanta.agent", logging.ERROR, "Failed to serialize argument for log message")
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,6 @@ from pyformance.registry import MetricsRegistry
 from tornado import netutil
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
-import build.env
 import inmanta
 import inmanta.agent
 import inmanta.app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,8 @@ from pyformance.registry import MetricsRegistry
 from tornado import netutil
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
+import build.env
+import inmanta
 import inmanta.agent
 import inmanta.app
 import inmanta.compiler as compiler
@@ -1128,3 +1130,10 @@ async def migrate_db_from(
     yield migrate
 
     await bootloader.stop()
+
+@pytest.fixture(scope="function", autouse=True)
+async def set_running_tests():
+    """
+    Ensure the RUNNING_TESTS variable is True when running tests
+    """
+    inmanta.RUNNING_TESTS = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1131,6 +1131,7 @@ async def migrate_db_from(
 
     await bootloader.stop()
 
+
 @pytest.fixture(scope="function", autouse=True)
 async def set_running_tests():
     """

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -16,11 +16,13 @@
     Contact: code@inmanta.com
 """
 import logging
+from typing import Any, Dict
 
 import pytest
 
 from inmanta import resources
 from inmanta.agent.handler import CRUDHandler, HandlerContext, ResourcePurged
+from inmanta.const import ResourceState
 from inmanta.resources import Id, PurgeableResource, resource
 from utils import log_contains, no_error_in_logs
 
@@ -85,3 +87,109 @@ def test_CRUD_handler_purged_response(purged_desired, purged_actual, excn, creat
     assert handler.deleted == delete
     no_error_in_logs(caplog)
     log_contains(caplog, "inmanta.agent.handler", logging.DEBUG, "resource aa::Aa[aa,aa=aa],v=1: Calling read_resource")
+
+
+@pytest.mark.parametrize(
+    "running_test",
+    [True, False],
+)
+def test_3470_CRUD_handler_with_unserializable_changes(running_test: bool, monkeypatch, caplog):
+    """
+    This test case checks that unserializable items in the 'changes' set not longer make
+    the CRUD handler hang in production and that an exception is raised when the
+    RUNNING_TEST variable is set to True.
+    """
+    import inmanta
+
+    monkeypatch.setattr(inmanta, "RUNNING_TESTS", running_test)
+
+    class DummyCrud(CRUDHandler):
+        def __init__(self):
+            self.updated = False
+
+        def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
+            resource.value = "b"
+
+        def update_resource(
+            self, ctx: HandlerContext, changes: Dict[str, Dict[str, Any]], resource: resources.PurgeableResource
+        ) -> None:
+            self.updated = True
+
+    @resource(name="aa::Aa", id_attribute="aa", agent="aa")
+    class TestResource(PurgeableResource):
+        fields = ("value",)
+
+    res = TestResource(Id(entity_type="aa::Aa", agent_name="aa", attribute="aa", attribute_value="aa", version=1))
+
+    # Sets are not JSON serializable
+    res.value = {"a"}
+    res.purged = False
+
+    ctx = HandlerContext(res, dry_run=False)
+
+    handler = DummyCrud()
+
+    if running_test:
+        handler.execute(ctx, res, dry_run=False)
+        assert ctx.status is ResourceState.failed
+        error_message = "Failed to serialize attribute {'a'}"
+
+        assert error_message in caplog.text
+
+    else:
+        handler.execute(ctx, res, dry_run=False)
+        assert ctx.status is ResourceState.deployed
+        assert handler.updated
+
+
+@pytest.mark.parametrize(
+    "running_test",
+    [True, False],
+)
+def test_3470_CRUD_handler_with_unserializable_items_log_message(running_test: bool, monkeypatch, caplog):
+    """
+    This test case checks that unserializable log messages no longer make
+    the CRUD handler hang in production and that an exception is raised when the
+    RUNNING_TEST variable is set to True.
+    """
+    import inmanta
+
+    monkeypatch.setattr(inmanta, "RUNNING_TESTS", running_test)
+
+    class DummyCrud(CRUDHandler):
+        def __init__(self):
+            self.updated = False
+
+        def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
+            resource.value = "b"
+            unserializable_set = {"b"}
+            ctx.debug(msg="Unserializable kwargs: ", kwargs={"unserializable": unserializable_set})
+
+        def update_resource(
+            self, ctx: HandlerContext, changes: Dict[str, Dict[str, Any]], resource: resources.PurgeableResource
+        ) -> None:
+            self.updated = True
+
+    @resource(name="aa::Aa", id_attribute="aa", agent="aa")
+    class TestResource(PurgeableResource):
+        fields = ("value",)
+
+    res = TestResource(Id(entity_type="aa::Aa", agent_name="aa", attribute="aa", attribute_value="aa", version=1))
+
+    res.value = "a"
+    res.purged = False
+
+    ctx = HandlerContext(res, dry_run=False)
+
+    handler = DummyCrud()
+
+    if running_test:
+        handler.execute(ctx, res, dry_run=False)
+        error_message = "Failed to serialize argument for log message"
+        assert ctx.status is ResourceState.failed
+        assert error_message in caplog.text
+
+    else:
+        handler.execute(ctx, res, dry_run=False)
+        assert ctx.status is ResourceState.deployed
+        assert handler.updated

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -282,6 +282,7 @@ def test_get_product_meta_data():
     """ Basic smoke test for testing utils"""
     assert get_product_meta_data() is not None
 
+
 def test_running_test_fixture():
     """
     Assert that the RUNNING_TESTS variable is set to True when we run the tests

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,6 +23,7 @@ import uuid
 
 import pytest
 
+import inmanta
 from inmanta import util
 from inmanta.util import CycleException, ensure_future_and_handle_exception, stable_depth_first
 from utils import LogSequence, get_product_meta_data, log_contains, no_error_in_logs
@@ -280,3 +281,9 @@ def test_is_sub_dict():
 def test_get_product_meta_data():
     """ Basic smoke test for testing utils"""
     assert get_product_meta_data() is not None
+
+def test_running_test_fixture():
+    """
+    Assert that the RUNNING_TESTS variable is set to True when we run the tests
+    """
+    assert inmanta.RUNNING_TESTS


### PR DESCRIPTION
# Description

add global variable RUNNING_TESTS to allow the following behavior:

- in production: cast unserializable items to str
- during tests: raise an exception

part of #3470 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
