### PR TITLE
Split query to improve performance

### DIFF
--- a/changelogs/unreleased/improve-query-performance.yml
+++ b/changelogs/unreleased/improve-query-performance.yml
@@ -1,0 +1,3 @@
+description: Improve query performance by splitting the query into two different queries.
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4983,25 +4983,7 @@ class Resource(BaseDocument):
         query = f"""
         SELECT DISTINCT ON (resource_id) first.resource_id, cm.date as first_generated_time,
         first.model as first_model, latest.resource_id as latest_resource_id, latest.resource_type,
-        latest.agent, latest.resource_id_value, latest.last_deploy as latest_deploy, latest.attributes, latest.status,
-        /* Split up the requires array to its elements and find the latest released version of
-            the resources to get their status, and build a single json object from them */
-        (SELECT JSON_OBJECT_AGG(substring(req.requires from '(.*),v='), s.status) as requires_status
-            FROM
-                (SELECT JSONB_ARRAY_ELEMENTS_TEXT(resource.attributes->'requires') as requires
-                    FROM resource
-                    WHERE resource_id = latest.resource_id and model = latest.model)
-                    as req
-                    INNER JOIN
-                        (SELECT DISTINCT ON (resource_id) resource_id, resource.environment, {status_subquery}
-                        FROM resource
-                        INNER JOIN configurationmodel cm
-                        ON resource.model = cm.version AND resource.environment = cm.environment
-                        WHERE resource.environment = $1 AND cm.released = TRUE
-                        ORDER BY resource_id, model desc
-                        ) as s
-                    ON substring(req.requires from '(.*),v=') = s.resource_id AND s.environment = $1
-                )
+        latest.agent, latest.resource_id_value, latest.last_deploy as latest_deploy, latest.attributes, latest.status
         FROM resource first
         INNER JOIN
             /* 'latest' is the latest released version of the resource */
@@ -5026,6 +5008,20 @@ class Resource(BaseDocument):
             return None
         record = result[0]
         parsed_id = resources.Id.parse_id(record["latest_resource_id"])
+        attributes = json.loads(record["attributes"])
+        requires = [resources.Id.parse_id(req).resource_str() for req in attributes["requires"]]
+
+        # fetch the status of each of the requires. This is not calculated in the database because the lack of joinable
+        # fields requires to calculate the status for each resource record, before it is filtered
+        status_query = f"""
+        SELECT DISTINCT ON (resource_id) resource_id, {status_subquery}
+        FROM resource
+        INNER JOIN configurationmodel cm ON resource.model = cm.version AND resource.environment = cm.environment
+        WHERE resource.environment = $1 AND cm.released = TRUE AND resource_id = ANY($2)
+        ORDER BY resource_id, model DESC;
+        """
+        status_result = await cls.select_query(status_query, [cls._get_value(env), cls._get_value(requires)], no_obj=True)
+
         return m.ReleasedResourceDetails(
             resource_id=record["latest_resource_id"],
             resource_type=record["resource_type"],
@@ -5035,9 +5031,9 @@ class Resource(BaseDocument):
             last_deploy=record["latest_deploy"],
             first_generated_time=record["first_generated_time"],
             first_generated_version=record["first_model"],
-            attributes=json.loads(record["attributes"]),
+            attributes=attributes,
             status=record["status"],
-            requires_status=json.loads(record["requires_status"]) if record["requires_status"] else {},
+            requires_status={record["resource_id"]: record["status"] for record in status_result},
         )
 
     @classmethod


### PR DESCRIPTION
# Description

The original query first calculates the deploy status for all resources in the database before it actually filters. It might be possible to do this correct in a single query but it would make the query even more complex than it already is.

This PR does the following:

- fetch the resource without requires status
- do a second query that calculates the resource status only for the requires

The correct solution would be to normalize the data so that there is a table that contains the requires. This could be used to improve this query but can also replace the current provides field.

This solution is not perfect but it does reduce the query time with more than 10x for a serious size.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
