### PR TITLE
Set GIT_ASKPASS environment variable on git clone command

### DIFF
--- a/changelogs/unreleased/set-git-askpass-env-var.yml
+++ b/changelogs/unreleased/set-git-askpass-env-var.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that forks of the `git clone` command have the `GIT_ASKPASS` environment variable set
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -34,7 +34,7 @@ from importlib.abc import Loader
 from importlib.machinery import ModuleSpec
 from itertools import chain
 from subprocess import CalledProcessError
-from typing import Any, Dict, Iterator, List, Optional, Pattern, Sequence, Set, Tuple, TypeVar
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Pattern, Sequence, Set, Tuple, TypeVar
 
 import pkg_resources
 from pkg_resources import DistInfoDistribution, Distribution, Requirement
@@ -587,7 +587,7 @@ class PythonEnvironment:
 
     @staticmethod
     def run_command_and_stream_output(
-        cmd: List[str], shell: bool = False, timeout: float = 10, env_vars: Optional[Dict[str, str]] = None
+        cmd: List[str], shell: bool = False, timeout: float = 10, env_vars: Optional[Mapping[str, str]] = None
     ) -> Tuple[int, List[str]]:
         """
         Similar to the _run_command_and_log_output method, but here, the output is logged on the fly instead of at the end
@@ -598,7 +598,7 @@ class PythonEnvironment:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             shell=shell,
-            **({"env": env_vars} if env_vars is not None else {}),
+            env=env_vars,
         )
 
         full_output: List[str] = []

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -586,7 +586,9 @@ class PythonEnvironment:
             return output.decode()
 
     @staticmethod
-    def run_command_and_stream_output(cmd: List[str], shell: bool = False, timeout: float = 10) -> Tuple[int, List[str]]:
+    def run_command_and_stream_output(
+        cmd: List[str], shell: bool = False, timeout: float = 10, env_vars: Optional[Dict[str, str]] = None
+    ) -> Tuple[int, List[str]]:
         """
         Similar to the _run_command_and_log_output method, but here, the output is logged on the fly instead of at the end
         of the sub-process.
@@ -596,6 +598,7 @@ class PythonEnvironment:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             shell=shell,
+            **({"env": env_vars} if env_vars is not None else {}),
         )
 
         full_output: List[str] = []

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -355,7 +355,7 @@ class CLIGitProvider(GitProvider):
         process_env["GIT_ASKPASS"] = "true"
         cmd = ["git", "clone", "--progress", src, dest]
 
-        return_code, _ = env.PythonEnvironment.run_command_and_stream_output(cmd)
+        return_code, _ = env.PythonEnvironment.run_command_and_stream_output(cmd, env_vars=process_env)
 
         if return_code != 0:
             raise Exception(f"An unexpected error occurred while cloning into {dest} from {src}.")


### PR DESCRIPTION
# Description

In PR #4554 it was forgotten to wire the `GIT_ASKPASS` environment to the fork of the `git clone` command. This PR resolves that problem.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
