### PR TITLE
agent inter module dependencies mark 1

### DIFF
--- a/changelogs/unreleased/5251-agent-inter-module-dependencies-mark-1.yml
+++ b/changelogs/unreleased/5251-agent-inter-module-dependencies-mark-1.yml
@@ -1,0 +1,7 @@
+description: Added a project option to install dependencies on other modules when loading code on the agent
+sections:
+  feature: "experimental: {{description}"
+change-type: minor
+destination-branches:
+  - iso6
+  - master

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -103,7 +103,7 @@ class SourceInfo(object):
         """List of python requirements associated with this source file"""
         if self._requires is None:
             # TODO: make this configurable
-            #self._requires = module.roject.get().modules[self._get_module_name()].get_strict_python_requirements_as_list()
+            # self._requires = module.roject.get().modules[self._get_module_name()].get_strict_python_requirements_as_list()
             self._requires = module.Project.get().modules[self._get_module_name()].get_all_python_requirements_as_list()
         return self._requires
 

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -31,7 +31,7 @@ from importlib.machinery import SourcelessFileLoader
 from itertools import chain, starmap
 from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
 
-from inmanta import const
+from inmanta import const, module
 from inmanta.stable_api import stable_api
 from inmanta.util import hash_file_streaming
 
@@ -96,17 +96,15 @@ class SourceInfo(object):
         """
         Returns an iterator over SourceInfo objects for all plugin source files in this Inmanta module (including this one).
         """
-        from inmanta.module import Project
-
-        return starmap(SourceInfo, Project.get().modules[self._get_module_name()].get_plugin_files())
+        return starmap(SourceInfo, module.Project.get().modules[self._get_module_name()].get_plugin_files())
 
     @property
     def requires(self) -> List[str]:
         """List of python requirements associated with this source file"""
-        from inmanta.module import Project
-
         if self._requires is None:
-            self._requires = Project.get().modules[self._get_module_name()].get_strict_python_requirements_as_list()
+            # TODO: make this configurable
+            #self._requires = module.roject.get().modules[self._get_module_name()].get_strict_python_requirements_as_list()
+            self._requires = module.Project.get().modules[self._get_module_name()].get_all_python_requirements_as_list()
         return self._requires
 
 
@@ -215,7 +213,7 @@ class CodeLoader(object):
         self.__check_dir()
 
         mod_dir = os.path.join(self.__code_dir, MODULE_DIR)
-        PluginModuleFinder.configure_module_finder(modulepaths=[mod_dir])
+        PluginModuleFinder.configure_module_finder(modulepaths=[mod_dir], prefer=True)
 
     def __check_dir(self) -> None:
         """
@@ -483,12 +481,14 @@ class PluginModuleFinder(Finder):
         cls.MODULE_FINDER = None
 
     @classmethod
-    def configure_module_finder(cls, modulepaths: List[str]) -> None:
+    def configure_module_finder(cls, modulepaths: List[str], *, prefer: bool = False) -> None:
         """
         Setup a custom module loader to handle imports in .py files of the modules. This finder will be stored
-        as the last finder in sys.meta_path.
+        as the last finder in sys.meta_path, unless prefer is True. If the custom module loader has already been
+        set up, does nothing (i.e. it is not moved to the front or the back of sys.meta_path).
 
         :param modulepaths: The directories where the module finder should look for modules.
