### PR TITLE
Fix broken link in quickstart

### DIFF
--- a/changelogs/unreleased/fix-broken-link-quickstart.yml
+++ b/changelogs/unreleased/fix-broken-link-quickstart.yml
@@ -1,0 +1,4 @@
+---
+description: Fix issue where a link in the documentation is broken on a non-existing sr-linux-topology anchor.
+change-type: patch
+destination-branches: [master, iso5]

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -212,7 +212,7 @@ _______________________________
 
 There are a bunch of examples present inside the `SR Linux` folder of the `examples` repository that you have cloned in the previous step, setting up the lab_.
 
-In this guide, we will showcase two examples on a small **CLOS** `topology <https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#sr-linux-topology>`_ to get you started:
+In this guide, we will showcase two examples on a small **CLOS** `topology <https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#user-content-sr-linux-topology>`_ to get you started:
 
 1. `interface <https://github.com/inmanta/examples/blob/master/Networking/SR%20Linux/interfaces.cf>`_ configuration.
 2. `OSPF <https://github.com/inmanta/examples/blob/master/Networking/SR%20Linux/ospf.cf>`_ configuration.
@@ -227,7 +227,7 @@ It could be useful to know that Inmanta uses the ``gNMI`` protocol to interface 
 SR Linux interface configuration
 __________________________________
 
-The `interfaces.cf <https://github.com/inmanta/examples/blob/master/Networking/SR%20Linux/interfaces.cf>`_ file contains the required configuration model to set IP addresses on point-to-point interfaces between the ``spine``, ``leaf1`` and ``leaf2`` devices according to the `aforementioned topology <https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#sr-linux-topology>`_.
+The `interfaces.cf <https://github.com/inmanta/examples/blob/master/Networking/SR%20Linux/interfaces.cf>`_ file contains the required configuration model to set IP addresses on point-to-point interfaces between the ``spine``, ``leaf1`` and ``leaf2`` devices according to the `aforementioned topology <https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#user-content-sr-linux-topology>`_.
 
 Let's have a look at the partial configuration model:
 
@@ -293,7 +293,7 @@ Now, we can deploy the model by referring to `Deploy the configuration model`_ s
 SR Linux OSPF configuration
 __________________________________
 
-The `ospf.cf <https://github.com/inmanta/examples/blob/master/Networking/SR%20Linux/ospf.cf>`_ file contains the required configuration model to first set IP addresses on point-to-point interfaces between the ``spine``, ``leaf1`` and ``leaf2`` devices according to the `aforementioned topology <https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#sr-linux-topology>`_ and then configure ``OSPF`` between them.
+The `ospf.cf <https://github.com/inmanta/examples/blob/master/Networking/SR%20Linux/ospf.cf>`_ file contains the required configuration model to first set IP addresses on point-to-point interfaces between the ``spine``, ``leaf1`` and ``leaf2`` devices according to the `aforementioned topology <https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#user-content-sr-linux-topology>`_ and then configure ``OSPF`` between them.
 
 This model build on top of the ``interfaces`` model that was discussed in `SR Linux interface configuration`_. It first `imports` the required packages, then configures ``interfaces`` on all the devices and after that, adds the required configuration model for ``OSPF``.
 


### PR DESCRIPTION
# Description

The link check failed on the link https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#sr-linux-topology, because the anchor `sr-linux-topology` could not be found. When inspecting the HTML page, it's true that no tag exists with that id. I assume some tags are generated implicitly, which causes the link checker to failed while there is no issue. The good new is that a tag exists with the id `user-content-sr-linux-topology` at the same level. This PR uses that id now.

Relevant HTML snippet:

```
<h2 dir="auto">
    <a id="user-content-sr-linux-topology" class="anchor" aria-hidden="true" href="#sr-linux-topology">
        <svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path>
        </svg>
    </a>
    SR Linux Topology
</h2>
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
