### PR TITLE
Fix issue tox iso4

### DIFF
--- a/changelogs/unreleased/fix-tox-issue-passenv.yml
+++ b/changelogs/unreleased/fix-tox-issue-passenv.yml
@@ -1,0 +1,4 @@
+description: Fix issue with passenv in tox.ini file
+change-type: patch
+destination-branches:
+  - iso4

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report 
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 # The INMANTA_RETRY_LIMITED_MULTIPLIER is used to set a multiplier in the retry_limited function
-passenv=SSH_AUTH_SOCK ASYNC_TEST_TIMEOUT HOME INMANTA_RETRY_LIMITED_MULTIPLIER
+passenv=SSH_AUTH_SOCK,ASYNC_TEST_TIMEOUT,HOME,INMANTA_RETRY_LIMITED_MULTIPLIER
 basepython = python3.6
 
 [testenv:pep8]


### PR DESCRIPTION
# Description

Some rules changed with the release of the new version of tox. One of those is the separator for the pass_env variable:
https://tox.wiki/en/4.0.3/faq.html#tox-4-changed-ini-rules

this commit fixes the issue

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
