### PR TITLE
set up .editorconfig to not trim newlines for sql files (#4527)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ max_line_length = 128
 
 [Makefile]
 indent_style = tab
+
+[*.sql]
+trim_trailing_whitespace = false

--- a/changelogs/unreleased/editorconfig-whitespace-sql.yml
+++ b/changelogs/unreleased/editorconfig-whitespace-sql.yml
@@ -1,0 +1,6 @@
+description: Set up .editorconfig to not trim newlines in sql files
+change-type: patch
+destination-branches:
+  - master
+  - iso5
+  - iso4


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4527