### PR TITLE
Fix bug where warnings messages were not shown to the user

### DIFF
--- a/changelogs/unreleased/fix-bug-warnings-not-shows-to-user.yml
+++ b/changelogs/unreleased/fix-bug-warnings-not-shows-to-user.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug where warnings messages were not shown to the user.
+change-type: patch
+destination-branches: [iso4]
+sections:
+  bugfix: "{{description}}"

--- a/docs/adr/0000-logging-warnings-using-the-python-warnings-or-logging-module.md
+++ b/docs/adr/0000-logging-warnings-using-the-python-warnings-or-logging-module.md
@@ -1,0 +1,34 @@
+# Logging warnings using the python warnings or logging module
+
+* Status: accepted
+* Date: 2022-10-18
+
+## Context and Problem Statement
+
+Python has two different ways to report warnings to the user. Warnings can be logged via the logger (`LOGGER.warning()`) or using the Python warnings module (`warnings.warn()`). It was unclear to developers which type of logger has to used in which circumstances.
+
+## Decision Drivers
+
+* By default, we don't want warnings in third-party libraries to be visible to end-users.
+
+## Pros and Cons of each method
+
+* LOGGER.warning():
+   * This logger just writes a message to the log.
+   * When the same message is logged twice, it will appear twice in the log.
+* warnings.warn():
+   * Each message is displayed only once.
+   * Pytest provides a nice overview of all warning logged during the executing of the test suite.
+   * Warnings are highly configurable through e.g. `warnings.filterwarnings`.
+
+## Decision Outcome
+
+- The `warnings` module will be configured as such that it ignores warnings logged from non-inmanta python modules. This way warnings from third-party libraries are ignored.
+- All warnings, for which we expect an action from the end-user, should be logged using the `warnings.warn()` method. An example is a log message that announces a feature deprecation. This user can be a user of the CLI, the API, a module or an extension developer.
+- All other warnings should be logged using the `LOGGER.warning()` method. These warnings usually indicate that something went wong at runtime. For example, an agent that hits the rate limiter.
+
+## Disclaimer
+
+At the time of writing we didn't have much experience with the different types of warnings and how they should be used.
+The things mentioned above are a first attempt to add more structure to how we log warnings, but we might have to come
+back on that decision later on.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | ... | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, ...]
+* [driver 2, e.g., a force, facing concern, ...]
+* ... <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* ... <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
+* ...
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, ...]
+* ...
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | ...] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | ...] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | ...] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* ... <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* ... <!-- numbers of links can vary -->

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -615,7 +615,7 @@ def cmd_parser() -> argparse.ArgumentParser:
         dest="warnings",
         choices=["warn", "ignore", "error"],
         default="warn",
