### PR TITLE
Fix agent restart storm

### DIFF
--- a/changelogs/unreleased/4398-fix-agent-restart-storm.yml
+++ b/changelogs/unreleased/4398-fix-agent-restart-storm.yml
@@ -3,7 +3,7 @@ description: Fix issue that causes an agent restart storm for all agents on an a
 issue-nr: 4398
 issue-repo: inmanta-core
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso4]
 sections:
   bugfix: "{{description}}"
   minor-improvement: "When the AutostartedAgentManager starts a new agent process, it now uses a dynamic timeout on the time to wait until all agents are active. The AutostartedAgentManager raises a timeout as soon as no new agent has become active in the past five seconds."

--- a/changelogs/unreleased/4398-fix-agent-restart-storm.yml
+++ b/changelogs/unreleased/4398-fix-agent-restart-storm.yml
@@ -1,0 +1,9 @@
+---
+description: Fix issue that causes an agent restart storm for all agents on an agent process when an agent on that process is paused.
+issue-nr: 4398
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"
+  minor-improvement: "When the AutostartedAgentManager starts a new agent process, it now uses a dynamic timeout on the time to wait until all agents are active. The AutostartedAgentManager raises a timeout as soon as no new agent has become active in the past five seconds."

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1145,3 +1145,67 @@ async def test_error_handling_agent_fork(server, environment, monkeypatch):
         await autostarted_agent_manager._ensure_agents(env=env, agents=["internal"], restart=True)
 
     assert exception_message in str(excinfo.value)
+
+
+async def test_are_agents_active(server, client, environment, agent_factory) -> None:
+    """
+    Ensure that the `AgentManager.are_agents_active()` method returns True when an agent
+    is in the up or the paused state.
+    """
+    agent_config.use_autostart_agent_map.set("True")
+    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
+    agent_name = "agent1"
+    env_id = UUID(environment)
+    env = await data.Environment.get_by_id(env_id)
+
+    # The agent is not started yet ->  it should not be active
+    assert not await agentmanager.are_agents_active(tid=env_id, endpoints=[agent_name])
+
+    # Start agent
+    await agentmanager.ensure_agent_registered(env, agent_name)
+    await agent_factory(environment=environment, agent_map={agent_name: ""}, agent_names=[agent_name])
+
+    # Verify agent is active
+    await retry_limited(agentmanager.are_agents_active, tid=env_id, endpoints=[agent_name], timeout=10)
+
+    # Pause agent
+    result = await client.agent_action(tid=env_id, name=agent_name, action=AgentAction.pause.value)
+    assert result.code == 200, result.result
+
+    # Ensure the agent is still active
+    await retry_limited(agentmanager.are_agents_active, tid=env_id, endpoints=[agent_name], timeout=10)
+
+
+async def test_dont_start_paused_agent(server, client, environment, caplog) -> None:
+    """
+    Ensure that the AutostartedAgentManager doesn't try to start an agent that is paused (inmanta/inmanta-core#4398).
+    """
+    env_id = UUID(environment)
+    agent_name = "agent1"
+
+    # Register agent in model
+    agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
+    env = await data.Environment.get_by_id(env_id)
+    await agent_manager.ensure_agent_registered(env=env, nodename=agent_name)
+
+    # Add agent1 to AUTOSTART_AGENT_MAP
+    result = await client.set_setting(tid=environment, id=data.AUTOSTART_AGENT_MAP, value={"internal": "", agent_name: ""})
+    assert result.code == 200, result.result
+
+    # Start agent1
+    autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
+    env = await data.Environment.get_by_id(env_id)
+    caplog.clear()
+    await autostarted_agent_manager._ensure_agents(env=env, agents=[agent_name])
+    assert len(autostarted_agent_manager._agent_procs) == 1
+    assert "Started new agent with PID" in caplog.text
+
+    # Pause agent1
+    result = await client.agent_action(tid=env_id, name=agent_name, action=AgentAction.pause.value)
+    assert result.code == 200, result.result
+
+    # Execute _ensure_agents() again and verify that no restart is triggered
+    caplog.clear()
+    await autostarted_agent_manager._ensure_agents(env=env, agents=[agent_name])
+    assert len(autostarted_agent_manager._agent_procs) == 1
+    assert "Started new agent with PID" not in caplog.text

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,7 +20,7 @@ import datetime
 import json
 import logging
 import uuid
-from typing import Any, Dict, Union, Callable, Awaitable
+from typing import Any, Awaitable, Callable, Dict, Union
 
 import pytest
 from pkg_resources import parse_version

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,36 +17,33 @@
 """
 import asyncio
 import datetime
-import inspect
 import json
 import logging
-import time
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Union, Callable, Awaitable
 
 import pytest
 from pkg_resources import parse_version
 from pydantic.tools import lru_cache
 
 from _pytest.mark import MarkDecorator
-from inmanta import data
+from inmanta import data, util
 from inmanta.protocol import Client
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.extensions import ProductMetadata
 from inmanta.util import get_compiler_version
 
 
-async def retry_limited(fun, timeout, *args, **kwargs):
-    async def fun_wrapper():
-        if inspect.iscoroutinefunction(fun):
-            return await fun(*args, **kwargs)
-        else:
-            return fun(*args, **kwargs)
-
-    start = time.time()
-    while time.time() - start < timeout and not (await fun_wrapper()):
-        await asyncio.sleep(0.1)
-    if not (await fun_wrapper()):
+async def retry_limited(
+    fun: Union[Callable[..., bool], Callable[..., Awaitable[bool]]],
+    timeout: float,
+    interval: float = 0.1,
+    *args: object,
+    **kwargs: object,
+) -> None:
+    try:
+        await util.retry_limited(fun, timeout, interval, *args, **kwargs)
+    except asyncio.TimeoutError:
         raise AssertionError("Bounded wait failed")
 
 


### PR DESCRIPTION
# Description

**Same PR as #4696 but scoped to the ISO4 branch now, due to a merge conflict.**

This PR:

* Ensures that paused agent are considered started to prevent an agent restart storm when there is a paused agent
* Adds a dynamic timeout to the AutostartedAgentManager on the time to wait until all AgentInstances of a newly started agent are active. A timeout will occur when not all AgentInstances are active and no new agent has become active in the last 5 seconds.

closes #4398

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
