### PR TITLE
Issue/4781 compiler service doesnt log consistently in same timezone

### DIFF
--- a/changelogs/unreleased/4781-compiler-service-doesnt-log-consistently-in-same-timezone.yml
+++ b/changelogs/unreleased/4781-compiler-service-doesnt-log-consistently-in-same-timezone.yml
@@ -1,6 +1,6 @@
 ---
 description: The compiler service now logs the requested time of a recompile using a consistent timezone
 change-type: patch
-destination-branches: [master, iso5]
+destination-branches: [master, iso5, iso4]
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/4781-compiler-service-doesnt-log-consistently-in-same-timezone.yml
+++ b/changelogs/unreleased/4781-compiler-service-doesnt-log-consistently-in-same-timezone.yml
@@ -1,0 +1,6 @@
+---
+description: The compiler service now logs the requested time of a recompile using a consistent timezone
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -637,7 +637,7 @@ class CompilerService(ServerSlice):
                 return
             env: Optional[data.Environment] = await data.Environment.get_by_id(environment)
             if env is None:
-                raise Exception("Can't queue compile: environment %s does not exist" % environment)
+                raise Exception("Can't dequeue compile: environment %s does not exist" % environment)
             nextrun = await data.Compile.get_next_run(environment)
             if nextrun and not env.halted:
                 task = self.add_background_task(self._run(nextrun))
@@ -724,7 +724,7 @@ class CompilerService(ServerSlice):
                 wait,
             )
         else:
-            LOGGER.debug("Running recompile without waiting: requested at %s", compile.requested)
+            LOGGER.debug("Running recompile without waiting: requested at %s", compile.requested.astimezone())
         await asyncio.sleep(wait)
 
     async def _run(self, compile: data.Compile) -> None:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -724,6 +724,7 @@ class CompilerService(ServerSlice):
                 wait,
             )
         else:
+            assert compile.requested is not None  # Make mypy happy
             LOGGER.debug("Running recompile without waiting: requested at %s", compile.requested.astimezone())
         await asyncio.sleep(wait)
 


### PR DESCRIPTION
# Description

Make sure the compiler service logs the requested compile time using a consistent timezone when running recompile without waiting.

closes #4781 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
