### PR TITLE
Fix issue where test cases fail due to pip version warning

### DIFF
--- a/changelogs/unreleased/ignore-warning-old-pip-version-2.yml
+++ b/changelogs/unreleased/ignore-warning-old-pip-version-2.yml
@@ -1,0 +1,4 @@
+---
+description: Fix issue where test cases fail when the tests are not executed using the latest version of pip.
+change-type: patch
+destination-branches: [master, iso5]


### PR DESCRIPTION
# Description

Pip version 22.1.2 seems to write a notice regarding a newer pip version being available to stdout. In the past these messages were written to stderr. This change breaks the parser of the method that parses the `pip list` output. This PR fixed this issue.

pip list output:
```
Package                       Version    Editable project location
----------------------------- ---------- ------------------------------------------------
alabaster                     0.7.12
arrow                         1.2.2
....
[notice] A new release of pip available: 22.1.2 -> 22.2
[notice] To update, run: pip install --upgrade pip
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
