### PR TITLE
Fix server-side compiles with conflicting SSL config in .inmanta file

### DIFF
--- a/changelogs/unreleased/4640-server-side-compiles-with-ssl.yml
+++ b/changelogs/unreleased/4640-server-side-compiles-with-ssl.yml
@@ -1,5 +1,5 @@
 ---
-description: Fix issue where server-side compiles fail when the server has SSL disabled but the project being compiled has a .inmanta file with SSL enabled.
+description: Fix issue where server-side compiles fail when the SSL configuration on the server doesn't match the SSL configuration defined in the .inmanta file of the project.
 issue-nr: 4640
 issue-repo: inmanta-core
 change-type: patch

--- a/changelogs/unreleased/4640-server-side-compiles-with-ssl.yml
+++ b/changelogs/unreleased/4640-server-side-compiles-with-ssl.yml
@@ -1,0 +1,8 @@
+---
+description: Fix issue where server-side compiles fail when the server has SSL disabled but the project being compiled has a .inmanta file with SSL enabled.
+issue-nr: 4640
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -491,7 +491,7 @@ def export_parser_config(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--server_address", dest="server", help="The address of the server to submit the model to")
     parser.add_argument("--server_port", dest="port", help="The port of the server to submit the model to")
     parser.add_argument("--token", dest="token", help="The token to auth to the server")
-    parser.add_argument("--ssl", help="Enable SSL", action="store_true", default=False)
+    parser.add_argument("--ssl", help="Enable SSL", action=argparse.BooleanOptionalAction)
     parser.add_argument("--ssl-ca-cert", dest="ca_cert", help="Certificate authority for SSL")
     parser.add_argument(
         "-X",
@@ -585,6 +585,8 @@ def export(options: argparse.Namespace) -> None:
 
     if options.ssl:
         Config.set("compiler_rest_transport", "ssl", "true")
+    else:
+        Config.set("compiler_rest_transport", "ssl", "false")
 
     if options.ca_cert is not None:
         Config.set("compiler_rest_transport", "ssl-ca-cert-file", options.ca_cert)

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -491,7 +491,7 @@ def export_parser_config(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--server_address", dest="server", help="The address of the server to submit the model to")
     parser.add_argument("--server_port", dest="port", help="The port of the server to submit the model to")
     parser.add_argument("--token", dest="token", help="The token to auth to the server")
-    parser.add_argument("--ssl", help="Enable SSL", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--ssl", help="Enable SSL", action=argparse.BooleanOptionalAction, default=None)
     parser.add_argument("--ssl-ca-cert", dest="ca_cert", help="Certificate authority for SSL")
     parser.add_argument(
         "-X",
@@ -583,10 +583,8 @@ def export(options: argparse.Namespace) -> None:
     if options.token is not None:
         Config.set("compiler_rest_transport", "token", options.token)
 
-    if options.ssl:
-        Config.set("compiler_rest_transport", "ssl", "true")
-    else:
-        Config.set("compiler_rest_transport", "ssl", "false")
+    if options.ssl is not None:
+        Config.set("compiler_rest_transport", "ssl", f"{options.ssl}".lower())
 
     if options.ca_cert is not None:
         Config.set("compiler_rest_transport", "ssl-ca-cert-file", options.ca_cert)

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -412,6 +412,8 @@ class CompileRun(object):
 
             if opt.server_ssl_cert.get() is not None:
                 cmd.append("--ssl")
+            else:
+                cmd.append("--no-ssl")
 
             if opt.server_ssl_ca_cert.get() is not None:
                 cmd.append("--ssl-ca-cert")

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -73,12 +73,15 @@ class EnvironmentFactory:
         return environment
 
     def write_main(self, main: str, environment: Optional[data.Environment] = None) -> None:
+        self.write_file(path="main.cf", content=main, environment=environment)
+
+    def write_file(self, path: str, content: str, environment: Optional[data.Environment] = None) -> None:
         if environment is not None:
             subprocess.check_output(["git", "checkout", environment.repo_branch], cwd=self.src_dir)
-        with open(os.path.join(self.src_dir, "main.cf"), "w", encoding="utf-8") as fd:
-            fd.write(main)
-        subprocess.check_output(["git", "add", "main.cf"], cwd=self.src_dir)
-        subprocess.check_output(["git", "commit", "-m", "write main.cf", "--allow-empty"], cwd=self.src_dir)
+        with open(os.path.join(self.src_dir, path), "w", encoding="utf-8") as fd:
+            fd.write(content)
+        subprocess.check_output(["git", "add", path], cwd=self.src_dir)
+        subprocess.check_output(["git", "commit", "-m", f"write {path}", "--allow-empty"], cwd=self.src_dir)
 
     def add_v1_module(self, module_name: str, *, plugin_code: str, template_dir: str) -> None:
         utils.v1_module_from_template(


### PR DESCRIPTION
# Description

Fix issue where server-side compiles fail when the SSL configuration on the server doesn't match the SSL configuration defined in the .inmanta file of the project.

closes #4640

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation