### PR TITLE
include misc dir in sdist for RPM build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,11 @@ include setup.cfg
 include src/inmanta/py.typed
 include src/inmanta/parser/parser.out
 
+# explainers for compiler exceptions
 recursive-include src *.j2
+
+# data for RPM build
+graft misc
 
 global-exclude *.pyc
 global-exclude */__pycache__/*

--- a/changelogs/unreleased/packaging-include-misc.yml
+++ b/changelogs/unreleased/packaging-include-misc.yml
@@ -1,0 +1,6 @@
+description: include misc dir in sdist package for RPM build
+change-type: patch
+destination-branches:
+  - iso4
+  - iso5
+  - master


### PR DESCRIPTION
# Description

The RPM builld requires the misc directory, which was removed from the sdist in #4435. This PR adds it again.

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
