### PR TITLE
Improve compiler test performance by caching the venv

### DIFF
--- a/changelogs/unreleased/compiler-test-performance.yml
+++ b/changelogs/unreleased/compiler-test-performance.yml
@@ -1,0 +1,3 @@
+description: Improved performance of compiler tests
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -1242,42 +1242,6 @@ import sys
         super(VirtualEnv, self).install_from_list(requirements_list, upgrade=upgrade, upgrade_strategy=upgrade_strategy)
 
 
-class ReentrantVirtualEnv(VirtualEnv):
-    """
-    A virtual env that can be de-activated and re-activated
-
-    This allows faster reloading due to improved caching of the working set
-
-    This is intended for use in testcases to require a lot of venv switching
-    """
-
-    def __init__(self, env_path: str) -> None:
-        super(ReentrantVirtualEnv, self).__init__(env_path)
-        self.working_set = None
-
-    def deactivate(self):
-        self._using_venv = False
-        self.working_set = pkg_resources.working_set
-
-    def use_virtual_env(self) -> None:
-        """
-        Activate the virtual environment.
-        """
-        if self._using_venv:
-            # We are in use, just ignore double activation
-            return
-
-        if not self.working_set:
-            # First run
-            super().use_virtual_env()
-        else:
-            # Later run
-            self._activate_that()
-            mock_process_env(python_path=self.python_path)
-            pkg_resources.working_set = self.working_set
-            self._using_venv = True
-
-
 class VenvCreationFailedError(Exception):
     def __init__(self, msg: str) -> None:
         super().__init__(msg)

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1709,7 +1709,7 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         path: str,
         autostd: bool = True,
         main_file: str = "main.cf",
-        venv_path: Optional[str] = None,
+        venv_path: Optional[Union[str, "env.VirtualEnv"]] = None,
         attach_cf_cache: bool = True,
         strict_deps_check: Optional[bool] = None,
     ) -> None:
@@ -1760,8 +1760,11 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         if venv_path is None:
             self.virtualenv = env.process_env
         else:
-            venv_path = os.path.abspath(venv_path)
-            self.virtualenv = env.VirtualEnv(venv_path)
+            if isinstance(venv_path, env.VirtualEnv):
+                self.virtualenv = venv_path
+            else:
+                venv_path = os.path.abspath(venv_path)
+                self.virtualenv = env.VirtualEnv(venv_path)
 
         self.loaded = False
         self.modules: Dict[str, Module] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ from inmanta.agent import handler
 from inmanta.agent.agent import Agent
 from inmanta.ast import CompilerException
 from inmanta.data.schema import SCHEMA_VERSION_TABLE
-from inmanta.env import LocalPackagePath
+from inmanta.env import LocalPackagePath, ReentrantVirtualEnv
 from inmanta.export import ResourceDict, cfg_env, unknown_parameters
 from inmanta.module import InmantaModuleRequirement, InstallMode, Project, RelationPrecedenceRule
 from inmanta.moduletool import ModuleTool
@@ -961,6 +961,7 @@ class SnippetCompilationTest(KeepOnFail):
         self.libs = tempfile.mkdtemp()
         self.repo = "https://github.com/inmanta/"
         self.env = tempfile.mkdtemp()
+        self.venv = ReentrantVirtualEnv(env_path=self.env)
         config.Config.load_config()
         self.keep_shared = False
         self.project = None
@@ -981,6 +982,7 @@ class SnippetCompilationTest(KeepOnFail):
         if not self._keep:
             shutil.rmtree(self.project_dir)
         self.project = None
+        self.venv.deactivate()
 
     def keep(self):
         self._keep = True
@@ -1041,7 +1043,7 @@ class SnippetCompilationTest(KeepOnFail):
     ):
         loader.PluginModuleFinder.reset()
         self.project = Project(
-            self.project_dir, autostd=autostd, main_file=main_file, venv_path=self.env, strict_deps_check=strict_deps_check
+            self.project_dir, autostd=autostd, main_file=main_file, venv_path=self.venv, strict_deps_check=strict_deps_check
         )
         Project.set(self.project)
         self.project.use_virtual_env()


### PR DESCRIPTION
# Description

Attempt to speed up compiler tests by improved caching

is this approach acceptable in principle? 

(we go from 81% of time to 29% of overhead in 

![image](https://user-images.githubusercontent.com/1788254/188640142-57c497c7-f067-4e1b-a71d-73a1909955ec.png)

)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
