### PR TITLE
reverted verbose logging in tox.ini

### DIFF
--- a/changelogs/unreleased/revert-verbose-logging.yml
+++ b/changelogs/unreleased/revert-verbose-logging.yml
@@ -1,0 +1,6 @@
+description: Revert verbose logging in tox.ini
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
 extras=
     dataflow_graphic
 # Set the environment variable INMANTA_EXTRA_PYTEST_ARGS='--fast' to run in fast mode
-commands=py.test --log-cli-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 # The INMANTA_RETRY_LIMITED_MULTIPLIER is used to set a multiplier in the retry_limited function


### PR DESCRIPTION
# Description

The logs got so big that responsiveness on Jenkins suffered from it.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
