### PR TITLE
5004/fix conflict with std

### DIFF
--- a/changelogs/unreleased/5004-constraint-conflict-std.yml
+++ b/changelogs/unreleased/5004-constraint-conflict-std.yml
@@ -1,0 +1,4 @@
+description: "constraints Jinja and email_validator to same version as std"
+change-type: patch
+destination-branches:
+  - iso4

--- a/changelogs/unreleased/5004-constraint-conflict-std.yml
+++ b/changelogs/unreleased/5004-constraint-conflict-std.yml
@@ -1,4 +1,6 @@
-description: "constraints Jinja and email_validator to same version as std"
+description: "adapt constraints to not conflict with those of std"
 change-type: patch
 destination-branches:
   - iso4
+sections:
+  bugfix: "{{description}}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,13 @@ docstring-parser==0.13
 email-validator==1.1.3
 execnet==1.9.0
 importlib_metadata==4.8.2
-jinja2==3.0.3
+jinja2==2.11
 more-itertools==8.12.0
 netifaces==0.11.0
 packaging==21.3
 pip==21.3.1
 ply==3.11
-pydantic==1.9.0
+pydantic==1.8.0
 pyformance==0.4
 PyJWT==2.3.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,13 @@ docstring-parser==0.13
 email-validator==1.1.3
 execnet==1.9.0
 importlib_metadata==4.8.2
-jinja2==2.11
+jinja2==2.11.3
 more-itertools==8.12.0
 netifaces==0.11.0
 packaging==21.3
 pip==21.3.1
 ply==3.11
-pydantic==1.8.0
+pydantic==1.9.0
 pyformance==0.4
 PyJWT==2.3.0
 python-dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,18 @@ requires = [
     "cryptography",
     # docstring-parser has been known to publish non-backwards compatible minors in the past
     "docstring-parser>=0.10,<0.14.0",
-    "email-validator",
+    "email_validator~=1.1",
     "execnet",
     "importlib_metadata",
-    "jinja2",
+    "Jinja2~=2.11",
+    # Dependency of Jinja2, later versions not compatible with Jinja2~=2.11
+    "MarkupSafe~=2.0.0",
     "more-itertools",
     "netifaces",
     "packaging",
     "ply",
     # Exclude pre-release due to https://github.com/samuelcolvin/pydantic/issues/3546
-    "pydantic!=1.9.0a1",
+    "pydantic~=1.8,!=1.9.0a1",
     "pyformance",
     "PyJWT",
     "python-dateutil",


### PR DESCRIPTION
# Description

The std module has a constraint on Jinja that is not present on core. Since the compiler environment is activated in-process after this dependency is already loaded in sys.modules, core's imcompatible version is used in practice. This commit will 
constrain Jinja to the same version as it is constrained to in the std module.

closes #5004 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
