### PR TITLE
Make test_real_time_logging test case more robust

### DIFF
--- a/changelogs/unreleased/fix-real-time-logging-test-case.yml
+++ b/changelogs/unreleased/fix-real-time-logging-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: Make the `test_real_time_logging` test case more robust.
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -1132,7 +1132,9 @@ def test_real_time_logging(caplog):
 
     # "two" should be logged at least one second after "one"
     delta: float = (last_log_line_time - first_log_line_time).total_seconds()
-    assert delta >= 1
+    expected_delta = 1
+    fault_tolerance = 0.01
+    assert abs(delta - expected_delta) <= fault_tolerance
 
 
 @pytest.mark.slowtest


### PR DESCRIPTION
# Description

The `test_real_time_logging` test case was failing with the following exception:

```
=================================== FAILURES ===================================
____________________________ test_real_time_logging ____________________________

caplog = <_pytest.logging.LogCaptureFixture object at 0x7fae1ff1ac70>

    @pytest.mark.slowtest
    def test_real_time_logging(caplog):
        """
        Make sure the logging in run_command_and_stream_output happens in real time
        """
        caplog.set_level(logging.DEBUG)
    
        cmd: List[str] = ["sh -c 'echo one && sleep 1 && echo two'"]
        return_code: int
        output: List[str]
        return_code, output = CommandRunner(LOGGER).run_command_and_stream_output(cmd, shell=True)
        assert return_code == 0
    
        assert "one" in caplog.records[0].message
        assert "one" in output[0]
        first_log_line_time: datetime = datetime.fromtimestamp(caplog.records[0].created)
    
        assert "two" in caplog.records[-1].message
        assert "two" in output[-1]
        last_log_line_time: datetime = datetime.fromtimestamp(caplog.records[-1].created)
    
        # "two" should be logged at least one second after "one"
        delta: float = (last_log_line_time - first_log_line_time).total_seconds()
>       assert delta >= 1
E       assert 0.999601 >= 1
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~