### PR TITLE
Issue/4455: removed resource sets are present in partial diff

### DIFF
--- a/changelogs/unreleased/4455-removed-resource-sets-present-in-export.yml
+++ b/changelogs/unreleased/4455-removed-resource-sets-present-in-export.yml
@@ -1,5 +1,5 @@
 ---
-description: Removed resource sets are present in partial diff raises excpetion
+description: raises exception if removed resource sets are present in partial diff
 issue-nr: 4455
 issue-repo: inmanta-core
 change-type: minor

--- a/changelogs/unreleased/4455-removed-resource-sets-present-in-export.yml
+++ b/changelogs/unreleased/4455-removed-resource-sets-present-in-export.yml
@@ -1,0 +1,6 @@
+---
+description: Removed resource sets are present in partial diff raises excpetion
+issue-nr: 4455
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso5]

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -380,6 +380,13 @@ class Exporter(object):
             self.failed = True
             LOGGER.warning("Compilation of model failed.")
 
+        intersection: set[str] = set(self._resource_sets.values()).intersection(set(resource_sets_to_remove))
+        if intersection:
+            raise Exception(
+                "Following resource sets are present in the removed resource sets and in the resources that are exported: %s"
+                % intersection
+            )
+
         if not self.failed:
             if export_plugin is not None:
                 # Run export plugin specified on CLI

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -685,18 +685,22 @@ std::ResourceSet(name="resource_set_2", resources=[b])
         }
     )
 
-    # Partial compile
-    await export_model(
-        model="""
-    entity Res extends std::Resource:
-        string name
-    end
+    with pytest.raises(Exception) as e:
+        # Partial compile
+        await export_model(
+            model="""
+        entity Res extends std::Resource:
+            string name
+        end
 
-    implement Res using std::none
+        implement Res using std::none
 
-    a = Res(name="the_resource_a")
-    std::ResourceSet(name="resource_set_1", resources=[a])
-            """,
-        partial_compile=True,
-        resource_sets_to_remove=["resource_set_1"],
+        a = Res(name="the_resource_a")
+        std::ResourceSet(name="resource_set_1", resources=[a])
+                """,
+            partial_compile=True,
+            resource_sets_to_remove=["resource_set_1"],
+        )
+    assert str(e.value).startswith(
+        "Following resource sets are present in the removed resource sets and in the resources that are exported: {'resource_set_1'}"
     )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -702,7 +702,8 @@ std::ResourceSet(name="resource_set_2", resources=[b])
             resource_sets_to_remove=["resource_set_1"],
         )
     assert str(e.value).startswith(
-        "Following resource sets are present in the removed resource sets and in the resources that are exported: {'resource_set_1'}"
+        "Following resource sets are present in the removed resource sets and in "
+        "the resources that are exported: {'resource_set_1'}"
     )
 
     # If the set does exist in the list but it is empty, there's no need to reject it.


### PR DESCRIPTION
# Description

When a partial export is done with --remove-resource-sets myset but myset is still present in the resources that are exported, the server does not reject this. It should. This behavior should be well defined and documented.

Corner case: if the set does exist in the list but it is empty, there's no need to reject it.

closes #4455 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
