### PR TITLE
issue/4908-add-module-plugin-deprecation

### DIFF
--- a/changelogs/unreleased/4908-add-module-and-plugin-deprecation.yml
+++ b/changelogs/unreleased/4908-add-module-and-plugin-deprecation.yml
@@ -1,5 +1,5 @@
 description: Add module and plugin deprecation mechanism
-issue-nr: 4651
+issue-nr: 4908
 change-type: patch
 destination-branches: [master, iso5]
 sections:

--- a/changelogs/unreleased/4908-add-module-and-plugin-deprecation.yml
+++ b/changelogs/unreleased/4908-add-module-and-plugin-deprecation.yml
@@ -1,0 +1,6 @@
+description: Add module and plugin deprecation mechanism
+issue-nr: 4651
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  minor-improvement: "{{description}}"

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -98,6 +98,7 @@ The ``setup.cfg`` file defines metadata about the module. The following code sni
   * ``name``: The name of the resulting Python package when this module is packaged. This name should follow the naming schema: ``inmanta-module-<module-name>``.
   * ``version``: The version of the module. Modules must use semantic versioning.
   * ``license``: The license under which the module is distributed.
+  * ``deprecated``: Optional field. If set to True, this module will print a warning deprecation message when used.
 
 * The ``install_requires`` config option in the ``options`` section of the ``setup.cfg`` file defines the dependencies of the
   module on other Inmanta modules and external Python libraries. These version specs use
@@ -190,6 +191,7 @@ three keys mandatory:
 * *license*: The license under which the module is distributed.
 * *version*: The version of this module. For a new module a start version could be 0.1dev0 These
   versions are parsed using the same version parser as python setuptools.
+* *deprecated*: Optional field. If set to True, this module will print a warning deprecation message when used.
 
 For example the following module.yml from the :doc:`../quickstart`
 

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -75,7 +75,7 @@ that converts a string to uppercase:
 
 The plugin decorator also accept the ``deprecated`` and ``replaced_by`` fields. When the ``deprecated`` field
 is set to ``True`` it prints out a warning that the plugin is deprecated. with the ``replaced_by`` string it is possible
-to tell by which plugin the current one has been replaced. for example if the code below is run
+to tell by which plugin the current one has been replaced. for example if the following plugin is called,
 
 .. code-block:: python
     :linenos:

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -161,7 +161,7 @@ the previous example would then look like this:
     try:
         from inmanta.plugins import deprecated
     except ImportError:
-    deprecated = lambda f=None, **kwargs: f if f is not None else deprecated
+        deprecated = lambda function=None, **kwargs: function if function is not None else deprecated
 
 
     @deprecated(replaced_by="my_new_plugin")

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -73,6 +73,31 @@ that converts a string to uppercase:
         return value.upper()
 
 
+The plugin decorator also accept the ``deprecated`` and ``replaced_by`` fields. When the ``deprecated`` field
+is set to ``True`` it prints out a warning that the plugin is deprecated. with the ``replaced_by`` string it is possible
+to tell by which plugin the current one has been replaced. for example if the code below is run
+
+.. code-block:: python
+    :linenos:
+
+    from inmanta.plugins import plugin
+
+    @plugin(deprecated=True, replaced_by="my_new_plugin")
+    def printf():
+        """
+            Prints inmanta
+        """
+        print("inmanta")
+
+
+it wil give following warning:
+
+.. code-block::
+
+    Plugin 'get_one' in module 'inmanta_plugins.<module_name>' is deprecated. It should be replaced by 'my_new_plugin'
+
+
+
 This plugin can be tested with:
 
 .. code-block:: inmanta

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -151,7 +151,7 @@ Should the replace_by argument be omitted, the warning would look like this:
 If you want your module to stay compatible with older versions of inmanta you will also need to add a little piece of code that changes how
 :func:`~inmanta.plugins.deprecated` is imported as it does not exist in all versions.
 
-The previous example would then look like this. For older inmanta versions, the replace the decorator with a no-op.
+The previous example would then look like this. For older inmanta versions, replace the decorator with a no-op.
 
 .. code-block:: python
     :linenos:

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -142,7 +142,7 @@ it will give following warning:
 
     Plugin 'printf' in module 'inmanta_plugins.<module_name>' is deprecated. It should be replaced by 'my_new_plugin'
 
-Should de replace_by argument be omitted, the warning would look like this:
+Should the replace_by argument be omitted, the warning would look like this:
 
 .. code-block::
 

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -125,7 +125,7 @@ for example if the plugin below is called:
 .. code-block:: python
     :linenos:
 
-    from inmanta.plugins import plugin,deprecated
+    from inmanta.plugins import plugin, deprecated
 
     @deprecated(replaced_by="my_new_plugin")
     @plugin

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -94,7 +94,7 @@ it wil give following warning:
 
 .. code-block::
 
