### PR TITLE
Fix test case test_compile_runner

### DIFF
--- a/changelogs/unreleased/fix-test-case-test-compile-runner.yml
+++ b/changelogs/unreleased/fix-test-case-test-compile-runner.yml
@@ -1,0 +1,4 @@
+---
+description: Take into account new compile stage (stage_name='Uninstall inmanta packages from the compiler venv') in test case test_compile_runner
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -416,22 +416,24 @@ async def test_compile_runner(environment_factory: EnvironmentFactory, server, c
     compile, stages = await compile_and_assert(env2, False, update=True)
     assert stages["Init"]["returncode"] == 0
     assert stages["Pulling updates"]["returncode"] == 0
+    assert stages["Uninstall inmanta packages from the compiler venv"]["returncode"] == 0
     assert stages["Updating modules"]["returncode"] == 0
     assert stages["Recompiling configuration model"]["returncode"] == 0
     out = stages["Recompiling configuration model"]["outstream"]
     assert f"{marker_print2} {no_marker}" in out
-    assert len(stages) == 4
+    assert len(stages) == 5
     assert compile.version is None
 
     environment_factory.write_main(make_main(marker_print3))
     compile, stages = await compile_and_assert(env2, False, update=True)
     assert stages["Init"]["returncode"] == 0
     assert stages["Pulling updates"]["returncode"] == 0
+    assert stages["Uninstall inmanta packages from the compiler venv"]["returncode"] == 0
     assert stages["Updating modules"]["returncode"] == 0
     assert stages["Recompiling configuration model"]["returncode"] == 0
     out = stages["Recompiling configuration model"]["outstream"]
     assert f"{marker_print3} {no_marker}" in out
-    assert len(stages) == 4
+    assert len(stages) == 5
     assert compile.version is None
 
     # Ensure that the pip binary created in the venv of the compiler service works correctly


### PR DESCRIPTION
# Description

The test case `test_compile_runner` broke due to the introduction of the new compile stage "Uninstall inmanta packages from the compiler venv" in #4779.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
