### PR TITLE
Added support for development builds of V2 modules

### DIFF
--- a/changelogs/unreleased/support-dev-builds-v2-modules.yml
+++ b/changelogs/unreleased/support-dev-builds-v2-modules.yml
@@ -1,0 +1,8 @@
+---
+description: Added support to create development builds of V2 modules
+issue-nr: 1184
+issue-repo: irt
+change-type: minor
+destination-branches: [master, iso5]
+sections:
+  feature: "{{description}}"

--- a/tests/moduletool/test_build.py
+++ b/tests/moduletool/test_build.py
@@ -18,6 +18,7 @@
 import importlib.util
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -35,10 +36,12 @@ from inmanta.module import ModuleMetadataFileNotFound
 from inmanta.moduletool import V2ModuleBuilder
 
 
-def run_module_build_soft(module_path: str, set_path_argument: bool, output_dir: Optional[str] = None) -> None:
+def run_module_build_soft(
+    module_path: str, set_path_argument: bool, output_dir: Optional[str] = None, dev_build: bool = False
+) -> str:
     if not set_path_argument:
         module_path = None
-    moduletool.ModuleTool().build(module_path, output_dir)
+    return moduletool.ModuleTool().build(module_path, output_dir, dev_build=dev_build)
 
 
 def run_module_build(module_path: str, set_path_argument: bool, output_dir: Optional[str] = None) -> None:
@@ -197,3 +200,15 @@ def test_build_invalid_module(tmpdir, modules_v2_dir: str):
 
     with pytest.raises(ModuleMetadataFileNotFound, match=f"Metadata file {setup_cfg_file} does not exist"):
         V2ModuleBuilder(module_copy_dir).build(os.path.join(module_copy_dir, "dist"))
+
+
+def test_create_dev_build_of_v2_module(tmpdir, modules_v2_dir: str) -> None:
+    """
+    Test whether the functionality to create a development build of a module, works correctly.
+    """
+    module_name = "minimalv2module"
+    module_dir = os.path.join(modules_v2_dir, module_name)
+    module_copy_dir = os.path.join(tmpdir, module_name)
+    shutil.copytree(module_dir, module_copy_dir)
+    path_to_wheel = run_module_build_soft(module_copy_dir, set_path_argument=True, dev_build=True)
+    assert re.search(r"\.dev[0-9]{14}", path_to_wheel)


### PR DESCRIPTION
# Description

This PR adds support to create development builds of V2 modules. 

Part of inmanta/irt#1184

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
