### PR TITLE
Fix path db dump tool

### DIFF
--- a/tests_common/copy_files_from_core.py
+++ b/tests_common/copy_files_from_core.py
@@ -53,7 +53,7 @@ simple_project_dir = os.path.join(data_dir, "simple_project")
 db_common_py = os.path.join(db_dir, "common.py")
 dest_db_common_py = os.path.join(dest_db_dir, "common.py")
 dump_tool_py = os.path.join(db_dir, "dump_tool.py")
-dest_dump_tool_py = os.path.join(dest_db_dir, "dump_tool.py")
+dest_dump_tool_py = os.path.join(dest_db_dir, "migration_tests", "dump_tool.py")
 dest_simple_project_dir = os.path.join(dest_db_dir, "simple_project")
 
 

--- a/tests_common/copy_files_from_core.py
+++ b/tests_common/copy_files_from_core.py
@@ -52,7 +52,7 @@ enduser_certs_dir = os.path.join(data_dir, "ca", "enduser-certs")
 simple_project_dir = os.path.join(data_dir, "simple_project")
 db_common_py = os.path.join(db_dir, "common.py")
 dest_db_common_py = os.path.join(dest_db_dir, "common.py")
-dump_tool_py = os.path.join(db_dir, "dump_tool.py")
+dump_tool_py = os.path.join(db_dir, "migration_tests", "dump_tool.py")
 dest_dump_tool_py = os.path.join(dest_db_dir, "migration_tests", "dump_tool.py")
 dest_simple_project_dir = os.path.join(dest_db_dir, "simple_project")
 


### PR DESCRIPTION
# Description

PR https://github.com/inmanta/inmanta-core/pull/4879 moved some files around put paths weren't adapted as they should have.
This commit will fix this.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
