### PR TITLE
fixed bug in eager promises on unset optional relations

### DIFF
--- a/changelogs/unreleased/4498-bugfix-eager-promises-unset-optionals.yml
+++ b/changelogs/unreleased/4498-bugfix-eager-promises-unset-optionals.yml
@@ -1,0 +1,7 @@
+description: "Fixed bug in eager promises on unset optional relations"
+change-type: patch
+# This feature has not been released yet so the bug was never end-user visible
+sections: {}
+destination-branches:
+  - master
+  - iso5

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -20,7 +20,16 @@ from itertools import chain
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Sequence, Tuple
 
 import inmanta.execute.dataflow as dataflow
-from inmanta.ast import Anchor, DirectExecuteException, Location, Named, Namespace, Namespaced, OptionalValueException, RuntimeException
+from inmanta.ast import (
+    Anchor,
+    DirectExecuteException,
+    Location,
+    Named,
+    Namespace,
+    Namespaced,
+    OptionalValueException,
+    RuntimeException,
+)
 from inmanta.execute.dataflow import DataflowGraph
 from inmanta.execute.runtime import (
     ExecutionUnit,
@@ -30,7 +39,6 @@ from inmanta.execute.runtime import (
     RawUnit,
     Resolver,
     ResultCollector,
-    ResultVariable,
     ResultVariable,
     Typeorvalue,
     VariableABC,
@@ -296,9 +304,7 @@ class VariableReferenceHook(RawResumer):
                 variable = unset
             else:
                 # all requires are present, execute instance
-                instance: object = self.instance.execute(
-                    instance_requires, resolver, queue
-                )
+                instance: object = self.instance.execute(instance_requires, resolver, queue)
 
                 if isinstance(instance, list):
                     raise RuntimeException(
@@ -332,7 +338,11 @@ class VariableReferenceHook(RawResumer):
 
     def __repr__(self) -> str:
         return "%s(%r, %s, %r, propagate_unset=%r)" % (
-            self.__class__.__name__, self.instance, self.name, self.variable_resumer, self.propagate_unset
+            self.__class__.__name__,
+            self.instance,
+            self.name,
+            self.variable_resumer,
+            self.propagate_unset,
         )
 
 

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -235,6 +235,10 @@ class VariableReferenceHook(RawResumer):
     attributes. Calls variable resumer with the variable object as soon as it's available.
     This class is not a full AST node, rather it is a Resumer only. It is meant to delegate common resumer behavior that would
     otherwise need to be implemented as custom resumer logic in each class that needs it.
+
+    :param instance: The instance this variable is an attribute of, if any. Can be a reference to a nested relation instance.
+    :param name: The name of the variable or instance attribute.
+    :param variable_resumer: The resumer that should be called when a value becomes available.
     """
 
     __slots__ = ("instance", "name", "variable_resumer")
@@ -270,7 +274,12 @@ class VariableReferenceHook(RawResumer):
         variable: ResultVariable[object]
         if self.instance is not None:
             # get the Instance
-            instance: object = self.instance.execute({k: v.get_value() for k, v in requires.items()}, resolver, queue)
+            try:
+                instance: object = self.instance.execute({k: v.get_value() for k, v in requires.items()}, resolver, queue)
+            # TODO: only catch OptionalValueException
+            except Exception as e:
+                breakpoint()
+                return
 
             if isinstance(instance, list):
                 raise RuntimeException(self, "can not get attribute %s, %s is not an entity but a list" % (self.name, instance))

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -273,18 +273,17 @@ class VariableReferenceHook(RawResumer):
         """
         Schedules this instance for execution. Waits for the variable's requirements before resuming.
         """
-        RawUnit(
-            queue,
-            resolver,
-            (
+        if self.instance is None:
+            self.resume({}, resolver, queue)
+        else:
+            RawUnit(
+                queue,
+                resolver,
                 # no need for gradual execution here because this class represents an attribute reference on self.instance,
                 # which is not allowed on multi variables (the only kind of variables that would benefit from gradual execution)
-                self.instance.requires_emit(resolver, queue, propagate_unset=self.propagate_unset)
-                if self.instance is not None
-                else {}
-            ),
-            self,
-        )
+                self.instance.requires_emit(resolver, queue, propagate_unset=self.propagate_unset),
+                self,
+            )
 
     def resume(self, requires: Dict[object, VariableABC], resolver: Resolver, queue: QueueScheduler) -> None:
         """

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -20,7 +20,7 @@ from itertools import chain
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Sequence, Tuple
 
 import inmanta.execute.dataflow as dataflow
-from inmanta.ast import Anchor, DirectExecuteException, Location, Named, Namespace, Namespaced, RuntimeException
+from inmanta.ast import Anchor, DirectExecuteException, Location, Named, Namespace, Namespaced, OptionalValueException, RuntimeException
 from inmanta.execute.dataflow import DataflowGraph
 from inmanta.execute.runtime import (
     ExecutionUnit,
@@ -30,6 +30,7 @@ from inmanta.execute.runtime import (
     RawUnit,
     Resolver,
     ResultCollector,
+    ResultVariable,
     ResultVariable,
     Typeorvalue,
     VariableABC,
@@ -239,20 +240,24 @@ class VariableReferenceHook(RawResumer):
     :param instance: The instance this variable is an attribute of, if any. Can be a reference to a nested relation instance.
     :param name: The name of the variable or instance attribute.
     :param variable_resumer: The resumer that should be called when a value becomes available.
+    :param propagate_unset: If True, propagate unset exceptions during instance execution to the resumer.
     """
 
-    __slots__ = ("instance", "name", "variable_resumer")
+    __slots__ = ("instance", "name", "variable_resumer", "propagate_unset")
 
     def __init__(
         self,
         instance: Optional["Reference"],
         name: str,
         variable_resumer: "VariableResumer",
+        *,
+        propagate_unset: bool = False,
     ) -> None:
         super().__init__()
         self.instance: Optional["Reference"] = instance
         self.name: str = name
         self.variable_resumer: "VariableResumer" = variable_resumer
+        self.propagate_unset: bool = propagate_unset
 
     def schedule(self, resolver: Resolver, queue: QueueScheduler) -> None:
         """
@@ -261,9 +266,13 @@ class VariableReferenceHook(RawResumer):
         RawUnit(
             queue,
             resolver,
-            # no need for gradual execution here because this class represents an attribute reference on self.instance,
-            # which is not allowed on multi variables (the only kind of variables that would benefit from gradual execution)
-            self.instance.requires_emit(resolver, queue) if self.instance is not None else {},
+            (
+                # no need for gradual execution here because this class represents an attribute reference on self.instance,
+                # which is not allowed on multi variables (the only kind of variables that would benefit from gradual execution)
+                self.instance.requires_emit(resolver, queue, propagate_unset=self.propagate_unset)
+                if self.instance is not None
+                else {}
+            ),
             self,
         )
 
@@ -274,24 +283,39 @@ class VariableReferenceHook(RawResumer):
         variable: ResultVariable[object]
         if self.instance is not None:
             # get the Instance
-            try:
-                instance: object = self.instance.execute({k: v.get_value() for k, v in requires.items()}, resolver, queue)
-            # TODO: only catch OptionalValueException
-            except Exception as e:
-                breakpoint()
-                return
-
-            if isinstance(instance, list):
-                raise RuntimeException(self, "can not get attribute %s, %s is not an entity but a list" % (self.name, instance))
-            if not isinstance(instance, Instance):
-                raise RuntimeException(
-                    self,
-                    "can not get attribute %s, %s is not an entity but a %s with value '%s'"
-                    % (self.name, self.instance, type(instance).__name__, instance),
+            instance_requires: dict[object, object] = {}
+            unset: Optional[VariableABC] = None
+            for k, v in requires.items():
+                try:
+                    instance_requires[k] = v.get_value()
+                except tuple([OptionalValueException] if self.propagate_unset else []):
+                    unset = v
+                    break
+                except Exception as e:
+                    print(f"Not caught with self.propagate_unset={self.propagate_unset}: {e}")
+                    raise
+            if unset is not None:
+                # propagate unset variable up the attribute reference chain
+                variable = unset
+            else:
+                # all requires are present, execute instance
+                instance: object = self.instance.execute(
+                    instance_requires, resolver, queue
                 )
 
-            # get the attribute result variable
-            variable = instance.get_attribute(self.name)
+                if isinstance(instance, list):
+                    raise RuntimeException(
+                        self, "can not get attribute %s, %s is not an entity but a list" % (self.name, instance)
+                    )
+                if not isinstance(instance, Instance):
+                    raise RuntimeException(
+                        self,
+                        "can not get attribute %s, %s is not an entity but a %s with value '%s'"
+                        % (self.name, self.instance, type(instance).__name__, instance),
+                    )
+
+                # get the attribute result variable
+                variable = instance.get_attribute(self.name)
         else:
             obj: Typeorvalue = resolver.lookup(self.name)
             if not isinstance(obj, ResultVariable):
@@ -310,7 +334,9 @@ class VariableReferenceHook(RawResumer):
         return "%s.%s" % (self.instance, self.name)
 
     def __repr__(self) -> str:
-        return "%s(%r, %s, %r)" % (self.__class__.__name__, self.instance, self.name, self.variable_resumer)
+        return "%s(%r, %s, %r, propagate_unset=%r)" % (
+            self.__class__.__name__, self.instance, self.name, self.variable_resumer, self.propagate_unset
+        )
 
 
 class VariableResumer:
@@ -322,7 +348,7 @@ class VariableResumer:
 
     def variable_resume(
         self,
-        variable: ResultVariable,
+        variable: VariableABC,
         resolver: Resolver,
         queue: QueueScheduler,
     ) -> None:
@@ -368,6 +394,7 @@ class StaticEagerPromise:
             self.instance,
             self.attribute,
             variable_resumer=dynamic,
+            propagate_unset=True,
         )
         self.statement.copy_location(hook)
         hook.schedule(resolver, queue)
@@ -388,7 +415,7 @@ class EagerPromise(VariableResumer):
         self._promise: Optional[ProgressionPromise] = None
         self._fulfilled: bool = False
 
-    def _acquire(self, variable: ResultVariable) -> None:
+    def _acquire(self, variable: VariableABC) -> None:
         """
         Entry point for the ResultVariable waiter: actually acquire the promise
         """
@@ -407,7 +434,7 @@ class EagerPromise(VariableResumer):
 
     def variable_resume(
         self,
-        variable: ResultVariable,
+        variable: VariableABC,
         resolver: Resolver,
         queue: QueueScheduler,
     ) -> None:

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -288,12 +288,9 @@ class VariableReferenceHook(RawResumer):
             for k, v in requires.items():
                 try:
                     instance_requires[k] = v.get_value()
-                except tuple([OptionalValueException] if self.propagate_unset else []):
+                except OptionalValueException if self.propagate_unset else ():
                     unset = v
                     break
-                except Exception as e:
-                    print(f"Not caught with self.propagate_unset={self.propagate_unset}: {e}")
-                    raise
             if unset is not None:
                 # propagate unset variable up the attribute reference chain
                 variable = unset

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -301,10 +301,6 @@ class VariableReferenceHook(RawResumer):
                 except (OptionalValueException,) if self.propagate_unset else ():
                     unset = v
                     break
-                except (RuntimeException,) if self.instance is not None else () as e:
-                    e.set_statement(self.instance)
-                    e.location = self.instance.location
-                    raise e
 
             if unset is not None:
                 # propagate unset variable up the attribute reference chain

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -289,7 +289,7 @@ class VariableReferenceHook(RawResumer):
         """
         Fetches the variable when it's available and calls variable resumer.
         """
-        variable: ResultVariable[object]
+        variable: VariableABC[object]
         if self.instance is not None:
             # get the Instance
             instance_requires: dict[object, object] = {}
@@ -297,7 +297,7 @@ class VariableReferenceHook(RawResumer):
             for k, v in requires.items():
                 try:
                     instance_requires[k] = v.get_value()
-                except OptionalValueException if self.propagate_unset else ():
+                except (OptionalValueException,) if self.propagate_unset else ():
                     unset = v
                     break
             if unset is not None:

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -32,6 +32,7 @@ from inmanta.ast import (
     KeyException,
     LocatableString,
     Location,
+    OptionalValueException,
     RuntimeException,
     TypeReferenceAnchor,
     TypingException,
@@ -317,6 +318,11 @@ class SetAttributeHelper(ExecutionUnit):
         except AttributeException as e:
             e.set_statement(self.stmt, False)
             raise
+        except OptionalValueException as e:
+            # OptionalValueException has only its instance as statement, override with more accurate statement and location
+            e.set_statement(self.stmt, True)
+            e.location = self.stmt.location
+            raise AttributeException(self.stmt, self.instance, self.attribute_name, e)
         except RuntimeException as e:
             e.set_statement(self.stmt, False)
             raise AttributeException(self.stmt, self.instance, self.attribute_name, e)

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -81,8 +81,8 @@ class SubConstructor(ExpressionStatement):
     def __init__(self, instance_type: "Entity", implements: "Implement") -> None:
         super().__init__()
         self.type = instance_type
-        self.location = instance_type.get_location()
         self.implements = implements
+        self.location = self.implements.get_location()
 
     def normalize(self) -> None:
         # Only track promises for implementations when they get emitted, because of limitation of current static normalization

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -90,7 +90,7 @@ class Reference(ExpressionStatement):
         return requires
 
     def execute(
-        self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler, *, propagate_unset: bool = False
+        self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler
     ) -> object:
         super().execute(requires, resolver, queue)
         return requires[self.name]
@@ -175,12 +175,6 @@ class VariableReader(VariableResumer, Generic[T]):
             variable.listener(self.resultcollector, self.owner.location)
         self.target.connect(variable)
 
-    def emit(self, resolver: Resolver, queue: QueueScheduler) -> None:
-        raise RuntimeException(self, "%s is not an actual AST node, it should never be executed" % self.__class__.__name__)
-
-    def execute(self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
-        raise RuntimeException(self, "%s is not an actual AST node, it should never be executed" % self.__class__.__name__)
-
 
 class IsDefinedGradual(VariableResumer, RawResumer, ResultCollector[object]):
     """
@@ -231,6 +225,12 @@ class IsDefinedGradual(VariableResumer, RawResumer, ResultCollector[object]):
             return True
         except OptionalValueException:
             return False
+
+    def emit(self, resolver: Resolver, queue: QueueScheduler) -> None:
+        raise RuntimeException(self, "%s is not an actual AST node, it should never be executed" % self.__class__.__name__)
+
+    def execute(self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
+        raise RuntimeException(self, "%s is not an actual AST node, it should never be executed" % self.__class__.__name__)
 
 
 class AttributeReference(Reference):

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -31,7 +31,15 @@ from inmanta.ast.statements import (
 )
 from inmanta.ast.statements.assign import Assign, SetAttribute
 from inmanta.execute.dataflow import DataflowGraph
-from inmanta.execute.runtime import QueueScheduler, RawUnit, Resolver, ResultCollector, ResultVariable, ResultVariableProxy, VariableABC
+from inmanta.execute.runtime import (
+    QueueScheduler,
+    RawUnit,
+    Resolver,
+    ResultCollector,
+    ResultVariable,
+    ResultVariableProxy,
+    VariableABC,
+)
 from inmanta.execute.util import NoneValue
 from inmanta.parser import ParserException
 from inmanta.stable_api import stable_api
@@ -64,7 +72,9 @@ class Reference(ExpressionStatement):
     def requires(self) -> List[str]:
         return [self.full_name]
 
-    def requires_emit(self, resolver: Resolver, queue: QueueScheduler, *, propagate_unset: bool = False) -> Dict[object, VariableABC]:
+    def requires_emit(
+        self, resolver: Resolver, queue: QueueScheduler, *, propagate_unset: bool = False
+    ) -> Dict[object, VariableABC]:
         requires: Dict[object, VariableABC] = super().requires_emit(resolver, queue)
         # FIXME: may be done more efficient?
         requires[self.name] = resolver.lookup(self.full_name)
@@ -79,7 +89,9 @@ class Reference(ExpressionStatement):
         requires[self.name] = var
         return requires
 
-    def execute(self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler, *, propagate_unset: bool = False) -> object:
+    def execute(
+        self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler, *, propagate_unset: bool = False
+    ) -> object:
         super().execute(requires, resolver, queue)
         return requires[self.name]
 
@@ -249,11 +261,18 @@ class AttributeReference(Reference):
     def requires(self) -> List[str]:
         return self.instance.requires()
 
-    def requires_emit(self, resolver: Resolver, queue: QueueScheduler, *, propagate_unset: bool = False) -> Dict[object, VariableABC]:
+    def requires_emit(
+        self, resolver: Resolver, queue: QueueScheduler, *, propagate_unset: bool = False
+    ) -> Dict[object, VariableABC]:
         return self.requires_emit_gradual(resolver, queue, None, propagate_unset=propagate_unset)
 
     def requires_emit_gradual(
-        self, resolver: Resolver, queue: QueueScheduler, resultcollector: Optional[ResultCollector], *, propagate_unset: bool = False
+        self,
+        resolver: Resolver,
+        queue: QueueScheduler,
+        resultcollector: Optional[ResultCollector],
+        *,
+        propagate_unset: bool = False,
     ) -> Dict[object, VariableABC]:
         requires: Dict[object, VariableABC] = self._requires_emit_promises(resolver, queue)
 

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -89,9 +89,7 @@ class Reference(ExpressionStatement):
         requires[self.name] = var
         return requires
 
-    def execute(
-        self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler
-    ) -> object:
+    def execute(self, requires: Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         super().execute(requires, resolver, queue)
         return requires[self.name]
 

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -31,7 +31,7 @@ from inmanta.ast.statements import (
 )
 from inmanta.ast.statements.assign import Assign, SetAttribute
 from inmanta.execute.dataflow import DataflowGraph
-from inmanta.execute.runtime import QueueScheduler, RawUnit, Resolver, ResultCollector, ResultVariable, VariableABC
+from inmanta.execute.runtime import QueueScheduler, RawUnit, Resolver, ResultCollector, ResultVariable, ResultVariableProxy, VariableABC
 from inmanta.execute.util import NoneValue
 from inmanta.parser import ParserException
 from inmanta.stable_api import stable_api
@@ -139,36 +139,29 @@ class Reference(ExpressionStatement):
 T = TypeVar("T")
 
 
-class VariableReader(VariableResumer, RawResumer, Generic[T]):
+# TODO: rename ResultVariableProxy -> ResultVariableReadProxy
+class VariableReader(VariableResumer, Generic[T]):
     """
     Resumes execution on a variable when it becomes avaiable, then waits for its completeness and copies its value to a target
     variable. Optionally subscribes a result collector to intermediate values.
     """
+    # TODO: docstring
 
     __slots__ = ("owner", "target", "resultcollector")
 
-    def __init__(self, owner: Statement, target: ResultVariable[T], resultcollector: Optional[ResultCollector[T]]) -> None:
+    def __init__(self, owner: Statement, target: ResultVariableProxy[T], resultcollector: Optional[ResultCollector[T]]) -> None:
         super().__init__()
         self.owner: Statement = owner
-        self.target: ResultVariable[T] = target
+        self.target: ResultVariableProxy[T] = target
         self.resultcollector: Optional[ResultCollector[T]] = resultcollector
 
-    def write_target(self, variable: VariableABC[object]) -> None:
-        """
-        Writes the target variable based on the complete variable's value.
-        """
-        self.target.set_value(self.target_value(variable), self.owner.location)
-
-    def target_value(self, variable: VariableABC[object]) -> T:
-        """
-        Returns the target value based on the complete variable's value.
-        """
-        try:
-            return variable.get_value()
-        except OptionalValueException as e:
-            e.set_statement(self.owner)
-            e.location = self.owner.location
-            raise e
+    # TODO: move this to the caller?
+    #try:
+    #    return variable.get_value()
+    #except OptionalValueException as e:
+    #    e.set_statement(self.owner)
+    #    e.location = self.owner.location
+    #    raise e
 
     def variable_resume(
         self,
@@ -178,15 +171,7 @@ class VariableReader(VariableResumer, RawResumer, Generic[T]):
     ) -> None:
         if self.resultcollector:
             variable.listener(self.resultcollector, self.owner.location)
-
-        if variable.is_ready():
-            self.write_target(variable)
-        else:
-            # reschedule on the variable's completeness
-            RawUnit(queue_scheduler, resolver, {self: variable}, self, override_exception_location=False)
-
-    def resume(self, requires: Dict[object, VariableABC], resolver: Resolver, queue_scheduler: QueueScheduler) -> None:
-        self.write_target(requires[self])
+        self.target.connect(variable)
 
     def emit(self, resolver: Resolver, queue: QueueScheduler) -> None:
         raise RuntimeException(self, "%s is not an actual AST node, it should never be executed" % self.__class__.__name__)
@@ -195,15 +180,18 @@ class VariableReader(VariableResumer, RawResumer, Generic[T]):
         raise RuntimeException(self, "%s is not an actual AST node, it should never be executed" % self.__class__.__name__)
 
 
-class IsDefinedGradual(VariableReader[bool], ResultCollector[object]):
+class IsDefinedGradual(VariableResumer, RawResumer, ResultCollector[object]):
     """
     Fill target variable with is defined result as soon as it gets known.
     """
+    # TODO: docstring
 
-    __slots__ = ()
+    __slots__ = ("owner", "target")
 
-    def __init__(self, owner: Statement, target: ResultVariable) -> None:
-        VariableReader.__init__(self, owner, target, resultcollector=self)
+    def __init__(self, owner: Statement, target: ResultVariable[bool]) -> None:
+        super().__init__()
+        self.owner: Statement = owner
+        self.target: ResultVariable[bool] = target
 
     def receive_result(self, value: object, location: Location) -> None:
         """
@@ -212,13 +200,26 @@ class IsDefinedGradual(VariableReader[bool], ResultCollector[object]):
         """
         self.target.set_value(True, self.owner.location)
 
-    def target_value(self, variable: ResultVariable[object]) -> bool:
+    def variable_resume(
+        self,
+        variable: ResultVariable[object],
+        resolver: Resolver,
+        queue_scheduler: QueueScheduler,
+    ) -> None:
+        if variable.is_ready():
+            self.target.set_value(self._target_value(variable), self.owner.location)
+        else:
+            # gradual execution: as soon as a value comes in, the result is known
+            variable.listener(self, self.owner.location)
+            # wait for variable completeness in case no value comes in at all
+            RawUnit(queue_scheduler, resolver, {self: variable}, self, override_exception_location=False)
+
+    def resume(self, requires: Dict[object, VariableABC], resolver: Resolver, queue_scheduler: QueueScheduler) -> None:
+        self.target.set_value(self._target_value(requires[self]), self.owner.location)
+
+    def _target_value(self, variable: ResultVariable[object]) -> bool:
         """
         Returns the target value based on the attribute variable's value or absence of a value.
-
-        We don't override `resume` so this method is always called when `variable` gets frozen, even if the target variable has
-        been set already. This shouldn't affect performance but the potential double set acts as a guard against inconsistent
-        internal state (if `receive_result` receives a result the eventual result of this method must be True).
         """
         try:
             value = variable.get_value()
@@ -270,7 +271,7 @@ class AttributeReference(Reference):
         # The tricky one!
 
         # introduce temp variable to contain the eventual result of this stmt
-        temp = ResultVariable()
+        temp = ResultVariableProxy()
         # construct waiter
         reader: VariableReader = VariableReader(owner=self, target=temp, resultcollector=resultcollector)
         hook: VariableReferenceHook = VariableReferenceHook(

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -139,13 +139,11 @@ class Reference(ExpressionStatement):
 T = TypeVar("T")
 
 
-# TODO: rename ResultVariableProxy -> ResultVariableReadProxy
 class VariableReader(VariableResumer, Generic[T]):
     """
-    Resumes execution on a variable when it becomes avaiable, then waits for its completeness and copies its value to a target
-    variable. Optionally subscribes a result collector to intermediate values.
+    Resumes execution on a variable when it becomes avaiable, then connects the target proxy variable to it.
+    Optionally subscribes a result collector to intermediate values.
     """
-    # TODO: docstring
 
     __slots__ = ("owner", "target", "resultcollector")
 
@@ -176,7 +174,6 @@ class IsDefinedGradual(VariableResumer, RawResumer, ResultCollector[object]):
     """
     Fill target variable with is defined result as soon as it gets known.
     """
-    # TODO: docstring
 
     __slots__ = ("owner", "target")
 

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -293,6 +293,7 @@ class ResultVariableProxy(VariableABC[T]):
     """
     A proxy for a reading from a ResultVariable that implements the VariableABC interface. Allows for assignment between
     variables without resolving the right hand side at the time of assignment.
+    This class does not support setting values or related operations such as acquiring progression promises.
     """
 
     __slots__ = ("variable", "_listeners", "_waiters")

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -176,7 +176,7 @@ class WrappedValueVariable(VariableABC[T]):
 
     def listener(self, resultcollector: ResultCollector[T], location: Location) -> None:
         if not isinstance(self.value, NoneValue):
-            resultcollector.receive_result(self.value)
+            resultcollector.receive_result(self.value, location)
 
     def waitfor(self, waiter: "Waiter") -> None:
         waiter.ready(self)
@@ -297,12 +297,12 @@ class ResultVariableProxy(VariableABC[T]):
 
     __slots__ = ("variable", "_listeners", "_waiters")
 
-    def __init__(self, variable: Optional[ResultVariable[T]] = None) -> None:
-        self.variable: Optional[ResultVariable[T]] = variable
+    def __init__(self, variable: Optional[VariableABC[T]] = None) -> None:
+        self.variable: Optional[VariableABC[T]] = variable
         self._listeners: Optional[list[tuple[ResultCollector[T], Location]]] = []
         self._waiters: Optional[list["Waiter"]] = []
 
-    def connect(self, variable: ResultVariable[T]) -> None:
+    def connect(self, variable: VariableABC[T]) -> None:
         """
         Connect this proxy to a variable. A proxy can only be connected to a single variable.
         """
@@ -334,7 +334,7 @@ class ResultVariableProxy(VariableABC[T]):
     def listener(self, resultcollector: ResultCollector[T], location: Location) -> None:
         if self.variable is None:
             assert self._listeners is not None  # only set to None after a variable is connected to prevent data leaks
-            self._listeners += resultcollector
+            self._listeners.append((resultcollector, location))
         else:
             self.variable.listener(resultcollector, location)
 

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -948,6 +948,7 @@ class ExecutionUnit(Waiter):
             self._unsafe_execute()
         except RuntimeException as e:
             e.set_statement(self.owner)
+            e.location = self.owner.location
             raise e
 
     def __repr__(self) -> str:

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -289,7 +289,6 @@ class ResultVariable(VariableABC[T], ResultCollector[T], ISetPromise[T]):
         return self._node
 
 
-# TODO: rename ResultVariableReadProxy
 class ResultVariableProxy(VariableABC[T]):
     """
     A proxy for a reading from a ResultVariable that implements the VariableABC interface. Allows for assignment between
@@ -947,7 +946,6 @@ class ExecutionUnit(Waiter):
         try:
             self._unsafe_execute()
         except RuntimeException as e:
-            # TODO: try replace=True
             e.set_statement(self.owner)
             raise e
 

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -114,9 +114,24 @@ class VariableABC(Generic[T]):
 
     __slots__ = ()
 
+    def is_ready(self) -> bool:
+        """
+        Returns true iff this variable does not expect any more values.
+        """
+        raise NotImplementedError()
+
     def get_value(self) -> T:
         """
         Returns the value object for this variable
+
+        :raises OptionalValueException: This is an optional variable that has not received a value (or explicit `null`).
+        """
+        raise NotImplementedError()
+
+    def listener(self, resultcollector: ResultCollector[T], location: Location) -> None:
+        """
+        Add a listener to report new values to. If the variable already has a value, this is reported immediately. Explicit
+        assignments of `null` will not be reported.
         """
         raise NotImplementedError()
 
@@ -125,6 +140,22 @@ class VariableABC(Generic[T]):
         Informs this variable that a waiter waits on its value. Once the variable receives a value, it should inform the waiter.
         """
         raise NotImplementedError()
+
+    def get_progression_promise(self, provider: "Statement") -> Optional[ProgressionPromise]:
+        """
+        Acquires a promise to progress this variable without necessarily setting a value. It is allowed to acquire a progression
+        promise greedily (overpromise) when a provider is likely to produce progress. The promise should then be fulfilled as
+        soon as it is known that no further progress will be made.
+
+        Returns None if this variable does not track progression promises.
+
+        e.g. a progression promise could be acquired by a conditional statement that might emit a new assignment statement for
+        this variable. As soon as the condition is evaluated this promise should be fulfilled.
+
+        This overpromising semantics allows for more strict promise tracking, providing more certainty on variable completeness
+        at the cost of disallowing circular logic.
+        """
+        return None
 
 
 class WrappedValueVariable(VariableABC[T]):
@@ -137,8 +168,15 @@ class WrappedValueVariable(VariableABC[T]):
     def __init__(self, value: T) -> None:
         self.value: T = value
 
+    def is_ready(self) -> bool:
+        return True
+
     def get_value(self) -> T:
         return self.value
+
+    def listener(self, resultcollector: ResultCollector[T], location: Location) -> None:
+        if not isinstance(self.value, NoneValue):
+            resultcollector.receive_result(self.value)
 
     def waitfor(self, waiter: "Waiter") -> None:
         waiter.ready(self)
@@ -177,22 +215,6 @@ class ResultVariable(VariableABC[T], ResultCollector[T], ISetPromise[T]):
         variable, set the value on the promise object.
         """
         return self
-
-    def get_progression_promise(self, provider: "Statement") -> Optional[ProgressionPromise]:
-        """
-        Acquires a promise to progress this variable without necessarily setting a value. It is allowed to acquire a progression
-        promise greedily (overpromise) when a provider is likely to produce progress. The promise should then be fulfilled as
-        soon as it is known that no further progress will be made.
-
-        Returns None if this variable does not track progression promises.
-
-        e.g. a progression promise could be acquired by a conditional statement that might emit a new assignment statement for
-        this variable. As soon as the condition is evaluated this promise should be fulfilled.
-
-        This overpromising semantics allows for more strict promise tracking, providing more certainty on variable completeness
-        at the cost of disallowing circular logic.
-        """
-        return None
 
     def fulfill(self, promise: IPromise) -> None:
         """
@@ -248,7 +270,7 @@ class ResultVariable(VariableABC[T], ResultCollector[T], ISetPromise[T]):
     def receive_result(self, value: T, location: Location) -> None:
         pass
 
-    def listener(self, resulcollector: ResultCollector[T], location: Location) -> None:
+    def listener(self, resultcollector: ResultCollector[T], location: Location) -> None:
         """
         Add a listener to report new values to, only for lists. Explicit assignments of `null` will not be reported.
         """
@@ -267,17 +289,19 @@ class ResultVariable(VariableABC[T], ResultCollector[T], ISetPromise[T]):
         return self._node
 
 
+# TODO: rename ResultVariableReadProxy
 class ResultVariableProxy(VariableABC[T]):
     """
-    A proxy for a ResultVariable that implements the VariableABC interface. Allows for assignment between variables without
-    resolving the right hand side at the time of assignment.
+    A proxy for a reading from a ResultVariable that implements the VariableABC interface. Allows for assignment between
+    variables without resolving the right hand side at the time of assignment.
     """
 
-    __slots__ = ("variable", "waiters")
+    __slots__ = ("variable", "_listeners", "_waiters")
 
     def __init__(self, variable: Optional[ResultVariable[T]] = None) -> None:
         self.variable: Optional[ResultVariable[T]] = variable
-        self.waiters: Optional[list["Waiter"]] = []
+        self._listeners: Optional[list[tuple[ResultCollector[T], Location]]] = []
+        self._waiters: Optional[list["Waiter"]] = []
 
     def connect(self, variable: ResultVariable[T]) -> None:
         """
@@ -286,10 +310,17 @@ class ResultVariableProxy(VariableABC[T]):
         if self.variable is not None and self.variable != variable:
             raise Exception("Trying to connect a variable to a proxy that is already connected to another variable.")
         self.variable = variable
-        assert self.waiters is not None  # only set to None after a variable is connected to prevent data leaks
-        for waiter in self.waiters:
+        assert self._listeners is not None  # only set to None after a variable is connected to prevent data leaks
+        assert self._waiters is not None  # only set to None after a variable is connected to prevent data leaks
+        for listener in self._listeners:
+            self.variable.listener(*listener)
+        for waiter in self._waiters:
             self.variable.waitfor(waiter)
-        self.waiters = None
+        self._listeners = None
+        self._waiters = None
+
+    def is_ready(self) -> bool:
+        return self.variable is not None and self.variable.is_ready()
 
     def get_value(self) -> T:
         """
@@ -301,15 +332,22 @@ class ResultVariableProxy(VariableABC[T]):
             )
         return self.variable.get_value()
 
+    def listener(self, resultcollector: ResultCollector[T], location: Location) -> None:
+        if self.variable is None:
+            assert self._listeners is not None  # only set to None after a variable is connected to prevent data leaks
+            self._listeners += resultcollector
+        else:
+            self.variable.listener(resultcollector, location)
+
     def waitfor(self, waiter: "Waiter") -> None:
         """
         Informs this variable that a waiter waits on its value. Once the variable receives a value, it should inform the waiter.
         """
-        if self.variable is not None:
-            self.variable.waitfor(waiter)
+        if self.variable is None:
+            assert self._waiters is not None  # only set to None after a variable is connected to prevent data leaks
+            self._waiters.append(waiter)
         else:
-            assert self.waiters is not None  # only set to None after a variable is connected to prevent data leaks
-            self.waiters.append(waiter)
+            self.variable.waitfor(waiter)
 
 
 class RelationAttributeVariable:

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -511,8 +511,6 @@ class Scheduler(object):
                     stmt = st
                     break
 
-            print(all_statements)
-            breakpoint()
             assert stmt is not None
 
             raise RuntimeException(stmt.expression, "not all statements executed %s" % all_statements)

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -322,6 +322,7 @@ class Scheduler(object):
 
         For performance reasons, we keep progress potential local and instead detect this situation here.
         """
+
         def resolve_proxies(variable: Optional[VariableABC]) -> Optional[VariableABC]:
             if variable is None or not isinstance(variable, ResultVariableProxy):
                 return variable

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -338,7 +338,6 @@ class Scheduler(object):
                         # get_progress_potential fails when there is a value already
                         continue
                     if real_rv.get_waiting_providers() > 0 and real_rv.get_progress_potential() > 0:
-                        print("selected")
                         freeze_candidates.append(real_rv)
 
         if not freeze_candidates:

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -46,6 +46,8 @@ from inmanta.execute.runtime import (
     QueueScheduler,
     RelationAttributeVariable,
     Resolver,
+    ResultVariableProxy,
+    VariableABC,
     Waiter,
 )
 from inmanta.execute.tracking import ModuleTracker
@@ -320,16 +322,23 @@ class Scheduler(object):
 
         For performance reasons, we keep progress potential local and instead detect this situation here.
         """
+        def resolve_proxies(variable: Optional[VariableABC]) -> Optional[VariableABC]:
+            if variable is None or not isinstance(variable, ResultVariableProxy):
+                return variable
+            return resolve_proxies(variable.variable)
+
         # Determine drvs that should be frozen to break the cycle
         freeze_candidates: List[DelayedResultVariable[object]] = []
         for waiter in allwaiters:
             for rv in waiter.requires.values():
-                if isinstance(rv, DelayedResultVariable):
-                    if rv.hasValue:
+                real_rv: Optional[VariableABC] = resolve_proxies(rv)
+                if isinstance(real_rv, DelayedResultVariable):
+                    if real_rv.hasValue:
                         # get_progress_potential fails when there is a value already
                         continue
-                    if rv.get_waiting_providers() > 0 and rv.get_progress_potential() > 0:
-                        freeze_candidates.append(rv)
+                    if real_rv.get_waiting_providers() > 0 and real_rv.get_progress_potential() > 0:
+                        print("selected")
+                        freeze_candidates.append(real_rv)
 
         if not freeze_candidates:
             return False

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -502,6 +502,8 @@ class Scheduler(object):
                     stmt = st
                     break
 
+            print(all_statements)
+            breakpoint()
             assert stmt is not None
 
             raise RuntimeException(stmt.expression, "not all statements executed %s" % all_statements)

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -106,8 +106,7 @@ Test()
         " self.n ({dir}/main.cf:8))"
         "\ncaused by:"
         "\n  Optional variable accessed that has no value (attribute `n` of `__config__::Test (instantiated at"
-        # TODO: final location is not the correct line
-        " {dir}/main.cf:13)`) (reported in __config__::Test (instantiated at {dir}/main.cf:13) ({dir}/main.cf:13))",
+        " {dir}/main.cf:13)`) (reported in self.m = self.n ({dir}/main.cf:8))",
     )
 
 

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -107,7 +107,7 @@ Test()
         "\ncaused by:"
         "\n  Optional variable accessed that has no value (attribute `n` of `__config__::Test (instantiated at"
         # TODO: final location is not the correct line
-        " {dir}/main.cf:13)`) (reported in __config__::Test (instantiated at {dir}/main.cf:13) ({dir}/main.cf:13))"
+        " {dir}/main.cf:13)`) (reported in __config__::Test (instantiated at {dir}/main.cf:13) ({dir}/main.cf:13))",
     )
 
 

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -102,8 +102,12 @@ implement Test using i
 
 Test()
         """,
-        "Optional variable accessed that has no value (attribute `n` of `__config__::Test (instantiated at {dir}/main.cf:13)`)"
-        " (reported in self.n ({dir}/main.cf:8))",
+        "Could not set attribute `m` on instance `__config__::Test (instantiated at {dir}/main.cf:13)` (reported in self.m ="
+        " self.n ({dir}/main.cf:8))"
+        "\ncaused by:"
+        "\n  Optional variable accessed that has no value (attribute `n` of `__config__::Test (instantiated at"
+        # TODO: final location is not the correct line
+        " {dir}/main.cf:13)`) (reported in __config__::Test (instantiated at {dir}/main.cf:13) ({dir}/main.cf:13))"
     )
 
 

--- a/tests/compiler/test_is_defined.py
+++ b/tests/compiler/test_is_defined.py
@@ -411,3 +411,25 @@ test = a.optional
     # (until #2793 has been implemented).
     # As a result this snippet is likely to fail without gradual execution for `is defined`.
     compiler.do_compile()
+
+
+def test_is_defined_below_null(snippetcompiler):
+    """
+    Verify behavior for `is defined` on a.b.c if a.b itself is not defined.
+    """
+    snippetcompiler.setup_for_error(
+        """
+entity A:
+end
+A.other [0:1] -- A
+implement A using std::none
+
+a = A(other=null)
+
+isdef = a.other.other is defined
+        """,
+        shouldbe=(
+            "Optional variable accessed that has no value (attribute `__config__::A.other` of `__config__::A (instantiated at"
+            " {dir}/main.cf:7)`) (reported in a.other.other ({dir}/main.cf:9))"
+        ),
+    )

--- a/tests/compiler/test_list.py
+++ b/tests/compiler/test_list.py
@@ -242,8 +242,9 @@ b1.a = a1
 b1.a = c1.a
 """
     )
-    with pytest.raises(OptionalValueException):
+    with pytest.raises(AttributeException) as exc_info:
         (_, scopes) = compiler.do_compile()
+    assert any(isinstance(cause, OptionalValueException) for cause in exc_info.value.get_causes())
 
 
 def test_608_opt_to_single(snippetcompiler):
@@ -282,8 +283,9 @@ b1.a = a1
 b1.a = c1.a
 """
     )
-    with pytest.raises(OptionalValueException):
+    with pytest.raises(AttributeException) as exc_info:
         (_, scopes) = compiler.do_compile()
+    assert any(isinstance(cause, OptionalValueException) for cause in exc_info.value.get_causes())
 
 
 def test_608_opt_to_single_2(snippetcompiler):

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -701,3 +701,45 @@ implement B using std::none
         """
     )
     compiler.do_compile()
+
+
+def test_optional_unset(snippetcompiler) -> None:
+    """
+    Verify the behavior of trying to access an optional relation attribute with no value.
+    """
+    snippetcompiler.setup_for_error(
+        """
+entity A:
+end
+A.other [0:1] -- A
+implement A using std::none
+
+a = A(other=null)
+other = a.other
+        """,
+        shouldbe=(
+            "Optional variable accessed that has no value (attribute `__config__::A.other` of `__config__::A (instantiated at"
+            " {dir}/main.cf:7)`) (reported in other = a.other ({dir}/main.cf:7))"
+        ),
+    )
+
+
+def test_optional_unset_nested(snippetcompiler) -> None:
+    """
+    Verify the behavior of trying to access an nested attribute of an optional relation attribute with no value.
+    """
+    snippetcompiler.setup_for_error(
+        """
+entity A:
+end
+A.other [0:1] -- A
+implement A using std::none
+
+a = A(other=null)
+other = a.other.other
+        """,
+        shouldbe=(
+            "Optional variable accessed that has no value (attribute `__config__::A.other` of `__config__::A (instantiated at"
+            " {dir}/main.cf:7)`) (reported in a.other.other ({dir}/main.cf:8))"
+        ),
+    )

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -719,7 +719,7 @@ other = a.other
         """,
         shouldbe=(
             "Optional variable accessed that has no value (attribute `__config__::A.other` of `__config__::A (instantiated at"
-            " {dir}/main.cf:7)`) (reported in other = a.other ({dir}/main.cf:7))"
+            " {dir}/main.cf:7)`) (reported in other = a.other ({dir}/main.cf:8))"
         ),
     )
 

--- a/tests/compiler/test_slots.py
+++ b/tests/compiler/test_slots.py
@@ -133,10 +133,11 @@ def create_instance(cls: Type[T]) -> T:
                 return create_instance(annotation)
         return DummyArgument()
 
-    args: Iterator[object] = (
-        create_argument(parameter.annotation) for name, parameter in inspect.signature(cls).parameters.items()
-    )
-    return cls(*args)
+    kwargs: dict[str, object] = {
+        name: create_argument(parameter.annotation) for name, parameter in inspect.signature(cls).parameters.items()
+    }
+    print(cls.__name__)
+    return cls(**kwargs)
 
 
 class DummyArgument:

--- a/tests/compiler/test_slots.py
+++ b/tests/compiler/test_slots.py
@@ -136,7 +136,6 @@ def create_instance(cls: Type[T]) -> T:
     kwargs: dict[str, object] = {
         name: create_argument(parameter.annotation) for name, parameter in inspect.signature(cls).parameters.items()
     }
-    print(cls.__name__)
     return cls(**kwargs)
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -19,7 +19,7 @@
 import pytest
 
 import inmanta.compiler as compiler
-from inmanta.ast import NotFoundException, RuntimeException
+from inmanta.ast import NotFoundException, OptionalValueException, RuntimeException
 from inmanta.execute.proxy import DynamicProxy
 from inmanta.execute.util import NoneValue
 
@@ -110,3 +110,24 @@ x = A()
         proxy.x
     with pytest.raises(NotFoundException):
         proxy.x
+
+
+def test_dynamic_proxy_optional_value_error(snippetcompiler):
+    """
+    Verify that accessing an unset optional value through a dynamic proxy results in an OptionalValueException.
+    """
+    proxy: object = proxy_object(
+        snippetcompiler,
+        """
+entity A:
+end
+A.other [0:1] -- A
+implement A using std::none
+
+x = A(other=null)
+        """,
+        "x",
+    )
+    assert isinstance(proxy, DynamicProxy)
+    with pytest.raises(OptionalValueException):
+        proxy.other


### PR DESCRIPTION
# Description

This PR moves evaluation of attribute references from `requires_emit` to `execute` (`ResultVariable.get_value()`) by introducing a result variable proxy. In addition to slightly improved semantics this allows for propagating unset variables. This is then used to fix the bug in the eager promises mechanism where a promise on an unset variable in a block that never gets executed would cause an exception. By propagating the unset variables, no execution units are left dangling (simply ignoring the exception would cause their requires to hang but by propagating the requires resolve to the unset variable one by one).

A couple of side effects:
- The `VariableReader` class has been greatly simplified. Some of its complexity has shifted to `IsDefinedGradualHelper`, the rest just ceased to be relevant.
- some error messages have slightly changed in the sense that failure now only occurs during execution rather than requires_emit. See tests changes for more details. I believe this is acceptable. I think the only fragile one is the `OptionalValueException` in `DynamicProxy` and that one has not changed (I've added a test for it).


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
