### PR TITLE
install_from_index should override PIP_EXTRA_INDEX_URL

### DIFF
--- a/changelogs/unreleased/4723-fix--override-pip-extra-index-url.yml
+++ b/changelogs/unreleased/4723-fix--override-pip-extra-index-url.yml
@@ -1,6 +1,8 @@
 ---
-description: make sure that the index present in PIP_EXTRA_INDEX_URL is not leaked to the pip install_from_index
+description: make sure that the index present in PIP_INDEX_URL or PIP_EXTRA_INDEX_URL is not leaked to pip when using install_from_index
 issue-nr: 4723
 issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/4723-fix--override-pip-extra-index-url.yml
+++ b/changelogs/unreleased/4723-fix--override-pip-extra-index-url.yml
@@ -1,0 +1,6 @@
+---
+description: make sure that the index present in PIP_EXTRA_INDEX_URL is not leaked to the pip install_from_index
+issue-nr: 4723
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -474,8 +474,9 @@ class PythonEnvironment:
         process_env = os.environ.copy()
         if index_urls is not None and "PIP_EXTRA_INDEX_URL" in process_env:
             del process_env["PIP_EXTRA_INDEX_URL"]
-        if "PIP_INDEX_URL" in process_env and index_urls is not None:
+        if index_urls is not None and "PIP_INDEX_URL" in process_env:
             del process_env["PIP_INDEX_URL"]
+
         return_code, full_output = self.run_command_and_stream_output(cmd, env_vars=process_env)
 
         if return_code != 0:

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -470,7 +470,10 @@ class PythonEnvironment:
             requirements_files=requirements_files,
         )
         process_env = os.environ.copy()
-        del process_env["PIP_EXTRA_INDEX_URL"]
+        if "PIP_EXTRA_INDEX_URL" in process_env:
+            del process_env["PIP_EXTRA_INDEX_URL"]
+        if "PIP_INDEX_URL" in process_env:
+            del process_env["PIP_INDEX_URL"]
         return_code, full_output = self.run_command_and_stream_output(cmd, env_vars=process_env)
 
         if return_code != 0:

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -522,7 +522,6 @@ class PythonEnvironment:
     ) -> None:
         if len(requirements) == 0:
             raise Exception("install_from_index requires at least one requirement to install")
