### PR TITLE
issue/317-add-web-ui-section-to-config-file-iso5

### DIFF
--- a/changelogs/unreleased/317-add-web-ui-section-to-the-configuration-file-iso5.yml
+++ b/changelogs/unreleased/317-add-web-ui-section-to-the-configuration-file-iso5.yml
@@ -1,0 +1,8 @@
+---
+description: The 'dashboard' and 'web-console' sections are being deprecated. The 'web-ui' section should now be used instead for configuration options related to web interfaces.
+change-type: minor
+issue-nr: 317
+issue-repo: inmanta-ui
+destination-branches: [iso5]
+sections:
+  deprecation-note: "{{description}}"

--- a/changelogs/unreleased/317-add-web-ui-section-to-the-configuration-file-iso5.yml
+++ b/changelogs/unreleased/317-add-web-ui-section-to-the-configuration-file-iso5.yml
@@ -1,5 +1,5 @@
 ---
-description: The 'dashboard' and 'web-console' sections are being deprecated. The 'web-ui' section should now be used instead for configuration options related to web interfaces.
+description: The 'dashboard' section is being deprecated. The 'web-ui' section should now be used instead for configuration options related to web interfaces.
 change-type: minor
 issue-nr: 317
 issue-repo: inmanta-ui

--- a/changelogs/unreleased/4976-deprecate-hyphens-identifiers.yml
+++ b/changelogs/unreleased/4976-deprecate-hyphens-identifiers.yml
@@ -1,0 +1,8 @@
+---
+description: Hyphens in identifiers are deprecated. Support will be removed in the next major releases
+issue-nr: 4976
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [iso5]
+sections:
+  deprecation-note: "{{description}}"

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -278,9 +278,20 @@ issued by keycloak.
 
    Show the correct configuration parameters in JSON format.
 
-Add the keycloak configuration parameters to the web-ui section of the inmanta-ui configuration file. Add a configuration
-file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the keycloak_realm, keycloak_auth_url and keycloak_client_id to the web-ui section. Use
+Add the keycloak configuration parameters to the dashboard section of the server configuration file. Add a configuration
+file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the realm, auth_url and client_id to the dashboard section. Use
 the parameters from the installation json file created by keycloak.
+
+.. code-block:: ini
+
+    [dashboard]
+    # keycloak specific configuration
+    realm=master
+    auth_url=http://localhost:8080/auth
+    client_id=inmanta
+
+.. note:: The dashboard section is being deprecated in favor of the web-ui section of the inmanta-ui extension. The following
+   configuration setup should be used instead:
 
 .. code-block:: ini
 

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -285,7 +285,7 @@ the parameters from the installation json file created by keycloak.
 .. code-block:: ini
 
     [web-ui]
-    # generic OpenID connect configuration
+    # generic OpenID Connect configuration
     oidc_realm=master
     oidc_auth_url=http://localhost:8080/auth
     oidc_client_id=inmanta

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -278,20 +278,9 @@ issued by keycloak.
 
    Show the correct configuration parameters in JSON format.
 
-Add the keycloak configuration parameters to the dashboard section of the server configuration file. Add a configuration
-file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the realm, auth_url and client_id to the dashboard section. Use
+Add the keycloak configuration parameters to the web-ui section of the inmanta-ui configuration file. Add a configuration
+file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the keycloak_realm, keycloak_auth_url and keycloak_client_id to the web-ui section. Use
 the parameters from the installation json file created by keycloak.
-
-.. code-block:: ini
-
-    [dashboard]
-    # keycloak specific configuration
-    realm=master
-    auth_url=http://localhost:8080/auth
-    client_id=inmanta
-
-.. note:: The dashboard section is being deprecated in favor of the web-ui section of the inmanta-ui extension. The following
-   configuration setup should be used instead:
 
 .. code-block:: ini
 

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -278,17 +278,17 @@ issued by keycloak.
 
    Show the correct configuration parameters in JSON format.
 
