### PR TITLE
Add support for partial compiles using the inmanta export command

### DIFF
--- a/changelogs/unreleased/4272-partial-compile-export-cmd.yml
+++ b/changelogs/unreleased/4272-partial-compile-export-cmd.yml
@@ -1,0 +1,6 @@
+---
+description: Add support for partial compiles using the `inmanta export` command.
+issue-nr: 4272
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso5]

--- a/changelogs/unreleased/4272-partial-compile-export-cmd.yml
+++ b/changelogs/unreleased/4272-partial-compile-export-cmd.yml
@@ -3,4 +3,4 @@ description: Add support for partial compiles using the `inmanta export` command
 issue-nr: 4272
 issue-repo: inmanta-core
 change-type: minor
-destination-branches: [master, iso5]
+destination-branches: [iso5]

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -492,13 +492,6 @@ def export_parser_config(parser: argparse.ArgumentParser) -> None:
         help="File to export compile data to. If omitted %s is used." % compiler.config.default_compile_data_file,
     )
     parser.add_argument(
-        "--no-cache",
-        dest="feature_compiler_cache",
-        help="Disable caching of compiled CF files",
-        action="store_false",
-        default=True,
-    )
-    parser.add_argument(
         "--partial",
         dest="partial_compile",
         help="Execute a partial export",

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -45,10 +45,9 @@ def put_partial(
     version: int,
     resource_state: Optional[Dict[ResourceIdStr, ResourceState]] = None,
     unknowns: Optional[List[Dict[str, PrimitiveTypes]]] = None,
-    version_info: Optional[model.ModelVersionInfo] = None,
     resource_sets: Optional[Dict[ResourceIdStr, Optional[str]]] = None,
     removed_resource_sets: Optional[List[str]] = None,
-    **kwargs: object,  # bypass the type checking for resources that result from the partial compile
+    **kwargs: object,  # bypass the type checking for the resources and version_info argument
 ) -> None:
     """
     Store a new version of the configuration model after a partial recompile.
@@ -59,10 +58,11 @@ def put_partial(
     :param version: The version of the configuration model
     :param resource_state: A dictionary with the initial const.ResourceState per resource id
     :param unknowns: A list of unknown parameters that caused the model to be incomplete
-    :param version_info: Model version information
     :param resource_sets: a dictionary describing which resources belong to which resource set
     :param removed_resource_sets: a list of resource_sets that should be deleted from the model
-    :param **kwargs: support value 'resources': a list of resource objects.
+    :param **kwargs: The following arguments are supported:
+              * resources: a list of resource objects.
+              * version_info: Model version information
     """
 
 

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -35,7 +35,6 @@ from inmanta.data import (
     DesiredStateVersionOrder,
     InvalidSort,
     QueryType,
-    model,
 )
 from inmanta.data.model import (
     DesiredStateVersion,
@@ -649,7 +648,7 @@ class OrchestrationService(protocol.ServerSlice):
         resources: object,
         resource_state: Optional[Dict[ResourceIdStr, ResourceState]] = None,
         unknowns: Optional[List[Dict[str, PrimitiveTypes]]] = None,
-        version_info: Optional[model.ModelVersionInfo] = None,
+        version_info: Optional[JsonType] = None,
         resource_sets: Optional[Dict[ResourceIdStr, Optional[str]]] = None,
         removed_resource_sets: Optional[List[str]] = None,
     ) -> None:
@@ -672,14 +671,13 @@ class OrchestrationService(protocol.ServerSlice):
 
         merger = PartialUpdateMerger(resources, resource_sets, removed_resource_sets, env)
         merged_resources, merged_resource_sets = await merger.merge_partial_with_old()
-        version_info_dict = version_info.dict() if version_info else None
         await self._put_version(
             env,
             version,
             merged_resources,
             resource_state,
             unknowns,
-            version_info_dict,
+            version_info,
             merged_resource_sets,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1116,16 +1116,35 @@ class SnippetCompilationTest(KeepOnFail):
             dirs.extend(add_to_module_path)
         return f"[{', '.join(dirs)}]"
 
-    def do_export(self, include_status=False, do_raise=True):
-        return self._do_export(deploy=False, include_status=include_status, do_raise=do_raise)
+    def do_export(
+        self,
+        include_status=False,
+        do_raise=True,
+        partial_compile: bool = False,
+        resource_sets_to_remove: Optional[List[str]] = None,
+    ):
+        return self._do_export(
+            deploy=False,
+            include_status=include_status,
+            do_raise=do_raise,
+            partial_compile=partial_compile,
+            resource_sets_to_remove=resource_sets_to_remove,
+        )
 
     def get_exported_json(self) -> JsonType:
         with open(os.path.join(self.project_dir, "dump.json")) as fh:
             return json.load(fh)
 
-    def _do_export(self, deploy=False, include_status=False, do_raise=True):
+    def _do_export(
+        self,
+        deploy=False,
+        include_status=False,
+        do_raise=True,
+        partial_compile: bool = False,
+        resource_sets_to_remove: Optional[List[str]] = None,
+    ):
         """
-        helper function to allow actual export to be run an a different thread
+        helper function to allow actual export to be run on a different thread
         i.e. export.run must run off main thread to allow it to start a new ioloop for run_sync
         """
 
@@ -1153,10 +1172,31 @@ class SnippetCompilationTest(KeepOnFail):
         # continue the export
         export = Exporter(options)
 
-        return export.run(types, scopes, model_export=False, include_status=include_status)
+        return export.run(
+            types,
+            scopes,
+            model_export=False,
+            include_status=include_status,
+            partial_compile=partial_compile,
+            resource_sets_to_remove=resource_sets_to_remove,
+        )
 
-    async def do_export_and_deploy(self, include_status=False, do_raise=True):
-        return await off_main_thread(lambda: self._do_export(deploy=True, include_status=include_status, do_raise=do_raise))
+    async def do_export_and_deploy(
+        self,
+        include_status=False,
+        do_raise=True,
+        partial_compile: bool = False,
+        resource_sets_to_remove: Optional[List[str]] = None,
+    ):
+        return await off_main_thread(
+            lambda: self._do_export(
+                deploy=True,
+                include_status=include_status,
+                do_raise=do_raise,
+                partial_compile=partial_compile,
+                resource_sets_to_remove=resource_sets_to_remove,
+            )
+        )
 
     def setup_for_error(self, snippet, shouldbe, indent_offset=0):
         """

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -466,3 +466,21 @@ std::ConfigFile(host=vm1, path="/test", content="")
     assert len(result.result["versions"]) == 0
 
     shutil.rmtree(workspace)
+
+
+async def test_export_invalid_argument_combination() -> None:
+    """
+    Ensure that the `inmanta export` command exits with an error when the --delete-resource-set option is
+    provided without the --partial option being provided.
+    """
+    args = [sys.executable, "-m", "inmanta.app", "export", "--delete-resource-set", "test"]
+    process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        (stdout, stderr) = await asyncio.wait_for(process.communicate(), timeout=5)
+    except asyncio.TimeoutError as e:
+        process.kill()
+        await process.communicate()
+        raise e
+
+    assert process.returncode == 1
+    assert "The --delete-resource-set option should always be used together with the --partial option" in stderr.decode("utf-8")


### PR DESCRIPTION
# Description

**Same PR as #4454 but scoped to the ISO5 branch due to a merge conflict.**

Add support for partial compiles using the `inmanta export` command.

closes #4272 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
