### PR TITLE
Issue/4780 add timestamp to logs iso4

### DIFF
--- a/changelogs/unreleased/4780-enable-timestamps-log-messages-tests.yml
+++ b/changelogs/unreleased/4780-enable-timestamps-log-messages-tests.yml
@@ -1,0 +1,4 @@
+description: Enable timestamp on the log messages produced by the test cases.
+issue-nr: 4780
+change-type: patch
+destination-branches: [iso4]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,6 @@ directory = "tests_common"
 
 [tool.irt.publish.python]
 public = true
+
+[tool.pytest.ini_options]
+log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"


### PR DESCRIPTION
# Description

Enable timestamp on the log messages produced by the test cases

closes https://github.com/inmanta/inmanta-core/issues/4780

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
