### PR TITLE
issue/4620-fix-log-project-install

### DIFF
--- a/changelogs/unreleased/4620-fix-log-project-install.yml
+++ b/changelogs/unreleased/4620-fix-log-project-install.yml
@@ -1,0 +1,5 @@
+---
+description: Fix issue in logs of project install. The 'verifying project' log line is logged twice
+issue-nr: 4620
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -2220,6 +2220,7 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
         """
         Verifies the integrity of the loaded project, with respect to both inter-module requirements and the Python environment.
         """
+        LOGGER.info("verifying project")
         self.verify_modules_cache()
         self.verify_module_version_compatibility()
         self.verify_python_requires()
@@ -2245,7 +2246,6 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
 
         :raises CompilerException: When one or more of the requirements of the project is not satisfied.
         """
-        LOGGER.info("verifying project")
         requirements: Dict[str, List[InmantaModuleRequirement]] = self.collect_requirements()
 
         exc_message = ""

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -431,7 +431,7 @@ def test_project_install_logs(
 
     # set up project
     snippetcompiler_clean.setup_for_snippet(
-        f"""
+        """
         """,
         autostd=False,
         install_project=False,

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -443,11 +443,11 @@ def test_project_install_logs(
     caplog.set_level(logging.INFO)
     ProjectTool().execute("install", [])
     log_sequence = LogSequence(caplog)
-    count = 0
+    count_verifying_project = 0
     for msg in log_sequence.caplog.messages:
         if msg == "verifying project":
-            count += 1
-    assert count == 1
+            count_verifying_project += 1
+    assert count_verifying_project == 1
 
 
 @pytest.mark.parametrize_any(


### PR DESCRIPTION
# Description

When executing a project install, the verifying project log line is logged twice.
This commit removes the duplication.

closes #4620  

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
