### PR TITLE
Fix bug in deactivation logic of the ReentrantVirtualEnv

### DIFF
--- a/changelogs/unreleased/fix-bug-in-reentrant-virtualenv.yml
+++ b/changelogs/unreleased/fix-bug-in-reentrant-virtualenv.yml
@@ -1,0 +1,4 @@
+---
+description: Fix bug in deactivation logic of the ReentrantVirtualEnv used by the snippetcompiler.
+change-type: patch
+destination-branches: [master, iso5]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1001,8 +1001,9 @@ class ReentrantVirtualEnv(VirtualEnv):
         self.working_set = None
 
     def deactivate(self):
-        self._using_venv = False
-        self.working_set = pkg_resources.working_set
+        if self._using_venv:
+            self._using_venv = False
+            self.working_set = pkg_resources.working_set
 
     def use_virtual_env(self) -> None:
         """

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -232,7 +232,7 @@ def test_object_to_id(snippetcompiler):
     snippetcompiler.do_export()
 
 
-def test_resource_invalid_agent_name_annotation(snippetcompiler):
+def test_resource_invalid_agent_name_annotation():
 
     import inmanta.resources
 


### PR DESCRIPTION
# Description

This PR fixes a bug in the deactivation logic of the ReentrantVirtualEnv, which is used by the compiler fixture for the compiler venv. The bug triggers when the `snippetcompiler` is used for the first time without calling into the `setup_for_snippet` method. That way the compiler venv is never created, because the `use_virtual_env` method of the `ReentrantVirtualEnv` class is never called. At the end of the first test case, the deactivation logic of the `ReentrantVirtualEnv` incorrectly assumes that the venv was created/activated. When the snippetcompiler fixture is then used in a second test case, the venv wouldn't be present on disk, while the `ReentrantVirtualEnv` class assumes is already exists. The result is that the second test case fails with the following error when it tries to do `pip install` using that compiler venv:

```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpeqw57m5s/bin/python'
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