-        help="The warning behaviour of the compiler. Must be one of 'warn', 'ignore', 'error'",
+        help="The warning behaviour. Must be one of 'warn', 'ignore', 'error'",
     )
     parser.add_argument(
         "-X", "--extended-errors", dest="errors", help="Show stack traces for errors", action="store_true", default=False

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -23,7 +23,6 @@ from typing import Dict, FrozenSet, Iterator, List, Optional, Sequence, Tuple, U
 
 from inmanta.ast import export
 from inmanta.stable_api import stable_api
-from inmanta.warnings import InmantaWarning
 
 try:
     from typing import TYPE_CHECKING
@@ -268,11 +267,12 @@ class Namespace(Namespaced):
         self.__parent = parent
         self.__children = {}  # type: Dict[str,Namespace]
         self.defines_types = {}  # type: Dict[str,NamedType]
+        self.visible_namespaces: Dict[str, Import]
         if self.__parent is not None:
-            self.visible_namespaces = {self.get_full_name(): MockImport(self)}  # type: Dict[str, Import]
+            self.visible_namespaces = {self.get_full_name(): MockImport(self)}
             self.__parent.add_child(self)
         else:
-            self.visible_namespaces = {name: MockImport(self)}  # type: Dict[str, Import]
+            self.visible_namespaces = {name: MockImport(self)}
         self.primitives = None  # type: Optional[Dict[str,Type]]
         self.scope = None  # type:  Optional[ExecutionContext]
 
@@ -581,13 +581,13 @@ class RuntimeException(CompilerException):
         return super(RuntimeException, self).format()
 
 
-class CompilerRuntimeWarning(InmantaWarning, RuntimeException):
+class CompilerRuntimeWarning(Warning, RuntimeException):
     """
     Baseclass for compiler warnings after parsing is complete.
     """
 
     def __init__(self, stmt: "Optional[Locatable]", msg: str) -> None:
-        InmantaWarning.__init__(self)
+        Warning.__init__(self)
         RuntimeException.__init__(self, stmt, msg)
 
 

--- a/src/inmanta/ast/blocks.py
+++ b/src/inmanta/ast/blocks.py
@@ -16,10 +16,10 @@
     Contact: code@inmanta.com
 """
 
+import warnings
 from itertools import chain
 from typing import TYPE_CHECKING, Dict, FrozenSet, Iterable, Iterator, List, Optional, Tuple
 
-import inmanta.warnings as inmanta_warnings
 from inmanta.ast import Anchor, Locatable, Namespace, RuntimeException, TypeNotFoundException, VariableShadowWarning
 from inmanta.ast.statements import DefinitionStatement, DynamicStatement, Statement
 from inmanta.execute.runtime import QueueScheduler, Resolver
@@ -95,7 +95,7 @@ class BasicBlock(object):
         scope and only that block is searched for shadowing with respect to the scope.
         """
         for var, shadowed_locs, orig_locs in self.shadowed_variables():
-            inmanta_warnings.warn(
+            warnings.warn(
                 VariableShadowWarning(
                     None,
                     "Variable `%s` shadowed: originally declared at %s, shadowed at %s"

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -19,9 +19,9 @@
 
 import logging
 import typing
+import warnings
 from typing import Dict, Iterator, List, Optional, Tuple
 
-import inmanta.warnings as inmanta_warnings
 from inmanta.ast import (
     AttributeReferenceAnchor,
     CompilerDeprecationWarning,
@@ -423,7 +423,7 @@ class DefineTypeConstraint(TypeDefinitionStatement):
         self.type.location = name.get_location()
         self.comment = None
         if self.name in TYPES:
-            inmanta_warnings.warn(CompilerRuntimeWarning(self, "Trying to override a built-in type: %s" % self.name))
+            warnings.warn(CompilerRuntimeWarning(self, "Trying to override a built-in type: %s" % self.name))
 
     def get_expression(self) -> ExpressionStatement:
         """
@@ -512,7 +512,7 @@ class DefineTypeDefault(TypeDefinitionStatement):
             raise TypingException(
                 self, "Default can only be define for an Entity, but %s is a %s" % (self.ctor.class_type, self.ctor.class_type)
             )
-        inmanta_warnings.warn(CompilerDeprecationWarning(self, "Default constructors are deprecated. Use inheritance instead."))
+        warnings.warn(CompilerDeprecationWarning(self, "Default constructors are deprecated. Use inheritance instead."))
 
         self.type.comment = self.comment
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -25,6 +25,7 @@ import re
 import subprocess
 import sys
 import traceback
+import warnings
 from abc import ABC, abstractmethod
 from io import BytesIO, TextIOBase
 from subprocess import CalledProcessError
@@ -52,7 +53,6 @@ import yaml
 from pkg_resources import parse_requirements, parse_version
 from pydantic import BaseModel, Field, NameEmail, ValidationError, validator
 
-import inmanta.warnings
 from inmanta import env, loader, plugins
 from inmanta.ast import CompilerException, LocatableString, Location, ModuleNotFoundException, Namespace, Range
 from inmanta.ast.blocks import BasicBlock
@@ -121,7 +121,7 @@ class InvalidMetadata(CompilerException):
         return msg
 
 
-class MetadataDeprecationWarning(inmanta.warnings.InmantaWarning):
+class MetadataDeprecationWarning(Warning):
     pass
 
 
@@ -372,7 +372,7 @@ class Metadata(BaseModel):
     def requires_to_list(cls, v: object) -> object:
         if isinstance(v, dict):
             # transform legacy format for backwards compatibility
-            inmanta.warnings.warn(
+            warnings.warn(
                 MetadataDeprecationWarning(
                     "The yaml dictionary syntax for specifying module requirements has been deprecated. Please use the"
                     " documented list syntax instead."

--- a/src/inmanta/parser/__init__.py
+++ b/src/inmanta/parser/__init__.py
@@ -21,7 +21,6 @@ from typing import Optional
 import inmanta.ast.export as ast_export
 from inmanta.ast import CompilerException, Range
 from inmanta.stable_api import stable_api
-from inmanta.warnings import InmantaWarning
 
 
 @stable_api
@@ -43,11 +42,11 @@ class ParserException(CompilerException):
         return error
 
 
-class ParserWarning(InmantaWarning, ParserException):
+class ParserWarning(Warning, ParserException):
     """Warning occurring during the parsing of the code"""
 
     def __init__(self, location: Range, value: object, msg: str) -> None:
-        InmantaWarning.__init__(self)
+        Warning.__init__(self)
         ParserException.__init__(self, location, value, msg)
         # Override parent message since it's not an error
         self.msg = msg

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -17,12 +17,12 @@
 """
 import logging
 import re
+import warnings
 from typing import List, Optional, Tuple, Union
 
 import ply.yacc as yacc
 from ply.yacc import YaccProduction
 
-import inmanta.warnings as inmanta_warnings
 from inmanta.ast import LocatableString, Location, Namespace, Range
 from inmanta.ast.blocks import BasicBlock
 from inmanta.ast.constraint.expression import IsDefined, Not, Operator
@@ -473,7 +473,7 @@ def deprecated_relation_warning(p: YaccProduction) -> None:
         values: Tuple[str, str] = tuple(v if v is not None else "" for v in multi)
         return "[%s:%s]" % values if values[0] != values[1] else "[%s]" % values[0]
 
-    inmanta_warnings.warn(
+    warnings.warn(
         SyntaxDeprecationWarning(
             p[0].location,
             None,

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -108,7 +108,6 @@ def get_bind_port() -> int:
             warnings.warn(
                 "Ignoring the server_rest_transport.port config option since the new config options "
                 "server.bind-port/server.bind-address are used.",
-                category=DeprecationWarning,
             )
         return server_bind_port.get()
     else:

--- a/src/inmanta/warnings.py
+++ b/src/inmanta/warnings.py
@@ -19,16 +19,9 @@
 import logging
 import warnings
 from enum import Enum
-from typing import Dict, List, Mapping, Optional, TextIO, Type, Union
+from typing import Dict, List,  Mapping, Optional, TextIO, Type, Union
 
-
-class InmantaWarning(Warning):
-    """
-    Base class for Inmanta Warnings.
-    """
-
-    def __init__(self, *args: object):
-        Warning.__init__(self, *args)
+REGEX_INMANTA_MODULE: str = r"^(inmanta|inmanta\..*|inmanta_.*)$"
 
 
 class WarningBehaviour(Enum):
@@ -40,15 +33,19 @@ class WarningBehaviour(Enum):
 class WarningRule:
     """
     A single rule for warning handling. Describes the desired behaviour when an error occurs.
-    When type is set, the rule is only applied to subclasses of the warning type.
+
+    :param module: A regex that must match the name of the module generating the warning.
     """
 
-    def __init__(self, action: WarningBehaviour, tp: Optional[Type[InmantaWarning]] = None) -> None:
+    def __init__(self, action: WarningBehaviour, module: Optional[str] = None) -> None:
         self.action: WarningBehaviour = action
-        self.type: Type[Warning] = tp if tp is not None else InmantaWarning
+        self.module: Optional[str] = module
 
     def apply(self) -> None:
-        warnings.filterwarnings(self.action.value, category=self.type)
+        if self.module is not None:
+            warnings.filterwarnings(self.action.value, module=self.module)
+        else:
+            warnings.filterwarnings(self.action.value)
 
 
 class WarningOption:
@@ -56,10 +53,10 @@ class WarningOption:
     An option to manage warnings. Consists of a name and a range of possible values, each tied to a warning rule.
     For example, applying
     WarningOption(
-        "disable-runtime-warnings",
-        {True: WarningRule(WarningBehaviour.IGNORE, CompilerRuntimeWarning)}
+        "disable-inmanta-warnings",
+        {True: WarningRule(WarningBehaviour.IGNORE, module=REGEX_INMANTA_MODULE)}
     )
-    would add a rule to ignore CompilerRuntimeWarnings but leave other warning's behaviour as is.
+    would add a rule to ignore Inmanta warnings but leave other warning's behaviour as is.
     """
 
     def __init__(self, name: str, options: Dict[Union[str, bool], WarningRule]) -> None:
@@ -87,9 +84,9 @@ class WarningsManager:
         WarningOption(
             "default",
             {
-                "warn": WarningRule(WarningBehaviour.WARN),
-                "ignore": WarningRule(WarningBehaviour.IGNORE),
-                "error": WarningRule(WarningBehaviour.ERROR),
+                "warn": WarningRule(WarningBehaviour.WARN, module=REGEX_INMANTA_MODULE),
+                "ignore": WarningRule(WarningBehaviour.IGNORE, module=REGEX_INMANTA_MODULE),
+                "error": WarningRule(WarningBehaviour.ERROR, module=REGEX_INMANTA_MODULE),
             },
         ),
     ]
@@ -118,9 +115,9 @@ class WarningsManager:
         # Control how warnings are shown
         warnings.showwarning = cls._showwarning
         # Ignore all external warnings.
-        warnings.filterwarnings(WarningBehaviour.IGNORE.value, category=Warning)
-        # Warn all InmantaWarnings by default. Behaviour can be controlled using the config.
-        warnings.filterwarnings(WarningBehaviour.WARN.value, category=InmantaWarning)
+        warnings.filterwarnings(WarningBehaviour.IGNORE.value)
+        # Warn all Inmanta-related warnings by default. Behaviour can be controlled using the --warnings argument on the CLI.
+        warnings.filterwarnings(WarningBehaviour.WARN.value, module=REGEX_INMANTA_MODULE)
 
     @classmethod
     def _showwarning(
@@ -143,21 +140,16 @@ class WarningsManager:
         :param line: Required for compatibility but will be ignored.
         """
         # implementation based on warnings._showwarnmsg_impl and logging._showwarning
-        text: str
-        logger: logging.Logger
-        if issubclass(category, InmantaWarning):
-            text = "%s: %s" % (category.__name__, message)
-            logger = logging.getLogger("inmanta.warnings")
-        else:
-            text = warnings.formatwarning(
-                # ignore type check because warnings.formatwarning accepts Warning instance but it's type definition doesn't
-                message,  # type: ignore
-                category,
-                filename,
-                lineno,
-                line,
-            )
-            logger = logging.getLogger("py.warnings")
+        text: str = warnings.formatwarning(
+            # ignore type check because warnings.formatwarning accepts Warning instance but it's type definition doesn't
+            message,  # type: ignore
+            category,
+            filename,
+            lineno,
+            line,
+        )
+        logger: logging.Logger = logging.getLogger("py.warnings")
+
         if file is not None:
             try:
                 # This code path is currently not used in our code base
@@ -168,8 +160,10 @@ class WarningsManager:
             logger.warning("%s", text)
 
 
-def warn(warning: InmantaWarning) -> None:
+def warn(*args, **kwargs) -> None:
     """
-    Warn using the supplied InmantaWarning instance.
+    A method that proxies call to `warnings.warn()`. This method is used by the test suite
+    to be able to log warnings from a module that is part of an Inmanta package. Warnings
+    created from the test suite would be considered a warnings from a third-party library.
     """
-    warnings.warn(warning)
+    warnings.warn(*args, **kwargs)

--- a/src/inmanta/warnings.py
+++ b/src/inmanta/warnings.py
@@ -19,7 +19,7 @@
 import logging
 import warnings
 from enum import Enum
-from typing import Dict, List,  Mapping, Optional, TextIO, Type, Union
+from typing import Dict, List, Mapping, Optional, TextIO, Type, Union
 
 REGEX_INMANTA_MODULE: str = r"^(inmanta|inmanta\..*|inmanta_.*)$"
 

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -25,34 +25,56 @@ import pytest
 import inmanta.compiler as compiler
 import inmanta.warnings as inmanta_warnings
 from inmanta.ast import CompilerDeprecationWarning, CompilerRuntimeWarning, VariableShadowWarning
-from inmanta.warnings import InmantaWarning, WarningsManager
+from inmanta.warnings import WarningsManager
+from utils import log_doesnt_contain
 
 
 @pytest.mark.parametrize(
     "option,expected_error,expected_warning",
     [(None, False, True), ("warn", False, True), ("ignore", False, False), ("error", True, False)],
 )
-@pytest.mark.parametrize("raise_external_warning", [True, False])
-def test_warnings(option: Optional[str], expected_error: bool, expected_warning: bool, raise_external_warning: bool):
-    message: str = "Some compiler runtime warning"
-    internal_warning: InmantaWarning = CompilerRuntimeWarning(None, message)
-    external_warning: Warning = Warning(None, "Some external warning")
+def test_warnings(option: Optional[str], expected_error: bool, expected_warning: bool) -> None:
+    """
+    Verify whether the setting to configure warnings works correctly.
+    """
+    message_compiler_warning: str = "Some compiler runtime warning"
+    internal_warning: CompilerRuntimeWarning = CompilerRuntimeWarning(None, message_compiler_warning)
+    message_internal_warning: str = "Some external warning"
+    external_warning: Warning = Warning(None, message_internal_warning)
+
+    def contains_warning(caught_warnings, category: Type[Warning], message: str) -> bool:
+        return any(issubclass(w.category, category) and str(w.message) == message for w in caught_warnings)
+
+    # Apply config
     WarningsManager.apply_config({"default": option} if option is not None else None)
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        # Log an external warning
+        warnings.warn(external_warning)
+        # Log an internal warning
         if expected_error:
             with pytest.raises(CompilerRuntimeWarning):
-                if raise_external_warning:
-                    # make sure external warnings are ignored (#1905)
-                    warnings.warn(external_warning)
                 inmanta_warnings.warn(internal_warning)
         else:
             inmanta_warnings.warn(internal_warning)
+        # Verify that the CompilerWarnings are filtered correctly with respect to the provided config option.
         if expected_warning:
-            assert len(w) == 1
-            assert issubclass(w[0].category, CompilerRuntimeWarning)
-            assert str(w[0].message) == message
+            assert len(caught_warnings) >= 1
+            assert contains_warning(caught_warnings, category=CompilerRuntimeWarning, message=message_compiler_warning)
         else:
-            assert len(w) == 0
+            assert not contains_warning(caught_warnings, category=CompilerRuntimeWarning, message=message_compiler_warning)
+        # Verify that the external warning is not logged
+        assert not contains_warning(caught_warnings, category=Warning, message=message_internal_warning)
+
+
+def test_filter_external_warnings(caplog) -> None:
+    """
+    Verify that warnings triggered from non-inmanta code are not displayed to the user.
+    """
+    message = "test message"
+    # Raising a warning from the test suite is considered an external exception.
+    # The file is not part of an inmanta package.
+    warnings.warn(message, category=DeprecationWarning)
+    log_doesnt_contain(caplog, "py.warnings", logging.WARNING, message)
 
 
 @pytest.mark.parametrize(
@@ -68,16 +90,13 @@ def test_warning_format(caplog, warning: Union[str, Warning], category: Type[War
     warnings.resetwarnings()
     warnings.filterwarnings("default", category=Warning)
     warnings.warn_explicit(warning, category, filename, lineno)
-    if isinstance(warning, InmantaWarning):
-        assert caplog.record_tuples == [("inmanta.warnings", logging.WARNING, "%s: %s" % (category.__name__, warning))]
-    else:
-        assert caplog.record_tuples == [
-            (
-                "py.warnings",
-                logging.WARNING,
-                warnings.formatwarning(warning, category, filename, lineno),  # type: ignore
-            )
-        ]
+    assert caplog.record_tuples == [
+        (
+            "py.warnings",
+            logging.WARNING,
+            warnings.formatwarning(warning, category, filename, lineno),  # type: ignore
+        )
+    ]
 
 
 def test_shadow_warning(snippetcompiler):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import warnings
 
 """
 About the use of @parametrize_any and @slowtest:
@@ -84,6 +85,7 @@ from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import SliceStartupException
 from inmanta.server.services.compilerservice import CompilerService, CompileRun
 from inmanta.types import JsonType
+from inmanta.warnings import WarningsManager
 
 # Import test modules differently when conftest is put into the inmanta_tests packages
 PYTEST_PLUGIN_MODE: bool = __file__ and os.path.dirname(__file__).split("/")[-1] == "inmanta_tests"
@@ -737,8 +739,12 @@ def clienthelper(client, environment):
 
 @pytest.fixture(scope="function", autouse=True)
 def capture_warnings():
+    # Ensure that the test suite uses the same config for warnings as the default config used by the CLI tools.
     logging.captureWarnings(True)
+    cmd_parser = inmanta.app.cmd_parser()
+    WarningsManager.apply_config({"default": cmd_parser.get_default("warnings")})
     yield
+    warnings.resetwarnings()
     logging.captureWarnings(False)
 
 


### PR DESCRIPTION
# Description

*Same PR as  #4979 but applied on iso4 due to a merge conflict*

* Our code base ignores all warning messages logged using `warnings.warn()` that don't extend from `warnings.InmantaWarning`. This PR ensures that all warnings logged to `warning.warn()` extend from that class.
* This PR ensures that the test suite configures the warnings module in the same way as it is configured when running the CLI tools. 
* Add adr record regarding logging.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
