### PR TITLE
fixed another workon test for CentOS hosts (among others)

### DIFF
--- a/changelogs/unreleased/inmanta-workon-test-fix-2.yml
+++ b/changelogs/unreleased/inmanta-workon-test-fix-2.yml
@@ -1,0 +1,5 @@
+description: "Fixed `tests/server/test_workon.py` for systems with no unqualified python binary"
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -446,7 +446,7 @@ async def assert_workon_state(
 
             # output three lines
             echo "$(pwd)"
-            which python
+            which python || echo ""  # make sure to always output a line, even if no python is found
             echo "${{PS1%%$test_workon_ps1_pre}}"
 
             # exit with result code

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -458,7 +458,7 @@ async def assert_workon_state(
         % (pre_activate if pre_activate is not None else "", post_activate if post_activate is not None else "")
     )
     assert (result.exit_code == 0) != invert_success_assert
-    lines: abc.Sequence[str] = result.stdout.splitlines()
+    lines: abc.Sequence[str] = result.stdout.split("\n")  # don't use splitlines because it ignores empty lines
     assert len(lines) == 3
     working_dir, python, ps1_prefix = lines
     assert (working_dir == str(expected_dir)) != invert_working_dir_assert

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -459,11 +459,12 @@ async def assert_workon_state(
     )
     assert (result.exit_code == 0) != invert_success_assert
     lines: abc.Sequence[str] = result.stdout.split("\n")  # don't use splitlines because it ignores empty lines
-    assert len(lines) == 3
-    working_dir, python, ps1_prefix = lines
+    assert len(lines) == 4  # trailing newline
+    working_dir, python, ps1_prefix, empty = lines
     assert (working_dir == str(expected_dir)) != invert_working_dir_assert
     assert (python == str(expected_dir.join(".env", "bin", "python"))) != invert_python_assert
     assert ps1_prefix == ("" if invert_ps1_assert else f"({arg}) ")
+    assert empty == ""
     assert result.stderr.strip() == expect_stderr.strip()
 
 


### PR DESCRIPTION
# Description

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
