### PR TITLE
Close stdout handler after streaming output from pip

### DIFF
--- a/changelogs/unreleased/ensure-to-close-file-handler-stream-from-pip.yml
+++ b/changelogs/unreleased/ensure-to-close-file-handler-stream-from-pip.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug where the stdout filehandler is not closed after streaming the output from pip into the logger.
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -678,8 +678,8 @@ class CommandRunner:
             shell=shell,
             env=env_vars,
         )
+        assert process.stdout is not None  # Make mypy happy
         try:
-            assert process.stdout is not None  # Make mypy happy
             for line in process.stdout:
                 # Eagerly consume the buffer to avoid a deadlock in case the subprocess fills it entirely.
                 output = line.decode().strip()

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -685,7 +685,7 @@ class CommandRunner:
             output = line.decode().strip()
             full_output.append(output)
             self.logger.debug(output)
-
+        process.stdout.close()
         return_code = process.wait(timeout=timeout)
 
         return return_code, full_output

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -670,6 +670,7 @@ class CommandRunner:
         Similar to the _run_command_and_log_output method, but here, the output is logged on the fly instead of at the end
         of the sub-process.
         """
+        full_output: List[str] = []
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -677,18 +678,23 @@ class CommandRunner:
             shell=shell,
             env=env_vars,
         )
+        try:
+            assert process.stdout is not None  # Make mypy happy
+            for line in process.stdout:
+                # Eagerly consume the buffer to avoid a deadlock in case the subprocess fills it entirely.
+                output = line.decode().strip()
+                full_output.append(output)
+                self.logger.debug(output)
+        finally:
+            process.stdout.close()
 
-        full_output: List[str] = []
-        assert process.stdout is not None  # Make mypy happy
-        for line in process.stdout:
-            # Eagerly consume the buffer to avoid a deadlock in case the subprocess fills it entirely.
-            output = line.decode().strip()
-            full_output.append(output)
-            self.logger.debug(output)
-        process.stdout.close()
-        return_code = process.wait(timeout=timeout)
-
-        return return_code, full_output
+        try:
+            return_code = process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            return -1, full_output
+        else:
+            return return_code, full_output
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
# Description

Fix bug where the stdout filehandler is not closed after streaming the output from pip into the logger.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
