### PR TITLE
issue/4968-soft-hard-retry

### DIFF
--- a/changelogs/unreleased/4968-soft-hard-retry-limited.yml
+++ b/changelogs/unreleased/4968-soft-hard-retry-limited.yml
@@ -1,0 +1,5 @@
+---
+description: Add hard timeout multiplier for retry_limited, configurable through env var.
+issue-nr: 4968
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -510,7 +510,7 @@ async def retry_limited(
     while time.time() - start < hard_timeout and not (await fun_wrapper()):
         await asyncio.sleep(interval)
     if not (await fun_wrapper()):
-        raise asyncio.TimeoutError(f"Wait condition was not reach after hard limit of {hard_timeout} seconds")
+        raise asyncio.TimeoutError(f"Wait condition was not reached after hard limit of {hard_timeout} seconds")
     if time.time() - start > timeout:
         raise asyncio.TimeoutError(
             f"Wait condition was met after {time.time() - start} seconds, but soft limit was set to {timeout} seconds"

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -498,6 +498,7 @@ async def retry_limited(
             return fun(*args, **kwargs)
 
     multiplier: int = os.environ.get("INMANTA_RETRY_LIMITED_MULTIPLIER", 1)
+    print(multiplier)
     hard_timeout = timeout * multiplier
     start = time.time()
     while time.time() - start < hard_timeout and not (await fun_wrapper()):

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -489,7 +489,7 @@ async def retry_limited(
 ) -> None:
     """
     This function makes use of the INMANTA_RETRY_LIMITED_MULTIPLIER env variable. If set, INMANTA_RETRY_LIMITED_MULTIPLIER
-    serves as multiplier: The timeout given as argument becomes a 'soft limit' and the "soft limit' mutliplied by the
+    serves as multiplier: The timeout given as argument becomes a 'soft limit' and the 'soft limit' multiplied by the
     multiplier (form the env var) becomes a "hard limit". If the hard limit is reached before the wait condition is fulfilled
     a Timeout exception is raised. If the wait condition is fulfilled before the hard limit is reached but after the soft
     limit is reached, a different Timeout exception is raised. if the Env var is not set, then the soft and hard limit are

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -57,6 +57,8 @@ S = TypeVar("S")
 class Timeout(Exception):
     """The operation exceeded the given deadline."""
 
+    pass
+
 
 def get_compiler_version() -> str:
     return COMPILER_VERSION

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -490,7 +490,7 @@ async def retry_limited(
     """
     This function makes use of the INMANTA_RETRY_LIMITED_MULTIPLIER env variable. If set, INMANTA_RETRY_LIMITED_MULTIPLIER
     serves as multiplier: The timeout given as argument becomes a 'soft limit' and the 'soft limit' multiplied by the
-    multiplier (from the env var) becomes a "hard limit". If the hard limit is reached before the wait condition is fulfilled
+    multiplier (from the env var) becomes a 'hard limit'. If the hard limit is reached before the wait condition is fulfilled
     a Timeout exception is raised. If the wait condition is fulfilled before the hard limit is reached but after the soft
     limit is reached, a different Timeout exception is raised. if the Env var is not set, then the soft and hard limit are
     the same.

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -55,7 +55,7 @@ S = TypeVar("S")
 
 
 class Timeout(Exception):
-    """The operation exceeded the given deadline."""
+    """The operation exceeded the given timeout."""
 
     pass
 

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -497,7 +497,7 @@ async def retry_limited(
         else:
             return fun(*args, **kwargs)
 
-    multiplier: int = os.environ.get("INMANTA_RETRY_LIMITED_MULTIPLIER", 1)
+    multiplier: int = int(os.environ.get("INMANTA_RETRY_LIMITED_MULTIPLIER", 1))
     print(multiplier)
     hard_timeout = timeout * multiplier
     start = time.time()

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -491,6 +491,15 @@ async def retry_limited(
     *args: object,
     **kwargs: object,
 ) -> None:
+    """
+    This function makes use of the INMANTA_RETRY_LIMITED_MULTIPLIER env variable. If set INMANTA_RETRY_LIMITED_MULTIPLIER
+    serves as multiplier: The timeout given as argument becomes a 'soft limit' and the "soft limit' mutliplied by the
+    multiplier (form the env var) becomes a "hard limit". If the hard limit is reached before the wait condition is fulfilled
+    a Timeout exception is raised. If the wait condition is fulfilled before the hard limit is reached but after the soft
+    limit is reached, a different Timeout exception is raised. if the Env var is not set, then the soft and hard limit are
+    the same.
+    """
+
     async def fun_wrapper() -> bool:
         if inspect.iscoroutinefunction(fun):
             return await fun(*args, **kwargs)
@@ -498,7 +507,6 @@ async def retry_limited(
             return fun(*args, **kwargs)
 
     multiplier: int = int(os.environ.get("INMANTA_RETRY_LIMITED_MULTIPLIER", 1))
-    print(multiplier)
     hard_timeout = timeout * multiplier
     start = time.time()
     while time.time() - start < hard_timeout and not (await fun_wrapper()):

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -494,7 +494,7 @@ async def retry_limited(
     **kwargs: object,
 ) -> None:
     """
-    This function makes use of the INMANTA_RETRY_LIMITED_MULTIPLIER env variable. If set INMANTA_RETRY_LIMITED_MULTIPLIER
+    This function makes use of the INMANTA_RETRY_LIMITED_MULTIPLIER env variable. If set, INMANTA_RETRY_LIMITED_MULTIPLIER
     serves as multiplier: The timeout given as argument becomes a 'soft limit' and the "soft limit' mutliplied by the
     multiplier (form the env var) becomes a "hard limit". If the hard limit is reached before the wait condition is fulfilled
     a Timeout exception is raised. If the wait condition is fulfilled before the hard limit is reached but after the soft

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -560,6 +560,7 @@ async def test_e2e_recompile_failure(compilerservice: CompilerService):
     assert f1 < s2
 
 
+@pytest.mark.slowtest
 async def test_server_partial_compile(server, client, environment, monkeypatch):
     """
     Test a partial_compile on the server
@@ -609,7 +610,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         env, force_update=False, do_export=False, remote_id=remote_id1, partial=True
     )
 
-    await retry_limited(wait_for_report, 0.001)
+    await retry_limited(wait_for_report, 10)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial")
     assert not verify_command_report(report, "--removed_resource_sets")
@@ -619,7 +620,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         env, force_update=False, do_export=False, remote_id=remote_id1, partial=True, removed_resource_sets=["a", "b", "c"]
     )
 
-    await retry_limited(wait_for_report, 0.001)
+    await retry_limited(wait_for_report, 10)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial --delete-resource-set a --delete-resource-set b --delete-resource-set c")
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -560,7 +560,6 @@ async def test_e2e_recompile_failure(compilerservice: CompilerService):
     assert f1 < s2
 
 
-@pytest.mark.slowtest
 async def test_server_partial_compile(server, client, environment, monkeypatch):
     """
     Test a partial_compile on the server
@@ -610,7 +609,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         env, force_update=False, do_export=False, remote_id=remote_id1, partial=True
     )
 
-    await retry_limited(wait_for_report, 0.1)
+    await retry_limited(wait_for_report, 0.001)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial")
     assert not verify_command_report(report, "--removed_resource_sets")
@@ -620,7 +619,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         env, force_update=False, do_export=False, remote_id=remote_id1, partial=True, removed_resource_sets=["a", "b", "c"]
     )
 
-    await retry_limited(wait_for_report, 0.01)
+    await retry_limited(wait_for_report, 0.001)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial --delete-resource-set a --delete-resource-set b --delete-resource-set c")
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -620,7 +620,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         env, force_update=False, do_export=False, remote_id=remote_id1, partial=True, removed_resource_sets=["a", "b", "c"]
     )
 
-    await retry_limited(wait_for_report, 10)
+    await retry_limited(wait_for_report, 0.01)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial --delete-resource-set a --delete-resource-set b --delete-resource-set c")
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -610,7 +610,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         env, force_update=False, do_export=False, remote_id=remote_id1, partial=True
     )
 
-    await retry_limited(wait_for_report, 10)
+    await retry_limited(wait_for_report, 0.1)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial")
     assert not verify_command_report(report, "--removed_resource_sets")

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,10 @@ deps=
 extras=
     dataflow_graphic
 # Set the environment variable INMANTA_EXTRA_PYTEST_ARGS='--fast' to run in fast mode
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/server/test_compilerservice.py::test_server_partial_compile
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
+# The INMANTA_RETRY_LIMITED_MULTIPLIER is used to set a multiplier in the retry_limited function
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME INMANTA_RETRY_LIMITED_MULTIPLIER
 basepython = python3.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ extras=
 commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/server/test_compilerservice.py::test_server_partial_compile
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
-passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME
+passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME INMANTA_RETRY_LIMITED_MULTIPLIER
 basepython = python3.9
 
 [testenv:pep8]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
 extras=
     dataflow_graphic
 # Set the environment variable INMANTA_EXTRA_PYTEST_ARGS='--fast' to run in fast mode
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests/server/test_compilerservice.py::test_server_partial_compile
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME


### PR DESCRIPTION
# Description

Add hard timeout multiplier for retry_limited, configurable through env var. The idea would is to be able to set the hard limit a lot higher than the soft limit. 

- Stop waiting when the wait condition is met or when the hard timeout is reached (raise exception)
- Raise an exception at the end of the retry_limited method when it took longer than soft_limit to reach the wait condition.

closes #4968 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
