### PR TITLE
Issue/fix path in migration check

### DIFF
--- a/changelogs/unreleased/fix-path-in-test-migration-check.yml
+++ b/changelogs/unreleased/fix-path-in-test-migration-check.yml
@@ -1,0 +1,4 @@
+---
+description: Change broken relative path to an absolute one.
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import os
 from pathlib import Path
 from typing import List
 
@@ -24,12 +25,13 @@ def test_migration_check():
     Make sure there is a database dump for the latest version of the db and
     that a migration test exists for this dump.
     """
-    versions_folder: Path = Path(".").absolute() / "src" / "inmanta" / "db" / "versions"
+    inmanta_dir: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
+    versions_folder: Path = Path(inmanta_dir) / "src" / "inmanta" / "db" / "versions"
     versions: List[Path] = list(versions_folder.glob("v" + "[0-9]" * 9 + ".py"))  # Migration files have format vYYYYMMDDN.py
     latest_version: Path = sorted(versions)[-1]
 
-    migration_tests_folder: Path = Path(".").absolute() / "tests" / "db" / "migration_tests"
+    migration_tests_folder: Path = Path(inmanta_dir) / "tests" / "db" / "migration_tests"
     dumps_folder: Path = migration_tests_folder / "dumps"
 
     dumps: List[Path] = list(dumps_folder.glob("v" + "[0-9]" * 9 + ".sql"))  # Dumps have format vYYYYMMDDN.sql

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -25,7 +25,7 @@ def test_migration_check():
     that a migration test exists for this dump.
     """
 
-    inmanta_dir: Path = Path(__file__).parent.absolute() / ".." / ".."
+    inmanta_dir: Path = Path(__file__).parent.parent.parent.absolute()
 
     versions_folder: Path = inmanta_dir / "src" / "inmanta" / "db" / "versions"
     versions: List[Path] = list(versions_folder.glob("v" + "[0-9]" * 9 + ".py"))  # Migration files have format vYYYYMMDDN.py

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -15,7 +15,6 @@
 
     Contact: code@inmanta.com
 """
-import os
 from pathlib import Path
 from typing import List
 
@@ -25,13 +24,14 @@ def test_migration_check():
     Make sure there is a database dump for the latest version of the db and
     that a migration test exists for this dump.
     """
-    inmanta_dir: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
-    versions_folder: Path = Path(inmanta_dir) / "src" / "inmanta" / "db" / "versions"
+    inmanta_dir: Path = Path(__file__).parent.absolute() / ".." / ".."
+
+    versions_folder: Path = inmanta_dir / "src" / "inmanta" / "db" / "versions"
     versions: List[Path] = list(versions_folder.glob("v" + "[0-9]" * 9 + ".py"))  # Migration files have format vYYYYMMDDN.py
     latest_version: Path = sorted(versions)[-1]
 
-    migration_tests_folder: Path = Path(inmanta_dir) / "tests" / "db" / "migration_tests"
+    migration_tests_folder: Path = inmanta_dir / "tests" / "db" / "migration_tests"
     dumps_folder: Path = migration_tests_folder / "dumps"
 
     dumps: List[Path] = list(dumps_folder.glob("v" + "[0-9]" * 9 + ".sql"))  # Dumps have format vYYYYMMDDN.sql


### PR DESCRIPTION
# Description

Relative paths were causing issues in the docker-pytest builds.
This PR changes the paths to absolute.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
