### PR TITLE
Fix bug where the result of the future of a resourceaction is set twice

### DIFF
--- a/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
+++ b/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
@@ -1,0 +1,5 @@
+---
+description: Fix bug where a ResourceAction fails with an InvalidStateError when the agent is shutdown
+change-type: patch
+destination-branches: [master, iso5, iso4]
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
+++ b/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
@@ -2,4 +2,5 @@
 description: Fix bug where a ResourceAction fails with an InvalidStateError when the agent is shutdown
 change-type: patch
 destination-branches: [master, iso5, iso4]
+sections:
   bugfix: "{{description}}"

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -471,7 +471,11 @@ class ResourceScheduler(object):
         dummy.future.set_result(ResourceActionResult(cancel=False))
 
     async def mark_deployment_as_finished(self, resource_actions: Iterable[ResourceActionBase]) -> None:
-        await asyncio.gather(*[resource_action.future for resource_action in resource_actions])
+        # This method is executing as a background task. As such, it will get cancelled when the agent is stopped.
+        # Because the asyncio.gather() call propagates cancellation, we shield the ResourceActionBase.future.
+        # Cancellation of these futures is handled by the ResourceActionBase.cancel() method. Not shielding them
+        # would cause the result of the future to be set twice, which results in an undesired InvalidStateError.
+        await asyncio.gather(*[asyncio.shield(resource_action.future) for resource_action in resource_actions])
         async with self.agent.critical_ratelimiter:
             if not self.finished():
                 return


### PR DESCRIPTION
# Description

Fix bug where a ResourceAction fails with an InvalidStateError when the agent is shutdown.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
