### PR TITLE
Fix incorrect documentation module freeze command

### DIFF
--- a/changelogs/unreleased/fix-incorrect-doc-module-freeze-command.yml
+++ b/changelogs/unreleased/fix-incorrect-doc-module-freeze-command.yml
@@ -4,5 +4,4 @@ issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso5, iso4]
 sections:
-  feature: 
   bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-incorrect-doc-module-freeze-command.yml
+++ b/changelogs/unreleased/fix-incorrect-doc-module-freeze-command.yml
@@ -1,0 +1,8 @@
+---
+description: Fix issue where the documentation of the `inmanta module freeze` command incorrectly indicates that it updates the project.yml file, while it updates the module.yml file.
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  feature: 
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-incorrect-doc-module-freeze-command.yml
+++ b/changelogs/unreleased/fix-incorrect-doc-module-freeze-command.yml
@@ -1,6 +1,5 @@
 ---
 description: Fix issue where the documentation of the `inmanta module freeze` command incorrectly indicates that it updates the project.yml file, while it updates the module.yml file.
-issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso5, iso4]
 sections:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -212,7 +212,7 @@ class ProjectTool(ModuleLikeTool):
         freeze.add_argument(
             "-o",
             "--outfile",
-            help="File in which to put the new project.yml, default is the existing project.yml",
+            help="File in which to put the new project.yml, default is the existing project.yml. Use - to write to stdout.",
             default=None,
         )
         freeze.add_argument(
@@ -528,25 +528,25 @@ mode.
             "--v1", dest="v1", help="Create a v1 module. By default a v2 module is created.", action="store_true"
         )
 
-        freeze = subparser.add_parser("freeze", help="Set all version numbers in project.yml")
+        freeze = subparser.add_parser("freeze", help="Set all version numbers in module.yml")
         freeze.add_argument(
             "-o",
             "--outfile",
-            help="File in which to put the new project.yml, default is the existing project.yml",
+            help="File in which to put the new module.yml, default is the existing module.yml. Use - to write to stdout.",
             default=None,
         )
         freeze.add_argument(
             "-r",
             "--recursive",
-            help="Freeze dependencies recursively. If not set, freeze_recursive option in project.yml is used,"
-            "which defaults to False",
+            help="Freeze dependencies recursively. If not set, freeze_recursive option in module.yml is used,"
+            " which defaults to False",
             action="store_true",
             default=None,
         )
         freeze.add_argument(
             "--operator",
             help="Comparison operator used to freeze versions, If not set, the freeze_operator option in"
-            " project.yml is used which defaults to ~=",
+            " module.yml is used which defaults to ~=",
             choices=[o.value for o in FreezeOperator],
             default=None,
         )


### PR DESCRIPTION
# Description

Fix issue where the documentation of the `inmanta module freeze` command incorrectly indicates that it updates the project.yml file, while it updates the module.yml file.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
