### PR TITLE
Reset data.Environment._settings dict after each test case

### DIFF
--- a/changelogs/unreleased/ensure-reset-of-env-settings.yml
+++ b/changelogs/unreleased/ensure-reset-of-env-settings.yml
@@ -1,0 +1,6 @@
+---
+description: Ensure that the dictionary, holding the environment settings, is reset by the cleanup fixtures to its initial state
+issue-nr: 927
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -481,12 +481,14 @@ async def clean_reset(create_db, clean_db):
     config.Config._reset()
     methods = inmanta.protocol.common.MethodProperties.methods.copy()
     loader.unload_inmanta_plugins()
+    default_settings = dict(data.Environment._settings)
     yield
     inmanta.protocol.common.MethodProperties.methods = methods
     config.Config._reset()
     reset_all_objects()
     loader.unload_inmanta_plugins()
     cache_manager.detach_from_project()
+    data.Environment._settings = default_settings
 
 
 def reset_all_objects():


### PR DESCRIPTION
# Description

inmanta/inmanta-lsm#979 adds LSM specific environment settings to the `data.Environment._settings` dictionary. This PR makes sure that the `_settings` dictionary is reset to its initial value after test case. 

Part of inmanta/inmanta-lsm#979

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
