### PR TITLE
Issue/fix failing test for automatisation of db migration test

### DIFF
--- a/changelogs/unreleased/1358-automate-testing-of-core-migration-check.yml
+++ b/changelogs/unreleased/1358-automate-testing-of-core-migration-check.yml
@@ -1,0 +1,6 @@
+---
+description: Add test to automatically check for the presence of a migration test
+issue-nr: 1358
+issue-repo: irt
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/changelogs/unreleased/1358-automate-testing-of-core-migration-check.yml
+++ b/changelogs/unreleased/1358-automate-testing-of-core-migration-check.yml
@@ -3,4 +3,4 @@ description: Add test to automatically check for the presence of a migration tes
 issue-nr: 1358
 issue-repo: irt
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso4]

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -29,8 +29,8 @@ def test_migration_check():
     versions: List[Path] = list(versions_folder.glob("v" + "[0-9]" * 9 + ".py"))  # Migration files have format vYYYYMMDDN.py
     latest_version: Path = sorted(versions)[-1]
 
-    migration_tests_folder: Path = Path(".").absolute() / "tests" / "db" / "migration_tests"
-    dumps_folder: Path = migration_tests_folder / "dumps"
+    migration_tests_folder: Path = Path(".").absolute() / "tests" / "db"
+    dumps_folder: Path = Path(".").absolute() / "tests" / "db" / "dumps"
 
     dumps: List[Path] = list(dumps_folder.glob("v" + "[0-9]" * 9 + ".sql"))  # Dumps have format vYYYYMMDDN.sql
     latest_dump: Path = sorted(dumps)[-1]

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -1,0 +1,57 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+from pathlib import Path
+from typing import List
+
+
+def test_migration_check():
+    """
+    Make sure there is a database dump for the latest version of the db and
+    that a migration test exists for this dump.
+    """
+    versions_folder: Path = Path(".").absolute() / "src" / "inmanta" / "db" / "versions"
+
+    versions: List[Path] = list(versions_folder.glob("v" + "[0-9]" * 9 + ".py"))  # Migration files have format vYYYYMMDDN.py
+    latest_version: Path = sorted(versions)[-1]
+
+    migration_tests_folder: Path = Path(".").absolute() / "tests" / "db" / "migration_tests"
+    dumps_folder: Path = migration_tests_folder / "dumps"
+
+    dumps: List[Path] = list(dumps_folder.glob("v" + "[0-9]" * 9 + ".sql"))  # Dumps have format vYYYYMMDDN.sql
+    latest_dump: Path = sorted(dumps)[-1]
+
+    assert latest_version.stem == latest_dump.stem
+
+    # Make sure the following lines have been removed from the dump:
+    forbidden_strings: List[str] = [
+        "SELECT pg_catalog.set_config('search_path', '', false);",
+        "SET default_table_access_method = heap;",
+    ]
+
+    with open(latest_dump, "r") as fh:
+        for line_no, line in enumerate(fh.readlines(), start=1):
+            if line.startswith("--"):
+                continue
+            if line.strip() in forbidden_strings:
+                raise Exception(
+                    f"Line '{line}' was found in dump {latest_dump} L{line_no}. Please remove or comment out this line."
+                )
+
+    migration_test: Path = sorted(migration_tests_folder.glob("test_v*" + latest_dump.stem + ".py"))[-1]
+
+    assert migration_test.is_file()


### PR DESCRIPTION
# Description

Merging into iso4 (https://github.com/inmanta/inmanta-core/pull/5100) failed because some paths have been modified in iso5

part of https://github.com/inmanta/irt/issues/1358

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
