### PR TITLE
Improved assertions on warnings

### DIFF
--- a/changelogs/unreleased/improved_warning_assertions.yml
+++ b/changelogs/unreleased/improved_warning_assertions.yml
@@ -1,0 +1,3 @@
+description: Improve assertions on warnings
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/server/test_incremental_deploy.py
+++ b/tests/server/test_incremental_deploy.py
@@ -32,6 +32,7 @@ from inmanta.server import SLICE_AGENT_MANAGER, SLICE_ORCHESTRATION, SLICE_RESOU
 from inmanta.server.services.orchestrationservice import OrchestrationService
 from inmanta.server.services.resourceservice import ResourceService
 from inmanta.util import get_compiler_version
+from utils import assert_no_warning
 
 
 class MultiVersionSetup(object):
@@ -322,8 +323,7 @@ async def test_deploy(server, agent: Agent, environment, caplog):
         result, _ = await resource_service.get_resources_for_agent(env, "agent1", version=v2, incremental_deploy=True, sid=sid)
         assert result == 500
 
-    for record in caplog.records:
-        assert record.levelname != "WARNING"
+    assert_no_warning(caplog)
 
 
 def strip_version(v):
@@ -369,8 +369,7 @@ async def test_deploy_scenarios(server, agent: Agent, environment, caplog):
 
         await setup.setup(orchestration_service, resource_service, env, sid)
 
-    for record in caplog.records:
-        assert record.levelname != "WARNING"
+    assert_no_warning(caplog)
 
 
 async def test_deploy_scenarios_removed_req_by_increment(server, agent: Agent, environment, caplog):
@@ -391,8 +390,7 @@ async def test_deploy_scenarios_removed_req_by_increment(server, agent: Agent, e
         resources = await setup.setup(orchestration_service, resource_service, env, sid)
         assert not resources[id2]["attributes"]["requires"]
 
-    for record in caplog.records:
-        assert record.levelname != "WARNING"
+    assert_no_warning(caplog)
 
 
 async def test_deploy_scenarios_removed_req_by_increment2(server, environment, caplog):
@@ -423,9 +421,7 @@ async def test_deploy_scenarios_removed_req_by_increment2(server, environment, c
 
         finally:
             await agent.stop()
-    for record in caplog.records:
-        # gets some logs when setting up agent
-        assert record.levelname != "WARNING" or record.name == "inmanta.config"
+    assert_no_warning(caplog)
 
 
 async def test_deploy_scenarios_added_by_send_event(server, agent: Agent, environment, caplog):
@@ -448,8 +444,7 @@ async def test_deploy_scenarios_added_by_send_event(server, agent: Agent, enviro
 
         await setup.setup(orchestration_service, resource_service, env, sid)
 
-    for record in caplog.records:
-        assert record.levelname != "WARNING"
+    assert_no_warning(caplog)
 
 
 async def test_deploy_scenarios_added_by_send_event_cad(server, agent: Agent, environment, caplog):
@@ -474,5 +469,4 @@ async def test_deploy_scenarios_added_by_send_event_cad(server, agent: Agent, en
         setup.add_resource("R6", "A1 D1", False, requires=[id1], agent="agent2")
         await setup.setup(orchestration_service, resource_service, env, sid)
 
-    for record in caplog.records:
-        assert record.levelname != "WARNING"
+    assert_no_warning(caplog)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -216,6 +216,20 @@ class LogSequence(object):
         self.assert_not("", logging.ERROR, "")
 
 
+NOISY_LOGGERS = [
+    "inmanta.config",  # Option deprecations
+    "inmanta.util",  # cancel background tasks
+]
+
+
+def assert_no_warning(caplog, loggers_to_allow: list[str] = NOISY_LOGGERS):
+    """
+    Assert there are no warning, except from the list of loggers to allow
+    """
+    for record in caplog.records:
+        assert record.levelname != "WARNING" or (record.name in loggers_to_allow)
+
+
 def configure(unused_tcp_port, database_name, database_port):
     import inmanta.agent.config  # noqa: F401
     import inmanta.server.config  # noqa: F401


### PR DESCRIPTION


# Description

Improved assertions on warnings to prevent warnings to leak from one testcase to another

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

