### PR TITLE
Fix tests that verify logging output

### DIFF
--- a/changelogs/unreleased/fix-broken-tests-logging.yml
+++ b/changelogs/unreleased/fix-broken-tests-logging.yml
@@ -1,0 +1,4 @@
+---
+description: Fix tests that verify the logging output that were broken due to #4869
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -34,12 +34,14 @@ from pkg_resources import Requirement
 from inmanta import compiler, const, env, loader, module
 from inmanta.ast import CompilerException
 from inmanta.config import Config
-from inmanta.env import ConflictingRequirements, PythonEnvironment
+from inmanta.env import CommandRunner, ConflictingRequirements
 from inmanta.module import InmantaModuleRequirement, InstallMode, ModuleLoadingException, ModuleNotFoundException
 from inmanta.moduletool import DummyProject, ModuleConverter, ModuleTool, ProjectTool
 from moduletool.common import BadModProvider, install_project
 from packaging import version
 from utils import LogSequence, PipIndex, log_contains, module_from_template
+
+LOGGER = logging.getLogger(__name__)
 
 
 def run_module_install(module_path: str, editable: bool, set_path_argument: bool) -> None:
@@ -1117,7 +1119,7 @@ def test_real_time_logging(caplog):
     cmd: List[str] = ["sh -c 'echo one && sleep 1 && echo two'"]
     return_code: int
     output: List[str]
-    return_code, output = PythonEnvironment.run_command_and_stream_output(cmd, shell=True)
+    return_code, output = CommandRunner(LOGGER).run_command_and_stream_output(cmd, shell=True)
     assert return_code == 0
 
     assert "one" in caplog.records[0].message
@@ -1182,7 +1184,7 @@ def test_pip_output(local_module_package_index: str, snippetcompiler_clean, capl
     for message, level in expected_logs:
         log_contains(
             caplog,
-            "inmanta.env",
+            "inmanta.pip",
             level,
             message,
         )
@@ -1210,7 +1212,7 @@ def test_git_clone_output(snippetcompiler_clean, caplog, modules_v2_dir):
     for message, level in expected_logs:
         log_contains(
             caplog,
-            "inmanta.env",
+            "inmanta.module",
             level,
             message,
         )
@@ -1250,7 +1252,7 @@ def test_no_matching_distribution(local_module_package_index: str, snippetcompil
         )
     log_contains(
         caplog,
-        "inmanta.env",
+        "inmanta.pip",
         logging.DEBUG,
         "No matching distribution found for inmanta-module-child-module==3.3.3",
     )
@@ -1282,7 +1284,7 @@ def test_no_matching_distribution(local_module_package_index: str, snippetcompil
 
     log_contains(
         caplog,
-        "inmanta.env",
+        "inmanta.pip",
         logging.DEBUG,
         "No matching distribution found for inmanta-module-child-module==3.3.3",
     )
@@ -1313,7 +1315,7 @@ def test_no_matching_distribution(local_module_package_index: str, snippetcompil
     )
     log_contains(
         caplog,
-        "inmanta.env",
+        "inmanta.pip",
         logging.DEBUG,
         "Successfully installed inmanta-module-child-module-3.3.3 inmanta-module-parent-module-1.2.3",
     )


### PR DESCRIPTION
# Description

PR #4869 broke some tests that verify logging output. This issue was not detected because the tests only run nightly.

Belongs to #4651

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
