### PR TITLE
Add support to only load environment settings from all extensions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.3.1
+current_version = 6.4.0
 
 [bumpversion:file:setup.py]
 search = version = "{current_version}"

--- a/changelogs/unreleased/add-new-way-to-register-environment-settings.yml
+++ b/changelogs/unreleased/add-new-way-to-register-environment-settings.yml
@@ -1,0 +1,9 @@
+---
+description: "Add support for extensions to register their environment settings via the `register_environment_settings` method in the `extension.py` file of the extension."
+issue-nr: 1366
+issue-repo: irt
+change-type: minor
+destination-branches: [master, iso5]
+sections:
+  feature: "{{description}}"
+  deprecation-note: "The `inmanta.server.services.environmentservice.register_setting` method, used by the extensions to register environment settings, has been deprecated. The `register_environment_settings` method in the `extension.py` of the extension has to be used instead."

--- a/changelogs/unreleased/add-new-way-to-register-environment-settings.yml
+++ b/changelogs/unreleased/add-new-way-to-register-environment-settings.yml
@@ -3,7 +3,7 @@ description: "Add support for extensions to register their environment settings 
 issue-nr: 1366
 issue-repo: irt
 change-type: minor
-destination-branches: [master, iso5]
+destination-branches: [iso5]
 sections:
   feature: "{{description}}"
   deprecation-note: "The `inmanta.server.services.environmentservice.register_setting` method, used by the extensions to register environment settings, has been deprecated. The `register_environment_settings` method in the `extension.py` of the extension has to be used instead."

--- a/docs/platform_developers/create_server_extension.rst
+++ b/docs/platform_developers/create_server_extension.rst
@@ -3,8 +3,9 @@ Creating a new server extension
 *******************************
 
 Inmanta server extensions are separate Python packages with their own release cycle that can add additional server slices
-to the orchestrator. Server slices are components in the service orchestrator. A slice can be responsible for API endpoints or
-provide internal services to other slices. The core server extension provides all slices of the core service orchestrator.
+and Inmanta environment settings to the orchestrator. Server slices are components in the service orchestrator.
+A slice can be responsible for API endpoints or provide internal services to other slices. The core server extension
+provides all slices of the core service orchestrator.
 
 
 The package layout of a server extension
@@ -27,18 +28,31 @@ required for a new extension called ``new_extension``.
 * The ``extension.py`` file must contain a ``setup`` function that registers the necessary server slices to the application
   context. An example ``extension.py`` file is shown below. The parameter ``<server-slice-instance>`` should be replaced with
   an instance of the server slice that belongs to the extension. Multiple server slices can be registered.
+* The ``extension.py`` file can contain an optional ``register_environment_settings`` function that allows an extension to
+  register extension-specific settings that can be used to customize an Inmanta environment.
 
 .. code-block:: python
 
     # File: extension.py
     from inmanta.server.extensions import ApplicationContext
+    from inmanta import data
 
     def setup(application: ApplicationContext) -> None:
         application.register_slice(<server-slice-instance>)
 
+    def register_environment_settings(application: ApplicationContext) -> None:
+        application.register_environment_setting(
+            data.Setting(
+                name="my_environment_setting",
+                default=False,
+                typ="bool",
+                validator=data.convert_boolean,
+                doc="Explain what the setting does.",
+            )
+        )
 
-.. tip:: Indicate which version of the Inmanta core is compatible with the developed extension by pinning the version of the
-         Inmanta core in the ``requirements.txt`` file of the extension.
+.. tip:: Indicate which version of the Inmanta core is compatible with the developed extension by constraining the version of the
+         Inmanta core package to a valid range in the ``setup.py`` file of the extension.
 
 
 Adding server slices to the extension

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -383,3 +383,12 @@ sort
 
 .. automodule:: inmanta.protocol.methods_v2
     :members:
+
+Server
+------
+
+.. autoclass:: inmanta.server.extensions.ApplicationContext
+    :show-inheritance:
+
+.. autoclass:: inmanta.server.bootloader.InmantaBootloader
+    :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-version = "6.3.1"
+version = "6.4.0"
 
 setup(
     version=version,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2524,11 +2524,9 @@ RETURNING last_version;
         return version
 
     @classmethod
-    async def register_setting(cls, setting: Setting) -> None:
+    def register_setting(cls, setting: Setting) -> None:
         """
-        Adds a new setting to the environments from outside inmanta-core.
-        As example, inmanta-lsm can use this method to add settings that are only
-        relevant for inmanta-lsm but that are needed in the environments.
+        Adds a new environment setting that was defined by an extension.
 
         :param setting: the setting that should be added to the existing settings
         """

--- a/src/inmanta/server/extensions.py
+++ b/src/inmanta/server/extensions.py
@@ -23,9 +23,11 @@ from typing import Any, Dict, Generic, List, Optional, TypeVar
 import pkg_resources
 import yaml
 
+from inmanta import data
 from inmanta.config import feature_file_config
 from inmanta.data.model import ExtensionStatus
 from inmanta.server.protocol import ServerSlice
+from inmanta.stable_api import stable_api
 
 LOGGER = logging.getLogger(__name__)
 
@@ -180,6 +182,7 @@ class FeatureManager:
         """Called when the server is stopped"""
 
 
+@stable_api
 class ApplicationContext:
     def __init__(self) -> None:
         self._slices: List[ServerSlice] = []
@@ -206,3 +209,15 @@ class ApplicationContext:
 
     def get_extension_statuses(self) -> List[ExtensionStatus]:
         return ServerSlice.get_extension_statuses(list(self._slices))
+
+    def register_environment_setting(self, setting: data.Setting) -> None:
+        """
+        Used by an Inmanta extension to register extension-specific environment settings.
+        """
+        data.Environment.register_setting(setting)
+
+    def get_environment_settings(self) -> list[data.Setting]:
+        """
+        Returns the list of all available environment settings
+        """
+        return sorted(data.Environment._settings.values(), key=lambda x: x.name)

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -23,6 +23,7 @@ import os
 import re
 import shutil
 import uuid
+import warnings
 from collections import defaultdict
 from collections.abc import Set
 from enum import Enum
@@ -615,4 +616,10 @@ class EnvironmentService(protocol.ServerSlice):
         relevant for inmanta-lsm but that are needed in the environment.
         :param setting: the setting that should be added to the existing settings
         """
-        await data.Environment.register_setting(setting)
+        warnings.warn(
+            "Registering environment settings via the inmanta.server.services.environmentservice.register_setting endpoint "
+            "is deprecated. Environment settings defined by an extension should be advertised via the "
+            "register_environment_settings method of the inmanta_ext.<extension_name>.extension.py file of an extension.",
+            category=DeprecationWarning,
+        )
+        data.Environment.register_setting(setting)

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -729,10 +729,11 @@ async def test_get_set_param(resource_container, environment, client, server):
     assert result.code == 200
 
 
-async def test_register_setting(environment, client, server):
+async def test_register_setting(environment, client, server, caplog):
     """
     Test registering a new setting.
     """
+    caplog.set_level(logging.WARNING)
     new_setting: Setting = Setting(
         name="a new boolean setting",
         default=False,
@@ -741,7 +742,16 @@ async def test_register_setting(environment, client, server):
         doc="a new setting",
     )
     env_slice: EnvironmentService = server.get_slice(SLICE_ENVIRONMENT)
+    caplog.clear()
     await env_slice.register_setting(new_setting)
+
+    log_contains(
+        caplog,
+        "py.warnings",
+        logging.WARNING,
+        "Registering environment settings via the inmanta.server.services.environmentservice.register_setting endpoint "
+        "is deprecated.",
+    )
     result = await client.get_setting(tid=environment, id="a new boolean setting")
     assert result.code == 200
     assert result.result["value"] is False

--- a/tests/data/test_load_env_setting/inmanta_ext/testext/__init__.py
+++ b/tests/data/test_load_env_setting/inmanta_ext/testext/__init__.py
@@ -1,0 +1,17 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""

--- a/tests/data/test_load_env_setting/inmanta_ext/testext/extension.py
+++ b/tests/data/test_load_env_setting/inmanta_ext/testext/extension.py
@@ -1,0 +1,35 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+from inmanta.server.extensions import ApplicationContext
+from inmanta import data
+
+
+def setup(application: ApplicationContext) -> None:
+    raise Exception("This method should not be called.")
+
+
+def register_environment_settings(application: ApplicationContext) -> None:
+    application.register_environment_setting(
+        data.Setting(
+            name="test",
+            typ="bool",
+            default=True,
+            doc="Some documentation",
+            validator=data.convert_boolean,
+        )
+    )

--- a/tests/server/test_env_settings.py
+++ b/tests/server/test_env_settings.py
@@ -326,7 +326,7 @@ async def test_environment_add_new_setting_parameter(server, client, environment
         doc="a new setting",
     )
 
-    await data.Environment.register_setting(new_setting)
+    data.Environment.register_setting(new_setting)
 
     result = await client.get_setting(tid=environment, id="a new setting")
     assert result.code == 200
@@ -351,7 +351,7 @@ async def test_environment_add_new_setting_parameter(server, client, environment
         doc="an existing setting",
     )
     with pytest.raises(KeyError):
-        await data.Environment.register_setting(existing_setting)
+        data.Environment.register_setting(existing_setting)
 
     result = await client.get_setting(tid=environment, id=data.AUTO_DEPLOY)
     assert result.code == 200
@@ -388,7 +388,7 @@ async def test_get_setting_no_longer_exist(server, client, environment):
         doc="new_setting",
     )
 
-    await data.Environment.register_setting(new_setting)
+    data.Environment.register_setting(new_setting)
 
     result = await client.get_setting(tid=environment, id="new_setting")
     assert result.code == 200

--- a/tests/test_import_entry_points.py
+++ b/tests/test_import_entry_points.py
@@ -115,3 +115,8 @@ def test_import_ast(import_entry_point: Callable[[str], Optional[int]]) -> None:
 
 def test_import_env(import_entry_point: Callable[[str], Optional[int]]) -> None:
     assert import_entry_point("inmanta.env") == 0
+
+
+def test_import_server(import_entry_point: Callable[[str], Optional[int]]) -> None:
+    assert import_entry_point("inmanta.server.extensions") == 0
+    assert import_entry_point("inmanta.server.bootloader") == 0

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -19,7 +19,7 @@ from os import path
 
 from setuptools import find_namespace_packages, setup
 
-version = "6.3.1"
+version = "6.4.0"
 
 requires = [
     "asyncpg",


### PR DESCRIPTION
# Description

**Same PR as #5042 but applied on the iso5 branch due to a merge conflict.**

Part of https://github.com/inmanta/irt/issues/1366

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
