### PR TITLE
FIX: optional field without default value

### DIFF
--- a/changelogs/unreleased/fix-optional-field-no-default.yml
+++ b/changelogs/unreleased/fix-optional-field-no-default.yml
@@ -1,0 +1,4 @@
+---
+description: Fixes an issue about optional values without default values
+change-type: patch
+destination-branches: [master, iso5]

--- a/changelogs/unreleased/fix-optional-field-no-default.yml
+++ b/changelogs/unreleased/fix-optional-field-no-default.yml
@@ -1,4 +1,4 @@
 ---
-description: Fixes an issue about optional values without default values
+description: Fixes an issue about optional values without default value
 change-type: patch
 destination-branches: [master, iso5]

--- a/changelogs/unreleased/fix-optional-field-no-default.yml
+++ b/changelogs/unreleased/fix-optional-field-no-default.yml
@@ -1,4 +1,6 @@
 ---
-description: Fixes an issue about optional fields without default value
+description: Fixes an issue about optional fields without default value not being populated correctly in DAO
 change-type: patch
 destination-branches: [master, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-optional-field-no-default.yml
+++ b/changelogs/unreleased/fix-optional-field-no-default.yml
@@ -1,4 +1,4 @@
 ---
-description: Fixes an issue about optional values without default value
+description: Fixes an issue about optional fields without default value
 change-type: patch
 destination-branches: [master, iso5]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1055,6 +1055,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         required: bool = not has_value
         default: object = default_unset
         is_many: bool = False
+
         # Only union with None (optional) is support
         if typing_inspect.is_union_type(annotation) and not typing_inspect.is_optional_type(annotation):
             raise InvalidAttribute(f"A union that is not an optional in field {attribute} is not supported.")
@@ -1159,6 +1160,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
     def __process_kwargs(self, from_postgres: bool, kwargs: Dict[str, object]) -> None:
         """This helper method process the kwargs provided to the constructor and populates the fields of the object."""
         fields = self.get_field_metadata()
+
         if "id" in fields and "id" not in kwargs:
             kwargs["id"] = uuid.uuid4()
 
@@ -1182,7 +1184,8 @@ class BaseDocument(object, metaclass=DocumentMeta):
         for name, field in fields.items():
             # when a default value is used, make sure it is copied
             if field.default:
-                setattr(self, name, copy.deepcopy(field.default_value))
+                setattr(self, name, copy.deepcopy(field.default_value)
+
             # update the list of required fields
             elif fields[name].required:
                 required_fields.append(name)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1055,7 +1055,6 @@ class BaseDocument(object, metaclass=DocumentMeta):
         required: bool = not has_value
         default: object = default_unset
         is_many: bool = False
-
         # Only union with None (optional) is support
         if typing_inspect.is_union_type(annotation) and not typing_inspect.is_optional_type(annotation):
             raise InvalidAttribute(f"A union that is not an optional in field {attribute} is not supported.")
@@ -1160,7 +1159,6 @@ class BaseDocument(object, metaclass=DocumentMeta):
     def __process_kwargs(self, from_postgres: bool, kwargs: Dict[str, object]) -> None:
         """This helper method process the kwargs provided to the constructor and populates the fields of the object."""
         fields = self.get_field_metadata()
-
         if "id" in fields and "id" not in kwargs:
             kwargs["id"] = uuid.uuid4()
 
@@ -1176,8 +1174,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
             else:
                 value = None
 
-            if value is not None:
-                setattr(self, name, value)
+            setattr(self, name, value)
 
             del fields[name]
 
@@ -1186,7 +1183,10 @@ class BaseDocument(object, metaclass=DocumentMeta):
             # when a default value is used, make sure it is copied
             if field.default:
                 setattr(self, name, copy.deepcopy(field.default_value))
-
+                if name == "returncode":
+                    print(name)
+                    print(field.default_value)
+                    print(self.returncode)
             # update the list of required fields
             elif fields[name].required:
                 required_fields.append(name)
@@ -2013,6 +2013,9 @@ class BaseDocument(object, metaclass=DocumentMeta):
                         result.append(record)
                     else:
                         result.append(cls(from_postgres=True, **record))
+                        import pudb
+
+                        pu.db
                 return result
 
     def to_dict(self) -> JsonType:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1185,6 +1185,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
             # when a default value is used, make sure it is copied
             if field.default:
                 setattr(self, name, copy.deepcopy(field.default_value))
+
             # update the list of required fields
             elif fields[name].required:
                 required_fields.append(name)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1184,8 +1184,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         for name, field in fields.items():
             # when a default value is used, make sure it is copied
             if field.default:
-                setattr(self, name, copy.deepcopy(field.default_value)
-
+                setattr(self, name, copy.deepcopy(field.default_value))
             # update the list of required fields
             elif fields[name].required:
                 required_fields.append(name)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2013,9 +2013,6 @@ class BaseDocument(object, metaclass=DocumentMeta):
                         result.append(record)
                     else:
                         result.append(cls(from_postgres=True, **record))
-                        import pudb
-
-                        pu.db
                 return result
 
     def to_dict(self) -> JsonType:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1183,10 +1183,6 @@ class BaseDocument(object, metaclass=DocumentMeta):
             # when a default value is used, make sure it is copied
             if field.default:
                 setattr(self, name, copy.deepcopy(field.default_value))
-                if name == "returncode":
-                    print(name)
-                    print(field.default_value)
-                    print(self.returncode)
             # update the list of required fields
             elif fields[name].required:
                 required_fields.append(name)

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -238,8 +238,8 @@ class Environment(BaseModel):
     id: uuid.UUID
     name: str
     project_id: uuid.UUID
-    repo_url: str
-    repo_branch: str
+    repo_url: Optional[str]
+    repo_branch: Optional[str]
     settings: Dict[str, EnvSettingType]
     halted: bool
     description: Optional[str]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -238,8 +238,8 @@ class Environment(BaseModel):
     id: uuid.UUID
     name: str
     project_id: uuid.UUID
-    repo_url: Optional[str]
-    repo_branch: Optional[str]
+    repo_url: str
+    repo_branch: str
     settings: Dict[str, EnvSettingType]
     halted: bool
     description: Optional[str]

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -207,6 +207,10 @@ class EnvironmentService(protocol.ServerSlice):
     async def create_environment(
         self, project_id: uuid.UUID, name: str, repository: str, branch: str, environment_id: Optional[uuid.UUID]
     ) -> Apireturn:
+        if repository is None:
+            repository = ""
+        if branch is None:
+            branch = ""
         return (
             200,
             {"environment": rename_fields(await self.environment_create(project_id, name, repository, branch, environment_id))},
@@ -354,6 +358,10 @@ class EnvironmentService(protocol.ServerSlice):
 
         if (repository is None and branch is not None) or (repository is not None and branch is None):
             raise BadRequest("Repository and branch should be set together.")
+        if repository is None:
+            repository = ""
+        if branch is None:
+            branch = ""
 
         # fetch the project first
         project = await data.Project.get_by_id(project_id)

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -207,10 +207,6 @@ class EnvironmentService(protocol.ServerSlice):
     async def create_environment(
         self, project_id: uuid.UUID, name: str, repository: str, branch: str, environment_id: Optional[uuid.UUID]
     ) -> Apireturn:
-        if repository is None:
-            repository = ""
-        if branch is None:
-            branch = ""
         return (
             200,
             {"environment": rename_fields(await self.environment_create(project_id, name, repository, branch, environment_id))},

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2472,7 +2472,7 @@ async def test_update_to_none_value(init_dataclasses_and_load_schema):
     assert env.repo_url is None
 
     env = await data.Environment.get_by_id(env.id)
-    assert env.repo_url == ""
+    assert env.repo_url is None
 
 
 async def test_query_resource_actions_simple(init_dataclasses_and_load_schema):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2966,3 +2966,25 @@ def test_arg_collector():
     assert args("a") == "$4"
     assert args("b") == "$5"
     assert args.get_values() == ["a", "b"]
+
+
+async def test_retrieve_optional_field_no_default(init_dataclasses_and_load_schema):
+    """
+    verify 'returncode' (optional field with no default value) exists on a report.
+    """
+    project = data.Project(name="test")
+    await project.insert()
+
+    env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
+    await env.insert()
+
+    started = datetime.datetime(2018, 7, 15, 12, 30)
+    completed = datetime.datetime(2018, 7, 15, 13, 00)
+    compile1 = data.Compile(environment=env.id, started=started, completed=completed)
+    await compile1.insert()
+
+    report = data.Report(started=datetime.datetime.now(), command="cmd", name="test", compile=compile1.id)
+    await report.insert()
+
+    report = await data.Report.get_by_id(report.id)
+    assert report.returncode is None

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2970,7 +2970,7 @@ def test_arg_collector():
 
 async def test_retrieve_optional_field_no_default(init_dataclasses_and_load_schema):
     """
-    verify 'returncode' (optional field with no default value) exists on a report.
+    verify that an optional field with no default value (returncode) exists on an object retrieved from the DB.
     """
     project = data.Project(name="test")
     await project.insert()


### PR DESCRIPTION
# Description

Optional fields which were not assigned None as default were causing issues:
when populating a DAO using `__process_kwargs`, if the value of an optional field was 
`None` in the DB, the DAO would not get this field populated. This caused issues when trying
to access the field as it did not exist.
This PR fixes this issue. 

While resolving this, an inconsistency between the DB and the objects caused some tests to fail:
the `repository` and `branch` fields of an environment that equals None in objects are stored as empty strings in the DB

closes https://github.com/inmanta/inmanta-lsm/issues/1078

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
