### PR TITLE
fix-issue-enum-paging-iso4

### DIFF
--- a/changelogs/unreleased/fix-issue-str-representation-database-order.yml
+++ b/changelogs/unreleased/fix-issue-str-representation-database-order.yml
@@ -1,0 +1,6 @@
+---
+description: Fix an issue about the __str__ function of the DatabaseOrder class which made it incompatible with python3.11
+change-type: patch
+destination-branches: [iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -182,7 +182,7 @@ class DatabaseOrder:
         sort: str,
     ) -> "DatabaseOrder":
         valid_sort_pattern: Pattern[str] = re.compile(
-            f"^({'|'.join(cls.get_valid_sort_columns())})\\.(asc|desc)$", re.IGNORECASE
+            f"^({'|'.join(cls.get_valid_sort_columns().keys())})\\.(asc|desc)$", re.IGNORECASE
         )
         match = valid_sort_pattern.match(sort)
         if match and len(match.groups()) == 2:
@@ -231,7 +231,7 @@ class DatabaseOrder:
         return ColumnNameStr(value_reference)
 
     def __str__(self) -> str:
-        return f"{self.order_by_column}.{self.order}"
+        return f"{self.order_by_column}.{self.order.value.lower()}"
 
     def get_order_by_column_type(self) -> Union[Type[datetime.datetime], Type[int], Type[str]]:
         """ The type of the order by column"""


### PR DESCRIPTION
# Description

Fix an issue about the `__str__ `function of the DatabaseOrder class with made it incompatible with python3.11

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
