### PR TITLE
Removed support for dictionaries in the requires metadata field

### DIFF
--- a/changelogs/unreleased/4974-remove-dict-requires-metadata-field.yml
+++ b/changelogs/unreleased/4974-remove-dict-requires-metadata-field.yml
@@ -1,0 +1,8 @@
+---
+description: Removed support to use a dictionary in the requires metadata field of a V1 module or an Inmanta project.
+issue-nr: 4974
+issue-repo: inmanta-core
+change-type: major
+destination-branches: [master]
+sections:
+  deprecation-note: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -266,10 +266,6 @@ class InvalidMetadata(CompilerException):
         return msg
 
 
-class MetadataDeprecationWarning(Warning):
-    pass
-
-
 class ModuleDeprecationWarning(Warning):
     pass
 
@@ -1118,20 +1114,6 @@ class MetadataFieldRequires(BaseModel):
     @validator("requires", pre=True)
     @classmethod
     def requires_to_list(cls, v: object) -> object:
-        if isinstance(v, dict):
-            # transform legacy format for backwards compatibility
-            warnings.warn(
-                MetadataDeprecationWarning(
-                    "The yaml dictionary syntax for specifying module requirements has been deprecated. Please use the"
-                    " documented list syntax instead."
-                )
-            )
-            result: List[str] = []
-            for key, value in v.items():
-                if not (isinstance(key, str) and isinstance(value, str) and value.startswith(key)):
-                    raise ValueError("Invalid legacy requires format, expected `mod: mod [constraint]`.")
-                result.append(value)
-            return result
         return cls.to_list(v)
 
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -407,7 +407,7 @@ requires: std > 1.0.0
 
 def test_module_requires_contains_dictionary(inmanta_module_v1):
     """
-    Verify that providing a dictionary to the 'requires' field of a V1 module results in an error
+    Verify that providing a dictionary to the 'requires' field of a V1 module results in an error.
     This is a legacy format that is no longer supported.
     """
     inmanta_module_v1.write_metadata_file(

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -405,9 +405,10 @@ requires: std > 1.0.0
     assert mod.requires() == [InmantaModuleRequirement.parse("std > 1.0.0")]
 
 
-def test_module_requires_legacy_invalid(inmanta_module_v1):
+def test_module_requires_contains_dictionary(inmanta_module_v1):
     """
-    Verify that providing a dictionary to the 'requires' property results in an error (This is a legacy format).
+    Verify that providing a dictionary to the 'requires' field of a V1 module results in an error
+    This is a legacy format that is no longer supported.
     """
     inmanta_module_v1.write_metadata_file(
         """


### PR DESCRIPTION
# Description

Removed support to use a dictionary in the requires metadata field of a V1 module or an Inmanta project.

closes #4974

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
