### PR TITLE
Support implicit removal of resource sets

### DIFF
--- a/changelogs/unreleased/4529-implicit-removal-resource-sets.yml
+++ b/changelogs/unreleased/4529-implicit-removal-resource-sets.yml
@@ -1,0 +1,6 @@
+---
+description: Support implicit removal of resource sets
+issue-nr: 4529
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso5]

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -374,7 +374,7 @@ class Exporter(object):
             # then process the configuration model to submit it to the mgmt server
             # This is the actuel export : convert entities to resources.
             self._load_resources(types)
-            resource_sets_to_remove_all = resource_sets_to_remove_all + self._empty_resource_sets
+            resource_sets_to_remove_all += self._empty_resource_sets
             # call dependency managers
             self._call_dep_manager(types)
             metadata[const.META_DATA_COMPILE_STATE] = const.Compilestate.success

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -134,6 +134,7 @@ class Exporter(object):
 
         self._resources: ResourceDict = {}
         self._resource_sets: Dict[str, Optional[str]] = {}
+        self._empty_resource_sets: List[str] = []
         self._resource_state: Dict[str, ResourceState] = {}
         self._unknown_objects: Set[str] = set()
         self._version = 0
@@ -221,6 +222,8 @@ class Exporter(object):
                         str(resource_in_set),
                         str(resource_set_instance),
                     )
+            if name not in resource_sets.values():
+                self._empty_resource_sets.append(name)
         self._resource_sets: Dict[str, Optional[str]] = resource_sets
 
     def _run_export_plugins_specified_in_config_file(self) -> None:
@@ -370,7 +373,7 @@ class Exporter(object):
             # then process the configuration model to submit it to the mgmt server
             # This is the actuel export : convert entities to resources.
             self._load_resources(types)
-
+            resource_sets_to_remove += self._empty_resource_sets
             # call dependency managers
             self._call_dep_manager(types)
             metadata[const.META_DATA_COMPILE_STATE] = const.Compilestate.success

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -364,7 +364,7 @@ class Exporter(object):
         """
         if not partial_compile and resource_sets_to_remove:
             raise Exception("Cannot remove resource sets when a full compile was done")
-        resource_sets_to_remove: List[str] = resource_sets_to_remove if resource_sets_to_remove is not None else []
+        resource_sets_to_remove_all: List[str] = list(resource_sets_to_remove) if resource_sets_to_remove is not None else []
 
         self.types = types
         self.scopes = scopes
@@ -374,7 +374,7 @@ class Exporter(object):
             # then process the configuration model to submit it to the mgmt server
             # This is the actuel export : convert entities to resources.
             self._load_resources(types)
-            resource_sets_to_remove.append(self._empty_resource_sets)
+            resource_sets_to_remove_all = resource_sets_to_remove_all + self._empty_resource_sets
             # call dependency managers
             self._call_dep_manager(types)
             metadata[const.META_DATA_COMPILE_STATE] = const.Compilestate.success
@@ -414,7 +414,7 @@ class Exporter(object):
             if types is not None and model_export:
                 model = ModelExporter(types).export_all()
 
-            self.commit_resources(self._version, resources, metadata, model, partial_compile, resource_sets_to_remove)
+            self.commit_resources(self._version, resources, metadata, model, partial_compile, resource_sets_to_remove_all)
             LOGGER.info("Committed resources with version %d" % self._version)
 
         if include_status:

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -206,6 +206,7 @@ class Exporter(object):
         )
         for resource_set_instance in resource_set_instances:
             name: str = resource_set_instance.get_attribute("name").get_value()
+            empty_set: bool = True
             resources_in_set: List[Instance] = resource_set_instance.get_attribute("resources").get_value()
             for resource_in_set in resources_in_set:
                 if resource_in_set in resource_mapping:
@@ -216,13 +217,14 @@ class Exporter(object):
                             f"{resource_sets[resource_id]} and {name}"
                         )
                     resource_sets[resource_id] = name
+                    empty_set = False
                 else:
                     LOGGER.warning(
                         "resource %s is part of ResourceSets %s but will not be exported.",
                         str(resource_in_set),
                         str(resource_set_instance),
                     )
-            if name not in resource_sets.values():
+            if empty_set:
                 self._empty_resource_sets.append(name)
         self._resource_sets = resource_sets
 

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -362,7 +362,7 @@ class Exporter(object):
         """
         if not partial_compile and resource_sets_to_remove:
             raise Exception("Cannot remove resource sets when a full compile was done")
-        resource_sets_to_remove_all: List[str] = resource_sets_to_remove if resource_sets_to_remove is not None else []
+        resource_sets_to_remove: List[str] = resource_sets_to_remove if resource_sets_to_remove is not None else []
 
         self.types = types
         self.scopes = scopes
