### PR TITLE
Issue/5047 contradicting log msg compiler service iso5

### DIFF
--- a/changelogs/unreleased/5047-fix-contradicting-log-message.yml
+++ b/changelogs/unreleased/5047-fix-contradicting-log-message.yml
@@ -1,4 +1,4 @@
 description: fix a contradicting message in the logs of the compiler service
 change-type: patch
-destination-branches: [iso5]
+destination-branches: [iso4, iso5]
 issue-nr: 5047

--- a/changelogs/unreleased/5047-fix-contradicting-log-message.yml
+++ b/changelogs/unreleased/5047-fix-contradicting-log-message.yml
@@ -1,0 +1,4 @@
+description: fix a contradicting message in the logs of the compiler service
+change-type: patch
+destination-branches: [master, iso5, iso4]
+issue-nr: 5047

--- a/changelogs/unreleased/5047-fix-contradicting-log-message.yml
+++ b/changelogs/unreleased/5047-fix-contradicting-log-message.yml
@@ -1,4 +1,4 @@
 description: fix a contradicting message in the logs of the compiler service
 change-type: patch
-destination-branches: [master, iso5, iso4]
+destination-branches: [iso5]
 issue-nr: 5047


### PR DESCRIPTION
# Description

fix a contradicting message in the logs of the compiler service.

closes https://github.com/inmanta/inmanta-core/issues/5047

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
