### PR TITLE
set up .editorconfig to not trim newlines for sql files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ max_line_length = 128
 
 [Makefile]
 indent_style = tab
+
+[*.sql]
+trim_trailing_whitespace = false

--- a/changelogs/unreleased/editorconfig-whitespace-sql.yml
+++ b/changelogs/unreleased/editorconfig-whitespace-sql.yml
@@ -1,0 +1,6 @@
+description: Set up .editorconfig to not trim newlines in sql files
+change-type: patch
+destination-branches:
+  - master
+  - iso5
+  - iso4


### PR DESCRIPTION
# Description

These recently got removed by accident from one of the sql files, presumably by someone's editor when they commented out the required line.
If accepted, I'll create a separate PR for inmanta-lsm

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
