### PR TITLE
improved transparency of get_connection in inmanta.data

### DIFF
--- a/changelogs/unreleased/data-connection-transparency.yml
+++ b/changelogs/unreleased/data-connection-transparency.yml
@@ -1,0 +1,6 @@
+description: "Improved transparency of get_connection method in inmanta.data"
+change-type: patch
+destination-branches:
+  # changes require Python 3.9 so not compatible with iso4
+  - master
+  - iso5

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -29,6 +29,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import abc, defaultdict
 from configparser import RawConfigParser
+from contextlib import AbstractAsyncContextManager
 from itertools import chain
 from typing import (
     Any,
@@ -937,13 +938,17 @@ class BaseDocument(object, metaclass=DocumentMeta):
         self.__process_kwargs(from_postgres, kwargs)
 
     @classmethod
-    def get_connection(cls) -> asyncpg.pool.PoolAcquireContext:
+    def get_connection(
+        cls, connection: Optional[asyncpg.connection.Connection] = None
+    ) -> AbstractAsyncContextManager[asyncpg.connection.Connection]:
         """
-        Returns a PoolAcquireContext that can be either awaited or used in an async with statement to receive a Connection.
+        Returns a context manager to acquire a connection. If an existing connection is passed, returns a dummy context manager
+        wrapped around that connection instance. This allows for transparent usage, regardless of whether a connection has
+        already been acquired.
         """
         # Make pypi happy
         assert cls._connection_pool is not None
-        return cls._connection_pool.acquire()
+        return cls._connection_pool.acquire() if connection is None else util.nullcontext(connection)
 
     @classmethod
     def table_name(cls) -> str:
@@ -1237,18 +1242,14 @@ class BaseDocument(object, metaclass=DocumentMeta):
     async def _fetch_query(
         cls, query: str, *values: object, connection: Optional[asyncpg.connection.Connection] = None
     ) -> Sequence[Record]:
-        if connection is None:
-            async with cls.get_connection() as con:
-                return await con.fetch(query, *values)
-        return await connection.fetch(query, *values)
+        async with cls.get_connection(connection) as con:
+            return await con.fetch(query, *values)
 
     @classmethod
     async def _execute_query(
         cls, query: str, *values: object, connection: Optional[asyncpg.connection.Connection] = None
     ) -> str:
-        if connection:
-            return await connection.execute(query, *values)
-        async with cls.get_connection() as con:
+        async with cls.get_connection(connection) as con:
             return await con.execute(query, *values)
 
     @classmethod
@@ -1884,7 +1885,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         no_obj: bool = False,
         connection: Optional[asyncpg.connection.Connection] = None,
     ) -> Sequence[Union[Record, TBaseDocument]]:
-        async def perform_query(con: asyncpg.connection.Connection) -> List[Union[Record, TBaseDocument]]:
+        async with cls.get_connection(connection) as con:
             async with con.transaction():
                 result: List[Union[Record, TBaseDocument]] = []
                 async for record in con.cursor(query, *values):
@@ -1893,11 +1894,6 @@ class BaseDocument(object, metaclass=DocumentMeta):
                     else:
                         result.append(cls(from_postgres=True, **record))
                 return result
-
-        if connection is None:
-            async with cls.get_connection() as con:
-                return await perform_query(con)
-        return await perform_query(connection)
 
     def to_dict(self) -> JsonType:
         """
@@ -2923,7 +2919,7 @@ class AgentInstance(BaseDocument):
         if not endpoints:
             return
 
-        async def _execute_query(con: asyncpg.connection.Connection) -> None:
+        async with cls.get_connection(connection) as con:
             await con.executemany(
                 f"""
                 INSERT INTO
@@ -2936,12 +2932,6 @@ class AgentInstance(BaseDocument):
                 """,
                 [tuple(map(cls._get_value, (cls._new_id(), tid, process, name))) for name in endpoints],
             )
-
-        if connection:
-            await _execute_query(connection)
-        else:
-            async with cls.get_connection() as con:
-                await _execute_query(con)
 
     @classmethod
     async def log_instance_expiry(
@@ -3064,7 +3054,7 @@ class Agent(BaseDocument):
         Restores default halted state. Returns a list of agents that should be unpaused.
         """
 
-        async def query_with_connection(connection: asyncpg.connection.Connection) -> List[str]:
+        async with cls.get_connection(connection) as con:
             async with connection.transaction():
                 unpause_on_resume = await cls._fetch_query(
                     f"SELECT name FROM {cls.table_name()} WHERE environment=$1 AND unpause_on_resume",
@@ -3077,12 +3067,6 @@ class Agent(BaseDocument):
                     connection=connection,
                 )
                 return sorted([r["name"] for r in unpause_on_resume])
