### PR TITLE
[FIX] fix timestamp in env_with_compile_reports fixtures to not be ol…

### DIFF
--- a/changelogs/unreleased/build-master-fix-failure-inmanta-core-962-compile-reports-older-than-7-days-get-deleted.yml
+++ b/changelogs/unreleased/build-master-fix-failure-inmanta-core-962-compile-reports-older-than-7-days-get-deleted.yml
@@ -1,0 +1,3 @@
+description: Fix the env_with_compile_reports fixture that was generating compile reports that would get deleted automatically.
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/server/test_compilereport_list.py
+++ b/tests/server/test_compilereport_list.py
@@ -34,8 +34,14 @@ def compile_ids(compile_objects):
 @pytest.fixture
 async def env_with_compile_reports(client, environment):
     compile_requested_timestamps = []
+
     for i in range(8):
-        requested = datetime.datetime.strptime(f"2021-09-09T11:{i}:00.0", "%Y-%m-%dT%H:%M:%S.%f")
+        """
+        Make sure the timestamp on these reports is not older than 7 days, otherwise they might
+        get automatically cleaned up by the server process that cleans up old compiles.
+        hours=-i ensures they are returned in ascending chronological order
+        """
+        requested = datetime.datetime.now().astimezone(datetime.timezone.utc) - datetime.timedelta(days=5, hours=-i)
         compile_requested_timestamps.append(requested)
         await data.Compile(
             id=uuid.uuid4(),


### PR DESCRIPTION
…der than 7 days

# Description

Ensure compile reports created in the env_with_compile_reports are not older than 7 days to prevent them from being automatically cleaned up by the server process cleaning up old compile reports.



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