@@ -372,7 +372,7 @@ class Exporter(object):
             # then process the configuration model to submit it to the mgmt server
             # This is the actuel export : convert entities to resources.
             self._load_resources(types)
-            resource_sets_to_remove_all.append(self._empty_resource_sets)
+            resource_sets_to_remove.append(self._empty_resource_sets)
             # call dependency managers
             self._call_dep_manager(types)
             metadata[const.META_DATA_COMPILE_STATE] = const.Compilestate.success
@@ -412,7 +412,7 @@ class Exporter(object):
             if types is not None and model_export:
                 model = ModelExporter(types).export_all()
 
-            self.commit_resources(self._version, resources, metadata, model, partial_compile, resource_sets_to_remove_all)
+            self.commit_resources(self._version, resources, metadata, model, partial_compile, resource_sets_to_remove)
             LOGGER.info("Committed resources with version %d" % self._version)
 
         if include_status:

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -360,10 +360,9 @@ class Exporter(object):
         """
         Run the export functions
         """
-        if resource_sets_to_remove is None:
-            resource_sets_to_remove = []
         if not partial_compile and resource_sets_to_remove:
             raise Exception("Cannot remove resource sets when a full compile was done")
+        resource_sets_to_remove_all: List[str] = resource_sets_to_remove if resource_sets_to_remove is not None else []
 
         self.types = types
         self.scopes = scopes
@@ -373,7 +372,7 @@ class Exporter(object):
             # then process the configuration model to submit it to the mgmt server
             # This is the actuel export : convert entities to resources.
             self._load_resources(types)
-            resource_sets_to_remove += self._empty_resource_sets
+            resource_sets_to_remove_all.append(self._empty_resource_sets)
             # call dependency managers
             self._call_dep_manager(types)
             metadata[const.META_DATA_COMPILE_STATE] = const.Compilestate.success
@@ -413,7 +412,7 @@ class Exporter(object):
             if types is not None and model_export:
                 model = ModelExporter(types).export_all()
 
-            self.commit_resources(self._version, resources, metadata, model, partial_compile, resource_sets_to_remove)
+            self.commit_resources(self._version, resources, metadata, model, partial_compile, resource_sets_to_remove_all)
             LOGGER.info("Committed resources with version %d" % self._version)
 
         if include_status:

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -224,7 +224,7 @@ class Exporter(object):
                     )
             if name not in resource_sets.values():
                 self._empty_resource_sets.append(name)
-        self._resource_sets: Dict[str, Optional[str]] = resource_sets
+        self._resource_sets = resource_sets
 
     def _run_export_plugins_specified_in_config_file(self) -> None:
         """

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -355,7 +355,7 @@ class Exporter(object):
         model_export: bool = False,
         export_plugin: Optional[str] = None,
         partial_compile: bool = False,
-        resource_sets_to_remove: Optional[List[str]] = None,
+        resource_sets_to_remove: Optional[Sequence[str]] = None,
     ) -> Union[Tuple[int, ResourceDict], Tuple[int, ResourceDict, Dict[str, ResourceState], Optional[Dict[str, Any]]]]:
         """
         Run the export functions

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -31,6 +31,61 @@ from inmanta.export import DependencyCycleException
 from utils import LogSequence, v1_module_from_template
 
 
