### PR TITLE
Issue/4984 drop default constructor

### DIFF
--- a/changelogs/unreleased/4984-drop-default-constructor.yml
+++ b/changelogs/unreleased/4984-drop-default-constructor.yml
@@ -1,0 +1,7 @@
+---
+description: Remove support for default constructors
+change-type: major
+issue-nr: 4984
+destination-branches: [master]
+sections:
+  deprecation-note: "{{description}}"

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -31,7 +31,6 @@ except ImportError:
 
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute  # noqa: F401
-    from inmanta.ast.entity import Entity
     from inmanta.ast.statements import Statement  # noqa: F401
     from inmanta.ast.statements.define import DefineEntity, DefineImport  # noqa: F401
     from inmanta.ast.type import NamedType, Type  # noqa: F401
@@ -237,7 +236,7 @@ class AttributeReferenceAnchor(Anchor):
     def resolve(self) -> Location:
         instancetype = self.namespace.get_type(self.type)
         # type check impossible atm due to import loop
-        assert isinstance(instancetype, Entity)
+        # assert isinstance(instancetype, Entity)
         entity_attribute: Optional[Attribute] = instancetype.get_attribute(self.attribute)
         assert entity_attribute is not None
         return entity_attribute.get_location()

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -29,7 +29,6 @@ try:
 except ImportError:
     TYPE_CHECKING = False
 
-
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute  # noqa: F401
     from inmanta.ast.entity import Entity
@@ -42,7 +41,6 @@ if TYPE_CHECKING:
 
 
 class Location(export.Exportable):
-
     __slots__ = ("file", "lnr")
 
     def __init__(self, file: str, lnr: int) -> None:
@@ -75,7 +73,6 @@ class Location(export.Exportable):
 
 
 class Range(Location):
-
     __slots__ = ("start_char", "end_lnr", "end_char")
 
     def __init__(self, file: str, start_lnr: int, start_char: int, end_lnr: int, end_char: int) -> None:
@@ -241,7 +238,9 @@ class AttributeReferenceAnchor(Anchor):
         instancetype = self.namespace.get_type(self.type)
         # type check impossible atm due to import loop
         assert isinstance(instancetype, Entity)
-        return instancetype.get_attribute(self.attribute).get_location()
+        entity_attribute: Optional[Attribute] = instancetype.get_attribute(self.attribute)
+        assert entity_attribute is not None
+        return entity_attribute.get_location()
 
 
 class Namespaced(Locatable):

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -32,6 +32,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute  # noqa: F401
+    from inmanta.ast.entity import Entity
     from inmanta.ast.statements import Statement  # noqa: F401
     from inmanta.ast.statements.define import DefineEntity, DefineImport  # noqa: F401
     from inmanta.ast.type import NamedType, Type  # noqa: F401
@@ -239,8 +240,8 @@ class AttributeReferenceAnchor(Anchor):
     def resolve(self) -> Location:
         instancetype = self.namespace.get_type(self.type)
         # type check impossible atm due to import loop
-        # assert isinstance(instancetype, EntityLike)
-        return instancetype.get_entity().get_attribute(self.attribute).get_location()
+        assert isinstance(instancetype, Entity)
+        return instancetype.get_attribute(self.attribute).get_location()
 
 
 class Namespaced(Locatable):

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -440,7 +440,7 @@ class Entity(NamedType):
         """
         Return the dictionary with default values
         """
-        values = []  # type: List[Tuple[str,ExpressionStatement]]
+        values = []  # type: List[Tuple[str,Optional[ExpressionStatement]]]
 
         # left most parent takes precedence
         for parent in reversed(self.parent_entities):

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -18,7 +18,6 @@
 
 # pylint: disable-msg=R0902,R0904
 