-
         constraint_files = constraint_files if constraint_files is not None else []
         inmanta_requirements = self._get_requirements_on_inmanta_package()
         self._run_pip_install_command(
@@ -606,8 +605,6 @@ class PythonEnvironment:
         Similar to the _run_command_and_log_output method, but here, the output is logged on the fly instead of at the end
         of the sub-process.
         """
-        print("===================")
-        print(env_vars)
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -469,10 +469,12 @@ class PythonEnvironment:
             constraints_files=constraints_files,
             requirements_files=requirements_files,
         )
+
+        # if index_urls are set, only use those. Otherwise, use the one from the environment
         process_env = os.environ.copy()
-        if "PIP_EXTRA_INDEX_URL" in process_env:
+        if index_urls is not None and "PIP_EXTRA_INDEX_URL" in process_env:
             del process_env["PIP_EXTRA_INDEX_URL"]
-        if "PIP_INDEX_URL" in process_env:
+        if "PIP_INDEX_URL" in process_env and index_urls is not None:
             del process_env["PIP_INDEX_URL"]
         return_code, full_output = self.run_command_and_stream_output(cmd, env_vars=process_env)
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -359,9 +359,6 @@ class PipCommandBuilder:
             if index_urls
             else ["--no-index"]
         )
-        print("===============================================================================================Flo")
-        print(index_urls)
-        print(index_args)
         constraints_files = constraints_files if constraints_files is not None else []
         requirements_files = requirements_files if requirements_files is not None else []
         return [
@@ -523,6 +520,9 @@ class PythonEnvironment:
     ) -> None:
         if len(requirements) == 0:
             raise Exception("install_from_index requires at least one requirement to install")
+
+        os.environ["PIP_EXTRA_INDEX_URL"] = ""
+
         constraint_files = constraint_files if constraint_files is not None else []
         inmanta_requirements = self._get_requirements_on_inmanta_package()
         self._run_pip_install_command(

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -520,7 +520,7 @@ class PythonEnvironment:
     ) -> None:
         if len(requirements) == 0:
             raise Exception("install_from_index requires at least one requirement to install")
-
+        print("=================1===============")
         os.environ["PIP_EXTRA_INDEX_URL"] = ""
 
         constraint_files = constraint_files if constraint_files is not None else []

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -360,6 +360,7 @@ class PipCommandBuilder:
             else ["--no-index"]
         )
         print("===============================================================================================Flo")
+        print(index_urls)
         print(index_args)
         constraints_files = constraints_files if constraints_files is not None else []
         requirements_files = requirements_files if requirements_files is not None else []

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -520,7 +520,7 @@ class PythonEnvironment:
     ) -> None:
         if len(requirements) == 0:
             raise Exception("install_from_index requires at least one requirement to install")
-        print("=================1===============")
+
         os.environ["PIP_EXTRA_INDEX_URL"] = ""
 
         constraint_files = constraint_files if constraint_files is not None else []

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -469,7 +469,9 @@ class PythonEnvironment:
             constraints_files=constraints_files,
             requirements_files=requirements_files,
         )
-        return_code, full_output = self.run_command_and_stream_output(cmd)
+        process_env = os.environ.copy()
+        del process_env["PIP_EXTRA_INDEX_URL"]
+        return_code, full_output = self.run_command_and_stream_output(cmd, env_vars=process_env)
 
         if return_code != 0:
             not_found: List[str] = []
@@ -520,8 +522,6 @@ class PythonEnvironment:
     ) -> None:
         if len(requirements) == 0:
             raise Exception("install_from_index requires at least one requirement to install")
-
-        os.environ["PIP_EXTRA_INDEX_URL"] = ""
 
         constraint_files = constraint_files if constraint_files is not None else []
         inmanta_requirements = self._get_requirements_on_inmanta_package()
@@ -606,6 +606,8 @@ class PythonEnvironment:
         Similar to the _run_command_and_log_output method, but here, the output is logged on the fly instead of at the end
         of the sub-process.
         """
+        print("===================")
+        print(env_vars)
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -359,6 +359,8 @@ class PipCommandBuilder:
             if index_urls
             else ["--no-index"]
         )
+        print("===============================================================================================Flo")
+        print(index_args)
         constraints_files = constraints_files if constraints_files is not None else []
         requirements_files = requirements_files if requirements_files is not None else []
         return [

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -471,13 +471,16 @@ class PythonEnvironment:
         )
 
         # if index_urls are set, only use those. Otherwise, use the one from the environment
-        process_env = os.environ.copy()
-        if index_urls is not None and "PIP_EXTRA_INDEX_URL" in process_env:
-            del process_env["PIP_EXTRA_INDEX_URL"]
-        if index_urls is not None and "PIP_INDEX_URL" in process_env:
-            del process_env["PIP_INDEX_URL"]
+        sub_env = os.environ.copy()
+        if index_urls is not None:
+            # setting this env_var to os.devnull disables the loading of all pip configuration files
+            sub_env["PIP_CONFIG_FILE"] = os.devnull
+        if index_urls is not None and "PIP_EXTRA_INDEX_URL" in sub_env:
+            del sub_env["PIP_EXTRA_INDEX_URL"]
+        if index_urls is not None and "PIP_INDEX_URL" in sub_env:
+            del sub_env["PIP_INDEX_URL"]
 
-        return_code, full_output = self.run_command_and_stream_output(cmd, env_vars=process_env)
+        return_code, full_output = self.run_command_and_stream_output(cmd, env_vars=sub_env)
 
         if return_code != 0:
             not_found: List[str] = []
@@ -1114,7 +1117,6 @@ class VirtualEnv(ActiveEnv):
             LOGGER.debug("Created a new virtualenv at %s", self.env_path)
 
         if not os.path.exists(self._path_pth_file):
