### PR TITLE
improved compatibility with PEP660 and latest setuptools

### DIFF
--- a/changelogs/unreleased/pep660-increased-compatibility.yml
+++ b/changelogs/unreleased/pep660-increased-compatibility.yml
@@ -1,0 +1,7 @@
+description: Improved editable v2 module compatibility with latest setuptools and PEP660 in edge case scenarios.
+sections:
+  minor-improvement: "{{description}}"
+change-type: patch
+destination-branches:
+  - iso5
+  - master

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -935,7 +935,9 @@ class ActiveEnv(PythonEnvironment):
     @classmethod
     def get_module_file(cls, module: str) -> Optional[Tuple[Optional[str], Loader]]:
         """
-        Get the location of the init file for a Python module within the active environment.
+        Get the location of the init file for a Python module within the active environment. Returns the file path as observed
+        by Python. For editable installs, this may or may not be a symlink to the actual location (see implementation
+        mechanisms in setuptools docs: https://setuptools.pypa.io/en/latest/userguide/development_mode.html).
 
         :return: A tuple of the path and the associated loader, if the module is found.
         """

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -700,7 +700,11 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
             return None
         if init is None:
             raise InvalidModuleException(f"Package {package} was installed but no __init__.py file could be found.")
-        pkg_installation_dir = os.path.abspath(os.path.dirname(init))
+        # TODO: test case
+        # In case of editable installs the path may contain symlinks to actual location (see
+        # PythonEnvironment.get_module_file docstring). Since modules contain non-Python files (of which setuptools may not be
+        # aware, therefore they may not exist in the link structure), we need the real path.
+        pkg_installation_dir = os.path.dirname(os.path.realpath(init))
         if os.path.exists(os.path.join(pkg_installation_dir, ModuleV2.MODULE_FILE)):
             # normal install: __init__.py is in module root
             return pkg_installation_dir

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -700,7 +700,6 @@ class ModuleV2Source(ModuleSource["ModuleV2"]):
             return None
         if init is None:
             raise InvalidModuleException(f"Package {package} was installed but no __init__.py file could be found.")
-        # TODO: test case
         # In case of editable installs the path may contain symlinks to actual location (see
         # PythonEnvironment.get_module_file docstring). Since modules contain non-Python files (of which setuptools may not be
         # aware, therefore they may not exist in the link structure), we need the real path.

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -1327,12 +1327,10 @@ class Test(Resource):
 
 @pytest.mark.skipif(
     "inmanta-core" in process_env.get_installed_packages(only_editable=True),
-    reason="Inmanta package protection in env.install_* not compatible with editable core in non-inherited venv."
+    reason="Inmanta package protection in env.install_* not compatible with editable core in non-inherited venv.",
 )
 @pytest.mark.slowtest
-async def test_v2_module_editable_with_links(
-    tmpvenv_active: tuple[py.path.local, py.path.local], modules_v2_dir: str
-) -> None:
+async def test_v2_module_editable_with_links(tmpvenv_active: tuple[py.path.local, py.path.local], modules_v2_dir: str) -> None:
     """
     One possible implementation mechanism for editable installs
     (https://setuptools.pypa.io/en/latest/userguide/development_mode.html#how-editable-installations-work) is to use a farm of

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -27,7 +27,7 @@ import py
 import pytest
 from pkg_resources import Requirement
 
-from inmanta import loader, plugins, resources
+from inmanta import const, loader, plugins, resources
 from inmanta.ast import CompilerException
 from inmanta.const import CF_CACHE_DIR
 from inmanta.env import ConflictingRequirements, LocalPackagePath, process_env
@@ -1323,3 +1323,34 @@ class Test(Resource):
                 assert info.path[-4:] == ".pyc"
 
     assert module_code
+
+
+@pytest.mark.skipif(
+    "inmanta-core" in process_env.get_installed_packages(only_editable=True),
+    reason="Inmanta package protection in env.install_* not compatible with editable core in non-inherited venv."
+)
+@pytest.mark.slowtest
+async def test_v2_module_editable_with_links(
+    tmpvenv_active: tuple[py.path.local, py.path.local], modules_v2_dir: str
+) -> None:
+    """
+    One possible implementation mechanism for editable installs
+    (https://setuptools.pypa.io/en/latest/userguide/development_mode.html#how-editable-installations-work) is to use a farm of
+    symlinks to the actual source files. Since setuptools is not necessarily aware of a module's non-Python files we need to
+    ensure our module discovery implementation is robust against this. Because setuptools provides no guarantees as to which
+    mechanism is used under which circumstances, we mimic such an editable install here.
+    """
+    module_dir: str = os.path.join(modules_v2_dir, "minimalv2module")
+    # start with non-editable install to populate site-packages with appropriate metadata (editable install would create pth
+    # files if a different mechanism is picked so we want to avoid that).
+    process_env.install_from_source([LocalPackagePath(path=module_dir, editable=False)])
+    # replace module dir in site-packages with symlink
+    rel_path_src: str = os.path.join(const.PLUGINS_PACKAGE, "minimalv2module")
+    module_dir_site_packages: str = os.path.join(process_env.site_packages_dir, rel_path_src)
+    shutil.rmtree(module_dir_site_packages)
+    os.symlink(os.path.join(module_dir, rel_path_src), module_dir_site_packages)
+
+    # verify that module can be found
+    module: Optional[ModuleV2] = ModuleV2Source([]).get_installed_module(DummyProject(autostd=False), "minimalv2module")
+    assert module is not None
+    assert module.path == module_dir


### PR DESCRIPTION
# Description

Improved editable v2 module compatibility with latest setuptools and PEP660 in edge case scenarios.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
