### PR TITLE
Fix broken link to grafana dashboard.

### DIFF
--- a/changelogs/unreleased/fix-broken-link-to-grafana-dashboard.yml
+++ b/changelogs/unreleased/fix-broken-link-to-grafana-dashboard.yml
@@ -1,4 +1,4 @@
 ---
-description: Fix broken link to grafana dashboard.
+description: Fix broken link to grafana dashboard + make tox.ini file compatible with tox 4
 change-type: patch
 destination-branches: [master, iso6, iso5, iso4]

--- a/changelogs/unreleased/fix-broken-link-to-grafana-dashboard.yml
+++ b/changelogs/unreleased/fix-broken-link-to-grafana-dashboard.yml
@@ -1,0 +1,4 @@
+---
+description: Fix broken link to grafana dashboard.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/docs/administrators/metering.rst
+++ b/docs/administrators/metering.rst
@@ -54,7 +54,7 @@ Setup guide
 
 #. Restart the inmanta server.
 #. [optional] install grafana, follow the instructions found at `<https://grafana.com/grafana/download>`_
-#. [optional] load the inmanta dashboard found at `<https://grafana.com/dashboards/10089>`_
+#. [optional] load the inmanta dashboard found at `<https://grafana.com/grafana/dashboards/10089-inmanta-api-performance/>`_
 
 Reported Metrics
 ----------------

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
     isort --verbose --check -sp setup.cfg --diff -rc src tests tests_common predictive_test_selection
 
 [testenv:docs]
-changedir=docs
+changedir={toxinidir}/docs
 setenv   =
     INMANTA_DONT_DISCOVER_VERSION = ""
 deps=
@@ -40,7 +40,7 @@ deps=
 commands=py.test -v check_sphinx.py -m "not link_check"
 
 [testenv:docs-link-check]
-changedir=docs
+changedir={toxinidir}/docs
 setenv   =
     INMANTA_DONT_DISCOVER_VERSION = ""
 deps=


### PR DESCRIPTION
# Description

* Fix broken link to grafana dashboard.
* Make tox.ini file compatible with tox 4

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
