### PR TITLE
Issue/5066 fix format warnings iso5

### DIFF
--- a/changelogs/unreleased/5066-fix-warnings-formats.yml
+++ b/changelogs/unreleased/5066-fix-warnings-formats.yml
@@ -1,0 +1,5 @@
+---
+description: fix the formatting of InmantaWarnings
+change-type: patch
+issue-nr: 5066
+destination-branches: [iso5]

--- a/docs/adr/0000-logging-warnings-using-the-python-warnings-or-logging-module.md
+++ b/docs/adr/0000-logging-warnings-using-the-python-warnings-or-logging-module.md
@@ -24,8 +24,14 @@ Python has two different ways to report warnings to the user. Warnings can be lo
 ## Decision Outcome
 
 - The `warnings` module will be configured as such that it ignores warnings logged from non-inmanta python modules. This way warnings from third-party libraries are ignored.
-- All warnings, for which we expect an action from the end-user, should be logged using the `warnings.warn()` method. An example is a log message that announces a feature deprecation. This user can be a user of the CLI, the API, a module or an extension developer.
+- All warnings, for which we expect an action from the end-user, should be logged using `warnings.warn()` method, and inherit from the InmantaWarning type. An example is a log message that announces a feature deprecation. This user can be a user of the CLI, the API, a module or an extension developer. Those warning won't contain the python trace.
 - All other warnings should be logged using the `LOGGER.warning()` method. These warnings usually indicate that something went wong at runtime. For example, an agent that hits the rate limiter.
+
+## Rationale
+
+- We don't want to display python traces to end users as they contain no useful information and are clogging the logs. To prevent this we use the InmantaWarning which use a different formatting rule.
+- InmantaWarning are also needed because the location the warning is about is not always the location that issues the warning. For example, when deprecated syntax is used in the inmanta model, we log a warning in core and the default warning formatter will include the line in core in the logs, while it is the line in the model that is important.
+  By using InmantaWarnings, we can manually include the correct filename and line number from the model in the warning message.
 
 ## Disclaimer
 

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional, Union
 
 from inmanta.ast import export
 from inmanta.stable_api import stable_api
+from inmanta.warnings import InmantaWarning
 
 try:
     from typing import TYPE_CHECKING
@@ -596,13 +597,13 @@ class RuntimeException(CompilerException):
         return super(RuntimeException, self).format()
 
 
-class CompilerRuntimeWarning(Warning, RuntimeException):
+class CompilerRuntimeWarning(InmantaWarning, RuntimeException):
     """
     Baseclass for compiler warnings after parsing is complete.
     """
 
     def __init__(self, stmt: "Optional[Locatable]", msg: str) -> None:
-        Warning.__init__(self)
+        InmantaWarning.__init__(self)
         RuntimeException.__init__(self, stmt, msg)
 
 