+async def export_model(
+    tmpdir,
+    modules_dir,
+    snippetcompiler,
+    model: str,
+    partial_compile: bool,
+    resource_sets_to_remove: Optional[List[str]] = None,
+) -> None:
+    init_py = """
+from inmanta.resources import (
+Resource,
+resource,
+)
+@resource("modulev1::Res", agent="name", id_attribute="name")
+class Res(Resource):
+fields = ("name",)
+"""
+
+    module_name: str = "minimalv1module"
+    module_path: str = str(tmpdir.join("modulev1"))
+    if os.path.exists(module_path):
+        shutil.rmtree(module_path)
+    v1_module_from_template(
+        os.path.join(modules_dir, module_name),
+        module_path,
+        new_content_init_cf=model,
+        new_content_init_py=init_py,
+        new_name="modulev1",
+    )
+
+    snippetcompiler.setup_for_snippet(
+        """
+import modulev1
+        """,
+        add_to_module_path=[str(tmpdir)],
+    )
+    await snippetcompiler.do_export_and_deploy(
+        partial_compile=partial_compile,
+        resource_sets_to_remove=resource_sets_to_remove,
+    )
+
+
+async def assert_resource_set_assignment(assignment: Dict[str, Optional[str]], environment) -> None:
+    """
+    Verify whether the resources on the server are assignment to the resource sets given via the assignment argument.
+
+    :param assignment: Map the value of name attribute of resource Res to the resource set that resource is expected to
+                       belong to.
+    """
+    resources = await Resource.get_resources_in_latest_version(environment=environment)
+    assert len(resources) == len(assignment)
+    actual_assignment = {r.attributes["name"]: r.resource_set for r in resources}
+    assert actual_assignment == assignment
+
+
 def test_id_mapping_export(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """import exp
@@ -424,58 +479,11 @@ async def test_resource_set(snippetcompiler, modules_dir: str, tmpdir, environme
     Test that resource sets are exported correctly, when a full compile or an incremental compile is done.
     """
 
-    async def export_model(
-        model: str,
-        partial_compile: bool,
-        resource_sets_to_remove: Optional[List[str]] = None,
-    ) -> None:
-        init_py = """
-from inmanta.resources import (
-    Resource,
-    resource,
-)
-@resource("modulev1::Res", agent="name", id_attribute="name")
-class Res(Resource):
-    fields = ("name",)
-"""
-
-        module_name: str = "minimalv1module"
-        module_path: str = str(tmpdir.join("modulev1"))
-        if os.path.exists(module_path):
-            shutil.rmtree(module_path)
-        v1_module_from_template(
-            os.path.join(modules_dir, module_name),
-            module_path,
-            new_content_init_cf=model,
-            new_content_init_py=init_py,
-            new_name="modulev1",
-        )
-
-        snippetcompiler.setup_for_snippet(
-            """
-    import modulev1
-            """,
-            add_to_module_path=[str(tmpdir)],
-        )
-        await snippetcompiler.do_export_and_deploy(
-            partial_compile=partial_compile,
-            resource_sets_to_remove=resource_sets_to_remove,
-        )
-
-    async def assert_resource_set_assignment(assignment: Dict[str, Optional[str]]) -> None:
-        """
-        Verify whether the resources on the server are assignment to the resource sets given via the assignment argument.
-
-        :param assignment: Map the value of name attribute of resource Res to the resource set that resource is expected to
-                           belong to.
-        """
-        resources = await Resource.get_resources_in_latest_version(environment=environment)
-        assert len(resources) == len(assignment)
-        actual_assignment = {r.attributes["name"]: r.resource_set for r in resources}
-        assert actual_assignment == actual_assignment
-
     # Full compile
     await export_model(
+        tmpdir,
+        modules_dir,
+        snippetcompiler,
         model="""
 entity Res extends std::Resource:
     string name
@@ -503,11 +511,15 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
             "the_resource_d": "resource_set_3",
             "the_resource_e": "resource_set_3",
             "the_resource_z": None,
-        }
+        },
+        environment=environment,
     )
 
     # Partial compile
     await export_model(
+        tmpdir,
+        modules_dir,
+        snippetcompiler,
         model="""
     entity Res extends std::Resource:
         string name
@@ -532,7 +544,8 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
             "the_resource_e": "resource_set_3",
             "the_resource_f": "resource_set_4",
             "the_resource_z": None,
-        }
+        },
+        environment=environment,
     )
 
 
@@ -605,3 +618,78 @@ implement std::Resource using std::none
 
     log_sequence = LogSequence(caplog)
     log_sequence.contains("inmanta.export", logging.WARNING, msg)
+
+
+async def test_empty_resource_set_removal(snippetcompiler, modules_dir: str, tmpdir, environment) -> None:
+    """
+    When a partial compile is ran, the exporter should trigger a deletion of each ResourceSet, defined in the partial model,
+    that doesn't have any resources associated
+    """
+
+    # Full compile
+    await export_model(
+        tmpdir,
+        modules_dir,
+        snippetcompiler,
+        model="""
+entity Res extends std::Resource:
+    string name
+end
+
+implement Res using std::none
+
+a = Res(name="the_resource_a")
+b = Res(name="the_resource_b")
+c = Res(name="the_resource_c")
+d = Res(name="the_resource_d")
+e = Res(name="the_resource_e")
+z = Res(name="the_resource_z")
+std::ResourceSet(name="resource_set_1", resources=[a,c])
+std::ResourceSet(name="resource_set_2", resources=[b])
+std::ResourceSet(name="resource_set_3", resources=[d, e])
+        """,
+        partial_compile=False,
+    )
+    await assert_resource_set_assignment(
+        assignment={
+            "the_resource_a": "resource_set_1",
+            "the_resource_b": "resource_set_2",
+            "the_resource_c": "resource_set_1",
+            "the_resource_d": "resource_set_3",
+            "the_resource_e": "resource_set_3",
+            "the_resource_z": None,
+        },
+        environment=environment,
+    )
+
+    # Partial compile
+    await export_model(
+        tmpdir,
+        modules_dir,
+        snippetcompiler,
+        model="""
+    entity Res extends std::Resource:
+        string name
+    end
+
+    implement Res using std::none
+
+    a = Res(name="the_resource_a")
+    c2 = Res(name="the_resource_c2")
+    f = Res(name="the_resource_f")
+    std::ResourceSet(name="resource_set_1", resources=[a,c2])
+    std::ResourceSet(name="resource_set_4", resources=[f])
+    std::ResourceSet(name="resource_set_3", resources=[])
+            """,
+        partial_compile=True,
+        resource_sets_to_remove=["resource_set_2"],
+    )
+    await assert_resource_set_assignment(
+        assignment={
+            "the_resource_a": "resource_set_1",
+            "the_resource_c2": "resource_set_1",
+            "the_resource_f": "resource_set_4",
+            "the_resource_z": None,
+        },
+        environment=environment,
+    )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -31,6 +31,20 @@ from inmanta.export import DependencyCycleException
 from utils import LogSequence, v1_module_from_template
 
 
