### PR TITLE
Store .cfc files in the root of the inmanta project

### DIFF
--- a/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
+++ b/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
@@ -1,0 +1,8 @@
+---
+description: The compiler cache (.cfc) files are now stored in the .cfcache directory in the root of the inmanta project instead of in the __cfcache__ directory in the inmanta modules.
+issue-nr: 4407
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
+++ b/changelogs/unreleased/4407-move-cfcache-files-to-project-root.yml
@@ -3,6 +3,6 @@ description: The compiler cache (.cfc) files are now stored in the .cfcache dire
 issue-nr: 4407
 issue-repo: inmanta-core
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso4]
 sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -289,3 +289,22 @@ class DesiredStateVersionStatus(str, Enum):
     candidate = "candidate"
     retired = "retired"
     skipped_candidate = "skipped_candidate"
+
+
+class NotificationSeverity(str, Enum):
+    """
+    The possible values determine the styling used by the frontend to show them,
+    so notifications with severity 'info' will be shown as informational messages,
+    the ones with 'error' as error messages and so on.
+    The 'message' category corresponds to a generic message, which
+    is shown without extra styling on the frontend.
+    """
+
+    message = "message"
+    info = "info"
+    success = "success"
+    warning = "warning"
+    error = "error"
+
+
+CF_CACHE_DIR = ".cfcache"

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -291,20 +291,4 @@ class DesiredStateVersionStatus(str, Enum):
     skipped_candidate = "skipped_candidate"
 
 
-class NotificationSeverity(str, Enum):
-    """
-    The possible values determine the styling used by the frontend to show them,
-    so notifications with severity 'info' will be shown as informational messages,
-    the ones with 'error' as error messages and so on.
-    The 'message' category corresponds to a generic message, which
-    is shown without extra styling on the frontend.
-    """
-
-    message = "message"
-    info = "info"
-    success = "success"
-    warning = "warning"
-    error = "error"
-
-
 CF_CACHE_DIR = ".cfcache"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -644,7 +644,14 @@ class Project(ModuleLike[ProjectMetadata]):
     PROJECT_FILE = "project.yml"
     _project = None
 
-    def __init__(self, path: str, autostd: bool = True, main_file: str = "main.cf", venv_path: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        path: str,
+        autostd: bool = True,
+        main_file: str = "main.cf",
+        venv_path: Optional[str] = None,
+        attach_cf_cache: bool = True,
+    ) -> None:
         """
         Initialize the project, this includes
          * Loading the project.yaml (into self._metadata)
@@ -690,6 +697,8 @@ class Project(ModuleLike[ProjectMetadata]):
         self.modules: Dict[str, Module] = {}
         self.root_ns = Namespace("__root__")
         self.autostd = autostd
+        if attach_cf_cache:
+            cache_manager.attach_to_project(path)
 
         self._ast_cache: Optional[Tuple[List[Statement], BasicBlock]] = None  # Cache for expensive method calls
         self._imports_cache: Optional[List[DefineImport]] = None  # Cache for expensive method calls

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -644,13 +644,7 @@ class Project(ModuleLike[ProjectMetadata]):
     PROJECT_FILE = "project.yml"
     _project = None
 
-    def __init__(
-        self,
-        path: str,
-        autostd: bool = True,
-        main_file: str = "main.cf",
-        venv_path: Optional[str] = None,
-    ) -> None:
+    def __init__(self, path: str, autostd: bool = True, main_file: str = "main.cf", venv_path: Optional[str] = None) -> None:
         """
         Initialize the project, this includes
          * Loading the project.yaml (into self._metadata)

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -650,7 +650,6 @@ class Project(ModuleLike[ProjectMetadata]):
         autostd: bool = True,
         main_file: str = "main.cf",
         venv_path: Optional[str] = None,
-        attach_cf_cache: bool = True,
     ) -> None:
         """
         Initialize the project, this includes
@@ -697,8 +696,7 @@ class Project(ModuleLike[ProjectMetadata]):
         self.modules: Dict[str, Module] = {}
         self.root_ns = Namespace("__root__")
         self.autostd = autostd
-        if attach_cf_cache:
-            cache_manager.attach_to_project(path)
+        cache_manager.attach_to_project(path)
 
         self._ast_cache: Optional[Tuple[List[Statement], BasicBlock]] = None  # Cache for expensive method calls
         self._imports_cache: Optional[List[DefineImport]] = None  # Cache for expensive method calls

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -32,26 +32,6 @@ from pkg_resources import parse_version
 
 from inmanta.ast import CompilerException
 from inmanta.command import CLIException, ShowUsageException
-from inmanta.const import CF_CACHE_DIR, MAX_UPDATE_ATTEMPT
-from inmanta.module import (
-    DummyProject,
-    FreezeOperator,
-    InmantaModuleRequirement,
-    InstallMode,
-    InvalidMetadata,
-    InvalidModuleException,
-    Module,
-    ModuleGeneration,
-    ModuleLike,
-    ModuleMetadataFileNotFound,
-    ModuleNotFoundException,
-    ModuleV1,
-    ModuleV2,
-    ModuleV2Source,
-    Project,
-    gitprovider,
-)
-from inmanta.stable_api import stable_api
 from inmanta.const import MAX_UPDATE_ATTEMPT
 from inmanta.module import FreezeOperator, InstallMode, Module, Project, gitprovider
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -32,6 +32,26 @@ from pkg_resources import parse_version
 
 from inmanta.ast import CompilerException
 from inmanta.command import CLIException, ShowUsageException
+from inmanta.const import CF_CACHE_DIR, MAX_UPDATE_ATTEMPT
+from inmanta.module import (
+    DummyProject,
+    FreezeOperator,
+    InmantaModuleRequirement,
+    InstallMode,
+    InvalidMetadata,
+    InvalidModuleException,
+    Module,
+    ModuleGeneration,
+    ModuleLike,
+    ModuleMetadataFileNotFound,
+    ModuleNotFoundException,
+    ModuleV1,
+    ModuleV2,
+    ModuleV2Source,
+    Project,
+    gitprovider,
+)
+from inmanta.stable_api import stable_api
 from inmanta.const import MAX_UPDATE_ATTEMPT
 from inmanta.module import FreezeOperator, InstallMode, Module, Project, gitprovider
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -15,7 +15,6 @@
 
     Contact: code@inmanta.com
 """
