### PR TITLE
added two compiler exceptions to the stable API

### DIFF
--- a/changelogs/unreleased/compiler-exceptions-stable-api.yml
+++ b/changelogs/unreleased/compiler-exceptions-stable-api.yml
@@ -1,0 +1,6 @@
+description: "Added ``inmanta.ast.AttributeException`` and ``inmanta.ast.DoubleSetException`` to the stable API"
+change-type: patch
+destination-branches:
+  - master
+  - iso5
+  - iso4

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -716,6 +716,7 @@ class WrappingRuntimeException(RuntimeException):
         return self.__cause__.importantance() + 1
 
 
+@stable_api
 class AttributeException(WrappingRuntimeException):
     """Exception raise when an attribute could not be set, always wraps another exception"""
 
@@ -802,6 +803,7 @@ class NotFoundException(RuntimeException):
         return 20
 
 
+@stable_api
 class DoubleSetException(RuntimeException):
     def __init__(
         self, variable: "ResultVariable", stmt: "Optional[Statement]", newvalue: object, newlocation: Location


### PR DESCRIPTION
# Description

added two compiler exceptions to the stable API

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
