### PR TITLE
fixed incorrect exception chaining for dependency conflict

### DIFF
--- a/changelogs/unreleased/4573-dependency-conflict-type-error.yml
+++ b/changelogs/unreleased/4573-dependency-conflict-type-error.yml
@@ -1,0 +1,5 @@
+description: Fixed incorrect exception chaining for conflicting dependencies exception
+change-type: patch
+destination-branches:
+  - iso5
+  - master

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -813,7 +813,7 @@ version: 0.0.1dev0"""
             try:
                 env.process_env.install_from_source([env.LocalPackagePath(path=install_path, editable=editable)])
             except env.ConflictingRequirements as e:
-                raise InvalidModuleException(e)
+                raise InvalidModuleException("Module installation failed due to conflicting dependencies") from e
 
         module_path: str = os.path.abspath(path) if path is not None else os.getcwd()
         module: Module = self.construct_module(None, module_path)

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -225,6 +225,41 @@ def test_module_install(snippetcompiler_clean, modules_v2_dir: str, editable: bo
         assert is_installed(python_module_name, False)
 
 
+@pytest.mark.slowtest
+def test_module_install_conflicting_requirements(tmpdir: py.path.local, snippetcompiler_clean, modules_v2_dir: str) -> None:
+    # TODO: docstring
+    # activate snippetcompiler's venv
+    snippetcompiler_clean.setup_for_snippet("")
+
+    module_from_template(
+        os.path.join(modules_v2_dir, "minimalv2module"),
+        os.path.join(str(tmpdir), "modone"),
+        new_name="modone",
+        new_requirements=[Requirement.parse("lorem~=0.0.1")],
+        install=True,
+    )
+    module_from_template(
+        os.path.join(modules_v2_dir, "minimalv2module"),
+        os.path.join(str(tmpdir), "modtwo"),
+        new_name="modtwo",
+        new_requirements=[Requirement.parse("lorem~=0.1.0")],
+        install=True,
+    )
+
+    module_path: str = os.path.join(str(tmpdir), "conflictingdeps")
+    module_from_template(
+        os.path.join(modules_v2_dir, "minimalv2module"),
+        module_path,
+        new_name="conflictingdeps",
+        new_requirements=[InmantaModuleRequirement.parse(name) for name in ("modone", "modtwo")],
+    )
+
+    with pytest.raises(module.InvalidModuleException) as exc_info:
+        run_module_install(module_path, False, True)
+    assert isinstance(exc_info.value.__cause__, ConflictingRequirements)
+    assert "caused by:" in exc_info.value.format_trace()
+
+
 @pytest.mark.parametrize_any("dev", [True, False])
 def test_module_install_version(
     tmpdir: py.path.local,

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -227,7 +227,9 @@ def test_module_install(snippetcompiler_clean, modules_v2_dir: str, editable: bo
 
 @pytest.mark.slowtest
 def test_module_install_conflicting_requirements(tmpdir: py.path.local, snippetcompiler_clean, modules_v2_dir: str) -> None:
-    # TODO: docstring
+    """
+    Verify that the module tool's install command raises an appropriate exception when a module has conflicting dependencies.
+    """
     # activate snippetcompiler's venv
     snippetcompiler_clean.setup_for_snippet("")
 


### PR DESCRIPTION
# Description

See https://docs.python.org/3/tutorial/errors.html#exception-chaining

closes #4573

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
