### PR TITLE
WIP: Cache the environment to reduce queries

### DIFF
--- a/changelogs/unreleased/cache-environments.yml
+++ b/changelogs/unreleased/cache-environments.yml
@@ -1,0 +1,3 @@
+description: Cache environments
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2439,7 +2439,7 @@ class Environment(BaseDocument):
 
     @classmethod
     def flush_cache(cls, env_id: Optional[uuid.UUID] = None) -> None:
-        if env_id:
+        if env_id is not None:
             if env_id in cls.__instance_cache:
                 del cls.__instance_cache[env_id]
         else:
@@ -2547,8 +2547,8 @@ class Environment(BaseDocument):
             await self.delete()
 
     async def delete(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
-        if self.id in self.__instance_cache:
-            del self.__instance_cache[self.id]
+        if self.id in Environment.__instance_cache:
+            del Environment.__instance_cache[self.id]
 
         await super().delete(connection)
 
@@ -2566,6 +2566,7 @@ RETURNING last_version;
             self.id,
             connection=connection,
         )
+        Environment.flush_cache()
         version = cast(int, record[0])
         self.last_version = version
         return version

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2045,7 +2045,7 @@ class Project(BaseDocument):
 
     async def delete(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         # flush the environment cache
-        Environment.flush_cache(self.id)
+        Environment.flush_cache()
         await super().delete(connection)
 
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2679,8 +2679,7 @@ RETURNING last_version;
 
     @classmethod
     async def close_connection_pool(cls) -> None:
-        """ Flush the cache when the connection is closed
-        """
+        """Flush the cache when the connection is closed"""
         await BaseDocument.close_connection_pool()
         cls.flush_cache()
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5611,7 +5611,7 @@ class ConfigurationModel(BaseDocument):
                 await Code.delete_all(connection=con, environment=self.environment, version=self.version)
 
                 # Acquire explicit lock to avoid deadlock. See ConfigurationModel docstring
-                await ResourceAction.lock_table(TableLockMode.SHARE, connection=con)
+                await ResourceAction.lock_table(TableLockMode.ROW_EXCLUSIVE, connection=con)
                 await Resource.delete_all(connection=con, environment=self.environment, model=self.version)
 
                 # Delete facts when the resources in this version are the only

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2476,6 +2476,7 @@ class Environment(BaseDocument):
         :param key: The name/key of the setting. It should be defined in _settings otherwise a keyerror will be raised.
         :param value: The value of the settings. The value should be of type as defined in _settings
         """
+        Environment.flush_cache()
         if key not in self._settings:
             raise KeyError()
         # TODO: convert this to a string
@@ -2505,6 +2506,8 @@ class Environment(BaseDocument):
         """
         if key not in self._settings:
             raise KeyError()
+
+        Environment.flush_cache()
 
         if self._settings[key].default is None:
             (filter_statement, values) = self._get_composed_filter(name=self.name, project=self.project, offset=2)
@@ -5602,7 +5605,7 @@ class ConfigurationModel(BaseDocument):
                 await Code.delete_all(connection=con, environment=self.environment, version=self.version)
 
                 # Acquire explicit lock to avoid deadlock. See ConfigurationModel docstring
-                await ResourceAction.lock_table(TableLockMode.ROW_EXCLUSIVE, connection=con)
+                await ResourceAction.lock_table(TableLockMode.SHARE, connection=con)
                 await Resource.delete_all(connection=con, environment=self.environment, model=self.version)
 
                 # Delete facts when the resources in this version are the only

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2043,6 +2043,11 @@ class Project(BaseDocument):
     def to_dto(self) -> m.Project:
         return m.Project(id=self.id, name=self.name, environments=[])
 
+    async def delete(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+        # flush the environment cache
+        Environment.flush_cache()
+        await super().delete(connection)
+
 
 def convert_boolean(value: Union[bool, str]) -> bool:
     if isinstance(value, bool):
@@ -2431,6 +2436,10 @@ class Environment(BaseDocument):
         AUTOSTART_AGENT_DEPLOY_INTERVAL: AUTOSTART_AGENT_INTERVAL,
         AUTOSTART_AGENT_DEPLOY_SPLAY_TIME: AUTOSTART_SPLAY,
     }  # name new_option -> name deprecated_option
+
+    @classmethod
+    def flush_cache(cls) -> None:
+        cls.__instance_cache = {}
 
     async def get(self, key: str, connection: Optional[asyncpg.connection.Connection] = None) -> m.EnvSettingType:
         """

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2677,6 +2677,13 @@ RETURNING last_version;
             return result[0]
         return None
 
+    @classmethod
+    async def close_connection_pool(cls) -> None:
+        """ Flush the cache when the connection is closed
+        """
+        await BaseDocument.close_connection_pool()
+        cls.flush_cache()
+
 
 class Parameter(BaseDocument):
     """

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -374,6 +374,7 @@ async def test_get_setting_no_longer_exist(server, client, environment):
     )
     values = [["new_setting"], True, "dev", project_id]
     await Environment._execute_query(setting_db_query, *values)
