### PR TITLE
Venv inheritance no pythonpath

### DIFF
--- a/changelogs/unreleased/4713-venv-inheritance-no-pythonpath.yml
+++ b/changelogs/unreleased/4713-venv-inheritance-no-pythonpath.yml
@@ -1,0 +1,7 @@
+description: "Don't set PYTHONPATH environment variable on venv activation: fixes editable install compatibility with setuptools<64"
+issue-nr: 4713
+sections:
+  minor-improvement: "{{description}}"
+destination-branches:
+  - iso5
+  - master

--- a/changelogs/unreleased/4713-venv-inheritance-no-pythonpath.yml
+++ b/changelogs/unreleased/4713-venv-inheritance-no-pythonpath.yml
@@ -2,6 +2,7 @@ description: "Don't set PYTHONPATH environment variable on venv activation: fixe
 issue-nr: 4713
 sections:
   minor-improvement: "{{description}}"
+change-type: patch
 destination-branches:
   - iso5
   - master

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -1137,8 +1137,6 @@ import sys
 
 # Ensure inheritance from all parent venvs + process their .pth files
 {add_site_dir_statements}
-# Also set the PYTHONPATH environment variable for any subprocess
-os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
         """
         script_as_oneliner = "; ".join(
             [line for line in script.split("\n") if line.strip() and not line.strip().startswith("#")]
@@ -1174,9 +1172,6 @@ os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
         sys.real_prefix = sys.prefix
         sys.prefix = base
         self._update_sys_path()
-
-        # Also set the python path environment variable for any subprocess
-        os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
 
     def install_from_index(
         self,


### PR DESCRIPTION
# Description
Don't set PYTHONPATH env var on venv activation

closes #4713

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
