### PR TITLE
Remove --progress option from git clone command

### DIFF
--- a/changelogs/unreleased/4919-remove-progress-option.yml
+++ b/changelogs/unreleased/4919-remove-progress-option.yml
@@ -1,0 +1,8 @@
+---
+description: "Fix issue where the progress information of the git clone command shows mixed log lines"
+issue-nr: 4919
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -354,7 +354,7 @@ class CLIGitProvider(GitProvider):
     def clone(self, src: str, dest: str) -> None:
         process_env = os.environ.copy()
         process_env["GIT_ASKPASS"] = "true"
-        cmd = ["git", "clone", "--progress", src, dest]
+        cmd = ["git", "clone", src, dest]
 
         return_code, _ = env.PythonEnvironment.run_command_and_stream_output(cmd, env_vars=process_env)
 


### PR DESCRIPTION
# Description

Fix issue where the progress information of the git clone command shows log lines being mixed together.

closes #4919

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
