### PR TITLE
Fix incorrect assignment in test case

### DIFF
--- a/changelogs/unreleased/fix-incorrect-assignment-modulev2metadata.yml
+++ b/changelogs/unreleased/fix-incorrect-assignment-modulev2metadata.yml
@@ -1,0 +1,4 @@
+---
+description: Fix incorrect assignment to module.ModuleV2Metadata
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -1321,7 +1321,7 @@ def test_constraints_logging_v2(modules_v2_dir, tmpdir, caplog, snippetcompiler_
     caplog.set_level(logging.DEBUG)
     index: PipIndex = PipIndex(artifact_dir=os.path.join(str(tmpdir), ".custom-index"))
 
-    module.ModuleV2Metadata = module_from_template(
+    module_from_template(
         os.path.join(modules_v2_dir, "minimalv2module"),
         os.path.join(str(tmpdir), "module_a_low"),
         new_version=version.Version("8.8.8"),
@@ -1330,7 +1330,7 @@ def test_constraints_logging_v2(modules_v2_dir, tmpdir, caplog, snippetcompiler_
         publish_index=index,
     )
 
-    module.ModuleV2Metadata = module_from_template(
+    module_from_template(
         os.path.join(modules_v2_dir, "minimalv2module"),
         os.path.join(str(tmpdir), "module_a_high"),
         new_version=version.Version("9.9.9"),
@@ -1339,7 +1339,7 @@ def test_constraints_logging_v2(modules_v2_dir, tmpdir, caplog, snippetcompiler_
         publish_index=index,
     )
 
-    module.ModuleV2Metadata = module_from_template(
+    module_from_template(
         os.path.join(modules_v2_dir, "minimalv2module"),
         os.path.join(str(tmpdir), "module_b"),
         new_version=version.Version("8.8.8"),


### PR DESCRIPTION
# Description

This PR fixes an issue in the test suite where `module.ModuleV2Metadata` is incorrectly overwritten. This issue was introduced in #4554. It lead to the following exception in the tests:

```
__________________________________ test_to_v2 __________________________________

    def test_to_v2():
        """
        Test whether the `to_v2()` method of `ModuleV1Metadata` works correctly.
        """
        v1_metadata = module.ModuleV1Metadata(
            name="a_test_module",
            description="A description",
            version="1.2.3",
            license="Apache 2.0",
            compiler_version="4.5.6",
            requires=["module_dep_1", "module_dep_2"],
        )
>       v2_metadata = v1_metadata.to_v2()

tests/test_modules.py:107: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = ModuleV1Metadata(requires=['module_dep_1', 'module_dep_2'], name='a_test_module', description='A description', freeze_recursive=False, freeze_operator='~=', version='1.2.3', license='Apache 2.0', compiler_version='4.5.6')

    def to_v2(self) -> "ModuleV2Metadata":
        values = self.dict()
        if values["description"] is not None:
            values["description"] = values["description"].replace("\n", " ")
        del values["compiler_version"]
        install_requires = [ModuleV2Source.get_package_name_for(r) for r in values["requires"]]
        del values["requires"]
        values["name"] = ModuleV2Source.get_package_name_for(values["name"])
>       return ModuleV2Metadata(**values, install_requires=install_requires)
E       TypeError: 'ModuleV2Metadata' object is not callable
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
