### PR TITLE
Issue/4455: removed resource sets are present in partial diff

### DIFF
--- a/changelogs/unreleased/4455-removed-resource-sets-present-in-export.yml
+++ b/changelogs/unreleased/4455-removed-resource-sets-present-in-export.yml
@@ -1,0 +1,6 @@
+---
+description: raises exception if removed resource sets are present in partial diff
+issue-nr: 4455
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso5]

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -660,13 +660,19 @@ class OrchestrationService(protocol.ServerSlice):
             resource_sets = {}
         if removed_resource_sets is None:
             removed_resource_sets = []
-
         try:
             resources = pydantic.parse_obj_as(List[ResourceMinimal], resources)
         except pydantic.ValidationError:
-            raise BadRequest(
+            raise Exception(
                 "Type validation failed for resources argument. "
                 f"Expected an argument of type List[Dict[str, Any]] but received {resources}"
+            )
+
+        intersection: set[str] = set(resource_sets.values()).intersection(set(removed_resource_sets))
+        if intersection:
+            raise Exception(
+                "Following resource sets are present in the removed resource sets and in the resources that are exported: %s"
+                % intersection
             )
 
         merger = PartialUpdateMerger(resources, resource_sets, removed_resource_sets, env)

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -671,8 +671,8 @@ class OrchestrationService(protocol.ServerSlice):
         intersection: set[str] = set(resource_sets.values()).intersection(set(removed_resource_sets))
         if intersection:
             raise Exception(
-                "Following resource sets are present in the removed resource sets and in the resources that are exported: %s"
-                % intersection
+                "Following resource sets are present in the removed resource sets and in the resources that are exported: "
+                f"{intersection}"
             )
 
         merger = PartialUpdateMerger(resources, resource_sets, removed_resource_sets, env)

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -663,14 +663,14 @@ class OrchestrationService(protocol.ServerSlice):
         try:
             resources = pydantic.parse_obj_as(List[ResourceMinimal], resources)
         except pydantic.ValidationError:
-            raise Exception(
+            raise BadRequest(
                 "Type validation failed for resources argument. "
                 f"Expected an argument of type List[Dict[str, Any]] but received {resources}"
             )
 
         intersection: set[str] = set(resource_sets.values()).intersection(set(removed_resource_sets))
         if intersection:
-            raise Exception(
+            raise BadRequest(
                 "Following resource sets are present in the removed resource sets and in the resources that are exported: "
                 f"{intersection}"
             )

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -993,7 +993,7 @@ async def test_put_partial_version(server, client, environment, clienthelper):
 
 async def test_put_partial_removed_rs_in_rs(server, client, environment, clienthelper):
     """
-    A test that throws and exception if a removed resource set is still present int the resourcesets
+    Test that an exception is thrown when a resource being exported belongs to a resource set that is being deleted.
     """
     version = await clienthelper.get_version()
     resources = [

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1057,7 +1057,9 @@ async def test_put_partial_removed_rs_in_rs(server, client, environment, clienth
 
     assert result.code == 500
     assert result.result["message"] == (
-        "An unexpected error occurred in the server while processing the request: (\"Following resource sets are present in the removed resource sets and in the resources that are exported: {'set-b'}\",)"
+        "An unexpected error occurred in the server while processing the request: "
+        '("Following resource sets are present in the removed resource sets and in the '
+        "resources that are exported: {'set-b'}\",)"
     )
     resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1055,11 +1055,10 @@ async def test_put_partial_removed_rs_in_rs(server, client, environment, clienth
         removed_resource_sets=["set-b"],
     )
 
-    assert result.code == 500
+    assert result.code == 400
     assert result.result["message"] == (
-        "An unexpected error occurred in the server while processing the request: "
-        '("Following resource sets are present in the removed resource sets and in the '
-        "resources that are exported: {'set-b'}\",)"
+        "Invalid request: Following resource sets are present in the removed resource sets and in the resources "
+        "that are exported: {'set-b'}"
     )
     resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -989,3 +989,82 @@ async def test_put_partial_version(server, client, environment, clienthelper):
         "test::Resource[agent1,key=key1],v=3 does not match the version argument "
         "(version: 2)"
     )
+
+
+async def test_put_partial_removed_rs_in_rs(server, client, environment, clienthelper):
+    """
+    A test that throws and exception if a removed resource set is still present int the resourcesets
+    """
+    version = await clienthelper.get_version()
+    resources = [
+        {
+            "key": "key1",
+            "value": "1",
+            "id": "test::Resource[agent1,key=key1],v=%d" % version,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key2",
+            "value": "2",
+            "id": "test::Resource[agent1,key=key2],v=%d" % version,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+    ]
+    resource_sets = {
+        "test::Resource[agent1,key=key1]": "set-a",
+        "test::Resource[agent1,key=key2]": "set-b",
+    }
+
+    result = await client.put_version(
+        tid=environment,
+        version=version,
+        resources=resources,
+        resource_state={},
+        unknowns=[],
+        version_info={},
+        compiler_version=get_compiler_version(),
+        resource_sets=resource_sets,
+    )
+    assert result.code == 200
+    version = await clienthelper.get_version()
+    resources_partial = [
+        {
+            "key": "key2",
+            "value": "200",
+            "id": "test::Resource[agent1,key=key2],v=%d" % version,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+    ]
+
+    result = await client.put_partial(
+        tid=environment,
+        version=version,
+        resources=resources_partial,
+        resource_state={},
+        unknowns=[],
+        version_info=None,
+        resource_sets={
+            "test::Resource[agent1,key=key2]": "set-b",
+        },
+        removed_resource_sets=["set-b"],
+    )
+
+    assert result.code == 500
+    assert result.result["message"] == (
+        "An unexpected error occurred in the server while processing the request: (\"Following resource sets are present in the removed resource sets and in the resources that are exported: {'set-b'}\",)"
+    )
+    resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
+    resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
+    assert len(resource_list) == 2
+    assert resource_list[0].attributes == {"key": "key1", "value": "1", "purged": False, "requires": [], "send_event": False}
+    assert resource_list[1].attributes == {"key": "key2", "value": "2", "purged": False, "requires": [], "send_event": False}
+    assert resource_sets_from_db == {
+        "test::Resource[agent1,key=key1]": "set-a",
+        "test::Resource[agent1,key=key2]": "set-b",
+    }


### PR DESCRIPTION
# Description

When a partial export is done with --remove-resource-sets myset but myset is still present in the resources that are exported, the server does not reject this. It should. This behavior should be well defined and documented.

Corner case: if the set does exist in the list but it is empty, there's no need to reject it.

closes https://github.com/inmanta/inmanta-core/issues/4455

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