-Add the keycloak configuration parameters to the dashboard section of the server configuration file. Add a configuration
-file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the realm, auth_url and client_id to the dashboard section. Use
+Add the keycloak configuration parameters to the web-ui section of the inmanta-ui configuration file. Add a configuration
+file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the keycloak_realm, keycloak_auth_url and keycloak_client_id to the web-ui section. Use
 the parameters from the installation json file created by keycloak.
 
 .. code-block:: ini
 
-    [dashboard]
+    [web-ui]
     # keycloak specific configuration
-    realm=master
-    auth_url=http://localhost:8080/auth
-    client_id=inmanta
+    keycloak_realm=master
+    keycloak_auth_url=http://localhost:8080/auth
+    keycloak_client_id=inmanta
 
 .. warning:: In a real setup, the url should contain public names instead of localhost, otherwise logins will only work
    on the machine that hosts inmanta server.

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -279,16 +279,16 @@ issued by keycloak.
    Show the correct configuration parameters in JSON format.
 
 Add the keycloak configuration parameters to the web-ui section of the inmanta-ui configuration file. Add a configuration
-file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the keycloak_realm, keycloak_auth_url and keycloak_client_id to the web-ui section. Use
+file called `/etc/inmanta/inmanta.d/keycloak.cfg`. Add the oidc_realm, oidc_auth_url and oidc_client_id to the web-ui section. Use
 the parameters from the installation json file created by keycloak.
 
 .. code-block:: ini
 
     [web-ui]
-    # keycloak specific configuration
-    keycloak_realm=master
-    keycloak_auth_url=http://localhost:8080/auth
-    keycloak_client_id=inmanta
+    # generic OpenID connect configuration
+    oidc_realm=master
+    oidc_auth_url=http://localhost:8080/auth
+    oidc_client_id=inmanta
 
 .. warning:: In a real setup, the url should contain public names instead of localhost, otherwise logins will only work
    on the machine that hosts inmanta server.

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -301,10 +301,17 @@ class Option(Generic[T]):
             has_deprecated_option = cfg.has_option(self.predecessor_option.section, self.predecessor_option.name)
             has_new_option = cfg.has_option(self.section, self.name)
             if has_deprecated_option and not has_new_option:
-                warnings.warn(
-                    "Config option %s is deprecated. Use %s instead." % (self.predecessor_option.name, self.name),
-                    category=DeprecationWarning,
-                )
+                if self.predecessor_option.section == self.section:
+                    warnings.warn(
+                        "Config option %s is deprecated. Use %s instead." % (self.predecessor_option.name, self.name),
+                        category=DeprecationWarning,
+                    )
+                else:
+                    warnings.warn(
+                        "Config option %s is in deprecated section %s. Use option %s in section %s instead." % (self.predecessor_option.name, self.predecessor_option.section, self.name, self.section),
+                        category=DeprecationWarning,
+                    )
+
                 return self.predecessor_option.get()
         out = cfg.get(self.section, self.name, fallback=self.get_default_value())
         return self.validate(out)

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -301,17 +301,10 @@ class Option(Generic[T]):
             has_deprecated_option = cfg.has_option(self.predecessor_option.section, self.predecessor_option.name)
             has_new_option = cfg.has_option(self.section, self.name)
             if has_deprecated_option and not has_new_option:
