### PR TITLE
issue/5047-contradicting-log-msg-compiler-service

### DIFF
--- a/changelogs/unreleased/5047-fix-contradicting-log-message.yml
+++ b/changelogs/unreleased/5047-fix-contradicting-log-message.yml
@@ -1,0 +1,4 @@
+description: fix a contradicting message in the logs of the compiler service
+change-type: patch
+destination-branches: [master, iso5]
+issue-nr: 5132

--- a/changelogs/unreleased/5047-fix-contradicting-log-message.yml
+++ b/changelogs/unreleased/5047-fix-contradicting-log-message.yml
@@ -1,4 +1,4 @@
 description: fix a contradicting message in the logs of the compiler service
 change-type: patch
-destination-branches: [master, iso5]
-issue-nr: 5132
+destination-branches: [master, iso5, iso4]
+issue-nr: 5047

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -728,7 +728,8 @@ class CompilerService(ServerSlice):
         else:
             env = await data.Environment.get_by_id(compile.environment)
             wait_time = await env.get(data.RECOMPILE_BACKOFF)
-            LOGGER.info("The recompile_backoff environment setting is enabled and set to %s seconds.", wait_time)
+            if wait_time:
+                LOGGER.info("The recompile_backoff environment setting is enabled and set to %s seconds.", wait_time)
         last_run = await data.Compile.get_last_run(compile.environment)
         if not last_run:
             wait: float = 0

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -731,7 +731,7 @@ class CompilerService(ServerSlice):
             if wait_time:
                 LOGGER.info("The recompile_backoff environment setting is enabled and set to %s seconds.", wait_time)
             else:
-                LOGGER.info("The recompile_backoff environment setting is disabled)
+                LOGGER.info("The recompile_backoff environment setting is disabled")
         last_run = await data.Compile.get_last_run(compile.environment)
         if not last_run:
             wait: float = 0

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -730,6 +730,8 @@ class CompilerService(ServerSlice):
             wait_time = await env.get(data.RECOMPILE_BACKOFF)
             if wait_time:
                 LOGGER.info("The recompile_backoff environment setting is enabled and set to %s seconds.", wait_time)
+            else:
+                LOGGER.info("The recompile_backoff environment setting is disabled)
         last_run = await data.Compile.get_last_run(compile.environment)
         if not last_run:
             wait: float = 0

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1148,11 +1148,11 @@ async def test_git_uses_environment_variables(environment_factory: EnvironmentFa
 
 
 @pytest.mark.parametrize(
-    "auto_recompile_wait,recompile_backoff,expected_log_message,expected_log_level, printed",
+    "auto_recompile_wait,recompile_backoff,expected_log_message,expected_log_level",
     [
-        ("0", "2.1", "The recompile_backoff environment setting is enabled and set to 2.1 seconds", logging.INFO, True),
-        ("2", "0", "This option is deprecated in favor of the recompile_backoff environment setting.", logging.WARNING, True),
-        ("0", "0", "The recompile_backoff environment setting is enabled and set to 2.1 seconds", logging.INFO, False),
+        ("0", "2.1", "The recompile_backoff environment setting is enabled and set to 2.1 seconds", logging.INFO),
+        ("2", "0", "This option is deprecated in favor of the recompile_backoff environment setting.", logging.WARNING),
+        ("0", "0", "The recompile_backoff environment setting is disabled", logging.INFO),
     ],
 )
 async def test_compileservice_auto_recompile_wait(
@@ -1165,7 +1165,6 @@ async def test_compileservice_auto_recompile_wait(
     recompile_backoff,
     expected_log_message,
     expected_log_level,
-    printed,
 ):
     """
     Test the auto-recompile-wait setting when multiple recompiles are requested in a short amount of time
@@ -1203,21 +1202,11 @@ async def test_compileservice_auto_recompile_wait(
         for i in range(3):
             await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
-        if printed:
-            LogSequence(caplog, allow_errors=False).contains(
-                "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
-            ).contains("inmanta.server.services.compilerservice", expected_log_level, expected_log_message,).contains(
-                "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
-            )
-        else:
-            LogSequence(caplog, allow_errors=False).contains(
-                "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
-            ).contains("inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting")
-            LogSequence(caplog, allow_errors=False).assert_not(
-                "inmanta.server.services.compilerservice",
-                expected_log_level,
-                expected_log_message,
-            )
+        LogSequence(caplog, allow_errors=False).contains(
+            "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
+        ).contains("inmanta.server.services.compilerservice", expected_log_level, expected_log_message,).contains(
+            "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
+        )
 
 
 async def test_compileservice_calculate_auto_recompile_wait(mocked_compiler_service_block, server):

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1148,10 +1148,11 @@ async def test_git_uses_environment_variables(environment_factory: EnvironmentFa
 
 
 @pytest.mark.parametrize(
-    "auto_recompile_wait,recompile_backoff,expected_log_message,expected_log_level",
+    "auto_recompile_wait,recompile_backoff,expected_log_message,expected_log_level, printed",
     [
-        ("0", "2.1", "The recompile_backoff environment setting is enabled and set to 2.1 seconds", logging.INFO),
-        ("2", "0", "This option is deprecated in favor of the recompile_backoff environment setting.", logging.WARNING),
+        ("0", "2.1", "The recompile_backoff environment setting is enabled and set to 2.1 seconds", logging.INFO, True),
+        ("2", "0", "This option is deprecated in favor of the recompile_backoff environment setting.", logging.WARNING, True),
+        ("0", "0", "The recompile_backoff environment setting is enabled and set to 2.1 seconds", logging.INFO, False),
     ],
 )
 async def test_compileservice_auto_recompile_wait(
@@ -1164,6 +1165,7 @@ async def test_compileservice_auto_recompile_wait(
     recompile_backoff,
     expected_log_message,
     expected_log_level,
+    printed,
 ):
     """
     Test the auto-recompile-wait setting when multiple recompiles are requested in a short amount of time
@@ -1201,11 +1203,21 @@ async def test_compileservice_auto_recompile_wait(
         for i in range(3):
             await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
-        LogSequence(caplog, allow_errors=False).contains(
-            "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
-        ).contains("inmanta.server.services.compilerservice", expected_log_level, expected_log_message,).contains(
-            "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
-        )
+        if printed:
+            LogSequence(caplog, allow_errors=False).contains(
+                "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
+            ).contains("inmanta.server.services.compilerservice", expected_log_level, expected_log_message,).contains(
+                "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
+            )
+        else:
+            LogSequence(caplog, allow_errors=False).contains(
+                "inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting"
+            ).contains("inmanta.server.services.compilerservice", logging.DEBUG, "Running recompile without waiting")
+            LogSequence(caplog, allow_errors=False).assert_not(
+                "inmanta.server.services.compilerservice",
+                expected_log_level,
+                expected_log_message,
+            )
 
 
 async def test_compileservice_calculate_auto_recompile_wait(mocked_compiler_service_block, server):


### PR DESCRIPTION
# Description

fix a contradicting message in the logs of the compiler service.

closes #5047 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
