### PR TITLE
fix-issue-enum-paging

### DIFF
--- a/changelogs/unreleased/fix-issue-str-representation-database-order.yml
+++ b/changelogs/unreleased/fix-issue-str-representation-database-order.yml
@@ -1,0 +1,6 @@
+---
+description: Fix an issue about the __str__ function of the DatabaseOrder class with made it incompatible with python3.11
+change-type: patch
+destination-branches: [master, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-issue-str-representation-database-order.yml
+++ b/changelogs/unreleased/fix-issue-str-representation-database-order.yml
@@ -1,5 +1,5 @@
 ---
-description: Fix an issue about the __str__ function of the DatabaseOrder class with made it incompatible with python3.11
+description: Fix an issue about the __str__ function of the DatabaseOrder class which made it incompatible with python3.11
 change-type: patch
 destination-branches: [master, iso5, iso4]
 sections:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -458,7 +458,7 @@ class SingleDatabaseOrder(DatabaseOrderV2, ABC):
         sort: str,
     ) -> T_SELF:
         valid_sort_pattern: Pattern[str] = re.compile(
-            f"^({'|'.join(cls.get_valid_sort_columns())})\\.(asc|desc)$", re.IGNORECASE
+            f"^({'|'.join(cls.get_valid_sort_columns().keys())})\\.(asc|desc)$", re.IGNORECASE
         )
         match = valid_sort_pattern.match(sort)
         if match and len(match.groups()) == 2:
@@ -551,7 +551,7 @@ class SingleDatabaseOrder(DatabaseOrderV2, ABC):
 
     def __str__(self) -> str:
         # used to serialize the order back to a  paging url
-        return f"{self.order_by_column}.{self.order}"
+        return f"{self.order_by_column}.{self.order.value.lower()}"
 
 
 class AbstractDatabaseOrderV2(SingleDatabaseOrder, ABC):


### PR DESCRIPTION
# Description

Fix an issue about the `__str__` function of the DatabaseOrder class with made it incompatible with python3.11

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
