### PR TITLE
Fix wait condition on start of autostarted agents

### DIFF
--- a/changelogs/unreleased/4722-fix-wait-condition-autostartedagentmgr.yml
+++ b/changelogs/unreleased/4722-fix-wait-condition-autostartedagentmgr.yml
@@ -1,0 +1,6 @@
+---
+description: Ensure that the AutostartedAgentManager waits until all required agents have a primary.
+issue-nr: 4722
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -1126,23 +1126,30 @@ class AutostartedAgentManager(ServerSlice):
             A TimeoutError is raised when not all AgentInstances are active and no new AgentInstance
             became active in the last 5 seconds.
             """
+            agent_statuses: Dict[str, Optional[AgentStatus]] = await data.Agent.get_statuses(env.id, set(agents))
+            # Only wait for agents that are not paused
+            expected_agents_in_up_state: Set[str] = {
+                agent_name
+                for agent_name, status in agent_statuses.items()
+                if status is not None and status is not AgentStatus.paused
+            }
+            actual_agents_in_up_state: Set[str] = set()
             timeout_in_sec = 5
-            nr_active_instances = 0
-            expected_nr_active_instances = len(agents)
             now = int(time.time())
 
-            while nr_active_instances < expected_nr_active_instances:
+            while len(expected_agents_in_up_state) != len(actual_agents_in_up_state):
                 await asyncio.sleep(0.1)
                 if int(time.time()) - now > timeout_in_sec:
                     raise asyncio.TimeoutError()
-                agent_statuses: List[Tuple[str, bool]] = await self._agent_manager.get_agent_active_status(
-                    tid=env.id, endpoints=agents
-                )
-                new_nr_active_instances = sum(1 for (_, active) in agent_statuses if active)
-                if new_nr_active_instances > nr_active_instances:
+                new_actual_agents_in_up_state = {
+                    agent_name
+                    for agent_name in expected_agents_in_up_state
+                    if (env.id, agent_name) in self._agent_manager.tid_endpoint_to_session
+                }
+                if len(new_actual_agents_in_up_state) > len(actual_agents_in_up_state):
                     # Reset timeout timer because a new instance became active
                     now = int(time.time())
-                nr_active_instances = new_nr_active_instances
+                actual_agents_in_up_state = new_actual_agents_in_up_state
 
         # Wait for all agents to start
         try:

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1263,6 +1263,7 @@ async def test_dont_start_paused_agent(server, client, environment, caplog) -> N
     """
     Ensure that the AutostartedAgentManager doesn't try to start an agent that is paused (inmanta/inmanta-core#4398).
     """
+    caplog.set_level(logging.DEBUG)
     env_id = UUID(environment)
     agent_name = "agent1"
 
@@ -1278,10 +1279,15 @@ async def test_dont_start_paused_agent(server, client, environment, caplog) -> N
     # Start agent1
     autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
     env = await data.Environment.get_by_id(env_id)
+    assert (env_id, agent_name) not in agent_manager.tid_endpoint_to_session
     caplog.clear()
     await autostarted_agent_manager._ensure_agents(env=env, agents=[agent_name])
+    # Ensure we wait until a primary has been elected for agent1
+    assert (env_id, agent_name) in agent_manager.tid_endpoint_to_session
     assert len(autostarted_agent_manager._agent_procs) == 1
     assert "Started new agent with PID" in caplog.text
+    # Ensure no timeout happened
+    assert "took too long to start" not in caplog.text
 
     # Pause agent1
     result = await client.agent_action(tid=env_id, name=agent_name, action=AgentAction.pause.value)
@@ -1292,3 +1298,5 @@ async def test_dont_start_paused_agent(server, client, environment, caplog) -> N
     await autostarted_agent_manager._ensure_agents(env=env, agents=[agent_name])
     assert len(autostarted_agent_manager._agent_procs) == 1
     assert "Started new agent with PID" not in caplog.text
+    # Ensure no timeout happened
+    assert "took too long to start" not in caplog.text


### PR DESCRIPTION
# Description

Ensure that the `AutostartedAgentManager` waits until all required agents have a primary.

closes #4722 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
