### PR TITLE
Fix bug in merging of version constraints

### DIFF
--- a/changelogs/unreleased/4409-patch-type-bug
+++ b/changelogs/unreleased/4409-patch-type-bug
@@ -1,0 +1,5 @@
+---
+description: Fix bug where set of constraint violations contains elements of different types
+issue-nr: 4409
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -774,8 +774,8 @@ class ActiveEnv(PythonEnvironment):
         )
 
         installed_versions: Dict[str, version.Version] = PythonWorkingSet.get_packages_in_working_set()
-        constraint_violations: Set[Tuple[Requirement, Optional[version.Version]]] = set(
-            (constraint, installed_versions.get(constraint.key, None))
+        constraint_violations: Set[VersionConflict] = set(
+            VersionConflict(constraint, installed_versions.get(constraint.key, None))
             for constraint in all_constraints
             if constraint.key not in installed_versions or str(installed_versions[constraint.key]) not in constraint
         )


### PR DESCRIPTION
# Description

This PR fixes the bug where the `all_violations` set contained elements of type `VersionConflict` and `Tuple`.

Part of #4409 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
