### PR TITLE
Add explicit error message when the migration test to the latest vers…

### DIFF
--- a/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
+++ b/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
@@ -1,5 +1,5 @@
 ---
-description: Add explicit error message when the migration test to the latest version is missing
+description: Dummy change entry
 issue-nr: 1358
 issue-repo: irt
 change-type: patch

--- a/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
+++ b/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
@@ -1,0 +1,6 @@
+---
+description: Add explicit error message when the migration test to the latest version is missing
+issue-nr: 1358
+issue-repo: irt
+change-type: patch
+destination-branches: [iso4]

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -1,0 +1,53 @@
+"""
+    Copyright 2022 Inmanta
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    Contact: code@inmanta.com
+"""
+from pathlib import Path
+from typing import List
+
+
+def test_migration_check():
+    """
+    Make sure there is a database dump for the latest version of the db and
+    that a migration test exists for this dump.
+    """
+    versions_folder: Path = Path(".").absolute() / "src" / "inmanta" / "db" / "versions"
+
+    versions: List[Path] = list(versions_folder.glob("v" + "[0-9]" * 9 + ".py"))  # Migration files have format vYYYYMMDDN.py
+    latest_version: Path = sorted(versions)[-1]
+
+    migration_tests_folder: Path = Path(".").absolute() / "tests" / "db"
+    dumps_folder: Path = Path(".").absolute() / "tests" / "db" / "dumps"
+
+    dumps: List[Path] = list(dumps_folder.glob("v" + "[0-9]" * 9 + ".sql"))  # Dumps have format vYYYYMMDDN.sql
+    latest_dump: Path = sorted(dumps)[-1]
+
+    assert latest_version.stem == latest_dump.stem
+
+    # Make sure the following lines have been removed from the dump:
+    forbidden_strings: List[str] = [
+        "SELECT pg_catalog.set_config('search_path', '', false);",
+        "SET default_table_access_method = heap;",
+    ]
+
+    with open(latest_dump, "r") as fh:
+        for line_no, line in enumerate(fh.readlines(), start=1):
+            if line.startswith("--"):
+                continue
+            if line.strip() in forbidden_strings:
+                raise Exception(
+                    f"Line '{line}' was found in dump {latest_dump} L{line_no}. Please remove or comment out this line."
+                )
+
+    migration_test: Path = sorted(migration_tests_folder.glob("test_v*" + latest_dump.stem + ".py"))[-1]
+
+    assert migration_test.is_file()


### PR DESCRIPTION
…ion is missing (Issue inmanta/irt#1358, PR #5110)

The changes initially covered by this PR have been merged into iso4 with https://github.com/inmanta/inmanta-core/commit/ea59dafdf7512afdfeb9fe49e203b37ddc75213d

This PR adds a dummy change entry to satisfy the check-all-project-invariants

Part of https://github.com/inmanta/irt/issues/1358

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