-                if self.predecessor_option.section == self.section:
-                    warnings.warn(
-                        "Config option %s is deprecated. Use %s instead." % (self.predecessor_option.name, self.name),
-                        category=DeprecationWarning,
-                    )
-                else:
-                    warnings.warn(
-                        "Config option %s is in deprecated section %s. Use option %s in section %s instead."
-                        % (self.predecessor_option.name, self.predecessor_option.section, self.name, self.section),
-                        category=DeprecationWarning,
-                    )
+                warnings.warn(
+                    "Config option %s.%s is deprecated. Use %s.%s instead." % (self.predecessor_option.section, self.predecessor_option.name, self.section, self.name),
+                    category=DeprecationWarning,
+                )
 
                 return self.predecessor_option.get()
         out = cfg.get(self.section, self.name, fallback=self.get_default_value())

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -308,7 +308,8 @@ class Option(Generic[T]):
                     )
                 else:
                     warnings.warn(
-                        "Config option %s is in deprecated section %s. Use option %s in section %s instead." % (self.predecessor_option.name, self.predecessor_option.section, self.name, self.section),
+                        "Config option %s is in deprecated section %s. Use option %s in section %s instead."
+                        % (self.predecessor_option.name, self.predecessor_option.section, self.name, self.section),
                         category=DeprecationWarning,
                     )
 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -302,7 +302,8 @@ class Option(Generic[T]):
             has_new_option = cfg.has_option(self.section, self.name)
             if has_deprecated_option and not has_new_option:
                 warnings.warn(
-                    "Config option %s.%s is deprecated. Use %s.%s instead." % (self.predecessor_option.section, self.predecessor_option.name, self.section, self.name),
+                    "Config option %s.%s is deprecated. Use %s.%s instead."
+                    % (self.predecessor_option.section, self.predecessor_option.name, self.section, self.name),
                     category=DeprecationWarning,
                 )
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -300,7 +300,7 @@ dash_realm = Option(
     "dashboard",
     "realm",
     "inmanta",
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_realm`] " "The realm to use for keycloak authentication.",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_realm`] The realm to use for keycloak authentication.",
     is_str,
 )
 
@@ -308,7 +308,7 @@ dash_auth_url = Option(
     "dashboard",
     "auth_url",
     None,
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_auth_url`] " "The auth url of the keycloak server to use.",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_auth_url`] The auth url of the keycloak server to use.",
     is_str,
 )
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -274,6 +274,52 @@ server_access_control_allow_origin = Option(
     is_str_opt,
 )
 
+#############################
+# Dashboard
+#############################
+
+dash_enable = Option(
+    "dashboard",
+    "enabled",
+    True,
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_enabled`] "
+    "Determines whether the server should host the dashboard or not",
+    is_bool,
+)
+
+dash_path = Option(
+    "dashboard",
+    "path",
+    "/usr/share/inmanta/dashboard",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_path`] "
+    "The path on the local file system where the dashboard can be found",
+    is_str,
+)
+
+dash_realm = Option(
+    "dashboard",
+    "realm",
+    "inmanta",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_realm`] " "The realm to use for keycloak authentication.",
+    is_str,
+)
+
+dash_auth_url = Option(
+    "dashboard",
+    "auth_url",
+    None,
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_auth_url`] " "The auth url of the keycloak server to use.",
+    is_str,
+)
+
+dash_client_id = Option(
+    "dashboard",
+    "client_id",
+    None,
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_client_id`] "
+    "The client id configured in keycloak for this application.",
+    is_str,
+)
 
 
 def default_hangtime() -> str:

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -274,23 +274,6 @@ server_access_control_allow_origin = Option(
     is_str_opt,
 )
 
-#############################
-# Dashboard
-#############################
-
-dash_enable = Option("dashboard", "enabled", True, "Determines whether the server should host the dashboard or not", is_bool)
-
-dash_path = Option(
-    "dashboard",
-    "path",
-    "/usr/share/inmanta/dashboard",
-    "The path on the local file system where the dashboard can be found",
-    is_str,
-)
-
-dash_realm = Option("dashboard", "realm", "inmanta", "The realm to use for keycloak authentication.", is_str)
-dash_auth_url = Option("dashboard", "auth_url", None, "The auth url of the keycloak server to use.", is_str)
-dash_client_id = Option("dashboard", "client_id", None, "The client id configured in keycloak for this application.", is_str)
 
 
 def default_hangtime() -> str:

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -300,7 +300,7 @@ dash_realm = Option(
     "dashboard",
     "realm",
     "inmanta",
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_realm`] The realm to use for keycloak authentication.",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc_realm`] The realm to use for keycloak authentication.",
     is_str,
 )
 
