### PR TITLE
New docs theme

### DIFF
--- a/changelogs/unreleased/use-new-theme.yml
+++ b/changelogs/unreleased/use-new-theme.yml
@@ -1,0 +1,6 @@
+description: Use a new theme for the documentation
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -73,6 +73,11 @@ html: openapi latexpdf
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+onlyhtml:
+	$(SPHINXBUILD) -b html -t include_redoc $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html. PDF and REST API documentation will be missing"
+
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
@@ -197,4 +202,3 @@ PNGs := $(foreach dir, $(IMAGEDIRS), $(patsubst %.svg,%.png,$(wildcard $(SOURCED
 
 # Make a rule to build the PDFs
 images: $(PNGs) $(PDFs)
-

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -6,3 +6,8 @@ dl.attribute .sig-prename {
 dl.relation .sig-prename {
     margin-left: 0.5em;
 }
+
+/* make a title smaller to not wrap */
+.sidebar-brand-text {
+    font-size: 1.2rem;
+}

--- a/docs/administrators.rst
+++ b/docs/administrators.rst
@@ -12,4 +12,3 @@ Administrator documentation
     administrators/credentials.rst
     administrators/logging.rst
     administrators/metering.rst
-    administrators/*

--- a/docs/administrators/operational_procedures.rst
+++ b/docs/administrators/operational_procedures.rst
@@ -136,6 +136,7 @@ Procedure
 
   * Keep a close eye on progress and problems that may arise.
   * In case of trouble, hit the emergency stop. Resuming after a stop is very easy and stopping gives you the time to investigate.
+
 7. Verify that automation setting are on
 
   * `agent_trigger_method_on_auto_deploy = push_incremental_deploy`

--- a/docs/administrators/operational_procedures.rst
+++ b/docs/administrators/operational_procedures.rst
@@ -123,7 +123,7 @@ Procedure
 
 3. Temporarily disable auto_deploy
 
-    * `auto_deploy = False`
+  * `auto_deploy = False`
 
 4. Click ‘recompile’ to install the project.
 
@@ -138,10 +138,10 @@ Procedure
   * In case of trouble, hit the emergency stop. Resuming after a stop is very easy and stopping gives you the time to investigate.
 7. Verify that automation setting are on
 
-    * `agent_trigger_method_on_auto_deploy = push_incremental_deploy`
-    * `auto_deploy = true`
-    * `push_on_auto_deploy = true`
-    * `server_compile = true`
+  * `agent_trigger_method_on_auto_deploy = push_incremental_deploy`
+  * `auto_deploy = true`
+  * `push_on_auto_deploy = true`
+  * `server_compile = true`
 
 8. If this model uses LSM, perform initial tests of all services via the API.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ html_theme = "furo"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-# html_title = None
+html_title = f"Inmanta OSS {release}"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None
@@ -198,7 +198,7 @@ html_static_path = ['_static']
 html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-# html_show_sphinx = True
+html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,9 +30,11 @@ from sphinx.errors import ConfigError
 extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.graphviz', 'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode', 'sphinxarg.ext', 'sphinxcontrib.contentui', 'sphinxcontrib.inmanta.config',
-    'sphinxcontrib.inmanta.dsl', 'sphinxcontrib.inmanta.environmentsettings', 'sphinx_click.ext', 'sphinx_tabs.tabs',
+    'sphinxcontrib.inmanta.dsl', 'sphinxcontrib.inmanta.environmentsettings', 'sphinx_click.ext', 'sphinx_design',
     'myst_parser',
 ]
+
+myst_enable_extensions = ["colon_fence"]
 
 def setup(app):
     # cut off license headers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.graphviz', 'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode', 'sphinxarg.ext', 'sphinxcontrib.contentui', 'sphinxcontrib.inmanta.config',
     'sphinxcontrib.inmanta.dsl', 'sphinxcontrib.inmanta.environmentsettings', 'sphinx_click.ext', 'sphinx_tabs.tabs',
-    'recommonmark',
+    'myst_parser',
 ]
 
 def setup(app):
@@ -122,7 +122,7 @@ release = version
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # The documentation build tool overrides this when extensions are included in the documentation build.
-exclude_patterns = ['extensions.rst']
+exclude_patterns = ['extensions.rst', 'adr/*.md']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None
@@ -147,14 +147,7 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ---------------------------------------------------
 
-# html_theme_options = {
-#     'logo_only': True,
-#     'display_version': True,
-# }
-# import sphinx_rtd_theme
-
-# html_theme = "sphinx_rtd_theme"
-# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "furo"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -186,9 +179,7 @@ html_static_path = ['_static']
 # html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-   '**': ['globaltoc.html', 'sourcelink.html', 'searchbox.html']
-}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
@@ -232,7 +223,7 @@ html_css_files = [
 
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
-# 'papersize': 'letterpaper',
+    'papersize': 'a4paper',
 
 # The font size ('10pt', '11pt' or '12pt').
 # 'pointsize': '10pt',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,6 +149,37 @@ pygments_style = 'sphinx'
 
 html_theme = "furo"
 
+html_css_files = [
+      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/fontawesome.min.css",
+      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/solid.min.css",
+      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/brands.min.css",
+]
+
+html_theme_options = {
+    "footer_icons": [
+        {
+            "name": "Website",
+            "url": "https://inmanta.com",
+            "class": "fa-solid fa-globe",
+        },
+        {
+            "name": "Linkedin",
+            "url": "https://www.linkedin.com/company/inmanta-nv/",
+            "class": "fa-brands fa-linkedin",
+        },
+        {
+            "name": "Twitter",
+            "url": "https://twitter.com/inmanta_com",
+            "class": "fa-brands fa-twitter",
+        },
+        {
+            "name": "GitHub",
+            "url": "https://github.com/inmanta",
+            "class": "fa-brands fa-github",
+        },
+    ],
+}
+
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 html_title = f"Inmanta OSS {release}"
@@ -215,7 +246,10 @@ html_show_copyright = True
 htmlhelp_basename = 'InmantaDoc'
 
 html_css_files = [
-    'css/custom.css',
+    "css/custom.css",
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/fontawesome.min.css",
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/solid.min.css",
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/brands.min.css",
 ]
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -2,41 +2,47 @@ Frequently asked questions
 ==========================
 
 How do I use Inmanta with a http/https proxy?
-    Use the http_proxy and https_proxy environment variables to specify the proxy server to use. For the server installed from
-    our RPMs, add the environment variable to the systemd unit file. Copy inmanta-server.service from /lib/systemd/systemd/system
-    to /etc/systemd/system and add the following lines to the [Service] section with the correct proxy server details::
+---------------------------------------------
+
+Use the http_proxy and https_proxy environment variables to specify the proxy server to use. For the server installed from
+our RPMs, add the environment variable to the systemd unit file. Copy inmanta-server.service from /lib/systemd/systemd/system
+to /etc/systemd/system and add the following lines to the [Service] section with the correct proxy server details::
 
 
-        Environment=http_proxy=1.2.3.4:5678
-        Environment=https_proxy=1.2.3.4:5678
+    Environment=http_proxy=1.2.3.4:5678
+    Environment=https_proxy=1.2.3.4:5678
 
-    Afterwards run systemctl daemon-reload and restart the inmanta server.
+Afterwards run systemctl daemon-reload and restart the inmanta server.
 
 
 I get a click related error/exception when I run inmanta-cli.
-    The following error is shown::
+-------------------------------------------------------------
 
-        Traceback (most recent call last):
-            File "/usr/bin/inmanta-cli", line 11, in <module>
-                sys.exit(main())
-            File "/opt/inmanta/lib64/python3.4/site-packages/inmanta/main.py", line 871, in main
-                cmd()
-            File "/opt/inmanta/lib64/python3.4/site-packages/click/core.py", line 722, in __call__
-                return self.main(*args, **kwargs)
-            File "/opt/inmanta/lib64/python3.4/site-packages/click/core.py", line 676, in main
-                _verify_python3_env()
-            File "/opt/inmanta/lib64/python3.4/site-packages/click/_unicodefun.py", line 118, in _verify_python3_env
-                'for mitigation steps.' + extra)
-        RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps.
+The following error is shown::
+
+    Traceback (most recent call last):
+        File "/usr/bin/inmanta-cli", line 11, in <module>
+            sys.exit(main())
+        File "/opt/inmanta/lib64/python3.4/site-packages/inmanta/main.py", line 871, in main
+            cmd()
+        File "/opt/inmanta/lib64/python3.4/site-packages/click/core.py", line 722, in __call__
+            return self.main(*args, **kwargs)
+        File "/opt/inmanta/lib64/python3.4/site-packages/click/core.py", line 676, in main
+            _verify_python3_env()
+        File "/opt/inmanta/lib64/python3.4/site-packages/click/_unicodefun.py", line 118, in _verify_python3_env
+            'for mitigation steps.' + extra)
+    RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps.
 
 
-    This error occurs when the locale are not set correctly. Make sure that LANG and LC_ALL are set. For example::
+This error occurs when the locale are not set correctly. Make sure that LANG and LC_ALL are set. For example::
 
-        export LC_ALL=en_US.utf8
-        export LANG=en_US.utf8
+    export LC_ALL=en_US.utf8
+    export LANG=en_US.utf8
 
 
 The model does not compile and exits with "could not complete model".
-    There is an upperbound on the number of iterations used in the model transformation algorithm. For large models this might
-    not be enough. This limit is controlled with the environment variable INMANTA_MAX_ITERATIONS The default value is set to
-    10000 iterations.
+---------------------------------------------------------------------
+
+There is an upperbound on the number of iterations used in the model transformation algorithm. For large models this might
+not be enough. This limit is controlled with the environment variable INMANTA_MAX_ITERATIONS The default value is set to
+10000 iterations.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,15 +53,7 @@ Currently, the Inmanta project is mainly developed and maintained by `Inmanta nv
     troubleshooting
     changelogs
 
-Additional resources
---------------------
-
-* `Inmanta User Mailinglist <https://groups.google.com/forum/#!forum/inmanta-users>`_
-* `Inmanta Developer Mailinglist <https://groups.google.com/forum/#!forum/inmanta-devel>`_
-* `Inmanta Twitter <https://twitter.com/inmanta_com>`_
-
 PDF version
 -----------
 
 Download: :download:`inmanta.pdf <inmanta.pdf>`
-

--- a/docs/install/install-server/install-server.inc
+++ b/docs/install/install-server/install-server.inc
@@ -1,9 +1,9 @@
 Install the software
 ####################
 
-.. tabs::
+.. tab-set::
 
-    .. tab:: RHEL 8
+    .. tab-item:: RHEL 8
 
         For RHEL 8 based systems use dnf:
 
@@ -31,7 +31,7 @@ Install the software
         files and systemd unit files. The web-console is installed with the server package.
 
 
-    .. tab:: Debian, Ubuntu and derivatives.
+    .. tab-item:: Debian, Ubuntu and derivatives.
 
         First make sure Python >= 3.9 and git are installed. Inmanta requires many dependencies so it is recommended to create a virtual env.
         Next install inmanta with pip install in the newly created virtual env.
@@ -68,7 +68,7 @@ Install the software
 
         If you want to use the web-console you need to install it as well:
 
-        Get the pre-built package from our `web-console github page<https://github.com/inmanta/web-console/packages/>`_. Click on the the package name to go to the package's main page, then on the right hand side under ``Assets``, you will see the compressed package. Download and extract it to your desired directory (preferably, on the same virtual env which was created earlier, in this case, /opt/inmanta). Next, open the ``inmanta.cfg`` file and at the bottom of the file, under the ``[web-console]`` section, change the ``path`` value to the ``dist`` directory of where you extracted the pre-built package. For instance:
+        Get the pre-built package from our `web-console github page <https://github.com/inmanta/web-console/packages/>`_. Click on the the package name to go to the package's main page, then on the right hand side under ``Assets``, you will see the compressed package. Download and extract it to your desired directory (preferably, on the same virtual env which was created earlier, in this case, /opt/inmanta). Next, open the ``inmanta.cfg`` file and at the bottom of the file, under the ``[web-console]`` section, change the ``path`` value to the ``dist`` directory of where you extracted the pre-built package. For instance:
 
         .. code-block:: ini
 
@@ -82,7 +82,7 @@ Install the software
             sudo /opt/inmanta/bin/inmanta -vv -c /opt/inmanta/inmanta.cfg --config-dir /opt/inmanta/inmanta.d server
 
 
-    .. tab:: Other
+    .. tab-item:: Other
 
         First make sure Python >= 3.9 and git are installed. Inmanta requires many dependencies so it is recommended to create a virtual env.
         Next install inmanta with ``pip install`` in the newly created virtual env.
@@ -128,7 +128,7 @@ Install the software
             sudo /opt/inmanta/bin/inmanta -vv -c /opt/inmanta/inmanta.cfg --config-dir /opt/inmanta/inmanta.d server
 
 
-    .. tab:: Windows
+    .. tab-item:: Windows
 
         On Windows only the compile and export commands are supported. This is useful in the :ref:`push-to-server` deployment mode of
         inmanta. First make sure you have Python >= 3.9 and git. Inmanta requires many dependencies so it is recommended to create a virtual env.
@@ -142,7 +142,7 @@ Install the software
             C:\inmanta\env\Script\inmanta --help
 
 
-    .. tab:: Source
+    .. tab-item:: Source
 
         Get the source either from our `release page on github <https://github.com/inmanta/inmanta-core/releases>`_ or clone/download a branch directly.
 

--- a/docs/install/install-server/install-server.inc
+++ b/docs/install/install-server/install-server.inc
@@ -3,9 +3,9 @@ Install the software
 
 .. tab-set::
 
-    .. tab-item:: RHEL 8
+    .. tab-item:: RHEL 8 and 9
 
-        For RHEL 8 based systems use dnf:
+        For RHEL, Almalinux and Rockylinux 8 and 9  based systems use dnf:
 
         .. code-block:: sh
 

--- a/docs/platform_developers/features.rst
+++ b/docs/platform_developers/features.rst
@@ -5,6 +5,7 @@ A default Inmanta install comes with all features enabled by default. :inmanta.c
 to a yaml file that enables or disables features. The format of this file is:
 
 .. code-block:: yaml
+
     slices:
         slice_name:
             feature_name: bool

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,21 +46,21 @@ _________________________
 
 This folder contains a **project.yml**, which looks like this:
 
-    .. code-block:: yaml
+.. code-block:: yaml
 
-        name: SR Linux Examples
-        description: Provides examples for the SR Linux module
-        author: Inmanta
-        author_email: code@inmanta.com
-        license: ASL 2.0
-        copyright: 2022 Inmanta
-        modulepath: libs
-        downloadpath: libs
-        repo:
-        - type: package
-            url: https://packages.inmanta.com/public/quickstart/python/simple/
-        install_mode: release
-        requires:
+    name: SR Linux Examples
+    description: Provides examples for the SR Linux module
+    author: Inmanta
+    author_email: code@inmanta.com
+    license: ASL 2.0
+    copyright: 2022 Inmanta
+    modulepath: libs
+    downloadpath: libs
+    repo:
+    - type: package
+        url: https://packages.inmanta.com/public/quickstart/python/simple/
+    install_mode: release
+    requires:
 
 
 - The ``modulepath`` setting defines that modules will be stored in ``libs`` directory.
@@ -185,12 +185,13 @@ A project is a collection of related environments. (e.g. development, testing, p
 There are **two ways** to create a project and an environment:
 
 1. Using Inmanta CLI (**recommended**):
-    .. code-block:: sh
 
-        # Create a project called test
-        inmanta-cli --host 172.30.0.3 project create -n test
-        # Create an environment called SR_Linux
-        inmanta-cli --host 172.30.0.3 environment create -p test -n SR_Linux --save
+.. code-block:: sh
+
+    # Create a project called test
+    inmanta-cli --host 172.30.0.3 project create -n test
+    # Create an environment called SR_Linux
+    inmanta-cli --host 172.30.0.3 environment create -p test -n SR_Linux --save
 
 
 The first option, ``inmanta-cli``, will automatically create a ``.inmanta`` file that contains the required information about the server and environment ID. The compiler uses this file to find the server and to export to the right environment.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,5 +1,3 @@
-    .. vim: spell
-
 Quickstart
 ***************
 
@@ -17,7 +15,7 @@ In this guide we start simple and manage a 3-node CLOS network with a spine and 
 
 
 Prerequisites
-----------------------------
+_________________________
 
 **Python version 3.9**, ``Docker``, ``Containerlab`` and ``Inmanta`` need to be installed on your machine and our ``SR Linux`` repository has to be cloned in order to proceed. Please make sure to follow the links below to that end.
 
@@ -472,7 +470,7 @@ Pick all or any of the devices you like, connect to them as discussed in `Connec
 
 
 Resetting the LAB environment
-_______________________________________________
+______________________________
 
 To fully clean up or reset the LAB, go to the **containerlab** folder and run the following commands:
 
@@ -491,7 +489,7 @@ This will give you a clean LAB the next time you run:
 
 
 Reusing existing modules
-------------------------------
+______________________________
 
 We host modules to set up and manage many systems on our Github. These are available under https://github.com/inmanta/.
 
@@ -502,7 +500,7 @@ to using them in an import statement. Some of our public modules are hosted in t
 
 
 Update the configuration model
-------------------------------
+_______________________________
 
 The provided configuration models can be easily modified to reflect your desired configuration. Be it a change in IP addresses or adding new devices to the model. All you need to do is to create a new or modify the existing configuration model, say ``interfaces.cf`` to introduce your desired changes.
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -196,7 +196,8 @@ Python Environment
     :undoc-members:
 
 Variables
-------
+----------
+
 .. autoclass:: inmanta.ast.variables.Reference
     :members: name
     :undoc-members:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==2.50.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==2.51.0
 bumpversion==0.6.0
 openapi_spec_validator==0.5.1
 pip2pi==0.8.2
@@ -11,4 +11,4 @@ flake8-junit-report==2.1.0
 
 # documentation theme
 furo==2022.12.7
-sphinx-design
+sphinx-design==0.3.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==2.48.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==2.50.0
 bumpversion==0.6.0
 openapi_spec_validator==0.5.1
 pip2pi==0.8.2

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,3 +11,4 @@ flake8-junit-report==2.1.0
 
 # documentation theme
 furo==2022.12.7
+sphinx-design

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,3 +8,6 @@ types-python-dateutil==2.8.19.4
 types-setuptools==65.6.0.2
 types-toml==0.10.8.1
 flake8-junit-report==2.1.0
+
+# documentation theme
+furo==2022.12.7


### PR DESCRIPTION
# Description

  - A new theme that is a bit lighter and provides better support for markdown. It also show a table toc on the right
  - Cleanup some warnings and bad rendering of RST
  - Switch to myst_parser instead of recommonmark
  - Add a target to the makefile to only build html to speedup dev cycle
  - Use a better and more flexible tabs library

Note: This one is broken until dev-deps are updated

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Changelog entry