### PR TITLE
Store .cfc files in the root of the inmanta project

### DIFF
--- a/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
+++ b/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
@@ -1,0 +1,8 @@
+---
+description: The compiler cache (.cfc) files are now stored in the .cfcache directory in the root of the inmanta project instead of in the __cfcache__ directory in the inmanta modules.
+issue-nr: 4407
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
+++ b/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
@@ -3,6 +3,6 @@ description: The compiler cache (.cfc) files are now stored in the .cfcache dire
 issue-nr: 4407
 issue-repo: inmanta-core
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso5]
 sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -302,3 +302,6 @@ class NotificationSeverity(str, Enum):
     success = "success"
     warning = "warning"
     error = "error"
+
+
+CF_CACHE_DIR = ".cfcache"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1447,6 +1447,7 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         autostd: bool = True,
         main_file: str = "main.cf",
         venv_path: Optional[str] = None,
+        attach_cf_cache: bool = True,
     ) -> None:
         """
         Initialize the project, this includes
@@ -1502,6 +1503,8 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         self.modules: Dict[str, Module] = {}
         self.root_ns = Namespace("__root__")
         self.autostd = autostd
+        if attach_cf_cache:
+            cache_manager.attach_to_project(path)
 
     def get_relation_precedence_policy(self) -> List[RelationPrecedenceRule]:
         return self._metadata.get_relation_precedence_rules()
@@ -2162,7 +2165,7 @@ class DummyProject(Project):
     """Placeholder project that does nothing"""
 
     def __init__(self, autostd: bool = True) -> None:
-        super().__init__(tempfile.gettempdir(), autostd=autostd)
+        super().__init__(tempfile.gettempdir(), autostd=autostd, attach_cf_cache=False)
 
     def _get_metadata_from_disk(self) -> ProjectMetadata:
         return ProjectMetadata(name="DUMMY")

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -42,7 +42,7 @@ import toml
 from inmanta import env
 from inmanta.ast import CompilerException
 from inmanta.command import CLIException, ShowUsageException
-from inmanta.const import MAX_UPDATE_ATTEMPT
+from inmanta.const import CF_CACHE_DIR, MAX_UPDATE_ATTEMPT
 from inmanta.module import (
     DummyProject,
     FreezeOperator,
@@ -890,7 +890,7 @@ class ModuleBuildFailedError(Exception):
         return self.msg
 
 
-BUILD_FILE_IGNORE_PATTERN: Pattern[str] = re.compile("|".join(("__pycache__", "__cfcache__", r".*\.pyc")))
+BUILD_FILE_IGNORE_PATTERN: Pattern[str] = re.compile("|".join(("__pycache__", "__cfcache__", r".*\.pyc", rf"{CF_CACHE_DIR}")))
 
 
 class V2ModuleBuilder:

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -15,7 +15,6 @@
 
     Contact: code@inmanta.com
 """
-
 import logging
 import re
 from itertools import accumulate
@@ -1174,5 +1173,5 @@ def parse(namespace: Namespace, filename: str, content: Optional[str] = None) ->
     if statements is not None:
         return statements
     statements = base_parse(namespace, filename, content)
-    cache_manager.cache(filename, statements)
+    cache_manager.cache(namespace, filename, statements)
     return statements

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ from inmanta.env import LocalPackagePath
 from inmanta.export import cfg_env, unknown_parameters
 from inmanta.module import InmantaModuleRequirement, InstallMode, Project, RelationPrecedenceRule
 from inmanta.moduletool import ModuleTool
+from inmanta.parser.plyInmantaParser import cache_manager
 from inmanta.protocol import VersionMatch
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_COMPILER
 from inmanta.server.bootloader import InmantaBootloader
@@ -484,6 +485,7 @@ async def clean_reset(create_db, clean_db):
     config.Config._reset()
     reset_all_objects()
     loader.unload_inmanta_plugins()
+    cache_manager.detach_from_project()
 
 
 def reset_all_objects():

--- a/tests/moduletool/test_build.py
+++ b/tests/moduletool/test_build.py
@@ -30,6 +30,7 @@ import pytest
 from pytest import MonkeyPatch
 
 from inmanta import moduletool
+from inmanta.const import CF_CACHE_DIR
 from inmanta.module import ModuleMetadataFileNotFound
 from inmanta.moduletool import V2ModuleBuilder
 
@@ -164,11 +165,14 @@ def test_build_v2_module_incomplete_package_data(tmpdir, modules_v2_dir: str, ca
         )
     )
 
-    # write some garbage cfcache and pyc files to verify those are ignored as well
+    # write some garbage .cfc and pyc files to verify those are ignored as well
     open(os.path.join(source_dir, "test.pyc"), "w").close()
     cfcache_dir: str = os.path.join(module_copy_dir, "model", "__cfcache__")
     os.makedirs(cfcache_dir, exist_ok=True)
     open(os.path.join(cfcache_dir, "test.cfc"), "w").close()
+    dot_cfcache_dir: str = os.path.join(module_copy_dir, CF_CACHE_DIR)
+    os.makedirs(dot_cfcache_dir, exist_ok=True)
+    open(os.path.join(dot_cfcache_dir, "test2.cfc"), "w").close()
 
     with caplog.at_level(logging.WARNING):
         V2ModuleBuilder(module_copy_dir).build(os.path.join(module_copy_dir, "dist"))

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -27,6 +27,7 @@ from pkg_resources import Requirement
 
 from inmanta import plugins
 from inmanta.compiler.config import feature_compiler_cache
+from inmanta.const import CF_CACHE_DIR
 from inmanta.env import LocalPackagePath, process_env
 from inmanta.module import (
     DummyProject,

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -47,7 +47,7 @@ from utils import PipIndex, module_from_template, v1_module_from_template
 @pytest.mark.parametrize_any("editable_install", [True, False])
 def test_v2_module_loading(editable_install: bool, tmpdir: py.path.local, snippetcompiler, capsys, modules_v2_dir: str) -> None:
     # Work around caching problem in venv
-    feature_compiler_cache.set("False")
+    feature_compiler_cache.set("True")
     # Disable modules_dir
     snippetcompiler.modules_dir = None
 

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -69,6 +69,10 @@ def test_v2_module_loading(editable_install: bool, tmpdir: py.path.local, snippe
     snippetcompiler.do_export()
     assert "Hello world" in capsys.readouterr().out
 
+    # Make sure the cache files are created
+    cache_folder = os.path.join(snippetcompiler.project_dir, CF_CACHE_DIR)
+    assert len(os.listdir(cache_folder)) > 0
+
 
 def test_v1_and_v2_module_installed_simultaneously(
     tmpdir: py.path.local, snippetcompiler_clean, capsys, caplog, modules_dir: str


### PR DESCRIPTION
# Description

**Same PR as #4424 but applied on the iso5 branch due to a merge conflict.**

The compiler cache (`.cfc`) files are now stored in the `.cfcache` directory in the root of the inmanta project instead of in the `__cfcache__` directory in the inmanta modules.

closes #4407 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