@@ -308,7 +308,7 @@ dash_auth_url = Option(
     "dashboard",
     "auth_url",
     None,
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_auth_url`] The auth url of the keycloak server to use.",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc_auth_url`] The auth url of the keycloak server to use.",
     is_str,
 )
 
@@ -316,7 +316,7 @@ dash_client_id = Option(
     "dashboard",
     "client_id",
     None,
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_client_id`] "
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc_client_id`] "
     "The client id configured in keycloak for this application.",
     is_str,
 )

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -282,7 +282,7 @@ dash_enable = Option(
     "dashboard",
     "enabled",
     True,
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_enabled`] "
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard-enabled`] "
     "Determines whether the server should host the dashboard or not",
     is_bool,
 )
@@ -291,7 +291,7 @@ dash_path = Option(
     "dashboard",
     "path",
     "/usr/share/inmanta/dashboard",
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard_path`] "
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.dashboard-path`] "
     "The path on the local file system where the dashboard can be found",
     is_str,
 )
@@ -300,7 +300,7 @@ dash_realm = Option(
     "dashboard",
     "realm",
     "inmanta",
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc_realm`] The realm to use for keycloak authentication.",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc-realm`] The realm to use for keycloak authentication.",
     is_str,
 )
 
@@ -308,7 +308,7 @@ dash_auth_url = Option(
     "dashboard",
     "auth_url",
     None,
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc_auth_url`] The auth url of the keycloak server to use.",
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc-auth-url`] The auth url of the keycloak server to use.",
     is_str,
 )
 
@@ -316,7 +316,7 @@ dash_client_id = Option(
     "dashboard",
     "client_id",
     None,
-    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc_client_id`] "
+    "[DEPRECATED USE :inmanta.config:option:`web-ui.oidc-client-id`] "
     "The client id configured in keycloak for this application.",
     is_str,
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,12 +40,20 @@ def test_environment_deprecated_options(caplog):
         Config.set(deprecated_option.section, deprecated_option.name, "22")
         caplog.clear()
         assert new_option.get() == 22
-        assert "Config option %s is deprecated. Use %s instead." % (deprecated_option.name, new_option.name) in caplog.text
+        assert (
+            "Config option %s.%s is deprecated. Use %s.%s instead."
+            % (deprecated_option.section, deprecated_option.name, new_option.section, new_option.name)
+            in caplog.text
+        )
 
         Config.set(new_option.section, new_option.name, "23")
         caplog.clear()
         assert new_option.get() == 23
-        assert "Config option %s is deprecated. Use %s instead." % (deprecated_option.name, new_option.name) not in caplog.text
+        assert (
+            "Config option %s.%s is deprecated. Use %s.%s instead."
+            % (deprecated_option.section, deprecated_option.name, new_option.section, new_option.name)
+            not in caplog.text
+        )
 
         Config.load_config()  # Reset config options to default values
         assert new_option.get() != 23
@@ -53,7 +61,11 @@ def test_environment_deprecated_options(caplog):
         Config.set(new_option.section, new_option.name, "24")
         caplog.clear()
         assert new_option.get() == 24
-        assert "Config option %s is deprecated. Use %s instead." % (deprecated_option.name, new_option.name) not in caplog.text
+        assert (
+            "Config option %s.%s is deprecated. Use %s.%s instead."
+            % (deprecated_option.section, deprecated_option.name, new_option.section, new_option.name)
+            not in caplog.text
+        )
 
 
 def test_options():


### PR DESCRIPTION
# Description


  - Move ui related options from inmanta-core to inmanta-ui
  - Log a deprecation warning when the web-console or the dashboard sections are used


part of [#317](https://github.com/inmanta/inmanta-ui/issues/317)
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
