### PR TITLE
fixed colorlog compatibility

### DIFF
--- a/changelogs/unreleased/colorlog-fixes.yml
+++ b/changelogs/unreleased/colorlog-fixes.yml
@@ -1,0 +1,5 @@
+description: Fixed some compatibility issues with colorlog library
+change-type: patch
+destination-branches:
+  - iso5
+  - master

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requires = [
     "click-plugins~=1.0",
     # click has been known to publish non-backwards compatible minors in the past (removed deprecated code in 8.1.0)
     "click>=8.0,<8.2",
-    "colorlog~=6.0",
+    "colorlog~=6.4",
     "cookiecutter>=1,<3",
     "crontab~=0.23",
     "cryptography>=36,<39",

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -86,9 +86,7 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
         reset: bool = True,
         no_color: bool = False,
     ):
-        super().__init__(
-            fmt, log_colors=log_colors, reset=reset, no_color=no_color
-        )
+        super().__init__(fmt, log_colors=log_colors, reset=reset, no_color=no_color)
         self.fmt = fmt
 
     def get_header_length(self, record: logging.LogRecord) -> int:

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -48,7 +48,7 @@ from types import FrameType
 from typing import Any, Callable, Coroutine, Dict, Optional
 
 import colorlog
-from colorlog.formatter import LogColors, SecondaryLogColors, _FormatStyle
+from colorlog.formatter import LogColors, SecondaryLogColors
 from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.util import TimeoutError
@@ -71,6 +71,12 @@ try:
 except ImportError:
     rpdb = None
 
+if typing.TYPE_CHECKING:
+    try:
+        from colorlog.formatter import _FormatStyle
+    except ImportError:
+        _FormatStyle = typing.Literal["%", "{", "$"]
+
 LOGGER = logging.getLogger("inmanta")
 
 
@@ -81,25 +87,22 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
         self,
         fmt: typing.Optional[str] = None,
         datefmt: typing.Optional[str] = None,
-        style: _FormatStyle = "%",
+        style: "_FormatStyle" = "%",
         log_colors: typing.Optional[LogColors] = None,
         reset: bool = True,
         secondary_log_colors: typing.Optional[SecondaryLogColors] = None,
         validate: bool = True,
         stream: typing.Optional[typing.IO] = None,
         no_color: bool = False,
-        force_color: bool = False,
-        defaults: typing.Optional[typing.Mapping[str, typing.Any]] = None,
     ):
         super().__init__(
-            fmt, datefmt, style, log_colors, reset, secondary_log_colors, validate, stream, no_color, force_color, defaults
+            fmt, datefmt, style, log_colors, reset, secondary_log_colors, validate, stream, no_color
         )
         self.fmt = fmt
         self.style = style
         self.validate = validate
-        self.defaults = defaults
 
-    def get_header_length(self, record):
+    def get_header_length(self, record: logging.LogRecord) -> int:
         """Get the header length of a given record."""
         # to get the length of the header we want to get the header without the color codes
         formatter = colorlog.ColoredFormatter(
@@ -112,8 +115,6 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
             validate=self.validate,
             stream=self.stream,
             no_color=True,
-            force_color=False,
-            defaults=self.defaults,
         )
         header = formatter.format(
             logging.LogRecord(
@@ -128,7 +129,7 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
         )
         return len(header)
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         """Format a record with added indentation."""
         indent = " " * self.get_header_length(record)
         head, *tail = super().format(record).splitlines(True)
@@ -817,7 +818,6 @@ def _get_log_formatter_for_stream_handler(timed: bool) -> logging.Formatter:
         formatter = MultiLineFormatter(
             log_format,
             reset=False,
-            force_color=False,
             no_color=True,
             datefmt=None,
         )


### PR DESCRIPTION
# Description

Fixed some minor issues with our usage of the `colorlog` library:
- bumped constraint from `~=6.0` to `~=6.4` because all versions in between are pre-releases we're not necessarily compatible with
- dropped fields we don't need that were only added in later versions of the library than the one in our constraint
- import underscore-prefixed type only when type checking and with a safe fallback
- added some typing

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
