### PR TITLE
Scope autouse fixture to core only

### DIFF
--- a/changelogs/unreleased/scope-autouse-fixture-to-core.yml
+++ b/changelogs/unreleased/scope-autouse-fixture-to-core.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that the autouse fixture `guard_invariant_on_v2_modules_in_data_dir` only activates on core and not on the extensions.
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1620,7 +1620,7 @@ async def migrate_db_from(
     await bootloader.stop(timeout=15)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=not PYTEST_PLUGIN_MODE)
 def guard_invariant_on_v2_modules_in_data_dir(modules_v2_dir: str) -> None:
     """
     When the test suite runs, the python environment used to build V2 modules is cached using the IsolatedEnvBuilderCached


### PR DESCRIPTION
# Description

Ensure that the autouse fixture `guard_invariant_on_v2_modules_in_data_dir` only activates on core and not on the extensions.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
