### PR TITLE
fixed inmanta-workon tests for docker-pytest

### DIFF
--- a/changelogs/unreleased/inmanta-workon-test-fix.yml
+++ b/changelogs/unreleased/inmanta-workon-test-fix.yml
@@ -1,0 +1,5 @@
+description: "Fixed `tests/server/test_workon.py` for non-activated test environments, e.g. docker-pytest"
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -22,6 +22,7 @@ import itertools
 import os
 import shutil
 import subprocess
+import sys
 import textwrap
 import uuid
 from collections import abc
@@ -121,6 +122,12 @@ def workon_bash(workon_workdir: py.path.local) -> abc.Iterator[Bash]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=str(workon_workdir),
+            env={
+                **os.environ,
+                # inmanta-workon expects inmanta-cli to be present in PATH but this might not be the case for the test
+                # environment (e.g. if the venv is not activated and the tests are executed with a fully qualified Python path)
+                "PATH": os.path.dirname(sys.executable) + os.pathsep + os.environ["PATH"],
+            },
         )
         stdout, stderr = await process.communicate()
         assert process.returncode is not None


### PR DESCRIPTION
# Description

I believe this should fix the test failures on Pytest in Docker.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
