### PR TITLE
Issue/fix error reporting when migration test is absent iso4

### DIFF
--- a/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent-iso4.yml
+++ b/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent-iso4.yml
@@ -1,0 +1,6 @@
+---
+description: Add explicit error message when the migration test to the latest version is missing
+issue-nr: 1358
+issue-repo: irt
+change-type: patch
+destination-branches: [iso4]

--- a/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
+++ b/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
@@ -1,5 +1,5 @@
 ---
-description: Dummy change entry
+description: Add explicit error message when the migration test to the latest version is missing
 issue-nr: 1358
 issue-repo: irt
 change-type: patch

--- a/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
+++ b/changelogs/unreleased/fix-error-reporting-when-migration-test-is-absent.yml
@@ -1,5 +1,5 @@
 ---
-description: Add explicit error message when the migration test to the latest version is missing
+description: Dummy change entry
 issue-nr: 1358
 issue-repo: irt
 change-type: patch

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -52,6 +52,11 @@ def test_migration_check():
                     f"Line '{line}' was found in dump {latest_dump} L{line_no}. Please remove or comment out this line."
                 )
 
-    migration_test: Path = sorted(migration_tests_folder.glob("test_v*" + latest_dump.stem + ".py"))[-1]
+    migration_tests: List[Path] = sorted(migration_tests_folder.glob("test_v*" + latest_dump.stem + ".py"))
+    if not migration_tests:
+        raise Exception(
+            f"No migration test to version {latest_dump.stem} was found in {migration_tests_folder}. Please add such a test."
+        )
+    migration_test: Path = migration_tests[-1]
 
     assert migration_test.is_file()


### PR DESCRIPTION
# Description

This PR adds the improved error reporting to iso4.
I initially thought I had added it with https://github.com/inmanta/inmanta-core/commit/ea59dafdf7512afdfeb9fe49e203b37ddc75213d and so I added a dummy changelog entry to comply with invariant checks.
It turns out it didn't actually made it into iso4, so this PR fixes that. Sorry for the confusion/hassle.

part of https://github.com/inmanta/irt/issues/1358

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