+async def assert_resource_set_assignment(environment, assignment: Dict[str, Optional[str]]) -> None:
+    """
+    Verify whether the resources on the server are assignment to the resource sets given via the assignment argument.
+
+    :param environment
+    :param assignment: Map the value of name attribute of resource Res to the resource set that resource is expected to
+                       belong to.
+    """
+    resources = await Resource.get_resources_in_latest_version(environment=environment)
+    assert len(resources) == len(assignment)
+    actual_assignment = {r.attributes["name"]: r.resource_set for r in resources}
+    assert actual_assignment == assignment
+
+
 def test_id_mapping_export(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """import exp
@@ -462,18 +476,6 @@ class Res(Resource):
             resource_sets_to_remove=resource_sets_to_remove,
         )
 
-    async def assert_resource_set_assignment(assignment: Dict[str, Optional[str]]) -> None:
-        """
-        Verify whether the resources on the server are assignment to the resource sets given via the assignment argument.
-
-        :param assignment: Map the value of name attribute of resource Res to the resource set that resource is expected to
-                           belong to.
-        """
-        resources = await Resource.get_resources_in_latest_version(environment=environment)
-        assert len(resources) == len(assignment)
-        actual_assignment = {r.attributes["name"]: r.resource_set for r in resources}
-        assert actual_assignment == assignment
-
     # Full compile
     await export_model(
         model="""
@@ -496,6 +498,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
         partial_compile=False,
     )
     await assert_resource_set_assignment(
+        environment,
         assignment={
             "the_resource_a": "resource_set_1",
             "the_resource_b": "resource_set_2",
@@ -503,7 +506,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
             "the_resource_d": "resource_set_3",
             "the_resource_e": "resource_set_3",
             "the_resource_z": None,
-        }
+        },
     )
 
     # Partial compile
@@ -525,6 +528,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
         resource_sets_to_remove=["resource_set_2"],
     )
     await assert_resource_set_assignment(
+        environment,
         assignment={
             "the_resource_a": "resource_set_1",
             "the_resource_c2": "resource_set_1",
@@ -532,7 +536,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
             "the_resource_e": "resource_set_3",
             "the_resource_f": "resource_set_4",
             "the_resource_z": None,
-        }
+        },
     )
 
 
@@ -651,18 +655,6 @@ class Res(Resource):
             resource_sets_to_remove=resource_sets_to_remove,
         )
 
-    async def assert_resource_set_assignment(assignment: Dict[str, Optional[str]]) -> None:
-        """
-        Verify whether the resources on the server are assignment to the resource sets given via the assignment argument.
-
-        :param assignment: Map the value of name attribute of resource Res to the resource set that resource is expected to
-                           belong to.
-        """
-        resources = await Resource.get_resources_in_latest_version(environment=environment)
-        assert len(resources) == len(assignment)
-        actual_assignment = {r.attributes["name"]: r.resource_set for r in resources}
-        assert actual_assignment == assignment
-
     # Full compile
     await export_model(
         model="""
@@ -685,6 +677,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
         partial_compile=False,
     )
     await assert_resource_set_assignment(
+        environment,
         assignment={
             "the_resource_a": "resource_set_1",
             "the_resource_b": "resource_set_2",
@@ -692,7 +685,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
             "the_resource_d": "resource_set_3",
             "the_resource_e": "resource_set_3",
             "the_resource_z": None,
-        }
+        },
     )
 
     # Partial compile
@@ -715,10 +708,11 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
         resource_sets_to_remove=["resource_set_2"],
     )
     await assert_resource_set_assignment(
+        environment,
         assignment={
             "the_resource_a": "resource_set_1",
             "the_resource_c2": "resource_set_1",
             "the_resource_f": "resource_set_4",
             "the_resource_z": None,
-        }
+        },
     )


### PR DESCRIPTION
# Description

When a partial compile is ran, the exporter should trigger a deletion of each ResourceSet, defined in the partial model, that doesn't have any resources associated. In other words, the exporter should pass each ResourceSet without resources to the removed_resource_sets argument of the put_partial endpoint.

closes #4529 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
