### PR TITLE
Fix: passenv in tox.ini file doesn't accept whitespaces (#5237)

### DIFF
--- a/changelogs/unreleased/fix-tox-issue-passenv.yml
+++ b/changelogs/unreleased/fix-tox-issue-passenv.yml
@@ -1,0 +1,7 @@
+description: Fix issue with passenv in tox.ini file
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5
+  - iso4

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report 
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 # The INMANTA_RETRY_LIMITED_MULTIPLIER is used to set a multiplier in the retry_limited function
-passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME INMANTA_RETRY_LIMITED_MULTIPLIER
+passenv=SSH_AUTH_SOCK,ASYNC_TEST_TIMEOUT,HOME,INMANTA_RETRY_LIMITED_MULTIPLIER
 basepython = python3.9
 
 [testenv:pep8]


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5237