### PR TITLE
[FIX] wrap database accesses in a transaction

### DIFF
--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -820,10 +820,8 @@ async def old_and_new_compile_report(server_with_frequent_cleanups, environment_
         "handled": True,
         "version": 1,
     }
-    await Compile(**old_compile).insert()
     compile_id_new = uuid.uuid4()
     new_compile = {**old_compile, "id": compile_id_new, "requested": now, "started": now, "completed": now}
-    await Compile(**new_compile).insert()
 
     report1 = {
         "id": uuid.UUID("2baa0175-9169-40c5-a546-64d646f62da6"),
@@ -843,8 +841,14 @@ async def old_and_new_compile_report(server_with_frequent_cleanups, environment_
         "name": "Recompiling configuration model",
         "compile": compile_id_new,
     }
-    await Report(**report1).insert()
-    await Report(**report2).insert()
+
+    async with Compile.get_connection() as con:
+        async with con.transaction():
+            await Compile(**old_compile).insert()
+            await Compile(**new_compile).insert()
+            await Report(**report1).insert()
+            await Report(**report2).insert()
+
     yield compile_id_old, compile_id_new
 
 


### PR DESCRIPTION
# Description

## Problem:

The `test_compileservice_cleanup` test depends on 2 fixtures:
- `server_with_frequent_cleanups` that periodically cleans up old `Compile` and `Report` database entries.
- `old_and_new_compile_report` that inserts data in the `Compile` and `Report` databases.

The issue arises when events happen in this order:

1) Insert in `Compile`
2) Server clean up 
3) Insert in `Report`  ==> **FAILS** because `Compile` has been cleaned up

## Solution
Execute all queries in the `old_and_new_compile_report` fixture in a transaction as such that the change is applied atomically.



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
