### PR TITLE
Issue/4388 deprecation warning setuptool iso5

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include LICENSE
-graft docs
 include tox.ini
 include setup.py
 include setup.cfg
@@ -7,10 +6,7 @@ include src/inmanta/py.typed
 include src/inmanta/parser/parser.out
 
 recursive-include src *.j2
-recursive-include docs *
-recursive-include misc *
 
 global-exclude *.pyc
 global-exclude */__pycache__/*
 global-exclude **/.env/**
-exclude docs/build/**

--- a/changelogs/unreleased/4388-fix-deprecation-warning-setuptools.yml
+++ b/changelogs/unreleased/4388-fix-deprecation-warning-setuptools.yml
@@ -1,0 +1,4 @@
+description: "fix deprecation warning for setuptools"
+change-type: patch
+destination-branches: [iso5, master]
+issue-nr: 4388

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from os import path
 
 requires = [
@@ -35,8 +35,6 @@ requires = [
     "toml~=0.10 ",
 ]
 
-# Package a dummy extensions so that the namespace package for extensions is not empty
-namespace_packages = ["inmanta_ext.core", "inmanta_plugins.1"]
 
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))
@@ -73,9 +71,10 @@ setup(
     },
     # Packaging
     package_dir={"": "src"},
-    packages=find_packages("src") + namespace_packages,
+    # All data files should be treated as namespace package according to
+    # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files
+    packages=find_namespace_packages(where="src"),
     # https://www.python.org/dev/peps/pep-0561/#packaging-type-information
-    package_data={"": ["misc/*", "docs/*"], "inmanta": ["py.typed"]},
     zip_safe=False,
     include_package_data=True,
     install_requires=requires,

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -17,7 +17,7 @@
 """
 from os import path
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 version = "6.1.1"
 
@@ -65,7 +65,9 @@ setup(
     project_urls={"Bug Tracker": "https://github.com/inmanta/inmanta-core/issues"},
     # Packaging
     package_dir={"": "src"},
-    packages=find_packages("src"),
+    # All data files should be treated as namespace package according to
+    # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#subdirectory-for-data-files
+    packages=find_namespace_packages(where="src"),
     include_package_data=True,
     install_requires=requires,
     entry_points={"pytest11": ["pytest-inmanta-tests = inmanta_tests.plugin"]},


### PR DESCRIPTION
# Description

Forward port fix of #4400 to iso5 and master

closes #4388 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
