### PR TITLE
Fix: increase timeout compiled environments

### DIFF
--- a/changelogs/unreleased/fix-increase-timeout-compiled-environments.yml
+++ b/changelogs/unreleased/fix-increase-timeout-compiled-environments.yml
@@ -1,0 +1,4 @@
+---
+description: increase the timeout for compiled_environments
+change-type: patch
+destination-branches: [master]

--- a/changelogs/unreleased/fix-increase-timeout-compiled-environments.yml
+++ b/changelogs/unreleased/fix-increase-timeout-compiled-environments.yml
@@ -1,4 +1,4 @@
 ---
 description: increase the timeout in the compiled_environments fixture
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso5]

--- a/changelogs/unreleased/fix-increase-timeout-compiled-environments.yml
+++ b/changelogs/unreleased/fix-increase-timeout-compiled-environments.yml
@@ -1,4 +1,4 @@
 ---
-description: increase the timeout for compiled_environments
+description: increase the timeout in the compiled_environments fixture
 change-type: patch
 destination-branches: [master]

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -176,7 +176,7 @@ async def compiled_environments(
             result.code == 204 for result in await asyncio.gather(*(client.is_compiling(env.id) for env in environments))
         )
 
-    await utils.retry_limited(all_compiles_done, 10)
+    await utils.retry_limited(all_compiles_done, 15)
 
     yield environments
 


### PR DESCRIPTION
# Description

increase the timeout in the compiled environments fixture.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
