### PR TITLE
Fix agent restart storm

### DIFF
--- a/changelogs/unreleased/4398-fix-agent-restart-storm.yml
+++ b/changelogs/unreleased/4398-fix-agent-restart-storm.yml
@@ -1,6 +1,6 @@
 ---
 description: Fix issue that causes an agent restart storm for all agents on an agent process when an agent on that process is paused.
-issue-nr: 2508
+issue-nr: 4398
 issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso5, iso4]

--- a/changelogs/unreleased/4398-fix-agent-restart-storm.yml
+++ b/changelogs/unreleased/4398-fix-agent-restart-storm.yml
@@ -1,0 +1,9 @@
+---
+description: Fix issue that causes an agent restart storm for all agents on an agent process when an agent on that process is paused.
+issue-nr: 2508
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"
+  minor-improvement: "When the AutostartedAgentManager starts a new agent process, it now uses a dynamic timeout on the time to wait until all agents are active. The AutostartedAgentManager raises a timeout as soon as no new agent has become active in the past five seconds."

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2938,26 +2938,6 @@ class AgentInstance(BaseDocument):
         return objects
 
     @classmethod
-    async def active_for_many(
-        cls: Type[TAgentInstance],
-        tid: uuid.UUID,
-        endpoints: List[str],
-    ) -> List[TAgentInstance]:
-        """
-        Return the AgentInstances for the given endpoints in the given environment that
-        are not expired (are in the up or paused state).
-        """
-        in_query = ",".join(f"${i+2}" for i in range(len(endpoints)))
-        query = f"""
-SELECT *
-FROM {cls.table_name()}
-WHERE tid=$1 AND name IN ({in_query}) AND expired is NULL
-        """
-        values = [cls._get_value(tid)] + [cls._get_value(ep) for ep in endpoints]
-        records = await cls._fetch_query(query, *values)
-        return [cls(from_postgres=True, **record) for record in records]
-
-    @classmethod
     async def active(cls: Type[TAgentInstance]) -> List[TAgentInstance]:
         objects = await cls.get_list(expired=None)
         return objects

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2943,6 +2943,9 @@ class AgentInstance(BaseDocument):
         tid: uuid.UUID,
         endpoints: List[str],
     ) -> List[TAgentInstance]:
+        """
+        Return the AgentInstances for the given endpoints in the given environment.
+        """
         in_query = ",".join(f"${i+2}" for i in range(len(endpoints)))
         query = f"""
 SELECT *

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2944,7 +2944,8 @@ class AgentInstance(BaseDocument):
         endpoints: List[str],
     ) -> List[TAgentInstance]:
         """
-        Return the AgentInstances for the given endpoints in the given environment.
+        Return the AgentInstances for the given endpoints in the given environment that
+        are not expired (are in the up or paused state).
         """
         in_query = ",".join(f"${i+2}" for i in range(len(endpoints)))
         query = f"""

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -1138,7 +1138,7 @@ class AutostartedAgentManager(ServerSlice):
 
             while nr_active_instances < expected_nr_active_instances:
                 await asyncio.sleep(0.1)
-                if now - int(time.time()) > timeout_in_sec:
+                if int(time.time()) - now > timeout_in_sec:
                     raise asyncio.TimeoutError()
                 instances = await data.AgentInstance.active_for_many(tid=env.id, endpoints=agents)
                 if len(instances) > nr_active_instances:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -52,7 +52,6 @@ from inmanta.server import protocol
 from inmanta.server.protocol import ReturnClient, ServerSlice, SessionListener, SessionManager
 from inmanta.server.server import Server
 from inmanta.types import Apireturn, ArgumentTypes
-from inmanta.util import retry_limited
 
 from ..data.paging import QueryIdentifier
 from . import config as server_config

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import UUID
+from collections import abc
 
 import asyncpg
 
@@ -624,7 +625,7 @@ class AgentManager(ServerSlice, SessionListener):
         """
         Return true iff all the given agents are in the up or the paused state.
         """
-        are_active: Tuple[bool, ...] = await asyncio.gather(*[self.is_agent_active(tid, e) for e in endpoints])
+        are_active: abc.Sequence[bool] = await asyncio.gather(*[self.is_agent_active(tid, e) for e in endpoints])
         return all(are_active)
 
     async def is_agent_active(self, tid: uuid.UUID, endpoint: str) -> bool:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -22,11 +22,11 @@ import sys
 import time
 import uuid
 from asyncio import queues, subprocess
+from collections import abc
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import UUID
-from collections import abc
 
 import asyncpg
 

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -36,7 +36,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from logging import Logger
 from types import TracebackType
-from typing import Awaitable, Callable, Coroutine, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import Awaitable, Callable, Coroutine, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union, cast
+from collections import abc
 
 from tornado import gen
 from tornado.ioloop import IOLoop
