### PR TITLE
don't make assumptions about ordering in test querying resources

### DIFF
--- a/changelogs/unreleased/fix-test-case-resource-ordering.yml
+++ b/changelogs/unreleased/fix-test-case-resource-ordering.yml
@@ -1,0 +1,5 @@
+description: don't make assumptions about ordering in test querying resources
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -662,7 +662,10 @@ async def test_put_partial_mixed_scenario(server, client, environment, clienthel
     )
 
     assert result.code == 200, result.result
-    resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
+    resource_list = sorted(
+        await data.Resource.get_resources_in_latest_version(uuid.UUID(environment)),
+        key=lambda r: r.attributes["key"],
+    )
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 9
     assert resource_list[0].attributes == {"key": "key1", "value": "100", "purged": False, "requires": [], "send_event": False}


### PR DESCRIPTION
# Description

Fixes docker-pytest for Ubuntu. I haven't investigated why the ordering is different (postgres SELECT behavior without `ORDER BY` does not seem to be defined, so that might be it) but I don't think that's really relevant.

closes #4733

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