-
-        if connection is not None:
-            return await query_with_connection(connection)
-
-        async with cls.get_connection() as con:
-            return await query_with_connection(con)
 
     @classmethod
     async def pause(
@@ -4217,6 +4201,8 @@ class Resource(BaseDocument):
         environment: uuid.UUID,
         resource_type: Optional[m.ResourceType] = None,
         attributes: Dict[PrimitiveTypes, PrimitiveTypes] = {},
+        *,
+        connection: Optional[asyncpg.connection.Connection] = None,
     ) -> List["Resource"]:
         """
         Returns the resources in the latest version of the configuration model of the given environment, that satisfy the
@@ -4239,7 +4225,7 @@ class Resource(BaseDocument):
             values.append(cls._get_value(resource_type))
 
         result = []
-        async with cls.get_connection() as con:
+        async with cls.get_connection(connection) as con:
             async with con.transaction():
                 async for record in con.cursor(query, *values):
                     resource = cls(from_postgres=True, **record)
@@ -4247,6 +4233,7 @@ class Resource(BaseDocument):
                     # This prevents injection attacks.
                     if util.is_sub_dict(attributes, resource.attributes):
                         result.append(resource)
+
         return result
 
     @classmethod
@@ -5289,7 +5276,7 @@ class ConfigurationModel(BaseDocument):
     async def mark_done_if_done(
         cls, environment: uuid.UUID, version: int, connection: Optional[asyncpg.connection.Connection] = None
     ) -> None:
-        async def do_query_exclusive(con: asyncpg.connection.Connection) -> None:
+        async with cls.get_connection(connection) as con:
             """
             Performs the query to mark done if done. Acquires a lock that blocks execution until other transactions holding
             this lock have committed. This makes sure that once a transaction performs this query, it needs to commit before
@@ -5326,12 +5313,6 @@ class ConfigurationModel(BaseDocument):
                     cls._get_value(DONE_STATES),
                 ]
                 await cls._execute_query(query, *values, connection=con)
-
-        if connection is None:
-            async with cls.get_connection() as con:
-                await do_query_exclusive(con)
-        else:
-            await do_query_exclusive(connection)
 
     @classmethod
     async def get_increment(

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4233,7 +4233,6 @@ class Resource(BaseDocument):
                     # This prevents injection attacks.
                     if util.is_sub_dict(attributes, resource.attributes):
                         result.append(resource)
-
         return result
 
     @classmethod

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3059,12 +3059,12 @@ class Agent(BaseDocument):
                 unpause_on_resume = await cls._fetch_query(
                     f"SELECT name FROM {cls.table_name()} WHERE environment=$1 AND unpause_on_resume",
                     cls._get_value(env),
-                    connection=connection,
+                    connection=con,
                 )
                 await cls._execute_query(
                     f"UPDATE {cls.table_name()} SET unpause_on_resume=NULL WHERE environment=$1",
                     cls._get_value(env),
-                    connection=connection,
+                    connection=con,
                 )
                 return sorted([r["name"] for r in unpause_on_resume])
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3055,7 +3055,7 @@ class Agent(BaseDocument):
         """
 
         async with cls.get_connection(connection) as con:
-            async with connection.transaction():
+            async with con.transaction():
                 unpause_on_resume = await cls._fetch_query(
                     f"SELECT name FROM {cls.table_name()} WHERE environment=$1 AND unpause_on_resume",
                     cls._get_value(env),

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 import asyncio
+import contextlib
 import datetime
 import enum
 import functools
@@ -501,3 +502,15 @@ class NamedLock:
             if self._named_locks_counters[name] <= 0:
                 del self._named_locks[name]
                 del self._named_locks_counters[name]
+
+
+class nullcontext(contextlib.nullcontext[T], contextlib.AbstractAsyncContextManager[T]):
+    """
+    nullcontext ported from Python 3.10 to support async
+    """
+
+    async def __aenter__(self) -> T:
+        return self.enter_result
+
+    async def __aexit__(self, *excinfo: object) -> None:
+        pass


### PR DESCRIPTION
# Description

Suggestion for improvement of the `get_connection` method in `inmanta.data.BaseDocument`. This class is part of the stable API and I changed the method signature in the sense that it can now only be used with a context manager where previously it could also be just awaited. But I'm pretty sure that this method isn't used outside of core, and if it is I expect it's used as a context manager.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