@@ -463,7 +464,11 @@ def add_future(future: Union[Future, Coroutine]) -> Task:
 
 
 async def retry_limited(
-    fun: Callable[[...], Union[bool, Awaitable[bool]]], timeout: float, interval: float = 0.1, *args, **kwargs
+    fun: Union[abc.Callable[..., bool], abc.Callable[..., abc.Awaitable[bool]]],
+    timeout: float,
+    interval: float = 0.1,
+    *args: object,
+    **kwargs: object,
 ) -> None:
     async def fun_wrapper() -> bool:
         if inspect.iscoroutinefunction(fun):

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -462,8 +462,14 @@ def add_future(future: Union[Future, Coroutine]) -> Task:
     return task
 
 
-async def retry_limited(fun, timeout, interval: float = 0.1, *args, **kwargs):
-    async def fun_wrapper():
+async def retry_limited(
+    fun: Callable[[...], Union[bool, Awaitable[bool]]],
+    timeout: float,
+    interval: float = 0.1,
+    *args,
+    **kwargs
+) -> None:
+    async def fun_wrapper() -> bool:
         if inspect.iscoroutinefunction(fun):
             return await fun(*args, **kwargs)
         else:

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -31,7 +31,7 @@ import time
 import uuid
 import warnings
 from abc import ABC, abstractmethod
-from asyncio import CancelledError, Future, Lock, Task, ensure_future, gather, sleep
+from asyncio import CancelledError, Future, Lock, Task, ensure_future, gather
 from collections import defaultdict
 from dataclasses import dataclass
 from logging import Logger
@@ -463,11 +463,7 @@ def add_future(future: Union[Future, Coroutine]) -> Task:
 
 
 async def retry_limited(
-    fun: Callable[[...], Union[bool, Awaitable[bool]]],
-    timeout: float,
-    interval: float = 0.1,
-    *args,
-    **kwargs
+    fun: Callable[[...], Union[bool, Awaitable[bool]]], timeout: float, interval: float = 0.1, *args, **kwargs
 ) -> None:
     async def fun_wrapper() -> bool:
         if inspect.iscoroutinefunction(fun):

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -32,12 +32,11 @@ import uuid
 import warnings
 from abc import ABC, abstractmethod
 from asyncio import CancelledError, Future, Lock, Task, ensure_future, gather
-from collections import defaultdict
+from collections import abc, defaultdict
 from dataclasses import dataclass
 from logging import Logger
 from types import TracebackType
-from typing import Awaitable, Callable, Coroutine, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union, cast
-from collections import abc
+from typing import Awaitable, Callable, Coroutine, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from tornado import gen
 from tornado.ioloop import IOLoop

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -462,11 +462,17 @@ def add_future(future: Union[Future, Coroutine]) -> Task:
     return task
 
 
-async def retry_limited(fun: Callable[[], bool], timeout: float, interval: float = 0.1) -> None:
+async def retry_limited(fun, timeout, interval: float = 0.1, *args, **kwargs):
+    async def fun_wrapper():
+        if inspect.iscoroutinefunction(fun):
+            return await fun(*args, **kwargs)
+        else:
+            return fun(*args, **kwargs)
+
     start = time.time()
-    while time.time() - start < timeout and not fun():
-        await sleep(interval)
-    if not fun():
+    while time.time() - start < timeout and not (await fun_wrapper()):
+        await asyncio.sleep(interval)
+    if not (await fun_wrapper()):
         raise asyncio.TimeoutError()
 
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1242,21 +1242,21 @@ async def test_are_agents_active(server, client, environment, agent_factory) -> 
     env_id = UUID(environment)
     env = await data.Environment.get_by_id(env_id)
 
-    # The agent is not started ->  it should not be available
+    # The agent is not started yet ->  it should not be active
     assert (not await agentmanager.are_agents_active(tid=env_id, endpoints=[agent_name]))
 
     # Start agent
     await agentmanager.ensure_agent_registered(env, agent_name)
     await agent_factory(environment=environment, agent_map={agent_name: ""}, agent_names=[agent_name])
 
-    # Verify agent is available
+    # Verify agent is active
     await retry_limited(agentmanager.are_agents_active, tid=env_id, endpoints=[agent_name], timeout=10)
 
     # Pause agent
     result = await client.agent_action(tid=env_id, name=agent_name, action=AgentAction.pause.value)
     assert result.code == 200, result.result
 
-    # Ensure the agent is still available
+    # Ensure the agent is still active
     await retry_limited(agentmanager.are_agents_active, tid=env_id, endpoints=[agent_name], timeout=10)
 
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -24,7 +24,6 @@ from asyncio import subprocess
 from typing import Dict, List, Optional, Set, Tuple
 from unittest.mock import Mock
 from uuid import UUID, uuid4
-import functools
 
 import pytest
 
@@ -1243,7 +1242,7 @@ async def test_are_agents_active(server, client, environment, agent_factory) -> 
     env = await data.Environment.get_by_id(env_id)
 
     # The agent is not started yet ->  it should not be active