+        :param prefer: Prefer this module finder over others, putting it first in sys.meta_path.
         """
         if cls.MODULE_FINDER is not None:
             # PluginModuleFinder already present in sys.meta_path
@@ -497,7 +497,10 @@ class PluginModuleFinder(Finder):
 
         # PluginModuleFinder not yet present in sys.meta_path.
         module_finder = PluginModuleFinder(modulepaths)
-        sys.meta_path.append(module_finder)
+        if prefer:
+            sys.meta_path.insert(0, module_finder)
+        else:
+            sys.meta_path.append(module_finder)
         cls.MODULE_FINDER = module_finder
 
     def find_module(self, fullname: str, path: Optional[str] = None) -> Optional[FileLoader]:

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -102,9 +102,12 @@ class SourceInfo(object):
     def requires(self) -> List[str]:
         """List of python requirements associated with this source file"""
         if self._requires is None:
-            # TODO: make this configurable
-            # self._requires = module.roject.get().modules[self._get_module_name()].get_strict_python_requirements_as_list()
-            self._requires = module.Project.get().modules[self._get_module_name()].get_all_python_requirements_as_list()
+            project: module.Project = module.Project.get()
+            mod: module.Module = project.modules[self._get_module_name()]
+            if project.metadata.agent_install_dependency_modules:
+                self._requires = mod.get_all_python_requirements_as_list()
+            else:
+                self._requires = mod.get_strict_python_requirements_as_list()
         return self._requires
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1552,6 +1552,23 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
                                   and that any violation will result in an error
                                 * When a non-strict check is done, only version conflicts in a direct dependency will result
                                   in an error. All other violations will only result in a warning message.
+    :param agent_install_dependency_modules: [EXPERIMENTAL FEATURE] If true, when a module declares Python dependencies on
+        other (v2) modules, the agent will install these dependency modules with pip. This option should only be enabled
+        if the agent is configured with the appropriate pip related environment variables. The option allows to an extent
+        for inter-module dependencies within handler code, even if the dependency module doesn't have any handlers that
+        would otherwise be considered relevant for this agent.
+
+        Care should still be taken when you use inter-module imports. The current code loading mechanism does not explicitly
+        order reloads. A general guideline is to use qualified imports where you can (import the module rather than objects
+        from the module). When this is not feasible, you should be aware of
+        `Python's reload semantics <https://docs.python.org/3/library/importlib.html#importlib.reload>`_ and take this into
+        account when making changes to handler code.
+
+        Another caveat is that if the dependency module does contain code that is relevant for the agent, it will be loaded
+        like any other handler code and it will be this code that is imported by any dependent modules (though depending on
+        the load order the very first import may use the version installed by pip). If at some point this dependency module's
+        handlers cease to be relevant for this agent, its code will remain stale. Therefore this feature should not be depended
+        on in transient scenarios like this.
     """
 
     _raw_parser: Type[YamlParser] = YamlParser
@@ -1569,6 +1586,7 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
     requires: List[str] = []
     relation_precedence_policy: List[constr(strip_whitespace=True, regex=_re_relation_precedence_rule, min_length=1)] = []
     strict_deps_check: bool = True
+    agent_install_dependency_modules: bool = False
 
     @validator("modulepath", pre=True)
     @classmethod

--- a/tests/data/plugins_project/libs/single_plugin_file/requirements.txt
+++ b/tests/data/plugins_project/libs/single_plugin_file/requirements.txt
@@ -1,0 +1,2 @@
+inmanta-module-std
+lorem

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -25,7 +25,7 @@ import shutil
 import sys
 from collections import abc
 from logging import INFO
-from typing import List, Set
+from typing import List, Optional, Set
 
 import py
 import pytest

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -321,7 +321,7 @@ def test_code_loader_prefer_finder(tmpdir: py.path.local) -> None:
     """
     assert not isinstance(sys.meta_path[0], loader.PluginModuleFinder)
     loader.CodeLoader(code_dir=str(tmpdir))
-    # it suffices to verify that the module finder is firs in the meta path:
+    # it suffices to verify that the module finder is first in the meta path:
     # `test_plugin_module_finder` verifies the actual loader behavior
     assert isinstance(sys.meta_path[0], loader.PluginModuleFinder)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -23,8 +23,8 @@ import inspect
 import os
 import shutil
 import sys
-from collections import abc
 from logging import INFO
+from types import ModuleType
 from typing import List, Optional, Set
 
 import py
@@ -233,42 +233,76 @@ def module_path(tmpdir):
 
 @pytest.mark.slowtest
 @pytest.mark.parametrize(
-    "prefer_finder",
-    [True, False],
+    "prefer_finder, reload",
+    [(True, False), (False, False), (True, True)],
 )
 def test_plugin_module_finder(
     tmpdir: py.path.local,
     tmpvenv_active_inherit: env.VirtualEnv,
     modules_dir: str,
     prefer_finder: bool,
-) -> abc.Iterator[None]:
+    reload: bool,
+) -> None:
     """
     Verify correct behavior of the PluginModuleFinder class, especially with respect to preference when a module is present
     both in the normal venv and in the finder's module path.
     The different scenarios are tested via parametrization rather than in a single test case to force proper cleanup in
     between.
