### PR TITLE
fixed incorrect top level module loading for v2 modules not in requires

### DIFF
--- a/changelogs/unreleased/fix-module-loading-edge-case.yml
+++ b/changelogs/unreleased/fix-module-loading-edge-case.yml
@@ -1,0 +1,7 @@
+description: Fixed incorrect top level module loading for nested imports when v2 module is present in venv but not in explicit requires
+change-type: patch
+sections:
+  bug-fixes: "{{description}}"
+destination-branches:
+  - master
+  - iso5

--- a/tests/data/modules_v2/elaboratev2module/model/_init.cf
+++ b/tests/data/modules_v2/elaboratev2module/model/_init.cf
@@ -1,3 +1,6 @@
+import elaboratev2module::alwaysimported
+
+
 entity Printer:
     string message
 end

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -530,6 +530,24 @@ def test_module_has_v2_requirements_on_non_imported_module(snippetcompiler, loca
 
 
 @pytest.mark.slowtest
+def test_module_v2_load_installed_without_required(snippetcompiler_clean, local_module_package_index: str) -> None:
+    """
+    Verify that module loading works as expected for a v2 module installed in the environment while it is not in any of the
+    requirements files. This is relevant for correct working of pytest-inmanta's auto-generated projects.
+    """
+    # set up venv
+    snippetcompiler_clean.setup_for_snippet("", autostd=False)
+    process_env.install_from_index(
+        [ModuleV2Source.get_python_package_requirement(InmantaModuleRequirement.parse("elaboratev2module"))],
+        index_urls=[local_module_package_index],
+    )
+
+    # set up project: import submodule only, don't add the module to requirements
+    project: Project = snippetcompiler_clean.setup_for_snippet("import elaboratev2module::alwaysimported", autostd=False)
+    assert {tup[0] for tup in project.load_module_recursive()} == {"elaboratev2module", "elaboratev2module::alwaysimported"}
+
+
+@pytest.mark.slowtest
 def test_project_requirements_dont_overwrite_core_requirements_source(
     snippetcompiler_clean,
     local_module_package_index: str,


### PR DESCRIPTION
# Description

The terraform module tests are failing when run against terraform as a v2 module because of a bug in core. This bug resulted in the top level terraform module being removed from the AST when it was not explicitly imported (only through its children).

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
