### PR TITLE
Issue/scheduler backward compatibility

### DIFF
--- a/changelogs/unreleased/scheduler_backward_compatibility.yml
+++ b/changelogs/unreleased/scheduler_backward_compatibility.yml
@@ -1,0 +1,3 @@
+description: Improve backward compatibility of util.Scheduler
+change-type: patch
+destination-branches: [master, iso5]


### PR DESCRIPTION
# Description

Improve backward compatibility of add_action

I did not add the second argument (initial_delay) back, nor did I make the named arguments work.
That would be too messy

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
