### PR TITLE
[FIX] Fail cleanly (without showing stack trace) when building docs locally (#4884)

### DIFF
--- a/changelogs/unreleased/fix-uncaught-exception-when-building-docs.yml
+++ b/changelogs/unreleased/fix-uncaught-exception-when-building-docs.yml
@@ -1,0 +1,4 @@
+---
+description: Fail cleanly (without showing stack trace) when building docs locally without setting the INMANTA_DONT_DISCOVER_VERSION variable
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 # serve to show the default.
 
 import sys, os, pkg_resources, datetime
+from sphinx.errors import ConfigError
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -93,7 +94,18 @@ if "INMANTA_DONT_DISCOVER_VERSION" in os.environ:
     #    this value will be overwritten with the ISO product version.
     version = "1.0.0"
 else:
-    version = pkg_resources.get_distribution("inmanta").version
+    try:
+        version = pkg_resources.get_distribution("inmanta").version
+    except pkg_resources.DistributionNotFound:
+        raise ConfigError(
+            """
+The inmanta package is not installed. This way sphinx failed to discover the version number that should be
+displayed on the documentation pages. Either install the inmanta package or set the environment variable
+INMANTA_DONT_DISCOVER_VERSION when the version number is not important for this documentation build. The latter
+solution will set the version number to 1.0.0.
+            """
+        )
+
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4884