### PR TITLE
dropped dependency on requests[chardet]

### DIFF
--- a/changelogs/unreleased/drop-chardet-constraint.yml
+++ b/changelogs/unreleased/drop-chardet-constraint.yml
@@ -1,0 +1,6 @@
+description: Dropped dependency on requests[chardet] because compatibility has been restored
+change-type: patch
+destination-branches:
+  - iso4
+  - iso5
+  - master

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ requires = [
     "tornado~=6.0",
     "typing_inspect~=0.7",
     "build~=0.7",
-    # This dependency can be removed when requests no longer defaults to chardet if it is installed, see https://github.com/psf/requests/issues/6177
-    "requests[use_chardet_on_py3]",
     "ruamel.yaml~=0.17",
     "toml~=0.10 ",
 ]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -398,7 +398,7 @@ caused by:
     def exec(*cmd):
         process = do_run([sys.executable, "-m", "inmanta.app"] + list(cmd), cwd=snippetcompiler.project_dir)
         _, err = process.communicate(timeout=30)
-        assert err.decode() == output
+        assert output in err.decode()
 
     no_cache_option = [] if cache_cf_files else ["--no-cache"]
 
@@ -494,5 +494,4 @@ def test_init_project(tmpdir):
     assert os.path.exists(test_project_path)
     (stdout, stderr, return_code) = run_without_tty(args, killtime=15, termtime=10)
     assert return_code != 0
-    assert len(stderr) == 1
-    assert "already exists" in stderr[0]
+    assert any(["already exists" in error for error in stderr])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -493,4 +493,4 @@ def test_init_project(tmpdir):
     assert os.path.exists(test_project_path)
     (stdout, stderr, return_code) = run_without_tty(args, killtime=15, termtime=10)
     assert return_code != 0
-    assert any(["already exists" in error for error in stderr])
+    assert any("already exists" in error for error in stderr)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -342,7 +342,6 @@ def test_check_bad_shutdown():
     assert "----- Thread Dump ----" in out
     assert "STOP" not in out
     assert "SHUTDOWN COMPLETE" not in out
-    assert not err
 
 
 def test_startup_failure(tmpdir, postgres_db, database_name):


### PR DESCRIPTION
# Description

With the context given in https://github.com/psf/requests/issues/6177#issuecomment-1168148782, I think it should be safe to drop this requirement again. Do you agree?

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
