### PR TITLE
fixed put_partial bug rejecting existing shared resources

### DIFF
--- a/changelogs/unreleased/put-partial-shared-resource-in-partial.yml
+++ b/changelogs/unreleased/put-partial-shared-resource-in-partial.yml
@@ -1,0 +1,5 @@
+description: Fixed bug where including a shared resource that already exists in a partial would be rejected
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -89,8 +89,12 @@ class ResourceWithResourceSet:
             return False
         new_resource_dict = self.resource.dict()
         old_resource_dict = other.resource.dict()
-        attr_names_new_resource = set(new_resource_dict.keys()).difference("id")
-        attr_names_old_resource = set(old_resource_dict.keys()).difference("id")
+        attr_names_new_resource = set(new_resource_dict.keys()).difference({"id", "version"})
+        attr_names_old_resource = set(old_resource_dict.keys()).difference({"id", "version"})
+        if attr_names_new_resource != attr_names_old_resource or any(
+            new_resource_dict[k] != old_resource_dict[k] for k in attr_names_new_resource
+        ):
+            print(new_resource_dict, old_resource_dict, attr_names_new_resource)
         return attr_names_new_resource != attr_names_old_resource or any(
             new_resource_dict[k] != old_resource_dict[k] for k in attr_names_new_resource
         )

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -91,10 +91,6 @@ class ResourceWithResourceSet:
         old_resource_dict = other.resource.dict()
         attr_names_new_resource = set(new_resource_dict.keys()).difference({"id", "version"})
         attr_names_old_resource = set(old_resource_dict.keys()).difference({"id", "version"})
-        if attr_names_new_resource != attr_names_old_resource or any(
-            new_resource_dict[k] != old_resource_dict[k] for k in attr_names_new_resource
-        ):
-            print(new_resource_dict, old_resource_dict, attr_names_new_resource)
         return attr_names_new_resource != attr_names_old_resource or any(
             new_resource_dict[k] != old_resource_dict[k] for k in attr_names_new_resource
         )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -490,6 +490,7 @@ b = Res(name="the_resource_b")
 c = Res(name="the_resource_c")
 d = Res(name="the_resource_d")
 e = Res(name="the_resource_e")
+y = Res(name="the_resource_y")
 z = Res(name="the_resource_z")
 std::ResourceSet(name="resource_set_1", resources=[a,c])
 std::ResourceSet(name="resource_set_2", resources=[b])
@@ -505,6 +506,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
             "the_resource_c": "resource_set_1",
             "the_resource_d": "resource_set_3",
             "the_resource_e": "resource_set_3",
+            "the_resource_y": None,
             "the_resource_z": None,
         },
     )
@@ -521,6 +523,9 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
     a = Res(name="the_resource_a")
     c2 = Res(name="the_resource_c2")
     f = Res(name="the_resource_f")
+    # y is a shared resource, identical to the one in previous compile
+    y = Res(name="the_resource_y")
+    # z is a shared resource not present in this model
     std::ResourceSet(name="resource_set_1", resources=[a,c2])
     std::ResourceSet(name="resource_set_4", resources=[f])
             """,
@@ -535,6 +540,7 @@ std::ResourceSet(name="resource_set_3", resources=[d, e])
             "the_resource_d": "resource_set_3",
             "the_resource_e": "resource_set_3",
             "the_resource_f": "resource_set_4",
+            "the_resource_y": None,
             "the_resource_z": None,
         },
     )


### PR DESCRIPTION
# Description

Fixed bug where including a shared resource that already exists in a partial would be rejected because the version was not excluded from the update check comparison.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
