### PR TITLE
Make interface of AgentCache backwards compatible with the old implementation

### DIFF
--- a/changelogs/unreleased/make-interface-agent-cache-backwards-compatible.yml
+++ b/changelogs/unreleased/make-interface-agent-cache-backwards-compatible.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that the interface of AgentCache is backwards compatible with the previous implementation, because pytest-inmanta depends on it.
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,21 +26,6 @@ from inmanta.agent.handler import cache
 from inmanta.resources import Id, Resource, resource
 
 
-class AgentInstanceMock:
-    def is_stopped(self) -> bool:
-        return False
-
-
-@pytest.fixture(scope="session")
-def agent_instance_mock():
-    """
-    The AgentCache needs a reference to an AgentInstance to verify whether
-    the AgentInstance is stopped or not. This fixture provides a mocked
-    AgentInstance that only has the is_stopped() method.
-    """
-    return AgentInstanceMock()
-
-
 @fixture()
 def my_resource():
     @resource("test::Resource", agent="agent", id_attribute="key")
@@ -52,15 +37,15 @@ def my_resource():
         fields = ("key", "value", "purged")
 
 
-def test_base(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_base():
+    cache = AgentCache()
     value = "test too"
     cache.cache_value("test", value)
     assert value == cache.find("test")
 
 
-def test_timout(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_timout():
+    cache = AgentCache()
     value = "test too"
     cache.cache_value("test", value, timeout=0.1)
     cache.cache_value("test2", value)
@@ -76,23 +61,23 @@ def test_timout(agent_instance_mock):
     assert value == cache.find("test2")
 
 
-def test_base_fail(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_base_fail():
+    cache = AgentCache()
     value = "test too"
     with pytest.raises(KeyError):
         assert value == cache.find("test")
 
 
-def test_resource(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_resource():
+    cache = AgentCache()
     value = "test too"
     resource = Id("test::Resource", "test", "key", "test", 100).get_instance()
     cache.cache_value("test", value, resource=resource)
     assert value == cache.find("test", resource=resource)
 
 
-def test_resource_fail(my_resource, agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_resource_fail(my_resource):
+    cache = AgentCache()
     value = "test too"
     resource = Id("test::Resource", "test", "key", "test", 100).get_instance()
     cache.cache_value("test", value, resource=resource)
@@ -101,8 +86,8 @@ def test_resource_fail(my_resource, agent_instance_mock):
         assert value == cache.find("test")
 
 
-def test_version_closed(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_version_closed():
+    cache = AgentCache()
     value = "test too"
     version = 200
     with pytest.raises(Exception):
@@ -110,8 +95,8 @@ def test_version_closed(agent_instance_mock):
         assert value == cache.find("test", version=version)
 
 
-def test_version(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_version():
+    cache = AgentCache()
     value = "test too"
     version = 200
     cache.open_version(version)
@@ -119,8 +104,8 @@ def test_version(agent_instance_mock):
     assert value == cache.find("test", version=version)
 
 
-def test_version_close(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_version_close():
+    cache = AgentCache()
     value = "test too"
     version = 200
     cache.open_version(version)
@@ -138,8 +123,8 @@ def test_version_close(agent_instance_mock):
         raise AssertionError("Should get exception")
 
 
-def test_context_manager(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_context_manager():
+    cache = AgentCache()
     value = "test too"
     version = 200
     with cache.manager(version):
@@ -156,7 +141,7 @@ def test_context_manager(agent_instance_mock):
         assert value == cache.find("test", version=version)
 
 
-def test_multi_threaded(agent_instance_mock):
+def test_multi_threaded():
     class Spy(object):
         def __init__(self):
             self.created = 0
@@ -171,7 +156,7 @@ def test_multi_threaded(agent_instance_mock):
         def delete(self):
             self.deleted += 1
 
-    cache = AgentCache(agent_instance_mock)
+    cache = AgentCache()
     version = 200
 
     cache.open_version(version)
@@ -210,8 +195,8 @@ def test_multi_threaded(agent_instance_mock):
     assert beta.deleted == beta.created
 
 
-def test_timout_and_version(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_timout_and_version():
+    cache = AgentCache()
     version = 200
 
     cache.open_version(version)
@@ -233,8 +218,8 @@ def test_timout_and_version(agent_instance_mock):
     assert value == cache.find("testx")
 
 
-def test_version_and_timout(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_version_and_timout():
+    cache = AgentCache()
     version = 200
 
     cache.open_version(version)
@@ -255,8 +240,8 @@ def test_version_and_timout(agent_instance_mock):
         cache.find("test", version=version)
 
 
-def test_version_fail(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_version_fail():
+    cache = AgentCache()
     value = "test too"
     version = 200
     cache.open_version(version)
@@ -266,8 +251,8 @@ def test_version_fail(agent_instance_mock):
         assert value == cache.find("test")
 
 
-def test_resource_and_version(agent_instance_mock):
-    cache = AgentCache(agent_instance_mock)
+def test_resource_and_version():
+    cache = AgentCache()
     value = "test too"
     resource = Id("test::Resource", "test", "key", "test", 100).get_instance()
     version = 200
@@ -276,7 +261,7 @@ def test_resource_and_version(agent_instance_mock):
     assert value == cache.find("test", resource=resource, version=version)
 
 
-def test_get_or_else(my_resource, agent_instance_mock):
+def test_get_or_else(my_resource):
     called = []
 
     def creator(param, resource, version):
@@ -284,7 +269,7 @@ def test_get_or_else(my_resource, agent_instance_mock):
         called.append("x")
         return param
 
-    cache = AgentCache(agent_instance_mock)
+    cache = AgentCache()
     value = "test too"
     value2 = "test too x"
     resource = Id("test::Resource", "test", "key", "test", 100).get_instance()
@@ -300,7 +285,7 @@ def test_get_or_else(my_resource, agent_instance_mock):
     assert value2 == cache.get_or_else("test", creator, resource=resource, version=version, param=value2)
 
 
-def test_get_or_else_none(agent_instance_mock):
+def test_get_or_else_none():
     called = []
 
     def creator(param, resource, version):
@@ -317,7 +302,7 @@ def test_get_or_else_none(agent_instance_mock):
             self.count += 1
             return out
 
-    cache = AgentCache(agent_instance_mock)
+    cache = AgentCache()
     value = "test too"
     resource = Id("test::Resource", "test", "key", "test", 100).get_instance()
     version = 100
@@ -343,7 +328,7 @@ def test_get_or_else_none(agent_instance_mock):
     assert seq.count == 3
 
 
-def test_decorator(agent_instance_mock):
+def test_decorator():
     class Closeable:
         def __init__(self):
             self.closed = False
@@ -354,7 +339,7 @@ def test_decorator(agent_instance_mock):
     my_closable = Closeable()
     my_closable_2 = Closeable()
 
-    xcache = AgentCache(agent_instance_mock)
+    xcache = AgentCache()
 
     class DT(object):
         def __init__(self, cache):


### PR DESCRIPTION
# Description

Ensure that the interface of AgentCache is backwards compatible with the previous implementation, because pytest-inmanta depends on it. #4932 introduced the braking change. #4932 didn't get merged into ISO4 due to a merge conflict. That's why this PR only acts on master and iso5. I will create a separate PR to apply #4932 and this PR iso4 as well.

Belongs to #4932

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
