### PR TITLE
add handling of empty lists

### DIFF
--- a/changelogs/unreleased/4743-database-update-empty-list-handling.yml
+++ b/changelogs/unreleased/4743-database-update-empty-list-handling.yml
@@ -1,0 +1,3 @@
+description: Fix handling of empty resource.provides
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/db/versions/v202211230.py
+++ b/src/inmanta/db/versions/v202211230.py
@@ -89,10 +89,14 @@ def query_part_convert_provides(from_value: str) -> str:
 
     # loop over the array and convert
     collect = f"""
-        (select
-             array_agg(
-               {convert}
-            )
-        from unnest({from_value}) element)"""
+        coalesce(
+            (select
+                 array_agg(
+                   {convert}
+                )
+            from unnest({from_value}) element),
+            ARRAY[]::character varying[]
+        )
+        """
 
     return collect

--- a/tests/db/migration_tests/test_v202209160_to_v202211230.py
+++ b/tests/db/migration_tests/test_v202209160_to_v202211230.py
@@ -82,7 +82,17 @@ async def test_query_parts(postgresql_client):
     out_decoded = json.loads(out)
     assert out_decoded == test_data_2
 
+    test_data_2["requires"] = []
+    out = await postgresql_client.fetchval(f"select {query_part_convert_requires('$1::jsonb')}", json.dumps(test_data_2))
+    out_decoded = json.loads(out)
+    assert out_decoded == test_data_2
+
     # provides
     test_in_data_3 = (["std::AgentConfig[internal,agentname=localhost],v=1", "std::xconf[internal,agentname=localhost],v=1"],)
     out = await postgresql_client.fetchval(f"select {query_part_convert_provides('$1::character varying[]')}", test_in_data_3)
     assert out == ["std::AgentConfig[internal,agentname=localhost]", "std::xconf[internal,agentname=localhost]"]
+
+    # provides
+    test_in_data_3 = ([],)
+    out = await postgresql_client.fetchval(f"select {query_part_convert_provides('$1::character varying[]')}", test_in_data_3)
+    assert out == []


### PR DESCRIPTION
# Description

Fix bug that causes

```
58538 2022-12-14 14:23:56,250 ERROR    inmanta.protocol.rest An exception occured during the request.
58539 Traceback (most recent call last):
58540   File "/opt/inmanta/lib64/python3.9/site-packages/inmanta/protocol/rest/__init__.py", line 495, in _execute_call
58541     result = await config.handler(**arguments.call_args)
58542   File "/opt/inmanta/lib64/python3.9/site-packages/inmanta/server/services/resourceservice.py", line 494, in resource_deploy_done
58543     waiting_agents = set([(Id.parse_id(prov).get_agent_name(), resource.resource_version_id) for prov in resource.provides])
58544 TypeError: 'NoneType' object is not iterable
``` 


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
