### PR TITLE
Fixed test case assumption that no external warnings are present

### DIFF
--- a/changelogs/unreleased/fix-test-case-warnings.yml
+++ b/changelogs/unreleased/fix-test-case-warnings.yml
@@ -1,0 +1,6 @@
+description: Fixed test case assumption that no external warnings are present
+change-type: patch
+destination-branches:
+  - iso4
+  - iso5
+  - master

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -199,7 +199,9 @@ C()
     message: str = "No value for attribute __config__::C.n. Assign null instead of leaving unassigned. ({dir}/main.cf:17)"
 
     def match(warning) -> bool:
-        return issubclass(warning.category, CompilerDeprecationWarning) and str(warning.message) == message.format(dir=snippetcompiler.project_dir)
+        return issubclass(warning.category, CompilerDeprecationWarning) and str(warning.message) == message.format(
+            dir=snippetcompiler.project_dir
+        )
 
     with warnings.catch_warnings(record=True) as ws:
         compiler.do_compile()


### PR DESCRIPTION
# Description

docker-pytest Ubuntu failure for iso4 was separate from the iso5+ one.

part of #4733

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
