### PR TITLE
Issue/4761 venv check

### DIFF
--- a/changelogs/unreleased/4761-venv-check.yml
+++ b/changelogs/unreleased/4761-venv-check.yml
@@ -1,4 +1,4 @@
-description: "Fix issue #4761 where the pip consistency check is too strict"
+description: "Fix issue where the pip consistency check is too strict"
 issue-nr: 4761
 change-type: patch
 destination-branches: [master, iso5]

--- a/changelogs/unreleased/4761-venv-check.yml
+++ b/changelogs/unreleased/4761-venv-check.yml
@@ -1,0 +1,6 @@
+description: "Fix issue #4761 where the pip consistency check is too strict"
+issue-nr: 4761
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -835,8 +835,6 @@ class ActiveEnv(PythonEnvironment):
         """
         Return the constraint violations that exist in this venv. Returns a tuple of non-strict and strict violations,
         in that order.
-
-
         """
 
         class OwnedRequirement(NamedTuple):

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -34,7 +34,7 @@ from importlib.abc import Loader
 from importlib.machinery import ModuleSpec
 from itertools import chain
 from subprocess import CalledProcessError
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Pattern, Sequence, Set, Tuple, TypeVar
+from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Pattern, Sequence, Set, Tuple, TypeVar
 
 import pkg_resources
 from pkg_resources import DistInfoDistribution, Distribution, Requirement
@@ -74,16 +74,26 @@ class VersionConflict:
 
     :param requirement: The requirement that is unsatisfied.
     :param installed_version: The version that is currently installed. None if the package is not installed.
+    :param owner: The package from which the constraint originates
     """
 
     requirement: Requirement
     installed_version: Optional[version.Version] = None
+    owner: Optional[str] = None
 
     def __str__(self) -> str:
+        owner = ""
+        if self.owner:
+            # Cfr pip
+            # Requirement already satisfied: certifi>=2017.4.17 in /[...]/site-packages
+            # (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==7.0.0) (2022.6.15)
+            owner = f" (from {self.owner})"
         if self.installed_version:
-            return f"Incompatibility between constraint {self.requirement} and installed version {self.installed_version}"
+            return (
+                f"Incompatibility between constraint {self.requirement} and installed version {self.installed_version}{owner}"
+            )
         else:
-            return f"Constraint {self.requirement} is not installed"
+            return f"Constraint {self.requirement} is not installed{owner}"
 
 
 class ConflictingRequirements(CompilerException):
@@ -825,14 +835,31 @@ class ActiveEnv(PythonEnvironment):
         """
         Return the constraint violations that exist in this venv. Returns a tuple of non-strict and strict violations,
         in that order.
+
+
         """
+
+        class OwnedRequirement(NamedTuple):
+            requirement: Requirement
+            owner: Optional[str] = None
+
+            def is_owned_by(self, owners: abc.Set[str]) -> bool:
+                return self.owner is None or self.owner in owners
+
         # all requirements of all packages installed in this environment
-        installed_constraints: abc.Set[Requirement] = frozenset(
-            requirement for dist_info in pkg_resources.working_set for requirement in dist_info.requires()
+        installed_constraints: abc.Set[OwnedRequirement] = frozenset(
+            OwnedRequirement(requirement, dist_info.key)
+            for dist_info in pkg_resources.working_set
+            for requirement in dist_info.requires()
         )
-        inmanta_constraints: abc.Set[Requirement] = frozenset(cls._get_requirements_on_inmanta_package())
-        extra_constraints: abc.Set[Requirement] = frozenset(constraints if constraints is not None else [])
-        all_constraints: abc.Set[Requirement] = installed_constraints | inmanta_constraints | extra_constraints
+        inmanta_constraints: abc.Set[OwnedRequirement] = frozenset(
+            OwnedRequirement(r, owner="inmanta-core") for r in cls._get_requirements_on_inmanta_package()
+        )
+        extra_constraints: abc.Set[OwnedRequirement] = frozenset(
+            (OwnedRequirement(r) for r in constraints) if constraints is not None else []
+        )
+
+        all_constraints: abc.Set[OwnedRequirement] = installed_constraints | inmanta_constraints | extra_constraints
 
         full_strict_scope: abc.Set[str] = PythonWorkingSet.get_dependency_tree(
             chain(
@@ -841,8 +868,8 @@ class ActiveEnv(PythonEnvironment):
                     if strict_scope is None
                     else (dist_info.key for dist_info in pkg_resources.working_set if strict_scope.fullmatch(dist_info.key))
                 ),
-                (requirement.key for requirement in inmanta_constraints),
-                (requirement.key for requirement in extra_constraints),
+                (requirement.requirement.key for requirement in inmanta_constraints),
+                (requirement.requirement.key for requirement in extra_constraints),
             )
         )
 
@@ -851,14 +878,16 @@ class ActiveEnv(PythonEnvironment):
         constraint_violations: set[VersionConflict] = set()
         constraint_violations_strict: set[VersionConflict] = set()
         for c in all_constraints:
-            if (c.key not in installed_versions or str(installed_versions[c.key]) not in c) and (
-                not c.marker or (c.marker and c.marker.evaluate())
+            requirement = c.requirement
+            if (requirement.key not in installed_versions or str(installed_versions[requirement.key]) not in requirement) and (
+                not requirement.marker or (requirement.marker and requirement.marker.evaluate())
             ):
                 version_conflict = VersionConflict(
-                    requirement=c,
-                    installed_version=installed_versions.get(c.key, None),
+                    requirement=requirement,
+                    installed_version=installed_versions.get(requirement.key, None),
+                    owner=c.owner,
                 )
-                if c.key in full_strict_scope:
+                if c.is_owned_by(full_strict_scope):
                     constraint_violations_strict.add(version_conflict)
                 else:
                     constraint_violations.add(version_conflict)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -424,6 +424,7 @@ def test_active_env_check_basic(
     )
 
 
+
 def test_active_env_check_constraints(caplog, tmpvenv_active_inherit: str) -> None:
     """
     Verify that the env.ActiveEnv.check() method's constraints parameter is taken into account as expected.
