### PR TITLE
Fix bug where the result of the future of a resourceaction is set twice

### DIFF
--- a/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
+++ b/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug where a ResourceAction fails with an InvalidStateError when the agent is shutdown
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
+++ b/changelogs/unreleased/fix-result-set-twice-on-resource-action.yml
@@ -1,6 +1,6 @@
 ---
 description: Fix bug where a ResourceAction fails with an InvalidStateError when the agent is shutdown
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso4]
 sections:
   bugfix: "{{description}}"


### PR DESCRIPTION
# Description

**Same PR as  #4960 but scoped to the iso4 branch due to a merge conflict.**

Fix bug where a ResourceAction fails with an InvalidStateError when the agent is shutdown.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
