### PR TITLE
Cache python environment used to build V2 modules

### DIFF
--- a/changelogs/unreleased/cache-build-env-v2-modules.yml
+++ b/changelogs/unreleased/cache-build-env-v2-modules.yml
@@ -1,0 +1,4 @@
+---
+description: Add support to cache the environment used to build v2 modules when running the test suite.
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -39,11 +39,11 @@ import yaml
 from cookiecutter.main import cookiecutter
 from pkg_resources import parse_version
 
-from build.env import IsolatedEnvBuilder
-import build.env
 import build
+import build.env
 import inmanta
 import toml
+from build.env import IsolatedEnvBuilder
 from inmanta import env
 from inmanta.ast import CompilerException
 from inmanta.command import CLIException, ShowUsageException

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -31,7 +31,8 @@ import time
 import zipfile
 from argparse import ArgumentParser
 from configparser import ConfigParser
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Sequence, Set
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Sequence, Set, Type
 
 import texttable
 import yaml
@@ -40,6 +41,7 @@ from pkg_resources import parse_version
 
 import build
 import build.env
+import inmanta
 import toml
 from inmanta import env
 from inmanta.ast import CompilerException
@@ -970,7 +972,67 @@ class ModuleBuildFailedError(Exception):
 BUILD_FILE_IGNORE_PATTERN: Pattern[str] = re.compile("|".join(("__pycache__", "__cfcache__", r".*\.pyc", rf"{CF_CACHE_DIR}")))
 
 
+class IsolatedEnvBuilderCached(build.env.IsolatedEnvBuilder):
+    """
+    An IsolatedEnvBuilder that maintains its build environment across invocations of the context manager.
+    This class is only used by the test suite. It decreases the runtime of the test suite because the build
+    environment is reused across test cases.
+
+    This class is a singleton. The get_instance() method should be used to obtain an instance of this class.
+    """
+
+    _instance: Optional[build.env.IsolatedEnvBuilder] = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._isolated_env: Optional[build.env._IsolatedEnvVenvPip] = None
+
+    @classmethod
+    def get_instance(cls) -> "IsolatedEnvBuilderCached":
+        """
+        This method should be used to obtain an instance of this class, because this class is a singleton.
+        """
+        if not cls._instance:
+            cls._instance = cls()
+        return cls._instance
+
+    def __enter__(self) -> build.env._IsolatedEnvVenvPip:
+        if not self._isolated_env:
+            # __enter__() was not called before
+            self._isolated_env = super(IsolatedEnvBuilderCached, self).__enter__()
+            # Install the build requirements. All modules in this test suite have the same build requirements, so
+            # we can choose any module here to install them
+            builder = build.ProjectBuilder(
+                srcdir=os.path.join(os.path.dirname(__file__), "..", "..", "tests", "data", "modules_v2", "minimalv2module"),
+                python_executable=self._isolated_env.executable,
+                scripts_dir=self._isolated_env.scripts_dir,
+            )
+            self._isolated_env.install(builder.build_system_requires)
+            self._isolated_env.install(builder.get_requires_for_build(distribution="wheel"))
+            # All build dependencies are installed, so we can disable the install() method on self._isolated_env.
+            # This prevents unnecessary pip processes from being spawned.
+            self._isolated_env.install = lambda *args, **kwargs: None
+        return self._isolated_env
+
+    def __exit__(
+        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+    ) -> None:
+        # Ignore implementation from the super class to keep the environment
+        pass
+
+    def destroy(self) -> None:
+        """
+        Cleanup the cached build environment. It should be called at the end of the test suite.
+        """
+        if self._isolated_env:
+            super(IsolatedEnvBuilderCached, self).__exit__(exc_type=None, exc_val=None, exc_tb=None)
+            self._isolated_env = None
+
+
 class V2ModuleBuilder:
+
+    DISABLE_ISOLATED_ENV_BUILDER_CACHE: bool = False
+
     def __init__(self, module_path: str) -> None:
         """
         :raises InvalidModuleException: The given module_path doesn't reference a valid module.
@@ -1135,12 +1197,24 @@ setup(name="{ModuleV2Source.get_package_name_for(self._module.name)}",
         metadata_file = os.path.join(build_path, "setup.cfg")
         shutil.copy(metadata_file, python_pkg_dir)
 
+    def _get_isolated_env_builder(self) -> "build.env.IsolatedEnvBuilder":
+        """
+        Returns the IsolatedEnvBuilder instance that should be used to build V2 modules. To speed to up the test
+        suite, the build environment is cached when the tests are ran. This is possible because all modules, built
+        by the test suite, have the same build requirements. For tests that need to test the code path used in
+        production, the V2ModuleBuilder.DISABLE_ISOLATED_ENV_BUILDER_CACHE flag can be set to True.
+        """
+        if inmanta.RUNNING_TESTS and not V2ModuleBuilder.DISABLE_ISOLATED_ENV_BUILDER_CACHE:
+            return IsolatedEnvBuilderCached.get_instance()
+        else:
+            return build.env.IsolatedEnvBuilder()
+
     def _build_v2_module(self, build_path: str, output_directory: str) -> str:
         """
         Build v2 module using PEP517 package builder.
         """
         try:
-            with build.env.IsolatedEnvBuilder() as env:
+            with self._get_isolated_env_builder() as env:
                 distribution = "wheel"
                 builder = build.ProjectBuilder(srcdir=build_path, python_executable=env.executable, scripts_dir=env.scripts_dir)
                 env.install(builder.build_system_requires)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import toml
 
 """
 About the use of @parametrize_any and @slowtest:
@@ -54,7 +55,7 @@ The following fixtures manage test environments:
 The deactive_venv autouse fixture cleans up all venv activation and resets inmanta.env.process_env to point to the outer
 environment.
 """
-
+import yaml
 
 import asyncio
 import concurrent
@@ -1619,6 +1620,40 @@ async def migrate_db_from(
     yield migrate
 
     await bootloader.stop(timeout=15)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def guard_invariant_on_v2_modules_in_data_dir(modules_v2_dir: str) -> None:
+    """
+    When the test suite runs, the python environment used to build V2 modules is cached using the IsolatedEnvBuilderCached
+    class. This cache relies on the fact that all modules in the tests/data/modules_v2 directory use the same build-backand
+    and build requirements. This guard verifies whether that assumption is fulfilled and raises an exception if it's not.
+    """
+    for dir_name in os.listdir(modules_v2_dir):
+        module_path = os.path.join(modules_v2_dir, dir_name)
+        pyproject_toml_path = os.path.join(module_path, "pyproject.toml")
+        error_message = f"""
+Module {module_path} has a pyproject.toml file that is incompatible with the requirements of this test suite.
+The build-backend and the build requirements should be set as follows:
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+All modules present in the tests/data/module_v2 directory should satisfy the above-mentioned requirements, because
+the test suite caches the python environment used to build the V2 modules. This cache relies on the assumption that all modules
+use the same build-backend and build requirements.
+        """.strip()
+        with open(pyproject_toml_path, "r", encoding="utf-8") as fh:
+            pyproject_toml_as_dct = toml.load(fh)
+            try:
+                if (
+                    pyproject_toml_as_dct["build-system"]["build-backend"] != "setuptools.build_meta" or
+                    set(pyproject_toml_as_dct["build-system"]["requires"]) != {"setuptools", "wheel"}
+                ):
+                    raise Exception(error_message)
+            except (KeyError, TypeError):
+                raise Exception(error_message)
 
 
 @pytest.fixture(scope="session", autouse=not PYTEST_PLUGIN_MODE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,8 +55,6 @@ The following fixtures manage test environments:
 The deactive_venv autouse fixture cleans up all venv activation and resets inmanta.env.process_env to point to the outer
 environment.
 """
-import yaml
-
 import asyncio
 import concurrent
 import csv
@@ -1647,10 +1645,9 @@ use the same build-backend and build requirements.
         with open(pyproject_toml_path, "r", encoding="utf-8") as fh:
             pyproject_toml_as_dct = toml.load(fh)
             try:
-                if (
-                    pyproject_toml_as_dct["build-system"]["build-backend"] != "setuptools.build_meta" or
-                    set(pyproject_toml_as_dct["build-system"]["requires"]) != {"setuptools", "wheel"}
-                ):
+                if pyproject_toml_as_dct["build-system"]["build-backend"] != "setuptools.build_meta" or set(
+                    pyproject_toml_as_dct["build-system"]["requires"]
+                ) != {"setuptools", "wheel"}:
                     raise Exception(error_message)
             except (KeyError, TypeError):
                 raise Exception(error_message)

--- a/tests/moduletool/test_build.py
+++ b/tests/moduletool/test_build.py
@@ -88,6 +88,7 @@ def test_build_v2_module(
     set_path_argument: bool,
     byte_code: bool,
     monkeypatch: MonkeyPatch,
+    disable_isolated_env_builder_cache: None,  # Test the code path used in production
 ) -> None:
     """
     Build a V2 package and verify that the required files are present in the resulting wheel.


### PR DESCRIPTION
# Description

Add support to cache the Python environment used to build V2 modules.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