-
 import logging
 import re
 from typing import List, Optional, Tuple, Union
@@ -1082,5 +1081,5 @@ def parse(namespace: Namespace, filename: str, content: Optional[str] = None) ->
     if statements is not None:
         return statements
     statements = base_parse(namespace, filename, content)
-    cache_manager.cache(filename, statements)
+    cache_manager.cache(namespace, filename, statements)
     return statements

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -50,7 +50,7 @@ a=1
     assert parser.cache_manager.hits == 2  # main.cf and std::init
 
     main_file = os.path.join(snippetcompiler.project_dir, "main.cf")
-    root_ns = snippetcompiler.project.root_ns
+    root_ns = Project.get().root_ns
     cached_main = parser.cache_manager._get_file_name(root_ns.get_child_or_create("main.cf"), main_file)
     Path(main_file).touch()
     # make the cache a tiny bit newer

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -22,7 +22,6 @@ from time import sleep
 import inmanta.parser.plyInmantaParser as parser
 from inmanta import compiler, loader
 from inmanta.module import Project
-from inmanta.parser.cache import CacheManager
 
 
 def test_caching(snippetcompiler):

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -27,7 +27,7 @@ from inmanta.parser.cache import CacheManager
 
 def test_caching(snippetcompiler):
     # reset counts
-    parser.cache_manager = CacheManager()
+    parser.cache_manager.reset_stats()
     snippetcompiler.setup_for_snippet(
         """
 a=1
@@ -39,7 +39,7 @@ a=1
     assert parser.cache_manager.failures == 0
 
     # reset counts
-    parser.cache_manager = CacheManager()
+    parser.cache_manager.reset_stats()
     # reset project ast cache
     Project.set(Project(snippetcompiler.project_dir, autostd=True))
     loader.unload_inmanta_plugins()
@@ -51,14 +51,15 @@ a=1
     assert parser.cache_manager.hits == 2  # main.cf and std::init
 
     main_file = os.path.join(snippetcompiler.project_dir, "main.cf")
-    cached_main = parser.cache_manager.get_file_name(main_file)
+    root_ns = snippetcompiler.project.root_ns
+    cached_main = parser.cache_manager._get_file_name(root_ns.get_child_or_create("main.cf"), main_file)
     Path(main_file).touch()
     # make the cache a tiny bit newer
     sleep(0.001)
     Path(cached_main).touch()
 
     # reset counts
-    parser.cache_manager = CacheManager()
+    parser.cache_manager.reset_stats()
     # reset project ast cache
     Project.set(Project(snippetcompiler.project_dir, autostd=True))
     loader.unload_inmanta_plugins()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,9 @@ from inmanta.agent.agent import Agent
 from inmanta.ast import CompilerException
 from inmanta.data.schema import SCHEMA_VERSION_TABLE
 from inmanta.export import cfg_env, unknown_parameters
+from inmanta.module import InmantaModuleRequirement, InstallMode, Project, RelationPrecedenceRule
+from inmanta.moduletool import ModuleTool
+from inmanta.parser.plyInmantaParser import cache_manager
 from inmanta.module import Project
 from inmanta.postgresproc import PostgresProc
 from inmanta.protocol import VersionMatch
@@ -393,6 +396,7 @@ async def clean_reset(create_db, clean_db):
     config.Config._reset()
     reset_all_objects()
     loader.unload_inmanta_plugins()
+    cache_manager.detach_from_project()
 
 
 def reset_all_objects():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,10 +75,8 @@ from inmanta.agent.agent import Agent
 from inmanta.ast import CompilerException
 from inmanta.data.schema import SCHEMA_VERSION_TABLE
 from inmanta.export import cfg_env, unknown_parameters
-from inmanta.module import InmantaModuleRequirement, InstallMode, Project, RelationPrecedenceRule
-from inmanta.moduletool import ModuleTool
-from inmanta.parser.plyInmantaParser import cache_manager
 from inmanta.module import Project
+from inmanta.parser.plyInmantaParser import cache_manager
 from inmanta.postgresproc import PostgresProc
 from inmanta.protocol import VersionMatch
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_COMPILER


### PR DESCRIPTION
# Description

**Same PR as #4424 but applied on the iso4 branch due to a merge conflict.**

The compiler cache (`.cfc`) files are now stored in the `.cfcache` directory in the root of the inmanta project instead of in the `__cfcache__` directory in the inmanta modules.

closes #4407 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