--- a/src/inmanta/ast/blocks.py
+++ b/src/inmanta/ast/blocks.py
@@ -15,7 +15,6 @@
 
     Contact: code@inmanta.com
 """
-
 import warnings
 from collections.abc import Set
 from itertools import chain

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -76,6 +76,7 @@ from inmanta.parser import plyInmantaParser
 from inmanta.parser.plyInmantaParser import cache_manager
 from inmanta.stable_api import stable_api
 from inmanta.util import get_compiler_version
+from inmanta.warnings import InmantaWarning
 from packaging import version
 from ruamel.yaml.comments import CommentedMap
 
@@ -266,11 +267,11 @@ class InvalidMetadata(CompilerException):
         return msg
 
 
-class MetadataDeprecationWarning(Warning):
+class MetadataDeprecationWarning(InmantaWarning):
     pass
 
 
-class ModuleDeprecationWarning(Warning):
+class ModuleDeprecationWarning(InmantaWarning):
     pass
 
 

--- a/src/inmanta/parser/__init__.py
+++ b/src/inmanta/parser/__init__.py
@@ -21,6 +21,7 @@ from typing import Optional
 import inmanta.ast.export as ast_export
 from inmanta.ast import CompilerException, LocatableString, Range
 from inmanta.stable_api import stable_api
+from inmanta.warnings import InmantaWarning
 
 
 @stable_api
@@ -42,11 +43,11 @@ class ParserException(CompilerException):
         return error
 
 
-class ParserWarning(Warning, ParserException):
+class ParserWarning(InmantaWarning, ParserException):
     """Warning occurring during the parsing of the code"""
 
     def __init__(self, location: Range, value: object, msg: str) -> None:
-        Warning.__init__(self)
+        InmantaWarning.__init__(self)
         ParserException.__init__(self, location, value, msg)
         # Override parent message since it's not an error
         self.msg = msg

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -18,11 +18,11 @@
 import inspect
 import os
 import subprocess
+import warnings
 from collections import abc
 from functools import reduce
 from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, List, Optional, Tuple, Type, TypeVar
 
-import inmanta
 import inmanta.ast.type as inmanta_type
 from inmanta import const, protocol
 from inmanta.ast import CompilerException, LocatableString, Location, Namespace, Range, RuntimeException, TypeNotFoundException
@@ -32,6 +32,7 @@ from inmanta.execute.proxy import DynamicProxy
 from inmanta.execute.runtime import QueueScheduler, Resolver, ResultVariable
 from inmanta.execute.util import Unknown
 from inmanta.stable_api import stable_api
+from inmanta.warnings import InmantaWarning
 
 T = TypeVar("T")
 
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
     from inmanta.compiler import Compiler
 
 
-class PluginDeprecationWarning(Warning):
+class PluginDeprecationWarning(InmantaWarning):
     pass
 
 
@@ -421,7 +422,7 @@ class Plugin(NamedType, metaclass=PluginMeta):
             msg: str = f"Plugin '{self.__function_name__}' in module '{self.__module__}' is deprecated."
             if self.replaced_by:
                 msg += f" It should be replaced by '{self.replaced_by}'."
-            inmanta.warnings.warn(PluginDeprecationWarning(msg))
+            warnings.warn(PluginDeprecationWarning(msg))
         self.check_requirements()
 
         def new_arg(arg: object) -> object:

--- a/src/inmanta/warnings.py
+++ b/src/inmanta/warnings.py
@@ -21,6 +21,17 @@ import warnings
 from enum import Enum
 from typing import Dict, List, Literal, Mapping, Optional, TextIO, Type, Union
 
+
+class InmantaWarning(Warning):
+    """
+    Base class for Inmanta Warnings.
+    Those warnings won't contain the python trace and are intended to be shown to end users.
+    """
+
+    def __init__(self, *args: object):
+        Warning.__init__(self, *args)
+
+
 REGEX_INMANTA_MODULE: str = r"^(inmanta|inmanta\..*|inmanta_.*)$"
 
 
@@ -140,15 +151,19 @@ class WarningsManager:
         :param line: Required for compatibility but will be ignored.
         """
         # implementation based on warnings._showwarnmsg_impl and logging._showwarning
-        text: str = warnings.formatwarning(
-            # ignore type check because warnings.formatwarning accepts Warning instance but it's type definition doesn't
-            message,  # type: ignore
-            category,
-            filename,
-            lineno,
-            line,
-        )
-        logger: logging.Logger = logging.getLogger("py.warnings")
+        if issubclass(category, InmantaWarning):
+            text = "%s: %s" % (category.__name__, message)
+            logger = logging.getLogger("inmanta.warnings")
+        else:
+            text: str = warnings.formatwarning(
+                # ignore type check because warnings.formatwarning accepts Warning instance but it's type definition doesn't
+                message,  # type: ignore
+                category,
+                filename,
+                lineno,
+                line,
+            )
+            logger: logging.Logger = logging.getLogger("py.warnings")
 
         if file is not None:
             try:

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -90,13 +90,16 @@ def test_warning_format(caplog, warning: Union[str, Warning], category: Type[War
     warnings.resetwarnings()
     warnings.filterwarnings("default", category=Warning)
     warnings.warn_explicit(warning, category, filename, lineno)
-    assert caplog.record_tuples == [
-        (
-            "py.warnings",
-            logging.WARNING,
-            warnings.formatwarning(warning, category, filename, lineno),  # type: ignore
-        )
-    ]
+    if isinstance(warning, inmanta_warnings.InmantaWarning):
+        assert caplog.record_tuples == [("inmanta.warnings", logging.WARNING, "%s: %s" % (category.__name__, warning))]
+    else:
+        assert caplog.record_tuples == [
+            (
+                "py.warnings",
+                logging.WARNING,
+                warnings.formatwarning(warning, category, filename, lineno),  # type: ignore
+            )
+        ]
 
 
 def test_shadow_warning(snippetcompiler):


### PR DESCRIPTION
# Description

https://github.com/inmanta/inmanta-core/pull/4979 removed InmantaWarnings which use another formatter than the default warnings. As we want to keep both formats, this PR adds the InmantaWarnings back.

closes https://github.com/inmanta/inmanta-core/issues/5066

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
