### PR TITLE
Issue/4976 add deprecation note hyphen identifiers

### DIFF
--- a/changelogs/unreleased/4976-deprecate-hyphens-identifiers.yml
+++ b/changelogs/unreleased/4976-deprecate-hyphens-identifiers.yml
@@ -1,0 +1,8 @@
+---
+description: Hyphens in identifiers are deprecated. Support will be removed in the next major releases
+issue-nr: 4976
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [iso5]
+sections:
+  deprecation-note: "{{description}}"


### PR DESCRIPTION
# Description

 add missing deprecation change entry for deprecation of hyphens in identifiers

closes #4976 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