-    assert (not await agentmanager.are_agents_active(tid=env_id, endpoints=[agent_name]))
+    assert not await agentmanager.are_agents_active(tid=env_id, endpoints=[agent_name])
 
     # Start agent
     await agentmanager.ensure_agent_registered(env, agent_name)

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -24,6 +24,7 @@ from asyncio import subprocess
 from typing import Dict, List, Optional, Set, Tuple
 from unittest.mock import Mock
 from uuid import UUID, uuid4
+import functools
 
 import pytest
 
@@ -1228,3 +1229,67 @@ async def test_error_handling_agent_fork(server, environment, monkeypatch):
         await autostarted_agent_manager._ensure_agents(env=env, agents=["internal"], restart=True)
 
     assert exception_message in str(excinfo.value)
+
+
+async def test_are_agents_active(server, client, environment, agent_factory) -> None:
+    """
+    Ensure that the `AgentManager.are_agents_active()` method returns True when an agent
+    is in the up or the paused state.
+    """
+    agent_config.use_autostart_agent_map.set("True")
+    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
+    agent_name = "agent1"
+    env_id = UUID(environment)
+    env = await data.Environment.get_by_id(env_id)
+
+    # The agent is not started ->  it should not be available
+    assert (not await agentmanager.are_agents_active(tid=env_id, endpoints=[agent_name]))
+
+    # Start agent
+    await agentmanager.ensure_agent_registered(env, agent_name)
+    await agent_factory(environment=environment, agent_map={agent_name: ""}, agent_names=[agent_name])
+
+    # Verify agent is available
+    await retry_limited(agentmanager.are_agents_active, tid=env_id, endpoints=[agent_name], timeout=10)
+
+    # Pause agent
+    result = await client.agent_action(tid=env_id, name=agent_name, action=AgentAction.pause.value)
+    assert result.code == 200, result.result
+
+    # Ensure the agent is still available
+    await retry_limited(agentmanager.are_agents_active, tid=env_id, endpoints=[agent_name], timeout=10)
+
+
+async def test_dont_start_paused_agent(server, client, environment, caplog) -> None:
+    """
+    Ensure that the AutostartedAgentManager doesn't try to start an agent that is paused (inmanta/inmanta-core#4398).
+    """
+    env_id = UUID(environment)
+    agent_name = "agent1"
+
+    # Register agent in model
+    agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
+    env = await data.Environment.get_by_id(env_id)
+    await agent_manager.ensure_agent_registered(env=env, nodename=agent_name)
+
+    # Add agent1 to AUTOSTART_AGENT_MAP
+    result = await client.set_setting(tid=environment, id=data.AUTOSTART_AGENT_MAP, value={"internal": "", agent_name: ""})
+    assert result.code == 200, result.result
+
+    # Start agent1
+    autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
+    env = await data.Environment.get_by_id(env_id)
+    caplog.clear()
+    await autostarted_agent_manager._ensure_agents(env=env, agents=[agent_name])
+    assert len(autostarted_agent_manager._agent_procs) == 1
+    assert "Started new agent with PID" in caplog.text
+
+    # Pause agent1
+    result = await client.agent_action(tid=env_id, name=agent_name, action=AgentAction.pause.value)
+    assert result.code == 200, result.result
+
+    # Execute _ensure_agents() again and verify that no restart is triggered
+    caplog.clear()
+    await autostarted_agent_manager._ensure_agents(env=env, agents=[agent_name])
+    assert len(autostarted_agent_manager._agent_procs) == 1
+    assert "Started new agent with PID" not in caplog.text

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,7 +47,13 @@ from libpip2pi.commands import dir2pi
 from packaging import version
 
 
-async def retry_limited(fun, timeout, interval: float = 0.1, *args, **kwargs):
+async def retry_limited(
+    fun: Union[abc.Callable[..., bool], abc.Callable[..., abc.Awaitable[bool]]],
+    timeout: float,
+    interval: float = 0.1,
+    *args: object,
+    **kwargs: object,
+) -> None:
     async def fun_wrapper():
         if inspect.iscoroutinefunction(fun):
             return await fun(*args, **kwargs)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,7 +47,7 @@ from libpip2pi.commands import dir2pi
 from packaging import version
 
 
-async def retry_limited(fun, timeout, *args, **kwargs):
+async def retry_limited(fun, timeout, interval: float = 0.1, *args, **kwargs):
     async def fun_wrapper():
         if inspect.iscoroutinefunction(fun):
             return await fun(*args, **kwargs)
@@ -56,7 +56,7 @@ async def retry_limited(fun, timeout, *args, **kwargs):
 
     start = time.time()
     while time.time() - start < timeout and not (await fun_wrapper()):
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(interval)
     if not (await fun_wrapper()):
         raise AssertionError("Bounded wait failed")
 


### PR DESCRIPTION
# Description

This PR:

* Ensures that paused agent are considered started to prevent an agent restart storm when there is a paused agent
* Adds a dynamic timeout to the AutostartedAgentManager on the time to wait until all AgentInstances of a newly started agent are active. A timeout will occur when not all AgentInstances are active and no new agent has become active in the last 5 seconds.

closes #4398

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