-    Plugin 'get_one' in module 'inmanta_plugins.<module_name>' is deprecated. It should be replaced by 'my_new_plugin'
+    Plugin 'printf' in module 'inmanta_plugins.<module_name>' is deprecated. It should be replaced by 'my_new_plugin'
 
 
 

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -2,6 +2,11 @@
 
 Developing Plugins
 *********************
+
+
+Adding new plugins
+========================
+
 Plugins provide :ref:`functions<lang-plugins>` that can be called from the :term:`DSL`. This is the
 primary mechanism to interface Python code with the orchestration model at compile time. For Example,
 this mechanism is also used for std::template and std::file. In addition to this, Inmanta also registers all
@@ -73,31 +78,6 @@ that converts a string to uppercase:
         return value.upper()
 
 
-The plugin decorator also accept the ``deprecated`` and ``replaced_by`` fields. When the ``deprecated`` field
-is set to ``True`` it prints out a warning that the plugin is deprecated. with the ``replaced_by`` string it is possible
-to tell by which plugin the current one has been replaced. for example if the following plugin is called,
-
-.. code-block:: python
-    :linenos:
-
-    from inmanta.plugins import plugin
-
-    @plugin(deprecated=True, replaced_by="my_new_plugin")
-    def printf():
-        """
-            Prints inmanta
-        """
-        print("inmanta")
-
-
-it wil give following warning:
-
-.. code-block::
-
-    Plugin 'printf' in module 'inmanta_plugins.<module_name>' is deprecated. It should be replaced by 'my_new_plugin'
-
-
-
 This plugin can be tested with:
 
 .. code-block:: inmanta
@@ -128,3 +108,68 @@ see :ref:`moddev-module`.
 
 .. todo:: context
 .. todo:: new statements
+
+
+
+
+Deprecate plugins
+========================
+
+
+To deprecate a plugin the :func:`~inmanta.plugins.deprecated` decorator can be used in combination with the :func:`~inmanta.plugins.plugin`
+decorator. Using this decorator will log a warning message when the function is called. This decorator also accepts an
+optional argument ``replaced_by`` which can be used to potentially improve the warning message by telling which other
+plugin should be used in the place of the current one.
+
+for example if the plugin below is called:
+
+.. code-block:: python
+    :linenos:
+
+    from inmanta.plugins import plugin,deprecated
+
+    @deprecated(replaced_by="my_new_plugin")
+    @plugin
+    def printf():
+        """
+            Prints inmanta
+        """
+        print("inmanta")
+
+
+it will give following warning:
+
+.. code-block::
+
+    Plugin 'printf' in module 'inmanta_plugins.<module_name>' is deprecated. It should be replaced by 'my_new_plugin'
+
+Should de replace_by argument be omitted, the warning would look like this:
+
+.. code-block::
+
+    Plugin 'printf' in module 'inmanta_plugins.<module_name>' is deprecated.
+
+If you want your module to stay backwards compatible you will also need to add a little piece of code that changes how
+:func:`~inmanta.plugins.deprecated` is imported as it does not exist in all versions.
+
+the previous example would then look like this:
+
+.. code-block:: python
+    :linenos:
+
+    from inmanta.plugins import plugin
+
+    try:
+        from inmanta.plugins import deprecated
+    except ImportError:
+    deprecated = lambda f=None, **kwargs: f if f is not None else deprecated
+
+
+    @deprecated(replaced_by="my_new_plugin")
+    @plugin
+    def printf():
+        """
+            Prints inmanta
+        """
+        print("inmanta")
+

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -115,7 +115,6 @@ see :ref:`moddev-module`.
 Deprecate plugins
 ========================
 
-
 To deprecate a plugin the :func:`~inmanta.plugins.deprecated` decorator can be used in combination with the :func:`~inmanta.plugins.plugin`
 decorator. Using this decorator will log a warning message when the function is called. This decorator also accepts an
 optional argument ``replaced_by`` which can be used to potentially improve the warning message by telling which other

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -151,7 +151,7 @@ Should the replace_by argument be omitted, the warning would look like this:
 If you want your module to stay compatible with older versions of inmanta you will also need to add a little piece of code that changes how
 :func:`~inmanta.plugins.deprecated` is imported as it does not exist in all versions.
 
-the previous example would then look like this:
+The previous example would then look like this. For older inmanta versions, the replace the decorator with a no-op.
 
 .. code-block:: python
     :linenos:

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -148,7 +148,7 @@ Should the replace_by argument be omitted, the warning would look like this:
 
     Plugin 'printf' in module 'inmanta_plugins.<module_name>' is deprecated.
 
-If you want your module to stay backwards compatible you will also need to add a little piece of code that changes how
+If you want your module to stay compatible with older versions of inmanta you will also need to add a little piece of code that changes how
 :func:`~inmanta.plugins.deprecated` is imported as it does not exist in all versions.
 
 the previous example would then look like this:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1340,6 +1340,7 @@ class ModuleRepoType(enum.Enum):
 
 @stable_api
 class ModuleRepoInfo(BaseModel):
