### PR TITLE
Make test case use snippetcompiler_clean fixture

### DIFF
--- a/changelogs/unreleased/use-snippetcompiler-clean-fixture.yml
+++ b/changelogs/unreleased/use-snippetcompiler-clean-fixture.yml
@@ -1,0 +1,4 @@
+---
+description: Fix test case that uses the snippetcompiler fixture while it should use the snippetcompiler_clean fixture.
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -1209,7 +1209,7 @@ def test_no_matching_distribution(local_module_package_index: str, snippetcompil
 
 
 @pytest.mark.slowtest
-def test_version_snapshot(local_module_package_index: str, snippetcompiler, caplog, modules_v2_dir, tmpdir):
+def test_version_snapshot(local_module_package_index: str, snippetcompiler_clean, caplog, modules_v2_dir, tmpdir):
     """
     Make sure the logs contain the correct version snapshot after each module installation.
     """
@@ -1259,7 +1259,7 @@ def test_version_snapshot(local_module_package_index: str, snippetcompiler, capl
 
     # Scenario 1
     # Installing module b
-    snippetcompiler.setup_for_snippet(
+    snippetcompiler_clean.setup_for_snippet(
         f"""
         import {module.ModuleV2.get_name_from_metadata(module_b)}
         """,
@@ -1284,7 +1284,7 @@ Modules versions after installation:
 
     # Scenario 2
     # Installing module c in the same environment
-    snippetcompiler.setup_for_snippet(
+    snippetcompiler_clean.setup_for_snippet(
         f"""
         import {module.ModuleV2.get_name_from_metadata(module_c)}
         """,


### PR DESCRIPTION
# Description

The test case `test_version_snapshot` was using the `snippetcompiler` fixture while it should use the `snippetcompiler_clean` fixture. This PR resolved that problem.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
