### PR TITLE
Issue/fix error reporting when migration test is absent

### DIFF
--- a/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
+++ b/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
@@ -1,0 +1,6 @@
+---
+description: Add explicit error message when the migration test to the latest version is missing
+issue-nr: 1358
+issue-repo: irt
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -52,6 +52,10 @@ def test_migration_check():
                     f"Line '{line}' was found in dump {latest_dump} L{line_no}. Please remove or comment out this line."
                 )
 
-    migration_test: Path = sorted(migration_tests_folder.glob("test_v*" + latest_dump.stem + ".py"))[-1]
-
+    migration_tests: List[Path] = sorted(migration_tests_folder.glob("test_v*" + latest_dump.stem + ".py"))
+    if not migration_tests:
+        raise Exception(
+            f"No migration test to version {latest_dump.stem} was found in {migration_tests_folder}. Please add such a test."
+        )
+    migration_test: Path = migration_tests[-1]
     assert migration_test.is_file()


### PR DESCRIPTION
# Description

This PR adds an explicit error message when the migration test is missing.

Part of https://github.com/inmanta/irt/issues/1358

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
