### PR TITLE
disabled put_partial method to exclude it from release

### DIFF
--- a/changelogs/unreleased/put-partial-disable.yml
+++ b/changelogs/unreleased/put-partial-disable.yml
@@ -1,0 +1,5 @@
+description: Tempararily disabled put_partial method to exclude it from the upcoming release while it is not yet in a stable state (#4412)
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -32,14 +32,14 @@ from .decorators import typedmethod
 from .openapi.model import OpenAPI
 
 
-@typedmethod(
-    path="/version/partial",
-    operation="PUT",
-    arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.compiler],
-    api_version=2,
-    varkw=True,
-)
+# @typedmethod(
+#     path="/version/partial",
+#     operation="PUT",
+#     arg_options=methods.ENV_OPTS,
+#     client_types=[ClientType.compiler],
+#     api_version=2,
+#     varkw=True,
+# )
 def put_partial(
     tid: uuid.UUID,
     version: int,

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -17,9 +17,14 @@
 """
 import uuid
 
+import pytest
+
 import utils
 from inmanta import data
 from inmanta.util import get_compiler_version
+
+
+pytest.skip(allow_module_level=True)
 
 
 async def test_resource_sets_via_put_version(server, client, environment, clienthelper):


### PR DESCRIPTION
# Description

Further discussion is required on #4412. To unblock the release I propose to temporarily disable this method.

If this is rejected, the follow-up ticket #4579 should be closed.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
