### PR TITLE
Issue/4475 allow dict lookup on unknown dict

### DIFF
--- a/changelogs/unreleased/4475-allow-dict-lookup-on-unknown-dict.yml
+++ b/changelogs/unreleased/4475-allow-dict-lookup-on-unknown-dict.yml
@@ -1,0 +1,7 @@
+description: Fix bug on value lookup in an unknown dict and on lookup with an unknown key.
+issue-nr: 4475
+change-type: patch
+destination-branches: [iso4, iso5, master]
+sections: {
+  bugfix: "{{description}}"
+}

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -385,10 +385,14 @@ class MapLookup(ReferenceStatement):
     def execute(self, requires: typing.Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         super().execute(requires, resolver, queue)
         mapv = self.themap.execute(requires, resolver, queue)
+        if isinstance(mapv, Unknown):
+            return Unknown(self)
         if not isinstance(mapv, dict):
             raise TypingException(self, "dict lookup is only possible on dicts, %s is not an object" % mapv)
 
         keyv = self.key.execute(requires, resolver, queue)
+        if isinstance(keyv, Unknown):
+            return Unknown(self)
         if not isinstance(keyv, str):
             raise TypingException(self, "dict keys must be string, %s is not a string" % keyv)
 

--- a/tests/compiler/test_unknown.py
+++ b/tests/compiler/test_unknown.py
@@ -129,3 +129,30 @@ foo::Entity.test [1] -- std::Entity
         """,
         "could not find type foo::Entity in namespace __config__ ({dir}/main.cf:2:1)",
     )
+
+
+def test_unknown_type_in_dicts(snippetcompiler):
+    """This test checks that accessing an unknown map, or a known map with an unknown key
+    rightfully propagates the unknown value.
+    """
+    snippetcompiler.setup_for_snippet(
+        """
+        import tests
+
+        unk = tests::unknown()
+        map = {"k": "v"}
+
+        map_lookup = unk["key"]
+        key_fetch = map[unk]
+
+        unknown_map_lookup = tests::is_uknown(map_lookup)
+        unknown_key_fetch = tests::is_uknown(key_fetch)
+
+        """
+    )
+
+    (_, scopes) = compiler.do_compile()
+    root = scopes.get_child("__config__")
+
+    assert root.lookup("unknown_map_lookup").get_value()
+    assert root.lookup("unknown_key_fetch").get_value()


### PR DESCRIPTION
# Description

return Unknown on Unknown map or key lookup

closes #4475 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