-
             # Venv was created using an older version of Inmanta -> Update pip binary and set sitecustomize.py file
             self._write_pip_binary()
             self._write_pth_file()

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -470,8 +470,9 @@ class PythonEnvironment:
             requirements_files=requirements_files,
         )
 
-        # if index_urls are set, only use those. Otherwise, use the one from the environment
         sub_env = os.environ.copy()
+
+        # if index_urls are set, only use those. Otherwise, use the one from the environment
         if index_urls is not None:
             # setting this env_var to os.devnull disables the loading of all pip configuration files
             sub_env["PIP_CONFIG_FILE"] = os.devnull

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -790,7 +790,7 @@ def test_pip_extra_index_env(
     and that it is not changed in the active env.
 
     The installation fails with an ModuleNotFoundException
-    as the index https://pypi.org/simple is needed to install lorem~=0.0.1
+    as the index https://pypi.org/simple is needed to install lorem~=0.0.1,
     but it is only present in the active env in PIP_EXTRA_INDEX_URL which is not know by the
     subprocess doing the pip install.
     """

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -789,7 +789,8 @@ def test_pip_extra_index_env(
     Test that PIP_EXTRA_INDEX_URL is not set in the subprocess doing an install_from_index
     but that it is not changed in the active env.
 
-    The installation fails as the index https://pypi.org/simple is needed to install lorem~=0.0.1
+    The installation fails with ad ModuleNotFoundException
+    as the index https://pypi.org/simple is needed to install lorem~=0.0.1
     but it is only present in the active env in PIP_EXTRA_INDEX_URL which is not know by the
     subprocess doing the pip install.
     """

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -787,7 +787,7 @@ def test_pip_extra_index_env(
 ) -> None:
     """
     Test that PIP_EXTRA_INDEX_URL is not set in the subprocess doing an install_from_index
-    but that it is not changed in the active env.
+    and that it is not changed in the active env.
 
     The installation fails with an ModuleNotFoundException
     as the index https://pypi.org/simple is needed to install lorem~=0.0.1

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -790,7 +790,8 @@ def test_pip_extra_index_env(
     but that it is not changed in the active env.
 
     The installation fails as the index https://pypi.org/simple is needed to install lorem~=0.0.1
-    but it is only present in the active env in PIP_EXTRA_INDEX_URL
+    but it is only present in the active env in PIP_EXTRA_INDEX_URL which is not know by the
+    subprocess doing the pip install.
     """
     os.environ["PIP_EXTRA_INDEX_URL"] = "https://pypi.org/simple"
     index: PipIndex = PipIndex(artifact_dir=os.path.join(str(tmpdir), ".custom-index"))

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -789,7 +789,7 @@ def test_pip_extra_index_env(
     Test that PIP_EXTRA_INDEX_URL is not set in the subprocess doing an install_from_index
     but that it is not changed in the active env.
 
-    The installation fails with ad ModuleNotFoundException
+    The installation fails with an ModuleNotFoundException
     as the index https://pypi.org/simple is needed to install lorem~=0.0.1
     but it is only present in the active env in PIP_EXTRA_INDEX_URL which is not know by the
     subprocess doing the pip install.

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
 extras=
     dataflow_graphic
 # Set the environment variable INMANTA_EXTRA_PYTEST_ARGS='--fast' to run in fast mode
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -s -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
 extras=
     dataflow_graphic
 # Set the environment variable INMANTA_EXTRA_PYTEST_ARGS='--fast' to run in fast mode
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -s -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME


### PR DESCRIPTION
# Description

The contract of env.PythonEnvironment.install_from_index is that it uses the index urls it receives as arguments (for project installs these are the index urls in the project.yml). While it does set --index-url and --extra-index-url, it does not set PIP_EXTRA_INDEX_URL="", so if it is set in the environment, it is leaked to the pip install. This commit will prevent this leak.

closes #4723

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
