### PR TITLE
marked partial compile features as experimental

### DIFF
--- a/changelogs/unreleased/4612-partial-compile-experimental.yml
+++ b/changelogs/unreleased/4612-partial-compile-experimental.yml
@@ -1,0 +1,6 @@
+description: Marked partial compile features as experimental because they may be subject to breaking changes in future releases.
+issue-nr: 4612
+change-type: patch
+destination-branches:
+  - iso5
+  - master

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -509,7 +509,7 @@ def export_parser_config(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--partial",
         dest="partial_compile",
-        help="Execute a partial export",
+        help="Execute a partial export (experimental, may receive breaking changes in future releases).",
         action="store_true",
         default=False,
     )

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -54,6 +54,8 @@ def put_partial(
 
     The version number must be obtained through the reserve_version call
 
+    This method is experimental and its interface may receive breaking changes in future releases.
+
     :param tid: The id of the environment
     :param version: The version of the configuration model
     :param resource_state: A dictionary with the initial const.ResourceState per resource id


### PR DESCRIPTION
# Description

Marked partial compile features as experimental because they may be subject to breaking changes in future releases. I followed the ticket in marking `--partial` as well, even though I don't think its behavior should change. It does give us a bit more flexibility.

I've added a task to revert this to #4412

closes #4612

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
