### PR TITLE
issue/5054-modulev2-invalid-version

### DIFF
--- a/changelogs/unreleased/5054-modulev2-invalid-version-exception.yml
+++ b/changelogs/unreleased/5054-modulev2-invalid-version-exception.yml
@@ -1,0 +1,6 @@
+description: Improve the error message when trying to build a moduleV2 with an invalid version name
+issue-nr: 5054
+change-type: patch
+destination-branches: [master, iso5]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -38,6 +38,7 @@ from io import BytesIO, TextIOBase
 from itertools import chain
 from subprocess import CalledProcessError
 from tarfile import TarFile
+from textwrap import indent
 from time import time
 from typing import (
     Any,

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -3037,10 +3037,7 @@ class ModuleV2(Module[ModuleV2Metadata]):
     ) -> None:
         self._is_editable_install = is_editable_install
         self._version: Optional[version.Version] = installed_version
-        try:
-            super(ModuleV2, self).__init__(project, path)
-        except InvalidMetadata:
-            raise
+        super(ModuleV2, self).__init__(project, path)
 
         if not os.path.exists(os.path.join(self.model_dir, "_init.cf")):
             raise InvalidModuleException(

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -26,6 +26,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import textwrap
 import traceback
 import types
 import warnings
@@ -38,7 +39,6 @@ from io import BytesIO, TextIOBase
 from itertools import chain
 from subprocess import CalledProcessError
 from tarfile import TarFile
-from textwrap import indent
 from time import time
 from typing import (
     Any,

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -258,7 +258,9 @@ class InvalidMetadata(CompilerException):
 
     @classmethod
     def _extend_msg_with_validation_information(cls, msg: str, validation_error: ValidationError) -> str:
-        msg += "\n" + display_errors(validation_error.errors())
+        errors = validation_error.errors()
+        if errors:
+            msg += "\n" + display_errors(errors)
         return msg
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -260,7 +260,7 @@ class InvalidMetadata(CompilerException):
     def _extend_msg_with_validation_information(cls, msg: str, validation_error: ValidationError) -> str:
         errors = validation_error.errors()
         if errors:
-            msg += "\n" + display_errors(errors)
+            msg += "\n" + textwrap.indent(display_errors(errors), " " * 2)
         return msg
 
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -646,7 +646,7 @@ mode.
         except (ModuleMetadataFileNotFound, InvalidMetadata, InvalidModuleException):
             try:
                 return ModuleV1(project, path)
-            except (ModuleMetadataFileNotFound, InvalidModuleException) as e:
+            except (ModuleMetadataFileNotFound, InvalidModuleException):
                 raise InvalidModuleException(f"No module can be found at {path}")
             except InvalidMetadata as e:
                 raise InvalidModuleException(e.msg)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -646,8 +646,10 @@ mode.
         except (ModuleMetadataFileNotFound, InvalidMetadata, InvalidModuleException):
             try:
                 return ModuleV1(project, path)
-            except (ModuleMetadataFileNotFound, InvalidMetadata, InvalidModuleException):
+            except (ModuleMetadataFileNotFound, InvalidModuleException) as e:
                 raise InvalidModuleException(f"No module can be found at {path}")
+            except InvalidMetadata as e:
+                raise InvalidModuleException(e.msg)
 
     def get_module(self, module: Optional[str] = None, project: Optional[Project] = None) -> Module:
         """Finds and loads a module, either based on the CWD or based on the name passed in as an argument and the project"""

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -508,7 +508,7 @@ packages = find_namespace:
 @pytest.mark.parametrize_any(
     "version, error_msg",
     [
-        ("0.0.1.dev0", "setup.cfg version should be a base version without tag. Use egg_info.tag_build to configure a " "tag"),
+        ("0.0.1.dev0", "setup.cfg version should be a base version without tag. Use egg_info.tag_build to configure a tag"),
         ("hello", "Version hello is not PEP440 compliant"),
     ],
 )
@@ -535,7 +535,7 @@ packages = find_namespace:
     )
     with pytest.raises(InvalidMetadata) as e:
         module.ModuleV2(None, inmanta_module_v2.get_root_dir_of_module())
-    assert f"Metadata defined in {inmanta_module_v2.get_metadata_file_path()} is invalid:\nversion\n" in str(e.value)
+    assert f"Metadata defined in {inmanta_module_v2.get_metadata_file_path()} is invalid:\n  version\n" in str(e.value)
     assert error_msg in str(e.value)
 
 

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -425,9 +425,9 @@ requires:
     cause = e.value.__cause__
     assert isinstance(cause, InvalidMetadata)
     assert (
-        "Metadata defined in /tmp/pytest-of-florent/pytest-49/test_module_requires_contains_0/mod/module.yml is invalid:\n"
+        f"Metadata defined in {inmanta_module_v1.get_metadata_file_path()} is invalid:\n"
         + "requires -> 0\n"
-        + " str type expected (type=type_error.str)"
+        + "  str type expected (type=type_error.str)"
         in cause.msg
     )
 
@@ -499,10 +499,44 @@ packages = find_namespace:
         """
     )
     if underscore:
-        with pytest.raises(InvalidModuleException):
+        with pytest.raises(InvalidMetadata):
             module.ModuleV2(None, inmanta_module_v2.get_root_dir_of_module())
     else:
         module.ModuleV2(None, inmanta_module_v2.get_root_dir_of_module())
+
+
+@pytest.mark.parametrize_any(
+    "version, error_msg",
+    [
+        ("0.0.1.dev0", "setup.cfg version should be a base version without tag. Use egg_info.tag_build to configure a " "tag"),
+        ("hello", "Version hello is not PEP440 compliant"),
+    ],
+)
+def test_module_v2_invalid_version(inmanta_module_v2: InmantaModule, version: str, error_msg: str):
+    """
+    Test module v2 metadata parsing with respect to module naming rules about dashes and underscores.
+    """
+    inmanta_module_v2.write_metadata_file(
+        f"""
+[metadata]
+name = inmanta-module-mymod
+version = {version}
+license = Apache 2.0
+
+[options]
+install_requires =
+  inmanta-modules-net ~=0.2.4
+  inmanta-modules-std >1.0,<2.5
+
+  cookiecutter~=1.7.0
+  cryptography>1.0,<3.5
+packages = find_namespace:
+        """
+    )
+    with pytest.raises(InvalidMetadata) as e:
+        module.ModuleV2(None, inmanta_module_v2.get_root_dir_of_module())
+    assert f"Metadata defined in {inmanta_module_v2.get_metadata_file_path()} is invalid:\nversion\n" in str(e.value)
+    assert error_msg in str(e.value)
 
 
 def test_module_v2_incompatible_commands(caplog, local_module_package_index: str, snippetcompiler, modules_v2_dir: str) -> None:

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -424,7 +424,12 @@ requires:
 
     cause = e.value.__cause__
     assert isinstance(cause, InvalidMetadata)
-    assert "('requires', 0)\n\tstr type expected (type_error.str)" in cause.msg
+    assert (
+        "Metadata defined in /tmp/pytest-of-florent/pytest-49/test_module_requires_contains_0/mod/module.yml is invalid:\n"
+        + "requires -> 0\n"
+        + " str type expected (type=type_error.str)"
+        in cause.msg
+    )
 
 
 def test_module_v2_metadata(inmanta_module_v2: InmantaModule) -> None:

--- a/tests/moduletool/test_module_tool_basics.py
+++ b/tests/moduletool/test_module_tool_basics.py
@@ -426,8 +426,8 @@ requires:
     assert isinstance(cause, InvalidMetadata)
     assert (
         f"Metadata defined in {inmanta_module_v1.get_metadata_file_path()} is invalid:\n"
-        + "requires -> 0\n"
-        + "  str type expected (type=type_error.str)"
+        + "  requires -> 0\n"
+        + "    str type expected (type=type_error.str)"
         in cause.msg
     )
 


### PR DESCRIPTION
# Description

When we create a v2 module and we set the version to an invalid python version, the build command will show a error message that doesn't give much information. This commit will improve the error message.

closes #5054

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
