### PR TITLE
db dump tool: include sql file extension

### DIFF
--- a/changelogs/unreleased/db-dump-tool-sql-extension.yml
+++ b/changelogs/unreleased/db-dump-tool-sql-extension.yml
@@ -1,0 +1,6 @@
+description: "db dump tool: include sql file extension for .editorconfig compatibility"
+change-type: patch
+destination-branches:
+  - iso4
+  - iso5
+  - master

--- a/tests/db/dump_tool.py
+++ b/tests/db/dump_tool.py
@@ -60,7 +60,7 @@ async def test_dump_db(server, client, postgres_db, database_name):
 
     project_dir = os.path.join(server.get_slice(SLICE_SERVER)._server_storage["environments"], str(env_id_1))
     project_source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "data", "simple_project")
-    outname = "dbdump"
+    outname = "dbdump.sql"
     print("Project at: ", project_dir)
 
     shutil.copytree(project_source, project_dir)


### PR DESCRIPTION
# Description

The `.editorconfig` contains
```
[*.sql]
trim_trailing_whitespace = false
```
Since this is rather important it would be helpful if the generated file already has the appropriate extension. As a small bonus it enables syntax highlighting.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