+    Environment.flush_cache()
 
     result = await client.get_setting(tid=environment, id="a setting")
     assert result.code == 404

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -45,7 +45,7 @@ async def environment(environment, client):
     yield environment
 
 
-async def test_purge_on_delete_requires(client: Client, server: Server, environment: str, clienthelper: ClientHelper):
+async def test_purge_on_delete_requires(client: Client, server: Server, environment: uuid.UUID, clienthelper: ClientHelper):
     """
     Test purge on delete of resources and inversion of requires
     """

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -45,7 +45,7 @@ async def environment(environment, client):
     yield environment
 
 
-async def test_purge_on_delete_requires(client: Client, server: Server, environment: uuid.UUID, clienthelper: ClientHelper):
+async def test_purge_on_delete_requires(client: Client, server: Server, environment: str, clienthelper: ClientHelper):
     """
     Test purge on delete of resources and inversion of requires
     """

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -719,14 +719,13 @@ async def test_fix_corrupted_database(init_dataclasses_and_load_schema):
     await assert_agent_db_state(tid, nr_procs=1, nr_non_expired_procs=1, nr_agent_instances=1, nr_non_expired_instances=1)
 
 
-async def test_session_creation_fails(server, environment, async_finalizer, caplog):
+async def test_session_creation_fails(server, environment: uuid.UUID, async_finalizer, caplog):
     """
     Verify that:
      * Session creation works correctly when the connectivity to the database works.
      * Session creation is refused when the connectivity to the database doesn't work.
        In that case the server state should stay consistent.
     """
-    env_id = UUID(environment)
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
     a = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     await a.add_end_point_name("agent1")
@@ -734,10 +733,10 @@ async def test_session_creation_fails(server, environment, async_finalizer, capl
     async_finalizer(a.stop)
 
     # Wait until session is created
-    await retry_limited(lambda: (env_id, "agent1") in agentmanager.tid_endpoint_to_session, 10)
+    await retry_limited(lambda: (environment, "agent1") in agentmanager.tid_endpoint_to_session, 10)
 
     # Verify that the session is created correctly
-    session = agentmanager.tid_endpoint_to_session[(env_id, "agent1")]
+    session = agentmanager.tid_endpoint_to_session[(environment, "agent1")]
     session_manager = session._sessionstore
     assert len(agentmanager.sessions) == 1
     assert session in agentmanager.sessions.values()
@@ -1192,6 +1191,7 @@ async def test_add_internal_agent_when_missing_in_agent_map(server, environment,
     # Remove the internal agent from the autostart_agent_map
     query = "UPDATE public.environment SET settings=jsonb_set(settings, $1::text[], to_jsonb($2::jsonb), TRUE)"
     await postgresql_client.execute(query, [data.AUTOSTART_AGENT_MAP], "{}")
+    data.Environment.flush_cache()
 
     # Assert internal agent not in autostart_agent_map
     env = await data.Environment.get_by_id(UUID(environment))

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -719,7 +719,7 @@ async def test_fix_corrupted_database(init_dataclasses_and_load_schema):
     await assert_agent_db_state(tid, nr_procs=1, nr_non_expired_procs=1, nr_agent_instances=1, nr_non_expired_instances=1)
 
 
-async def test_session_creation_fails(server, environment, async_finalizer, caplog):
+async def test_session_creation_fails(server, environment: str, async_finalizer, caplog):
     """
     Verify that:
      * Session creation works correctly when the connectivity to the database works.


### PR DESCRIPTION
# Description

This PR tries to cache environments because on every API call we actually query the database using a new connection and a new transaction.

There are still quite some test cases failing and I have the feeling this is getting out of control. A cleaner solution, but a lot more work, is to create an environment object that lazily loads all data.

In most calls we do two things:
- Verify that the environment exists
- Use the `.id` attribute to use in other methods call or queries.

Only caching the existence of the environment might be a an easier solution. I first want to get feedback on this before continuing. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
