### PR TITLE
Fix race condition in test case test_autostart_mapping_update_uri

### DIFF
--- a/changelogs/unreleased/fix-race-in-test-autostart-mapping-update-uri.yml
+++ b/changelogs/unreleased/fix-race-in-test-autostart-mapping-update-uri.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in test case `test_autostart_mapping_update_uri`
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -1533,8 +1533,6 @@ async def test_autostart_mapping_update_uri(server, client, environment, async_f
     env_uuid = uuid.UUID(environment)
     agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
     agent_name = "internal"
-    result = await client.set_setting(environment, data.AUTOSTART_AGENT_MAP, {agent_name: ""})
-    assert result.code == 200
 
     # Start agent
     a = agent.Agent(hostname=agent_name, environment=env_uuid, code_loader=False)
@@ -1553,7 +1551,7 @@ async def test_autostart_mapping_update_uri(server, client, environment, async_f
     result = await client.set_setting(environment, data.AUTOSTART_AGENT_MAP, {agent_name: "localhost"})
     assert result.code == 200
 
-    await retry_limited(lambda: f"Updating the URI of the endpoint {agent_name} from  to localhost" in caplog.text, 10)
+    await retry_limited(lambda: f"Updating the URI of the endpoint {agent_name} from local: to localhost" in caplog.text, 10)
 
     # Pause agent
     result = await client.agent_action(tid=env_uuid, name="internal", action=const.AgentAction.pause.value)
@@ -1561,10 +1559,10 @@ async def test_autostart_mapping_update_uri(server, client, environment, async_f
 
     # Update agentmap when internal agent is paused
     caplog.clear()
-    result = await client.set_setting(environment, data.AUTOSTART_AGENT_MAP, {agent_name: ""})
+    result = await client.set_setting(environment, data.AUTOSTART_AGENT_MAP, {agent_name: "local:"})
     assert result.code == 200
 
-    await retry_limited(lambda: f"Updating the URI of the endpoint {agent_name} from localhost to " in caplog.text, 10)
+    await retry_limited(lambda: f"Updating the URI of the endpoint {agent_name} from localhost to local:" in caplog.text, 10)
 
 
 async def test_autostart_clear_environment(server, client, resource_container, environment, no_agent_backoff):


### PR DESCRIPTION
# Description

The race condition is triggered by the API call to `client.set_setting()`. That endpoint starts a background task that call the `notify_agent_about_agent_map_update()` endpoint on the agent, which produces the log line of the form `Updating the URI of the endpoint <endpoint> from <x> to <y>` when the impacted agent has a session with the server. The race condition happens when the agent, started by the test case, establishes a session with the server before the background task started by the first call to `client.set_setting()` finishes. In that case the `notify_agent_about_agent_map_update()` endpoint is called twice on the agent before the first assertion on the log output happens. This results in the following two log lines:

```
Updating the URI of the endpoint internal from local: to <empty-string>
```
```
Updating the URI of the endpoint internal from <empty-string> to localhost
```
Instead of just one log line when the agent didn't establish a session with the server on time:

```
Updating the URI of the endpoint internal from local: to localhost
```

As such the test case fails, because it cannot find the expected log line in the log. I didn't see a reason for the first `client.set_setting()` call, so I removed it to prevent the race condition.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
