### PR TITLE
Set dependency between docker containers

### DIFF
--- a/changelogs/unreleased/set-startup-order-in-docker-compose.yml
+++ b/changelogs/unreleased/set-startup-order-in-docker-compose.yml
@@ -1,0 +1,6 @@
+---
+description: Set the startup/shutdown order between the Inmanta server and the database in the docker-compose file
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  minor-improvement: "{{description}}"

--- a/docs/install/install-server-with-docker/install-server.inc
+++ b/docs/install/install-server-with-docker/install-server.inc
@@ -38,6 +38,8 @@ Here is a minimalist docker-compose file content that can be used to deploy the 
             networks:
                 inm_net:
                     ipv4_address: 172.30.0.3
+            depends_on:
+                - "postgres"
             command: "server --wait-for-host inmanta_db --wait-for-port 5432"
 
     networks:


### PR DESCRIPTION
# Description

Set the startup/shutdown order between the Inmanta server and the database in the docker-compose file.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