-from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union  # noqa: F401
 
 from inmanta.ast import (
@@ -52,44 +51,7 @@ if TYPE_CHECKING:
 import inmanta.ast.attribute
 
 
-class EntityLike(NamedType):
-
-    parent_entities: "List[Entity]"
-
-    @abstractmethod
-    def _get_own_defaults(self) -> "Dict[str, ExpressionStatement]":
-        """get defaults defined on this entity"""
-        pass
-
-    def get_default(self, name: str) -> "ExpressionStatement":
-        defaults = self.get_default_values()
-        if name not in defaults:
-            raise AttributeError(name)
-        return defaults[name]
-
-    def get_default_values(self) -> "Dict[str,ExpressionStatement]":
-        """
-        Return the dictionary with default values
-        """
-        values = []  # type: List[Tuple[str,ExpressionStatement]]
-
-        # left most parent takes precedence
-        for parent in reversed(self.parent_entities):
-            values.extend(parent.get_default_values().items())
-
-        # self takes precedence
-        values.extend(self._get_own_defaults().items())
-        # make dict, remove doubles
-        dvalues = dict(values)
-        # remove erased defaults
-        return {k: v for k, v in dvalues.items() if v is not None}
-
-    @abstractmethod
-    def get_entity(self) -> "Entity":
-        pass
-
-
-class Entity(EntityLike, NamedType):
+class Entity(NamedType):
     """
     This class models a defined entity in the domain model of the configuration model.
 
@@ -474,11 +436,22 @@ class Entity(EntityLike, NamedType):
                 self.index_queue[key] = [(target, stmt)]
         return None
 
-    def get_entity(self) -> "Entity":
+    def get_default_values(self) -> "Dict[str,ExpressionStatement]":
         """
-        Get the entity (follow through defaults if needed)
+        Return the dictionary with default values
         """
-        return self
+        values = []  # type: List[Tuple[str,ExpressionStatement]]
+
+        # left most parent takes precedence
+        for parent in reversed(self.parent_entities):
+            values.extend(parent.get_default_values().items())
+
+        # self takes precedence
+        values.extend(self._get_own_defaults().items())
+        # make dict, remove doubles
+        dvalues = dict(values)
+        # remove erased defaults
+        return {k: v for k, v in dvalues.items() if v is not None}
 
     def final(self, excns: List[CompilerException]) -> None:
         for key, indices in self.index_queue.items():
@@ -561,69 +534,3 @@ class Implement(Locatable):
             return
         self.normalized = True
         self.constraint.normalize()
-
-
-class Default(EntityLike):
-    """
-    This class models default values for a constructor.
-    """
-
-    def __init__(self, namespace: Namespace, name: str) -> None:
-        Type.__init__(self)
-        self.name = name
-        self._namespace = namespace
-        self.entity = None  # type: Entity
-        self._defaults = {}  # type: Dict[str,ExpressionStatement]
-        self.comment = None  # type: Optional[str]
-
-    def _get_own_defaults(self) -> "Dict[str, ExpressionStatement]":
-        return self._defaults
-
-    def set_entity(self, entity: EntityLike) -> None:
-        self.entity = entity
-        self.parent_entities = [entity]
-
-    def add_default(self, name: str, value: "ExpressionStatement") -> None:
-        """
-        Add a default value
-        """
-        self._defaults[name] = value
-
-    def get_default(self, name: str) -> "ExpressionStatement":
-        """
-        Get a default value for a given name
-        """
-        if name in self._defaults:
-            return self._defaults[name]
-
-        if isinstance(self._entity, Default):
-            return self._entity.get_default(name)
-
-        raise AttributeError(name)
-
-    def get_entity(self) -> Entity:
-        """
-        Get the entity (follow through defaults if needed)
-        """
-        return self.entity.get_entity()
-
-    def __repr__(self) -> str:
-        """
-        The representation of this type
-        """
-        return "Default(%s)" % (self.get_full_name())
-
-    def __str__(self) -> str:
-        """
-        The pretty string of this type
-        """
-        return "%s" % (self.get_full_name())
-
-    def get_full_name(self) -> str:
-        """
-        Get the full name of the entity
-        """
-        return self._namespace.get_full_name() + "::" + self.__name
-
-    def get_namespace(self) -> "Namespace":
-        return self._namespace

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -24,7 +24,6 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 from inmanta.ast import (
     AttributeReferenceAnchor,
-    CompilerDeprecationWarning,
     CompilerException,
     CompilerRuntimeWarning,
     DuplicateException,
@@ -43,9 +42,8 @@ from inmanta.ast import (
 from inmanta.ast.attribute import Attribute, RelationAttribute
 from inmanta.ast.blocks import BasicBlock
 from inmanta.ast.constraint.expression import Equals
-from inmanta.ast.entity import Default, Entity, EntityLike, Implement, Implementation
+from inmanta.ast.entity import Entity, Implement, Implementation
 from inmanta.ast.statements import BiStatement, ExpressionStatement, Literal, Statement, TypeDefinitionStatement
-from inmanta.ast.statements.generator import Constructor
 from inmanta.ast.type import TYPES, ConstraintType, NullableType, Type, TypedList
 from inmanta.execute.runtime import ExecutionUnit, QueueScheduler, Resolver, ResultVariable
 from inmanta.plugins import Plugin
@@ -365,12 +363,10 @@ class DefineImplement(DefinitionStatement):
         try:
             entity_type = self.namespace.get_type(self.entity)
 
-            if not isinstance(entity_type, EntityLike):
+            if not isinstance(entity_type, Entity):
                 raise TypingException(
                     self, "Implementation can only be define for an Entity, but %s is a %s" % (self.entity, entity_type)
                 )
-
-            entity_type = entity_type.get_entity()
 
             # If one implements statement has parent declared, set to true
             entity_type.implements_inherits |= self.inherit
@@ -485,57 +481,6 @@ class DefineTypeConstraint(TypeDefinitionStatement):
         self.expression.normalize()
 
 
-class DefineTypeDefault(TypeDefinitionStatement):
-    """
-    Define a new entity that is based on an existing entity and default values for attributes.
-
-    :param name: The name of the new type
-    :param class_ctor: A constructor statement
-    """
-
-    type: Default
-
-    def __init__(self, namespace: Namespace, name: LocatableString, class_ctor: Constructor):
-        TypeDefinitionStatement.__init__(self, namespace, str(name))
-        self.type = Default(namespace, self.name)
-        self.ctor = class_ctor
-        self.comment = None
-        self.type.location = name.get_location()
-        self.anchors.extend(class_ctor.get_anchors())
-        if "-" in self.name:
-            raise HyphenException(name)
-
-    def pretty_print(self) -> str:
-        return "typedef %s as %s" % (self.name, self.ctor.pretty_print())
-
-    def __repr__(self) -> str:
-        """
-        Get a representation of this default
-        """
-        return self.pretty_print()
-
-    def evaluate(self) -> None:
-        """
-        Evaluate this statement.
-        """
-        # the base class
-        type_class = self.namespace.get_type(self.ctor.class_type)
-
-        if not isinstance(type_class, EntityLike):
-            raise TypingException(
-                self, "Default can only be define for an Entity, but %s is a %s" % (self.ctor.class_type, self.ctor.class_type)
-            )
-        warnings.warn(CompilerDeprecationWarning(self, "Default constructors are deprecated. Use inheritance instead."))
-
-        self.type.comment = self.comment
-
-        default = self.type
-        default.set_entity(type_class)
-
-        for name, value in self.ctor.get_attributes().items():
-            default.add_default(name, value)
-
-
 Relationside = Tuple[LocatableString, Optional[LocatableString], Optional[Tuple[int, Optional[int]]]]
 
 
@@ -583,13 +528,6 @@ class DefineRelation(BiStatement):
             e.set_location(self.location)
             raise e
 
-        if isinstance(left, Default):
-            raise TypingException(
-                self,
-                "Can not define relation on a default constructor %s, use base type instead: %s "
-                % (left.name, left.get_entity().get_full_name()),
-            )
-
         assert isinstance(left, Entity), "%s is not an entity" % left
 
         # Duplicate checking is in entity.normalize
@@ -600,13 +538,6 @@ class DefineRelation(BiStatement):
         except TypeNotFoundException as e:
             e.set_location(self.location)
             raise e
-
-        if isinstance(right, Default):
-            raise TypingException(
-                self,
-                "Can not define relation on a default constructor %s, use base type instead: %s "
-                % (right.name, right.get_entity().get_full_name()),
-            )
 
         assert isinstance(right, Entity), "%s is not an entity" % right
         # Duplicate checking is in entity.normalize
@@ -675,9 +606,9 @@ class DefineIndex(DefinitionStatement):
         """
         Add the index to the entity
         """
-        entity_like = self.namespace.get_type(self.type)
-        assert isinstance(entity_like, EntityLike), "%s is not an entity or default" % entity_like
-        entity_type = entity_like.get_entity()
+        entity = self.namespace.get_type(self.type)
+        assert isinstance(entity, Entity), "%s is not an entity or default" % entity
+        entity_type = entity
 
         allattributes = entity_type.get_all_attribute_names()
         for attribute in self.attributes:

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -606,9 +606,8 @@ class DefineIndex(DefinitionStatement):
         """
         Add the index to the entity
         """
-        entity = self.namespace.get_type(self.type)
-        assert isinstance(entity, Entity), "%s is not an entity" % entity
-        entity_type = entity
+        entity_type = self.namespace.get_type(self.type)
+        assert isinstance(entity_type, Entity), "%s is not an entity" % entity_type
 
         allattributes = entity_type.get_all_attribute_names()
         for attribute in self.attributes:

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -607,7 +607,7 @@ class DefineIndex(DefinitionStatement):
         Add the index to the entity
         """
         entity = self.namespace.get_type(self.type)
-        assert isinstance(entity, Entity), "%s is not an entity or default" % entity
+        assert isinstance(entity, Entity), "%s is not an entity" % entity
         entity_type = entity
 
         allattributes = entity_type.get_all_attribute_names()

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -618,6 +618,7 @@ class Constructor(ExpressionStatement):
         constructor is the rhs, if appliccable.
         """
         type_class = self.type
+        assert type_class
 
         # kwargs
         kwarg_attrs: dict[str, object] = {}
@@ -629,7 +630,7 @@ class Constructor(ExpressionStatement):
                     )
                 attribute = type_class.get_attribute(k)
                 if attribute is None:
-                    raise TypingException(self, "no attribute %s on type %s" % (k, self.type.get_full_name()))
+                    raise TypingException(self, "no attribute %s on type %s" % (k, type_class.get_full_name()))
                 kwarg_attrs[k] = v
 
         lhs_inverse_assignment: Optional[tuple[str, object]] = None

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -677,6 +677,7 @@ class Constructor(ExpressionStatement):
 
         # the type to construct
         type_class = self.type
+        assert type_class
 
         # kwargs and implicit inverse from lhs
         late_args: abc.Mapping[str, object] = self._collect_required_dynamic_arguments(requires, resolver, queue)

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -39,7 +39,7 @@ from inmanta.execute.util import NoneValue, Unknown
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute, RelationAttribute
     from inmanta.ast.blocks import BasicBlock
-    from inmanta.ast.entity import Entity, Implement, Implementation  # noqa: F401
+    from inmanta.ast.entity import Entity, Implementation
     from inmanta.ast.statements import RawResumer, RequiresEmitStatement, Resumer, Statement
     from inmanta.compiler import Compiler
     from inmanta.execute.scheduler import PrioritisedDelayedResultVariableQueue

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -39,7 +39,7 @@ from inmanta.execute.util import NoneValue, Unknown
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute, RelationAttribute
     from inmanta.ast.blocks import BasicBlock
-    from inmanta.ast.entity import Default, Entity, EntityLike, Implement, Implementation  # noqa: F401
+    from inmanta.ast.entity import Entity, Implement, Implementation  # noqa: F401
     from inmanta.ast.statements import RawResumer, RequiresEmitStatement, Resumer, Statement
     from inmanta.compiler import Compiler
     from inmanta.execute.scheduler import PrioritisedDelayedResultVariableQueue

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -27,14 +27,7 @@ from inmanta.ast import Anchor, CompilerException, CycleException, Location, Mul
 from inmanta.ast.attribute import RelationAttribute
 from inmanta.ast.entity import Entity, Implementation
 from inmanta.ast.statements import DefinitionStatement, TypeDefinitionStatement
-from inmanta.ast.statements.define import (
-    DefineEntity,
-    DefineImplement,
-    DefineIndex,
-    DefineRelation,
-    DefineTypeConstraint,
-    DefineTypeDefault,
-)
+from inmanta.ast.statements.define import DefineEntity, DefineImplement, DefineIndex, DefineRelation, DefineTypeConstraint
 from inmanta.ast.type import TYPES, Type
 from inmanta.const import LOG_LEVEL_TRACE
 from inmanta.execute.proxy import UnsetException
@@ -227,10 +220,7 @@ class Scheduler(object):
         other_definitions = [t for t in definitions if not isinstance(t, DefineImplement)]
         entities: Dict[str, DefineEntity] = {t.fullName: t for t in other_definitions if isinstance(t, DefineEntity)}
         type_constraints = [t for t in other_definitions if isinstance(t, DefineTypeConstraint)]
-        typedefaults = [t for t in other_definitions if isinstance(t, DefineTypeDefault)]
-        other_definitions = [
-            t for t in other_definitions if not isinstance(t, (DefineEntity, DefineTypeDefault, DefineTypeConstraint))
-        ]
+        other_definitions = [t for t in other_definitions if not isinstance(t, (DefineEntity, DefineTypeConstraint))]
         indices = [t for t in other_definitions if isinstance(t, DefineIndex)]
         other_definitions = [t for t in other_definitions if not isinstance(t, DefineIndex)]
 
@@ -242,9 +232,6 @@ class Scheduler(object):
         # parents first
         for entity in self.sort_entities(entities):
             entity.evaluate()
-
-        for typedefault in typedefaults:
-            typedefault.evaluate()
 
         for other in other_definitions:
             other.evaluate()

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -39,7 +39,6 @@ from inmanta.ast.statements.define import (
     DefineIndex,
     DefineRelation,
     DefineTypeConstraint,
-    DefineTypeDefault,
     TypeDeclaration,
 )
 from inmanta.ast.statements.generator import ConditionalExpression, Constructor, For, If, WrappedKwargs
@@ -625,9 +624,7 @@ def p_typedef_1(p: YaccProduction) -> None:
 
 def p_typedef_cls(p: YaccProduction) -> None:
     """typedef_inner : TYPEDEF CID AS constructor"""
-    assert namespace
-    p[0] = DefineTypeDefault(namespace, p[2], p[4])
-    attach_lnr(p, 2)
+    raise ParserException(p[2].location, str(p[2]), "The use of default constructors is no longer supported")
 
 
 # index

--- a/tests/compiler/test_defaults.py
+++ b/tests/compiler/test_defaults.py
@@ -184,50 +184,6 @@ def test_default_remove(snippetcompiler):
         compiler.do_compile()
 
 
-def test_gradual_default(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
-        """
-entity Server:
-    string a="a"
-    string b
-end
-
-typedef Server2 as Server(b="b")
-
-Server2()
-
-implement Server using std::none
-"""
-    )
-    compiler.do_compile()
-
-
-def test_default_on_relation(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
-        """
-entity Server:
-    string a="a"
-    string b
-end
-
-entity Option:
-end
-
-Server.options [0:] -- Option
-
-all = Option()
-
-typedef Server2 as Server(b="b", options=all)
-
-Server2()
-
-implement Server using std::none
-implement Option using std::none
-"""
-    )
-    compiler.do_compile()
-
-
 def test_1292_default_type_check(snippetcompiler):
     snippetcompiler.setup_for_error(
         """

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -114,26 +114,6 @@ typedef tcp-port as int matching self > 0 and self < 65535
     assert str(e.value) == message
 
 
-def test_deprecation_minus_in_typedef_default_name(snippetcompiler):
-    with pytest.raises(HyphenException) as e:
-        snippetcompiler.setup_for_snippet(
-            """
-entity Car:
-   string brand
-end
-
-typedef Corsa-opel as Car(brand="opel")
-            """
-        )
-        compiler.do_compile()
-
-    message: str = (
-        f"The use of '-' in identifiers is not allowed. please rename Corsa-opel. "
-        f"(reported in Corsa-opel ({snippetcompiler.project_dir}/main.cf:6:9))"
-    )
-    assert str(e.value) == message
-
-
 def test_deprecation_minus_in_assign_variable_name(snippetcompiler):
     with pytest.raises(HyphenException) as e:
         snippetcompiler.setup_for_snippet(

--- a/tests/compiler/test_docs.py
+++ b/tests/compiler/test_docs.py
@@ -90,23 +90,6 @@ typedef foo as string matching /^a+$/
     assert types["__config__::foo"].comment.strip() == 'Foo is a stringtype that only allows "a"'
 
 
-def test_doc_string_on_typedefault(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
-        """
-entity File:
-    number x
-end
-
-typedef Foo as File(x=5)
-\"""
-    Foo is a stringtype that only allows "a"
-\"""
-"""
-    )
-    (types, _) = compiler.do_compile()
-    assert types["__config__::Foo"].comment.strip() == 'Foo is a stringtype that only allows "a"'
-
-
 def test_doc_string_on_impl(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -234,3 +234,19 @@ implement C using std::none
 caused by:
   Invalid class type for __config__::A (instantiated at {dir}/main.cf:3), should be __config__::B (reported in Construct(C) ({dir}/main.cf:2))""",  # noqa: E501
     )
+
+
+def test_exception_default_constructors(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+typedef MyType as A(n = 42)
+
+entity A:
+    number n
+    number m
+end
+
+implement A using std::none
+        """,
+        """Syntax error: The use of default constructors is no longer supported ({dir}/main.cf:2:9)""",
+    )

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -146,17 +146,6 @@ Stdhost deploy_host [1] -- [0:1] Agent inmanta_agent
         compiler.do_compile()
 
 
-def test_issue_132_relation_on_default(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
-        """
-typedef CFG as std::File(mode=755)
-CFG cfg [1] -- [1] std::File stuff
-"""
-    )
-    with pytest.raises(TypingException):
-        compiler.do_compile()
-
-
 def test_issue_141(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -24,7 +24,7 @@ import pytest
 
 import inmanta.compiler as compiler
 import inmanta.warnings as inmanta_warnings
-from inmanta.ast import CompilerDeprecationWarning, CompilerRuntimeWarning, VariableShadowWarning
+from inmanta.ast import CompilerRuntimeWarning, VariableShadowWarning
 from inmanta.warnings import WarningsManager
 from utils import log_doesnt_contain
 
@@ -177,31 +177,6 @@ end
         assert any(
             issubclass(w.category, VariableShadowWarning) and str(w.message) == message % (2, 4) for w in caught_warnings
         )
-
-
-def test_deprecation_warning_default_constructors(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
-        """
-typedef MyType as A(n = 42)
-
-entity A:
-    number n
-    number m
-end
-
-implement A using std::none
-        """
-    )
-    message: str = (
-        "Default constructors are deprecated."
-        " Use inheritance instead. (reported in typedef MyType as A(n=42) ({dir}/main.cf:2))"
-    )
-    message = message.format(dir=snippetcompiler.project_dir)
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        compiler.do_compile()
-
-        assert len(caught_warnings) >= 1
-        assert any(issubclass(w.category, CompilerDeprecationWarning) and str(w.message) == message for w in caught_warnings)
 
 
 def test_2030_type_overwrite_warning(snippetcompiler):

--- a/tests/test_compiler_entrypoints.py
+++ b/tests/test_compiler_entrypoints.py
@@ -49,16 +49,12 @@ implementation a for Test:
 end
 
 implement Test using a
-
-typedef Test3 as Test(b="a")
-
-y = Test3(a="xx")
 """,
         autostd=False,
     )
     anchormap = compiler.anchormap()
 
-    assert len(anchormap) == 13
+    assert len(anchormap) == 9
 
     checkmap = {(r.lnr, r.start_char, r.end_char): t.lnr for r, t in anchormap}
 
@@ -76,10 +72,6 @@ y = Test3(a="xx")
     verify_anchor(19, 22, 26, 2)
     verify_anchor(23, 11, 15, 2)
     verify_anchor(23, 22, 23, 19)
-    verify_anchor(25, 18, 22, 2)
-    verify_anchor(25, 23, 24, 4)
-    verify_anchor(27, 5, 10, 25)
-    verify_anchor(27, 11, 12, 3)
 
 
 def test_anchors_two(snippetcompiler):
@@ -173,10 +165,6 @@ def test_get_types_and_scopes(snippetcompiler):
 
     implement Test using a
 
-    typedef Test3 as Test(b="a")
-
-    y = Test3(a="xx")
-
     """
     )
 
@@ -198,7 +186,6 @@ def test_get_types_and_scopes(snippetcompiler):
         "__config__::Test2",
         "__config__::foo",
         "__config__::a",
-        "__config__::Test3",
     ]
     assert sorted(namespace_to_type_name["__config__"]) == sorted(expected_types_in_config_ns)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -37,14 +37,7 @@ from inmanta.ast.statements.assign import (
     StringFormat,
 )
 from inmanta.ast.statements.call import FunctionCall
-from inmanta.ast.statements.define import (
-    DefineEntity,
-    DefineImplement,
-    DefineIndex,
-    DefineTypeConstraint,
-    DefineTypeDefault,
-    TypeDeclaration,
-)
+from inmanta.ast.statements.define import DefineEntity, DefineImplement, DefineIndex, DefineTypeConstraint, TypeDeclaration
 from inmanta.ast.statements.generator import ConditionalExpression, Constructor, If
 from inmanta.ast.variables import AttributeReference, Reference
 from inmanta.execute.util import NoneValue
@@ -596,20 +589,6 @@ typedef abc as string matching std::is_base64_encoded(self)
     assert isinstance(left_side_equals, FunctionCall)
     assert isinstance(right_side_equals, Literal)
     assert isinstance(right_side_equals.value, bool) and right_side_equals.value
-
-
-def test_typedef2():
-    statements = parse_code(
-        """
-typedef ConfigFile as File(mode = 644, owner = "root", group = "root")
-"""
-    )
-
-    assert len(statements) == 1
-    stmt = statements[0]
-    assert isinstance(stmt, DefineTypeDefault)
-    assert stmt.name == "ConfigFile"
-    assert isinstance(stmt.ctor, Constructor)
 
 
 def test_index():
@@ -1537,21 +1516,6 @@ def test_doc_string_on_typedef():
     statements = parse_code(
         """
 typedef foo as string matching /^a+$/
-\"""
-    Foo is a stringtype that only allows "a"
-\"""
-"""
-    )
-    assert len(statements) == 1
-
-    stmt = statements[0]
-    assert str(stmt.comment).strip() == 'Foo is a stringtype that only allows "a"'
-
-
-def test_doc_string_on_typedefault():
-    statements = parse_code(
-        """
-typedef Foo as File(x=5)
 \"""
     Foo is a stringtype that only allows "a"
 \"""


### PR DESCRIPTION
# Description
drop default constructors

drop redundant EntityLike ABC (move docstrings to Entity where appropriate).

Drop get_entity() method and simply use the entity where it's currently used

closes #4984


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
