### PR TITLE
Fix race condition in test_purge_on_delete_compile_failed

### DIFF
--- a/changelogs/unreleased/fix-race-condition-in-test-case
+++ b/changelogs/unreleased/fix-race-condition-in-test-case
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in test case test_purge_on_delete_compile_failed
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/changelogs/unreleased/fix-race-condition-in-test-case
+++ b/changelogs/unreleased/fix-race-condition-in-test-case
@@ -1,4 +1,0 @@
----
-description: Fix race condition in test case test_purge_on_delete_compile_failed
-change-type: patch
-destination-branches: [master, iso5, iso4]

--- a/changelogs/unreleased/fix-race-condition-in-test-case.yml
+++ b/changelogs/unreleased/fix-race-condition-in-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in test case test_purge_on_delete_compile_failed
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -22,7 +22,7 @@ from datetime import datetime
 
 import pytest
 
-from inmanta import const, data
+from inmanta import const, data, config
 from inmanta.agent.agent import Agent
 from inmanta.export import unknown_parameters
 from inmanta.main import Client
@@ -179,6 +179,9 @@ async def test_purge_on_delete_compile_failed(client: Client, server: Server, cl
     """
     Test purge on delete of resources
     """
+    config.Config.set("config", "agent-deploy-interval", "0")
+    config.Config.set("config", "agent-repair-interval", "0")
+
     agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
     await agent.start()
     aclient = agent._client

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -22,7 +22,7 @@ from datetime import datetime
 
 import pytest
 
-from inmanta import const, data, config
+from inmanta import config, const, data
 from inmanta.agent.agent import Agent
 from inmanta.export import unknown_parameters
 from inmanta.main import Client


### PR DESCRIPTION
# Description

Fix race condition present in test case `test_purge_on_delete_compile_failed`, where the state of a model goes to deploying again when the deploy/repair timer of an agent triggers.

```
_____________________ test_purge_on_delete_compile_failed ______________________
03:10:09 
03:10:09 client = <inmanta.protocol.endpoints.Client object at 0x7f8df0b78490>
03:10:09 server = <inmanta.server.protocol.Server object at 0x7f8dd0ea4430>
03:10:09 clienthelper = <utils.ClientHelper object at 0x7f8e01d1f460>
03:10:09 environment = '41941274-3135-417a-8d23-fc02d47f4d23'
03:10:09 
03:10:09     async def test_purge_on_delete_compile_failed(client: Client, server: Server, clienthelper: ClientHelper, environment: str):
03:10:09         """
03:10:09         Test purge on delete of resources
03:10:09         """
03:10:09         agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
03:10:09         await agent.start()
03:10:09         aclient = agent._client
03:10:09     
03:10:09         version = await clienthelper.get_version()
03:10:09     
03:10:09         resources = [
03:10:09             {
03:10:09                 "group": "root",
03:10:09                 "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
03:10:09                 "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
03:10:09                 "owner": "root",
03:10:09                 "path": "/tmp/file1",
03:10:09                 "permissions": 644,
03:10:09                 "purged": False,
03:10:09                 "reload": False,
03:10:09                 "requires": [],
03:10:09                 "purge_on_delete": True,
03:10:09                 "version": version,
03:10:09             },
03:10:09             {
03:10:09                 "group": "root",
03:10:09                 "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
03:10:09                 "id": "std::File[vm1,path=/tmp/file2],v=%d" % version,
03:10:09                 "owner": "root",
03:10:09                 "path": "/tmp/file2",
03:10:09                 "permissions": 644,
03:10:09                 "purged": False,
03:10:09                 "reload": False,
03:10:09                 "purge_on_delete": True,
03:10:09                 "requires": ["std::File[vm1,path=/tmp/file1],v=%d" % version],
03:10:09                 "version": version,
03:10:09             },
03:10:09             {
03:10:09                 "group": "root",
03:10:09                 "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
03:10:09                 "id": "std::File[vm1,path=/tmp/file3],v=%d" % version,
03:10:09                 "owner": "root",
03:10:09                 "path": "/tmp/file3",
03:10:09                 "permissions": 644,
03:10:09                 "purged": False,
03:10:09                 "reload": False,
03:10:09                 "requires": [],
03:10:09                 "purge_on_delete": True,
03:10:09                 "version": version,
03:10:09             },
03:10:09         ]
03:10:09     
03:10:09         await clienthelper.put_version_simple(resources, version)
03:10:09     
03:10:09         # Release the model and set all resources as deployed
03:10:09         result = await client.release_version(environment, version, False)
03:10:09         assert result.code == 200
03:10:09     
03:10:09         now = datetime.now()
03:10:09         result = await aclient.resource_action_update(
03:10:09             environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
03:10:09         )
03:10:09         assert result.code == 200
03:10:09     
03:10:09         result = await aclient.resource_action_update(
03:10:09             environment, ["std::File[vm1,path=/tmp/file2],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
03:10:09         )
03:10:09         assert result.code == 200
03:10:09     
03:10:09         result = await aclient.resource_action_update(
03:10:09             environment, ["std::File[vm1,path=/tmp/file3],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
03:10:09         )
03:10:09         assert result.code == 200
03:10:09     
03:10:09         result = await client.get_version(environment, version)
03:10:09         assert result.code == 200
03:10:09         assert result.result["model"]["version"] == version
03:10:09         assert result.result["model"]["total"] == len(resources)
03:10:09         assert result.result["model"]["done"] == len(resources)
03:10:09         assert result.result["model"]["released"]
03:10:09 >       assert result.result["model"]["result"] == const.VersionState.success.name
03:10:09 E       AssertionError: assert 'deploying' == 'success'
03:10:09 E         - success
03:10:09 E         + deploying
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
