### PR TITLE
fixed some unstable tests

### DIFF
--- a/changelogs/unreleased/fix-unstable-tests-purge-on-delete.yml
+++ b/changelogs/unreleased/fix-unstable-tests-purge-on-delete.yml
@@ -1,0 +1,5 @@
+description: Fixed some unstable tests
+change-type: patch
+destination-branches:
+  - iso5
+  - master

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -261,7 +261,12 @@ async def test_purge_on_delete_compile_failed(client: Client, server: Server, cl
     assert result.result["model"]["total"] == len(resources)
     assert result.result["model"]["done"] == len(resources)
     assert result.result["model"]["released"]
-    assert result.result["model"]["result"] == const.VersionState.success.name
+
+    async def is_success() -> bool:
+        result = await client.get_version(environment, version)
+        return result.result["model"]["result"] == const.VersionState.success.name
+
+    await retry_limited(is_success, timeout=10)
 
     # New version with only file3
     version = await clienthelper.get_version()
@@ -373,7 +378,12 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
     assert result.result["model"]["total"] == len(resources)
     assert result.result["model"]["done"] == len(resources)
     assert result.result["model"]["released"]
-    assert result.result["model"]["result"] == const.VersionState.success.name
+
+    async def is_success() -> bool:
+        result = await client.get_version(environment, version)
+        return result.result["model"]["result"] == const.VersionState.success.name
+
+    await retry_limited(is_success, timeout=10)
 
     # New version with only file3
     version = await clienthelper.get_version()
@@ -600,7 +610,12 @@ async def test_disable_purge_on_delete(client: Client, clienthelper: ClientHelpe
 
     result = await client.get_version(environment, version)
     assert result.code == 200
-    assert result.result["model"]["result"] == const.VersionState.success.name
+
+    async def is_success() -> bool:
+        result = await client.get_version(environment, version)
+        return result.result["model"]["result"] == const.VersionState.success.name
+
+    await retry_limited(is_success, timeout=10)
 
     # Empty version
     version = await clienthelper.get_version()


### PR DESCRIPTION
# Description

#4871 moved the `mark_deploy_if_done` call to a background task. These two tests weren't updated to account for that.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
