### PR TITLE
Issue/4589 convert a v1 module to a v2 with the presence of a setuppy file

### DIFF
--- a/changelogs/unreleased/4589-convert-a-v1-module-to-a-v2-with-the-presence-of-a-setuppy-file.yml
+++ b/changelogs/unreleased/4589-convert-a-v1-module-to-a-v2-with-the-presence-of-a-setuppy-file.yml
@@ -1,6 +1,6 @@
 ---
 description: Reject v1tov2 module conversion when a setup.py is present
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [master, iso5]
 sections:
   minor-improvement: "{{description}}"

--- a/changelogs/unreleased/4589-convert-a-v1-module-to-a-v2-with-the-presence-of-a-setuppy-file.yml
+++ b/changelogs/unreleased/4589-convert-a-v1-module-to-a-v2-with-the-presence-of-a-setuppy-file.yml
@@ -1,0 +1,6 @@
+---
+description: Reject v1tov2 module conversion when a setup.py is present
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1183,6 +1183,13 @@ class ModuleConverter:
         if os.path.exists(os.path.join(output_directory, "inmanta_plugins")):
             raise CLIException("inmanta_plugins folder already exists, aborting. Please remove/rename this file", exitcode=1)
 
+        if os.path.exists(os.path.join(output_directory, "setup.py")):
+            raise CLIException(
+                f"Cannot convert v1 module at {output_directory} to v2 because a setup.py file is present."
+                " Please remove/rename this file",
+                exitcode=1,
+            )
+
         setup_cfg = self.get_setup_cfg(output_directory, warn_on_merge=True)
         self._do_update(output_directory, setup_cfg, warn_on_merge=True)
 

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -124,6 +124,16 @@ def test_module_conversion_in_place_cli(tmpdir, monkeypatch: MonkeyPatch):
     path = os.path.normpath(os.path.join(__file__, os.pardir, os.pardir, "data", "modules", module_name))
     shutil.copytree(path, tmpdir)
     monkeypatch.chdir(tmpdir)
+
+    # Check that v1tov2 conversions are rejected when a setup.py file is present
+    setup_py_path = os.path.join(tmpdir, "setup.py")
+    with open(setup_py_path, "a"):
+        # create empty setup.py
+        pass
+    with pytest.raises(CLIException):
+        moduletool.ModuleTool().v1tov2(None)
+    os.remove(setup_py_path)
+
     moduletool.ModuleTool().v1tov2(None)
     assert_v2_module(module_name, tmpdir)
 

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -130,8 +130,13 @@ def test_module_conversion_in_place_cli(tmpdir, monkeypatch: MonkeyPatch):
     with open(setup_py_path, "a"):
         # create empty setup.py
         pass
-    with pytest.raises(CLIException):
+    with pytest.raises(CLIException) as excinfo:
         moduletool.ModuleTool().v1tov2(None)
+    message = (
+        f"Cannot convert v1 module at {tmpdir} to v2 because a setup.py file is present."
+        " Please remove/rename this file"
+    )
+    assert message in excinfo.value.args
     os.remove(setup_py_path)
 
     moduletool.ModuleTool().v1tov2(None)

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -133,8 +133,7 @@ def test_module_conversion_in_place_cli(tmpdir, monkeypatch: MonkeyPatch):
     with pytest.raises(CLIException) as excinfo:
         moduletool.ModuleTool().v1tov2(None)
     message = (
-        f"Cannot convert v1 module at {tmpdir} to v2 because a setup.py file is present."
-        " Please remove/rename this file"
+        f"Cannot convert v1 module at {tmpdir} to v2 because a setup.py file is present." " Please remove/rename this file"
     )
     assert message in excinfo.value.args
     os.remove(setup_py_path)

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -132,9 +132,7 @@ def test_module_conversion_in_place_cli(tmpdir, monkeypatch: MonkeyPatch):
         pass
     with pytest.raises(CLIException) as excinfo:
         moduletool.ModuleTool().v1tov2(None)
-    message = (
-        f"Cannot convert v1 module at {tmpdir} to v2 because a setup.py file is present." " Please remove/rename this file"
-    )
+    message = f"Cannot convert v1 module at {tmpdir} to v2 because a setup.py file is present. Please remove/rename this file"
     assert message in excinfo.value.args
     os.remove(setup_py_path)
 


### PR DESCRIPTION
# Description

Reject v1tov2 module conversion when a setup.py is present.

closes #4589 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
