### PR TITLE
Fix bug where lock is acquired on wrong database table

### DIFF
--- a/changelogs/unreleased/4834-acquire-lock-on-correct-db-table.yml
+++ b/changelogs/unreleased/4834-acquire-lock-on-correct-db-table.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug where a cascading delete of an environment causes a deadlock because it acquires a table-level lock on an incorrect database table.
+issue-nr: 4834
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5573,7 +5573,7 @@ class ConfigurationModel(BaseDocument):
                 await Code.delete_all(connection=con, environment=self.environment, version=self.version)
 
                 # Acquire explicit lock to avoid deadlock. See ConfigurationModel docstring
-                await self.lock_table(TableLockMode.SHARE, connection=con)
+                await ResourceAction.lock_table(TableLockMode.SHARE, connection=con)
                 await Resource.delete_all(connection=con, environment=self.environment, model=self.version)
 
                 # Delete facts when the resources in this version are the only


### PR DESCRIPTION
# Description

Fix bug where lock is acquired on the ConfigurationModel table instead of the ResourceAction table. This bug causes deadlocks.

closes #4834

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