+
     url: str
     type: ModuleRepoType = ModuleRepoType.git
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -2522,14 +2522,13 @@ class Module(ModuleLike[TModuleMetadata], ABC):
 
         :param project: A reference to the project this module belongs to.
         :param path: Where is the module stored
-
         """
         if not os.path.exists(path):
             raise InvalidModuleException(f"Directory {path} doesn't exist")
         super().__init__(path)
 
         if self.metadata.deprecated:
-            inmanta.warnings.warn(ModuleDeprecationWarning("aie aie"))
+            inmanta.warnings.warn(ModuleDeprecationWarning(f"Module {self.name} has been deprecated"))
         self._project: Optional[Project] = project
         self.ensure_versioned()
         self.model_dir = os.path.join(self.path, Module.MODEL_DIR)

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -84,8 +84,10 @@ try:
 except ImportError:
     TYPE_CHECKING = False
 
+
 if TYPE_CHECKING:
     from pkg_resources.packaging.version import Version  # noqa: F401
+
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -94,6 +94,7 @@ LOGGER = logging.getLogger(__name__)
 Path = NewType("Path", str)
 ModuleName = NewType("ModuleName", str)
 
+
 T = TypeVar("T")
 TModule = TypeVar("TModule", bound="Module")
 TProject = TypeVar("TProject", bound="Project")

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -493,8 +493,6 @@ def plugin(
     commands: Optional[List[str]] = None,
     emits_statements: bool = False,
     allow_unknown: bool = False,
-    deprecated: bool = False,
-    replaced_by: Optional[str] = None,
 ) -> Callable:  # noqa: H801
     """
     Python decorator to register functions with inmanta as plugin
