### PR TITLE
Resolve issue where the status endpoint can block

### DIFF
--- a/changelogs/unreleased/fix-hanging-status-endpoint.yml
+++ b/changelogs/unreleased/fix-hanging-status-endpoint.yml
@@ -1,0 +1,5 @@
+description: Fix bug where the status endpoint can become non-responsive
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3609,7 +3609,7 @@ class Compile(BaseDocument):
     @classmethod
     async def get_next_compiles_count(cls) -> int:
         """Get the number of compiles in the queue for ALL environments"""
-        result = await cls._fetch_int(f"SELECT count(*) FROM {cls.table_name()} WHERE NOT handled and completed IS NOT NULL")
+        result = await cls._fetch_int(f"SELECT count(*) FROM {cls.table_name()} WHERE NOT handled AND completed IS NULL")
         return result
 
     @classmethod

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -679,7 +679,7 @@ class CompilerService(ServerSlice):
 
     async def _recover(self) -> None:
         """Restart runs after server restart"""
-        # one run per env max to get startedf
+        # one run per env max to get started
         runs = await data.Compile.get_next_run_all()
         self._queue_count_cache = await data.Compile.get_next_compiles_count() - len(runs)
         for run in runs:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -504,9 +504,11 @@ class CompilerService(ServerSlice):
         self._global_lock = asyncio.locks.Lock()
         self.listeners: List[CompileStateListener] = []
         self._scheduled_full_compiles: Dict[uuid.UUID, Tuple[TaskMethod, str]] = {}
+        # cache the queue count for DB-less and lock-less access to number of tasks
+        self._queue_count_cache: int = 0
 
     async def get_status(self) -> Dict[str, ArgumentTypes]:
-        return {"task_queue": await data.Compile.get_next_compiles_count(), "listeners": len(self.listeners)}
+        return {"task_queue": self._queue_count_cache, "listeners": len(self.listeners)}
 
     def add_listener(self, listener: CompileStateListener) -> None:
         self.listeners.append(listener)
@@ -642,7 +644,7 @@ class CompilerService(ServerSlice):
             # don't execute any compiles in a halted environment
             if env.halted:
                 return
-
+            self._queue_count_cache += 1
             if compile.environment not in self._recompiles or self._recompiles[compile.environment].done():
                 task = self.add_background_task(self._run(compile))
                 self._recompiles[compile.environment] = task
@@ -677,7 +679,9 @@ class CompilerService(ServerSlice):
 
     async def _recover(self) -> None:
         """Restart runs after server restart"""
+        # one run per env max to get startedf
         runs = await data.Compile.get_next_run_all()
+        self._queue_count_cache = await data.Compile.get_next_compiles_count() - len(runs)
         for run in runs:
             await self._queue(run)
         unhandled = await data.Compile.get_unhandled_compiles()
@@ -749,6 +753,7 @@ class CompilerService(ServerSlice):
         Runs a compile request. At completion, looks for similar compile requests based on _compile_merge_key and marks
         those as completed as well.
         """
+        self._queue_count_cache -= 1
         await self._auto_recompile_wait(compile)
 
         compile_merge_key: Hashable = CompilerService._compile_merge_key(compile)
@@ -784,6 +789,7 @@ class CompilerService(ServerSlice):
         if self.is_stopping():
             return
         self.add_background_task(self._notify_listeners(compile))
+        self._queue_count_cache -= len(merge_candidates)
         for merge_candidate in merge_candidates:
             self.add_background_task(self._notify_listeners(merge_candidate))
         await self._dequeue(compile.environment)

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -507,9 +507,11 @@ async def retry_limited(
         raise ValueError("value of INMANTA_RETRY_LIMITED_MULTIPLIER must be bigger or equal to 1.")
     hard_timeout = timeout * multiplier
     start = time.time()
-    while time.time() - start < hard_timeout and not (await fun_wrapper()):
+    result = await fun_wrapper()
+    while time.time() - start < hard_timeout and not result:
         await asyncio.sleep(interval)
-    if not (await fun_wrapper()):
+        result = await fun_wrapper()
+    if not result:
         raise asyncio.TimeoutError(f"Wait condition was not reached after hard limit of {hard_timeout} seconds")
     if time.time() - start > timeout:
         raise asyncio.TimeoutError(

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -345,7 +345,7 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
             # First one is never queued, so not counted
             # Last iteration here doesn't de-queue an item, but allows it to complete
             # So don't handle last 2
-            compiler_cache_consistent(4 - i)
+            await compiler_cache_consistent(4 - i)
 
     await compiler_cache_consistent(3)
 


### PR DESCRIPTION
# Description

This PR prevents the status endpoint form hanging when the DB is in trouble.

I produces a fully redundant, local cache of the compiler queue size.
I'm in general not a fan of redundant data like this, but the only alternative I see is to bake in a timeout in the status endpoint so it only reports data is can collect .e.g `<10ms` 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

