### PR TITLE
Bump compiler version to 2022.4

### DIFF
--- a/changelogs/unreleased/bump-compiler-version-2022-4.yml
+++ b/changelogs/unreleased/bump-compiler-version-2022-4.yml
@@ -1,0 +1,4 @@
+---
+description: Bump the compiler version to 2022.4
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-COMPILER_VERSION = "2022.3"
+COMPILER_VERSION = "2022.4"
 RUNNING_TESTS = False
 """
     This is enabled/disabled by the test suite when tests are run.


### PR DESCRIPTION
# Description

Bump the compiler version to 2022.4 as the lsm module needs it as a dependency.

Part of inmanta/lsm#481

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