@@ -440,6 +441,13 @@ def test_active_env_check_constraints(caplog, tmpvenv_active_inherit: str) -> No
 
     caplog.clear()
     create_install_package("test-package-one", version.Version("1.0.0"), [])
+    env.ActiveEnv.check(in_scope, constraints)
+    assert "Incompatibility between constraint" not in caplog.text
+
+    # Add an external dependency, that should not matter
+    # trigger #4791
+    caplog.clear()
+    create_install_package("ext-package-one", version.Version("1.0.0"), [Requirement.parse("test-package-one==1.0")])
     env.ActiveEnv.check(in_scope, constraints)
     assert "Incompatibility between constraint" not in caplog.text
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -453,7 +453,7 @@ def test_active_env_check_constraints(caplog, tmpvenv_active_inherit: str) -> No
     caplog.clear()
     v: version.Version = version.Version("2.0.0")
     create_install_package("test-package-one", v, [])
-    # test for #4791
+    # test for #4761
     # without additional constrain, this is not a hard failure
     # except for the unrelated package, which should produce a warning
     env.ActiveEnv.check(in_scope, [])

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -444,7 +444,7 @@ def test_active_env_check_constraints(caplog, tmpvenv_active_inherit: str) -> No
     assert "Incompatibility between constraint" not in caplog.text
 
     # Add an unrelated package to the venv, that should not matter
-    # setup for #4791
+    # setup for #4761
     caplog.clear()
     create_install_package("ext-package-one", version.Version("1.0.0"), [Requirement.parse("test-package-one==1.0")])
     env.ActiveEnv.check(in_scope, constraints)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -424,7 +424,6 @@ def test_active_env_check_basic(
     )
 
 
-
 def test_active_env_check_constraints(caplog, tmpvenv_active_inherit: str) -> None:
     """
     Verify that the env.ActiveEnv.check() method's constraints parameter is taken into account as expected.
@@ -444,8 +443,8 @@ def test_active_env_check_constraints(caplog, tmpvenv_active_inherit: str) -> No
     env.ActiveEnv.check(in_scope, constraints)
     assert "Incompatibility between constraint" not in caplog.text
 
-    # Add an external dependency, that should not matter
-    # trigger #4791
+    # Add an unrelated package to the venv, that should not matter
+    # setup for #4791
     caplog.clear()
     create_install_package("ext-package-one", version.Version("1.0.0"), [Requirement.parse("test-package-one==1.0")])
     env.ActiveEnv.check(in_scope, constraints)
@@ -454,6 +453,16 @@ def test_active_env_check_constraints(caplog, tmpvenv_active_inherit: str) -> No
     caplog.clear()
     v: version.Version = version.Version("2.0.0")
     create_install_package("test-package-one", v, [])
+    # test for #4791
+    # without additional constrain, this is not a hard failure
+    # except for the unrelated package, which should produce a warning
+    env.ActiveEnv.check(in_scope, [])
+    assert (
+        "Incompatibility between constraint test-package-one==1.0 and installed version 2.0.0 (from ext-package-one)"
+        in caplog.text
+    )
+
+    caplog.clear()
     with pytest.raises(env.ConflictingRequirements):
         env.ActiveEnv.check(in_scope, constraints)
 


### PR DESCRIPTION
# Description

Improve the scoping of the venv check: it scoped on the required package, not on the owner of the requirement

closes #4761 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
