### PR TITLE
 issue/4684-keep-requirements-v1tov2 

### DIFF
--- a/changelogs/unreleased/4684-keep-requirements-v1tov2.yml
+++ b/changelogs/unreleased/4684-keep-requirements-v1tov2.yml
@@ -1,0 +1,6 @@
+description: "Fix issue where the v1tov2 command removes the requirements.txt file"
+issue-nr: 4761
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/4684-keep-requirements-v1tov2.yml
+++ b/changelogs/unreleased/4684-keep-requirements-v1tov2.yml
@@ -1,5 +1,5 @@
 description: "Fix issue where the v1tov2 command removes the requirements.txt file"
-issue-nr: 4761
+issue-nr: 4684
 change-type: patch
 destination-branches: [master, iso5]
 sections:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1189,10 +1189,6 @@ class ModuleConverter:
     def _do_update(self, output_directory: str, setup_cfg: ConfigParser, warn_on_merge: bool = False) -> None:
         # remove module.yaml
         os.remove(os.path.join(output_directory, self._module.MODULE_FILE))
-        # remove requirements.txt
-        req = os.path.join(output_directory, "requirements.txt")
-        if os.path.exists(req):
-            os.remove(req)
         # move plugins or create
         old_plugins = os.path.join(output_directory, "plugins")
         new_plugins = os.path.join(output_directory, "inmanta_plugins", self._module.name)

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -140,8 +140,8 @@ def assert_v2_module(module_name, tmpdir, minimal=False):
     assert os.path.exists(os.path.join(tmpdir, "setup.cfg"))
     assert os.path.exists(os.path.join(tmpdir, "pyproject.toml"))
     assert os.path.exists(os.path.join(tmpdir, "MANIFEST.in"))
+    assert os.path.exists(os.path.join(tmpdir, "requirements.txt"))
 
-    assert not os.path.exists(os.path.join(tmpdir, "requirements.txt"))
     assert not os.path.exists(os.path.join(tmpdir, "module.yml"))
 
     assert os.path.exists(os.path.join(tmpdir, "model", "_init.cf"))

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -140,7 +140,6 @@ def assert_v2_module(module_name, tmpdir, minimal=False):
     assert os.path.exists(os.path.join(tmpdir, "setup.cfg"))
     assert os.path.exists(os.path.join(tmpdir, "pyproject.toml"))
     assert os.path.exists(os.path.join(tmpdir, "MANIFEST.in"))
-    assert os.path.exists(os.path.join(tmpdir, "requirements.txt"))
 
     assert not os.path.exists(os.path.join(tmpdir, "module.yml"))
 
@@ -148,6 +147,7 @@ def assert_v2_module(module_name, tmpdir, minimal=False):
     assert os.path.exists(os.path.join(tmpdir, "inmanta_plugins", module_name, "__init__.py"))
 
     if not minimal:
+        assert os.path.exists(os.path.join(tmpdir, "requirements.txt"))
         assert os.path.exists(os.path.join(tmpdir, "files", "test.txt"))
         assert os.path.exists(os.path.join(tmpdir, "templates", "template.txt.j2"))
         assert os.path.exists(os.path.join(tmpdir, "model", "other.cf"))


### PR DESCRIPTION
# Description

The v1tov2 command removes the requirements.txt file. This file should be kept.

closes #4684 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