+
+    :param prefer_finder: Configure the custom module finder to be preferred over the default finders.
+    :param reload: Instead of only importing the module at the end, already import it before setting up the finder and reload
+        it after, checking that the change of source works as expected.
     """
     module: str = "mymodule"
     python_module: str = f"{const.PLUGINS_PACKAGE}.{module}"
+
+    # set up libs dir for the custom module finder
     libs_dir: py.path.local = tmpdir.mkdir("libs")
     module_dir: py.path.local = libs_dir.join(module)
     utils.v1_module_from_template(
         os.path.join(modules_dir, "minimalv1module"),
         str(module_dir),
         new_name=module,
-        new_content_init_py="",
+        new_content_init_py="where = 'libs'",
     )
-    moduletool.ModuleTool().install(path=str(module_dir))
+
+    # install module in venv
+    venv_module_dir: py.path.local = tmpdir.join("mymodule_for_venv")
+    utils.v1_module_from_template(
+        str(module_dir),
+        str(venv_module_dir),
+        new_content_init_py="where = 'venv'",
+    )
+    moduletool.ModuleTool().install(path=str(venv_module_dir))
+
+    module_to_reload: Optional[ModuleType] = None
+    if reload:
+        # load it once before setting up the finder
+        module_to_reload = importlib.import_module(python_module)
+
+    # set up module finder
     assert not any(isinstance(finder, loader.PluginModuleFinder) for finder in sys.meta_path)
     loader.PluginModuleFinder.configure_module_finder(modulepaths=[str(libs_dir)], prefer=prefer_finder)
-    # verify that the correct module will be loaded
+
+    # verify that the correct module will be loaded: either the one from the venv or the one in libs, depending on parameters
     assert isinstance(sys.meta_path[0 if prefer_finder else -1], loader.PluginModuleFinder)
+    # reload now to refresh ModuleSpec and associated loader
+    if reload:
+        assert module_to_reload is not None
+        importlib.reload(module_to_reload)
     spec: Optional[importlib.machinery.ModuleSpec] = importlib.util.find_spec(python_module)
     assert spec is not None
     assert spec.loader is not None
     assert isinstance(spec.loader, loader.PluginModuleLoader) == prefer_finder
-    # verify that import works
-    importlib.import_module(python_module)
+
+    # verify that import works and imports the correct module
+    mod: ModuleType
+    if reload:
+        assert module_to_reload is not None
+        mod = module_to_reload
+    else:
+        mod = importlib.import_module(python_module)
+    assert mod.where == "libs" if prefer_finder else "venv"
 
 
 def test_code_loader_prefer_finder(tmpdir: py.path.local) -> None:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -102,6 +102,16 @@ def test_code_manager(tmpdir: py.path.local):
     with pytest.raises(loader.SourceNotFoundException):
         mgr.register_code("test2", str)
 
+    # verify requirements behavior
+    source_info: SourceInfo = single_type_list[0]
+    # by default only install non-module dependencies
+    assert source_info.requires == ["lorem"]
+    project._metadata.agent_install_dependency_modules = True
+    # reset cache
+    source_info._requires = None
+    # when enabled, also install dependencies on other modules
+    assert source_info.requires == ["inmanta-module-std", "lorem"]
+
 
 def test_code_loader(tmp_path, caplog):
     """Test loading a new module"""


### PR DESCRIPTION
# Description

Adds a project option to install dependencies on other modules when loading code on the agent. Makes sure code loaded by the agent gets precedence on the code installed by pip.

closes #5251

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] Add second reviewer
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
