### PR TITLE
Fix: backwards compatibility EntityLike 

### DIFF
--- a/changelogs/unreleased/fix-issue-entitylike.yml
+++ b/changelogs/unreleased/fix-issue-entitylike.yml
@@ -1,0 +1,4 @@
+---
+description: add back the get_default() function in Entity (was previously in EntityLike) and some backwards compatibility
+change-type: patch
+destination-branches: [master]

--- a/changelogs/unreleased/fix-issue-entitylike.yml
+++ b/changelogs/unreleased/fix-issue-entitylike.yml
@@ -1,4 +1,4 @@
 ---
-description: add back the get_default() function in Entity (was previously in EntityLike) and some backwards compatibility
+description: adds back the get_default() function in Entity (was previously in EntityLike) and some backwards compatibility
 change-type: patch
 destination-branches: [master]

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -478,6 +478,7 @@ class Entity(NamedType):
         return self.location
 
 
+# Kept for backwards compatibility. May be dropped from iso7 onwards.
 EntityLike = Entity
 
 

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -453,6 +453,15 @@ class Entity(NamedType):
         # remove erased defaults
         return {k: v for k, v in dvalues.items() if v is not None}
 
+    def get_default(self, name: str) -> "ExpressionStatement":
+        """
+        Get a default value for a given name
+        """
+        defaults = self.get_default_values()
+        if name not in defaults:
+            raise AttributeError(name)
+        return defaults[name]
+
     def final(self, excns: List[CompilerException]) -> None:
         for key, indices in self.index_queue.items():
             for _, stmt in indices:
@@ -467,6 +476,9 @@ class Entity(NamedType):
 
     def get_location(self) -> Location:
         return self.location
+
+
+EntityLike = Entity
 
 
 class Implementation(NamedType):


### PR DESCRIPTION
# Description

EntityLike where dropped in (https://github.com/inmanta/inmanta-core/pull/5120) and caused some fallout.
This PR will fix some backwards compatibility issues.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