@@ -539,8 +537,8 @@ def plugin(
             dictionary["opts"] = {"bin": commands, "emits_statements": emits_statements, "allow_unknown": allow_unknown}
             dictionary["call"] = wrapper
             dictionary["__function__"] = fnc
-            dictionary["deprecated"] = deprecated
-            dictionary["replaced_by"] = replaced_by
+            # dictionary["deprecated"] = deprecated
+            # dictionary["replaced_by"] = replaced_by
 
             bases = (Plugin,)
             PluginMeta.__new__(PluginMeta, name, bases, dictionary)
@@ -558,3 +556,14 @@ def plugin(
     elif function is not None:
         fnc = curry_name(commands=commands, emits_statements=emits_statements, allow_unknown=allow_unknown)
         return fnc(function)
+
+
+@stable_api
+def deprecated(
+    function: Optional[Callable] = None,
+) -> Callable:  # noqa: H801
+    def wrapper_accepting_arguments(arg1, arg2):
+        print("My arguments are: {0}, {1}".format(arg1, arg2))
+        function(arg1, arg2)
+
+    return wrapper_accepting_arguments

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -262,7 +262,7 @@ class Plugin(NamedType, metaclass=PluginMeta):
 
             spec_type = arg_spec.annotations[arg]
             if spec_type == Context:
-                self._context = PluginMeta.get_functions()
+                self._context = i
             else:
                 if default_start is not None and default_start <= i:
                     default_value = arg_spec.defaults[default_start - i]

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -155,6 +155,7 @@ class PluginMeta(type):
         return subclass
 
     __functions: Dict[str, Type["Plugin"]] = {}
+    __function_name_mapping: Dict[str, str] = {}
 
     @classmethod
     def add_function(cls, plugin_class: Type["Plugin"]) -> None:
@@ -168,8 +169,18 @@ class PluginMeta(type):
             raise Exception("All plugin modules should be loaded in the %s package" % const.PLUGINS_PACKAGE)
 
         name = "::".join(ns_parts[1:])
+        name = cls._build_name(str(plugin_class.__function_name__), str(plugin_class.__module__))
+        original_name = cls._build_name(str(plugin_class.__function_name__), str(plugin_class.__module__))
         cls.__functions[name] = plugin_class
+        cls.__function_name_mapping["a"] = name
 
+    def _build_name(cls,name:str, module: str):
+        ns_parts = module.split(".")
+        ns_parts.append(name)
+        if ns_parts[0] != const.PLUGINS_PACKAGE:
+            raise Exception("All plugin modules should be loaded in the %s package" % const.PLUGINS_PACKAGE)
+
+        return "::".join(ns_parts[1:])
     @classmethod
     def get_functions(cls) -> Dict[str, "Type[Plugin]"]:
         """
@@ -549,8 +560,10 @@ def plugin(
             dictionary["opts"] = {"bin": commands, "emits_statements": emits_statements, "allow_unknown": allow_unknown}
             dictionary["call"] = wrapper
             dictionary["__function__"] = fnc
+            dictionary[""] = fnc
             dictionary["deprecated"] = False
             dictionary["replaced_by"] = None
+            dictionary["original_name"] = fnc.__name__
 
             bases = (Plugin,)
             PluginMeta.__new__(PluginMeta, name, bases, dictionary)

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -195,8 +195,8 @@ class PluginMeta(type):
             cls.__functions[fnc.plugin_name].replaced_by = replaced_by
         else:
             raise Exception(
-                f"Can not deprecate plugin '{full_name}': The '@deprecated' decorator should be used right before the "
-                f"'@plugin' decorator. "
+                f"Can not deprecate plugin '{full_name}': The '@deprecated' decorator should be used in combination with the "
+                f"'@plugin' decorator and should be set first."
             )
 
     @classmethod

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -425,12 +425,12 @@ class Plugin(NamedType, metaclass=PluginMeta):
         """
         The function call itself
         """
-        self.check_requirements()
         if self.deprecated:
             msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated. "
             if self.replaced_by:
                 msg += f"It should be replaced by '{self.replaced_by}'"
             inmanta.warnings.warn(PluginDeprecationWarning(msg))
+        self.check_requirements()
 
         def new_arg(arg: object) -> object:
             if isinstance(arg, Context):

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -426,9 +426,9 @@ class Plugin(NamedType, metaclass=PluginMeta):
         """
         The function call itself
         """
-        if Plugin.deprecated:
+        if self.deprecated:
             msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated."
-            if Plugin.replaced_by:
+            if self.replaced_by:
                 msg += f" It should be replaced by '{self.replaced_by}'."
             inmanta.warnings.warn(PluginDeprecationWarning(msg))
         self.check_requirements()

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -425,11 +425,11 @@ class Plugin(NamedType, metaclass=PluginMeta):
         """
         The function call itself
         """
-        # if self.deprecated:
-        #     msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated."
-        #     if self.replaced_by:
-        #         msg += f" It should be replaced by '{self.replaced_by}'"
-        #     inmanta.warnings.warn(PluginDeprecationWarning(msg))
+        if self.deprecated:
+            msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated."
+            if self.replaced_by:
+                msg += f" It should be replaced by '{self.replaced_by}'"
+            inmanta.warnings.warn(PluginDeprecationWarning(msg))
         self.check_requirements()
 
         def new_arg(arg: object) -> object:

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -426,9 +426,9 @@ class Plugin(NamedType, metaclass=PluginMeta):
         The function call itself
         """
         if self.deprecated:
-            msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated. "
+            msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated."
             if self.replaced_by:
-                msg += f"It should be replaced by '{self.replaced_by}'"
+                msg += f" It should be replaced by '{self.replaced_by}'"
             inmanta.warnings.warn(PluginDeprecationWarning(msg))
         self.check_requirements()
 

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -196,7 +196,7 @@ class PluginMeta(type):
         else:
             raise Exception(
                 f"Can not deprecate plugin '{full_name}': The '@deprecated' decorator should be used in combination with the "
-                f"'@plugin' decorator and should be set first."
+                f"'@plugin' decorator and should be placed first."
             )
 
     @classmethod

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -572,7 +572,7 @@ def plugin(
 
 @stable_api
 def deprecated(
-    function: Optional[Callable] = None, replaced_by: Optional[str] = None, **kwargs: Dict[str, object]
+    function: Optional[Callable] = None, *, replaced_by: Optional[str] = None, **kwargs: Dict[str, object]
 ) -> Callable:  # noqa: H801
     def inner(fnc: Callable):
         PluginMeta.deprecate_function(fnc, replaced_by)

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -426,9 +426,9 @@ class Plugin(NamedType, metaclass=PluginMeta):
         """
         The function call itself
         """
-        if self.deprecated:
+        if Plugin.deprecated:
             msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated."
-            if self.replaced_by:
+            if Plugin.replaced_by:
                 msg += f" It should be replaced by '{self.replaced_by}'."
             inmanta.warnings.warn(PluginDeprecationWarning(msg))
         self.check_requirements()

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -187,7 +187,7 @@ class PluginMeta(type):
             cls.__functions[full_name].deprecated = True
             cls.__functions[full_name].replaced_by = replaced_by
         else:
-            raise Exception("Can not deprecate a plugin that was not found in the context")
+            raise Exception(f"Can not deprecate a plugin {full_name} as it does not exist")
 
     @classmethod
     def clear(cls, inmanta_module: Optional[str] = None) -> None:

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -187,7 +187,7 @@ class PluginMeta(type):
             cls.__functions[full_name].deprecated = True
             cls.__functions[full_name].replaced_by = replaced_by
         else:
-            raise Exception(f"Can not deprecate a plugin {full_name} as it does not exist")
+            raise Exception(f"Can not deprecate plugin {full_name} as it does not exist")
 
     @classmethod
     def clear(cls, inmanta_module: Optional[str] = None) -> None:

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -208,7 +208,8 @@ class PluginMeta(type):
             cls.__functions[function_name].replaced_by = replaced_by
         else:
             raise Exception(
-                f"Can not deprecate plugin '{full_name}': The '@deprecated' decorator should be used right before the '@plugin' decorator."
+                f"Can not deprecate plugin '{full_name}': The '@deprecated' decorator should be used right before the "
+                f"'@plugin' decorator. "
             )
 
     @classmethod

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -207,7 +207,9 @@ class PluginMeta(type):
             cls.__functions[function_name].deprecated = True
             cls.__functions[function_name].replaced_by = replaced_by
         else:
-            raise Exception(f"Can not deprecate plugin {full_name} as it does not exist")
+            raise Exception(
+                f"Can not deprecate plugin '{full_name}': The '@deprecated' decorator should be used right before the '@plugin' decorator."
+            )
 
     @classmethod
     def clear(cls, inmanta_module: Optional[str] = None) -> None:

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -178,13 +178,6 @@ class PluginMeta(type):
         return dict(cls.__functions)
 
     @classmethod
-    def get_originals(cls) -> Dict[str, str]:
-        """
-        Get the original name of all the functions with the associated function name
-        """
-        return dict(cls.__function_name_mapping)
-
-    @classmethod
     def deprecate_function(cls, fnc: Callable, replaced_by: Optional[str] = None) -> None:
         name = fnc.__name__
         ns_parts = str(fnc.__module__).split(".")
@@ -515,7 +508,7 @@ def plugin(
     commands: Optional[List[str]] = None,
     emits_statements: bool = False,
     allow_unknown: bool = False,
-) -> Callable:  # noqa: H801
+) -> Callable:
     """
     Python decorator to register functions with inmanta as plugin
 
@@ -590,7 +583,7 @@ def plugin(
 @stable_api
 def deprecated(
     function: Optional[Callable] = None, *, replaced_by: Optional[str] = None, **kwargs: Dict[str, object]
-) -> Callable:  # noqa: H801
+) -> Callable:
     def inner(fnc: Callable):
         PluginMeta.deprecate_function(fnc, replaced_by)
         return fnc

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -204,6 +204,7 @@ class Plugin(NamedType, metaclass=PluginMeta):
     def __init__(self, namespace: Namespace) -> None:
         self.ns = namespace
         self.namespace = namespace
+
         self._context = -1
         self._return = None
 
@@ -426,9 +427,9 @@ class Plugin(NamedType, metaclass=PluginMeta):
         """
         self.check_requirements()
         if self.deprecated:
-            msg: str = f"function '{self.__function_name__}' in plugins of module '{self.__module__}' is deprecated. "
+            msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated. "
             if self.replaced_by:
-                msg += f"It should be replaced by function '{self.replaced_by}'"
+                msg += f"It should be replaced by '{self.replaced_by}'"
             inmanta.warnings.warn(PluginDeprecationWarning(msg))
 
         def new_arg(arg: object) -> object:

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -15,10 +15,10 @@
 
     Contact: code@inmanta.com
 """
-
 import inspect
 import os
 import subprocess
+from collections import abc
 from functools import reduce
 from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, List, Optional, Tuple, Type, TypeVar
 
@@ -161,14 +161,7 @@ class PluginMeta(type):
         """
         Add a function plugin class
         """
-        name = plugin_class.__function_name__
-        ns_parts = str(plugin_class.__module__).split(".")
-        ns_parts.append(name)
-        if ns_parts[0] != const.PLUGINS_PACKAGE:
-            raise Exception("All plugin modules should be loaded in the %s package" % const.PLUGINS_PACKAGE)
-
-        name = "::".join(ns_parts[1:])
-        cls.__functions[name] = plugin_class
+        cls.__functions[plugin_class.__fq_plugin_name__] = plugin_class
 
     @classmethod
     def get_functions(cls) -> Dict[str, "Type[Plugin]"]:
@@ -176,21 +169,6 @@ class PluginMeta(type):
         Get all functions that are registered
         """
         return dict(cls.__functions)
-
-    @classmethod
-    def deprecate_function(cls, fnc: Callable, replaced_by: Optional[str] = None) -> None:
-        name = fnc.__name__
-        ns_parts = str(fnc.__module__).split(".")
-        ns_parts.append(name)
-        full_name = "::".join(ns_parts[1:])
-        if hasattr(fnc, "plugin_name"):
-            cls.__functions[fnc.plugin_name].deprecated = True
-            cls.__functions[fnc.plugin_name].replaced_by = replaced_by
-        else:
-            raise Exception(
-                f"Can not deprecate plugin '{full_name}': The '@deprecated' decorator should be used in combination with the "
-                f"'@plugin' decorator and should be placed first."
-            )
 
     @classmethod
     def clear(cls, inmanta_module: Optional[str] = None) -> None:
@@ -215,6 +193,9 @@ class Plugin(NamedType, metaclass=PluginMeta):
     """
     This class models a plugin that can be called from the language.
     """
+
+    deprecated: bool = False
+    replaced_by: Optional[str] = None
 
     def __init__(self, namespace: Namespace) -> None:
         self.ns = namespace
@@ -436,6 +417,11 @@ class Plugin(NamedType, metaclass=PluginMeta):
                 if len(result[0]) == 0:
                     raise Exception("%s requires %s to be available in $PATH" % (self.__function_name__, _bin))
 
+    @classmethod
+    def deprecate_function(cls, replaced_by: Optional[str] = None) -> None:
+        cls.deprecated = True
+        cls.replaced_by = replaced_by
+
     def __call__(self, *args: object, **kwargs: object) -> object:
         """
         The function call itself
@@ -551,20 +537,20 @@ def plugin(
             if ns_parts[0] != const.PLUGINS_PACKAGE:
                 raise Exception("All plugin modules should be loaded in the %s package" % const.PLUGINS_PACKAGE)
 
-            fnc.plugin_name = "::".join(ns_parts[1:])
+            fq_plugin_name = "::".join(ns_parts[1:])
 
             dictionary = {}
             dictionary["__module__"] = fnc.__module__
+
             dictionary["__function_name__"] = name
+            dictionary["__fq_plugin_name__"] = fq_plugin_name
+
             dictionary["opts"] = {"bin": commands, "emits_statements": emits_statements, "allow_unknown": allow_unknown}
             dictionary["call"] = wrapper
             dictionary["__function__"] = fnc
-            dictionary["deprecated"] = False
-            dictionary["replaced_by"] = None
 
             bases = (Plugin,)
-            PluginMeta.__new__(PluginMeta, name, bases, dictionary)
-
+            fnc.__plugin__ = PluginMeta.__new__(PluginMeta, name, bases, dictionary)
             return fnc
 
         return call
@@ -582,10 +568,20 @@ def plugin(
 
 @stable_api
 def deprecated(
-    function: Optional[Callable] = None, *, replaced_by: Optional[str] = None, **kwargs: Dict[str, object]
+    function: Optional[Callable] = None, *, replaced_by: Optional[str] = None, **kwargs: abc.Mapping[str, object]
 ) -> Callable:
+    """
+    the kwargs are currently ignored but where added in cas we want to add something later on.
+    """
+
     def inner(fnc: Callable):
-        PluginMeta.deprecate_function(fnc, replaced_by)
+        if hasattr(fnc, "__plugin__"):
+            fnc.__plugin__.deprecate_function(replaced_by)
+        else:
+            raise Exception(
+                f"Can not deprecate '{fnc.__name__}': The '@deprecated' decorator should be used in combination with the "
+                f"'@plugin' decorator and should be placed first."
+            )
         return fnc
 
     if function is not None:

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -571,7 +571,7 @@ def deprecated(
     function: Optional[Callable] = None, *, replaced_by: Optional[str] = None, **kwargs: abc.Mapping[str, object]
 ) -> Callable:
     """
-    the kwargs are currently ignored but where added in cas we want to add something later on.
+    the kwargs are currently ignored but where added in case we want to add something later on.
     """
 
     def inner(fnc: Callable):

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -183,7 +183,6 @@ class PluginMeta(type):
         ns_parts = str(fnc.__module__).split(".")
         ns_parts.append(name)
         full_name = "::".join(ns_parts[1:])
-        print(full_name)
         if full_name in cls.get_functions():
             cls.__functions[full_name].deprecated = True
             cls.__functions[full_name].replaced_by = replaced_by

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -572,8 +572,7 @@ def plugin(
 
 @stable_api
 def deprecated(
-    function: Optional[Callable] = None,
-    replaced_by: Optional[str] = None,
+    function: Optional[Callable] = None, replaced_by: Optional[str] = None, **kwargs: Dict[str, object]
 ) -> Callable:  # noqa: H801
     def inner(fnc: Callable):
         PluginMeta.deprecate_function(fnc, replaced_by)

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -483,10 +483,8 @@ def get_one() -> "int":
             if replaced_by:
                 replaced_by_name = replaced_by.replace('"', "")
                 assert (
-                    f"function 'get_one' in plugins of module 'inmanta_plugins.test_module' is deprecated. It should be "
-                    f"replaced by function '{replaced_by_name}'" in str(warning.message)
+                    f"Plugin 'get_one' in module 'inmanta_plugins.test_module' is deprecated. It should be "
+                    f"replaced by '{replaced_by_name}'" in str(warning.message)
                 )
             else:
-                assert f"function 'get_one' in plugins of module 'inmanta_plugins.test_module' is deprecated. " in str(
-                    warning.message
-                )
+                assert f"Plugin 'get_one' in module 'inmanta_plugins.test_module' is deprecated. " in str(warning.message)

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -543,7 +543,7 @@ def get_one() -> "int":
 
 @pytest.mark.parametrize_any(
     "decorator1,decorator2",
-    [('@plugin("custom_name")', "@deprecated"), ("@plugin", "@deprecated"), ("", "@deprecated")],
+    [("@plugin", "@deprecated"), ("", "@deprecated")],
 )
 def test_modules_fail_deprecated(
     tmpdir: str, snippetcompiler_clean, modules_dir: str, decorator1: str, decorator2: str

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -445,9 +445,10 @@ def test_modules_plugin_deprecation(
     libs_dir: str = os.path.join(str(tmpdir), "libs")
 
     test_module_plugin_contents: str = f"""
-from inmanta.plugins import plugin
+from inmanta.plugins import plugin, deprecated
 
-@plugin(deprecated={deprecated}, replaced_by={replaced_by})
+@deprecated(replaced_by="newplugin")
+@plugin
 def get_one() -> "int":
     return 1
         """.strip()

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -587,4 +587,4 @@ def get_one() -> "int":
 
     with pytest.raises(Exception) as e:
         compiler.do_compile()
-    assert "Can not deprecate a plugin test_module::get_one as it does not exist" in e.value.msg
+    assert "Can not deprecate plugin test_module::get_one as it does not exist" in e.value.msg

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -588,8 +588,8 @@ def get_one() -> "int":
     with pytest.raises(Exception) as e:
         compiler.do_compile()
     assert (
-        "Can not deprecate plugin 'test_module::get_one': The '@deprecated' decorator should be used right before the '@plugin' decorator."
-        in e.value.msg
+        "Can not deprecate plugin 'test_module::get_one': The '@deprecated' decorator should be used in combination with the "
+        f"'@plugin' decorator and should be set first." in e.value.msg
     )
 
 

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -487,4 +487,4 @@ def get_one() -> "int":
                     f"replaced by '{replaced_by_name}'" in str(warning.message)
                 )
             else:
-                assert f"Plugin 'get_one' in module 'inmanta_plugins.test_module' is deprecated. " in str(warning.message)
+                assert "Plugin 'get_one' in module 'inmanta_plugins.test_module' is deprecated. " in str(warning.message)

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -607,7 +607,7 @@ def test_modules_plugin_custom_name_deprecated(
     test_module: str = "test_module"
     libs_dir: str = os.path.join(str(tmpdir), "libs")
 
-    test_module_plugin_contents: str = f"""
+    test_module_plugin_contents: str = """
 from inmanta.plugins import plugin, deprecated
 
 @deprecated

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -589,7 +589,7 @@ def get_one() -> "int":
         compiler.do_compile()
     assert (
         "Can not deprecate plugin 'test_module::get_one': The '@deprecated' decorator should be used in combination with the "
-        f"'@plugin' decorator and should be set first." in e.value.msg
+        f"'@plugin' decorator and should be placed first." in e.value.msg
     )
 
 

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -589,7 +589,7 @@ def get_one() -> "int":
         compiler.do_compile()
     assert (
         "Can not deprecate plugin 'test_module::get_one': The '@deprecated' decorator should be used in combination with the "
-        f"'@plugin' decorator and should be placed first." in e.value.msg
+        "'@plugin' decorator and should be placed first." in e.value.msg
     )
 
 

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -543,7 +543,7 @@ def get_one() -> "int":
 
 @pytest.mark.parametrize_any(
     "decorator1,decorator2",
-    [("@plugin", "@deprecated"), ("", "@deprecated")],
+    [('@plugin("custom_name")', "@deprecated"), ("@plugin", "@deprecated"), ("", "@deprecated")],
 )
 def test_modules_fail_deprecated(
     tmpdir: str, snippetcompiler_clean, modules_dir: str, decorator1: str, decorator2: str
@@ -587,7 +587,10 @@ def get_one() -> "int":
 
     with pytest.raises(Exception) as e:
         compiler.do_compile()
-    assert "Can not deprecate plugin test_module::get_one as it does not exist" in e.value.msg
+    assert (
+        "Can not deprecate plugin 'test_module::get_one': The '@deprecated' decorator should be used right before the '@plugin' decorator."
+        in e.value.msg
+    )
 
 
 def test_modules_plugin_custom_name_deprecated(
@@ -625,7 +628,7 @@ def get_one() -> "int":
         f"""
        import {test_module}
 
-       value = {test_module}::get_one()
+       value = {test_module}::custom_name()
                    """.strip(),
         add_to_module_path=[libs_dir],
         autostd=False,

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -588,7 +588,7 @@ def get_one() -> "int":
     with pytest.raises(Exception) as e:
         compiler.do_compile()
     assert (
-        "Can not deprecate plugin 'test_module::get_one': The '@deprecated' decorator should be used in combination with the "
+        "Can not deprecate 'get_one': The '@deprecated' decorator should be used in combination with the "
         "'@plugin' decorator and should be placed first." in e.value.msg
     )
 

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -494,7 +494,7 @@ def get_one() -> "int":
 )
 def test_modules_failed_import_deprecated(tmpdir: str, snippetcompiler_clean, modules_dir: str, decorator: str) -> None:
     """
-    to ensure backwards compatibility of modules when using the deprecated decorator
+    to ensure backwards compatibility of modules when using the @deprecated decorator
     a little piece of code is proposed in the docs:
     try:
         from inmanta.plugins import deprecated

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -474,7 +474,6 @@ install_requires =
     assert mod.metadata.license == "Apache 2.0"
 
 
-# @pytest.mark.parametrize("deprecated", ["deprecated: true", "deprecated: false", ""])
 @pytest.mark.parametrize("deprecated", ["", "deprecated: true", "deprecated: false"])
 def test_module_v2_deprecation(inmanta_module_v2: InmantaModule, deprecated):
     inmanta_module_v2.write_metadata_file(

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -396,7 +396,7 @@ version: 1.0.0
         if len(w):
             warning = w[0]
             assert issubclass(warning.category, ModuleDeprecationWarning)
-            assert "aie aie" in str(warning.message)
+            assert "Module mod has been deprecated" in str(warning.message) in str(warning.message)
 
 
 def test_module_requires_single(inmanta_module_v1):
@@ -492,7 +492,7 @@ license = Apache 2.0
         if len(w):
             warning = w[0]
             assert issubclass(warning.category, ModuleDeprecationWarning)
-            assert "aie aie" in str(warning.message)
+            assert "Module mod1 has been deprecated" in str(warning.message)
 
 
 @pytest.mark.parametrize("underscore", [True, False])

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -38,6 +38,7 @@ from inmanta.module import (
     InvalidMetadata,
     InvalidModuleException,
     MetadataDeprecationWarning,
+    ModuleDeprecationWarning,
     Project,
 )
 from inmanta.moduletool import ModuleTool
@@ -379,6 +380,25 @@ requires:
     assert mod.requires() == [InmantaModuleRequirement.parse("std"), InmantaModuleRequirement.parse("ip > 1.0.0")]
 
 
+@pytest.mark.parametrize("deprecated", ["", "deprecated: true", "deprecated: false"])
+def test_module_v1_deprecation(inmanta_module_v1, deprecated):
+    inmanta_module_v1.write_metadata_file(
+        f"""
+name: mod
+license: ASL
+version: 1.0.0
+{deprecated}
+        """
+    )
+    with warnings.catch_warnings(record=True) as w:
+        module.ModuleV1(None, inmanta_module_v1.get_root_dir_of_module())
+        assert len(w) == 1 if deprecated == "deprecated: true" else len(w) == 0
+        if len(w):
+            warning = w[0]
+            assert issubclass(warning.category, ModuleDeprecationWarning)
+            assert "aie aie" in str(warning.message)
+
+
 def test_module_requires_single(inmanta_module_v1):
     inmanta_module_v1.write_metadata_file(
         """
@@ -452,6 +472,27 @@ install_requires =
     assert mod.metadata.name == "inmanta-module-mod1"
     assert mod.metadata.version == "1.2.3"
     assert mod.metadata.license == "Apache 2.0"
+
+
+# @pytest.mark.parametrize("deprecated", ["deprecated: true", "deprecated: false", ""])
+@pytest.mark.parametrize("deprecated", ["", "deprecated: true", "deprecated: false"])
+def test_module_v2_deprecation(inmanta_module_v2: InmantaModule, deprecated):
+    inmanta_module_v2.write_metadata_file(
+        f"""
+[metadata]
+name = inmanta-module-mod1
+version = 1.2.3
+license = Apache 2.0
+{deprecated}
+        """
+    )
+    with warnings.catch_warnings(record=True) as w:
+        module.ModuleV2(None, inmanta_module_v2.get_root_dir_of_module())
+        assert len(w) == 1 if deprecated == "deprecated: true" else len(w) == 0
+        if len(w):
+            warning = w[0]
+            assert issubclass(warning.category, ModuleDeprecationWarning)
+            assert "aie aie" in str(warning.message)
 
 
 @pytest.mark.parametrize("underscore", [True, False])


### PR DESCRIPTION
# Description

The goal of this commit is to add a deprecation mechanism to core for modules and plugins.

 - Add a deprecated boolean field to module.yml When this is set to true, the compiler should issue a deprecation warning when the module is imported
 - Add a deprecated and replaced_by field to the @plugin decorator. When set to true it should print out a warning that the plugin is deprecated. When replaced_by is set the message will also say by which plugin the current one has been replaced
 

closes #4908

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
