### PR TITLE
[poc] Unmanaged resource

### DIFF
--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -822,6 +822,22 @@ class ResourceHandler(object):
         except Exception:
             raise Exception("Unable to upload file to the server.")
 
+    def execute_discover_resource(self, ctx: HandlerContext, resource: resources.Resource):
+        ctx.info("execute_discover_resource")
+        self.pre(ctx, resource)
+        result = self.discover_resource(ctx)
+        if result:
+
+            def call():
+                client = protocol.Client("agent")
+                return client.discovered_resources_create(
+                    env=self._agent.environment, discovered_resource_name=result[0], value=result[1]
+                )
+
+            self.run_sync(call)
+
+        self.post(ctx, resource)
+
 
 @stable_api
 class CRUDHandler(ResourceHandler):
@@ -829,6 +845,13 @@ class CRUDHandler(ResourceHandler):
     This handler base class requires CRUD methods to be implemented: create, read, update and delete. Such a handler
     only works on purgeable resources.
     """
+
+    def discover_resource(self, ctx: HandlerContext) -> None:
+        """
+        :param context: Context can be used to get values discovered in the read method. For example, the id used in API
+                calls. This context should also be used to let the handler know what changes were made to the
+                resource.
+        """
 
     def read_resource(self, ctx: HandlerContext, resource: resources.PurgeableResource) -> None:
         """

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -158,6 +158,7 @@ class ResourceAction(str, Enum):
     dryrun = "dryrun"
     getfact = "getfact"
     other = "other"
+    discovery = "discovery"
 
 
 STATE_UPDATE = [ResourceAction.deploy]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5442,6 +5442,22 @@ class EnvironmentMetricsTimer(BaseDocument):
     __primary_key__ = ("environment", "metric_name", "timestamp")
 
 
+class DiscoveredResources(BaseDocument):
+    """
+    discovered resources
+
+    :param environment: the environment of those resources
+    :param discovered_resource_name: The name of the resources
+    :param values: The values
+    """
+
+    environment: uuid.UUID
+    discovered_resource_name: str
+    values: list[object]
+
+    __primary_key__ = ("environment", "discovered_resource_name", "values")
+
+
 _classes = [
     Project,
     Environment,
@@ -5460,6 +5476,7 @@ _classes = [
     Notification,
     EnvironmentMetricsGauge,
     EnvironmentMetricsTimer,
+    DiscoveredResources,
 ]
 
 

--- a/src/inmanta/db/versions/v202212015.py
+++ b/src/inmanta/db/versions/v202212015.py
@@ -1,0 +1,32 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from asyncpg import Connection
+
+
+async def update(connection: Connection) -> None:
+    schema = """
+CREATE TABLE IF NOT EXISTS public.discoveredresources (
+    environment uuid NOT NULL REFERENCES environment(id) ON DELETE CASCADE,
+    discovered_resource_name VARCHAR NOT NULL,
+    values jsonb[] NOT NULL,
+    PRIMARY KEY (environment, discovered_resource_name)
+);
+    """
+
+    await connection.execute(schema)

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -20,7 +20,7 @@
 
 import datetime
 import uuid
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from inmanta import const, data, resources
 from inmanta.data import model
@@ -480,6 +480,41 @@ def resource_action_update(
 # Manage configuration model versions
 
 
+@typedmethod(
+    path="/discovered_resources",
+    validate_sid=False,
+    operation="POST",
+    agent_server=True,
+    arg_options=ENV_OPTS,
+    client_types=[const.ClientType.agent],
+)
+def discovered_resources_create(env: uuid.UUID, discovered_resource_name: str, value: List[Dict[str, str]]) -> None:
+    """
+    Send discovered resource to the server
+
+    :param env: The id of the environment this resource belongs to
+    :param discovered_resource_name: The resource with the given resource_version_id id from the agent
+    """
+
+
+@typedmethod(
+    path="/discovered_resources",
+    validate_sid=False,
+    operation="GET",
+    agent_server=True,
+    arg_options=ENV_OPTS,
+    client_types=[const.ClientType.agent],
+)
+def get_discovered_resources(
+    env: uuid.UUID,
+) -> list[str]:
+    """
+    get the discovered resources to the server
+
+    :param tid: The id of the environment this resource belongs to
+    """
+
+
 @method(path="/version", operation="GET", arg_options=ENV_OPTS, client_types=[const.ClientType.api])
 def list_versions(tid: uuid.UUID, start: int = None, limit: int = None):
     """
@@ -781,9 +816,32 @@ def set_parameters(tid: uuid.UUID, parameters: list):
     """
 
 
+@method(path="/discover_facts", operation="GET", arg_options=ENV_OPTS, client_types=[const.ClientType.api])
+def discover_facts(tid: uuid.UUID):
+    """
+    discover all resources for an environment
+
+    :param tid: The environment
+    """
+
+
+@method(
+    path="/discover_resources_client",
+    operation="POST",
+    arg_options=AGENT_ENV_OPTS,
+    server_agent=True,
+    client_types=[const.ClientType.agent],
+)
+def discover_resources_client(tid: uuid.UUID, agent_name: str, version: int):
+    """
+    discover all resources for an environment and a client
+
+    :param tid: The environment
+    :agent_name: the name of an agent
+    """
+
+
 # Get parameters from the agent
-
-
 @method(path="/agent_parameter", operation="POST", server_agent=True, timeout=5, arg_options=AGENT_ENV_OPTS, client_types=[])
 def get_parameter(tid: uuid.UUID, agent: str, resource: dict):
     """

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -499,11 +499,9 @@ def discovered_resources_create(env: uuid.UUID, discovered_resource_name: str, v
 
 @typedmethod(
     path="/discovered_resources",
-    validate_sid=False,
     operation="GET",
-    agent_server=True,
     arg_options=ENV_OPTS,
-    client_types=[const.ClientType.agent],
+    client_types=[const.ClientType.api],
 )
 def get_discovered_resources(
     env: uuid.UUID,

--- a/tests/agent_server/conftest.py
+++ b/tests/agent_server/conftest.py
@@ -30,7 +30,7 @@ from inmanta.agent.agent import Agent
 from inmanta.agent.handler import CRUDHandler, HandlerContext, ResourceHandler, ResourcePurged, SkipResource, provider
 from inmanta.data.model import ResourceIdStr
 from inmanta.resources import IgnoreResourceException, PurgeableResource, Resource, resource
-from inmanta.server import SLICE_AGENT_MANAGER
+from inmanta.server import SLICE_AGENT_MANAGER, protocol
 from inmanta.util import get_compiler_version
 from utils import retry_limited
 
@@ -203,6 +203,45 @@ def resource_container():
         """
 
         fields = ("key", "value", "set_state_to_deployed", "purged")
+
+    @resource("test::Discover1", agent="agent", id_attribute="key")
+    class Discover1(PurgeableResource):
+        """
+        calls the Discover endpoint to discover resources.
+        """
+
+        fields = ("key", "value")
+
+    @provider("test::Discover1", name="test_discover1")
+    class Discover1(CRUDHandler):
+        def discover_resource(self, ctx: HandlerContext):
+            return "test1", [{"key1": "value1", "key2": "value2"}, {"key3": "value3", "key4": "value4"}]
+
+    @resource("test::Discover2", agent="agent", id_attribute="key")
+    class Discover2(PurgeableResource):
+        """
+        calls the Discover endpoint to discover resources.
+        """
+
+        fields = ("key", "value")
+
+    @provider("test::Discover2", name="test_discover2")
+    class Discover2(CRUDHandler):
+        def discover_resource(self, ctx: HandlerContext):
+            return "test2", [{"key5": "value5", "key6": "value6", "key7": "value7"}]
+
+    @resource("test::Discover3", agent="agent", id_attribute="key")
+    class Discover3(PurgeableResource):
+        """
+        calls the Discover endpoint to discover resources.
+        """
+
+        fields = ("key", "value")
+
+    @provider("test::Discover3", name="test_discover2")
+    class Discover3(CRUDHandler):
+        def discover_resource(self, ctx: HandlerContext):
+            return "test3", [{"key8": "value8"}]
 
     @provider("test::Resource", name="test_resource")
     class Provider(ResourceHandler):

--- a/tests/db/migration_tests/test_v202212010_to_v202212015.py
+++ b/tests/db/migration_tests/test_v202212010_to_v202212015.py
@@ -1,0 +1,63 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import os
+from typing import AsyncIterator, Awaitable, Callable, List
+
+import pytest
+from asyncpg import Connection
+
+from db.common import PGRestore
+from inmanta.server.bootloader import InmantaBootloader
+
+
+@pytest.fixture
+async def migrate_v202212010_to_v202212015(
+    hard_clean_db, hard_clean_db_post, postgresql_client: Connection, server_config
+) -> AsyncIterator[Callable[[], Awaitable[None]]]:
+    """
+    Returns a callable that performs a v202211230 database restore and migrates to v202212010.
+    """
+    # Get old tables
+    with open(os.path.join(os.path.dirname(__file__), "dumps/v202212010.sql"), "r") as fh:
+        await PGRestore(fh.readlines(), postgresql_client).run()
+
+    ibl = InmantaBootloader()
+
+    # When the bootloader is started, it also executes the migration to v202212010
+    yield ibl.start
+    await ibl.stop(timeout=15)
+
+
+async def test_added_discoveredresources_tables(
+    migrate_v202212010_to_v202212015: Callable[[], Awaitable[None]],
+    get_tables_in_db: Callable[[], Awaitable[List[str]]],
+) -> None:
+    """
+    Test whether the environment_metrics_counter table was added
+    """
+
+    # The table is not present before the migration
+    tables = await get_tables_in_db()
+    assert "discoveredresources" not in tables
+
+    # Migrate DB schema
+    await migrate_v202212010_to_v202212015()
+
+    # The table is added to the database
+    tables = await get_tables_in_db()
+    assert "discoveredresources" in tables


### PR DESCRIPTION
# Description

this is a Poc for https://app.zenhub.com/workspaces/core-5a7c152b04a1652024289b7b/issues/gh/inmanta/inmanta-core/5140

The  endpoint to trigger discovery of resources in called `discover_facts`. 
`discover_facts` will go over all agents in the environment and get the client for each agent.
for each client it will call `discover_resources_client` which will in turn call `discover_resources_instance`
`discover_resources_instance` will go over all the resources of an agent instance and call the `resource_handler.execute_discover_resource ` for each resource. 

the `execute_discover_resource` will call the `pre` function, followed by the `discover_resource` function, followed by the `post` function. If some resources are discovered by `discover_resource`, they are added to the DB using `discovered_resources_create`


Here is an example handler that works with this code:

```
@provider("aws::Subnets", name="ec2")
class SubnetsHandler(AWSHandler):
    def _get_subnets(self):
        return list(
            self._ec2.subnets.all()
        )

    def discover_resource(self, ctx: HandlerContext):
        sns = self._get_subnets()
        result = []
        for sn in sns:
            result.append({
                "vpc_id":str(sn.vpc_id),
                "availability_zone":str(sn.availability_zone),
                "availability_zone_id":str(sn.availability_zone_id),
                "available_ip_address_count":str(sn.available_ip_address_count),
                "cidr_block":str(sn.cidr_block),
                "owner_id":str(sn.owner_id),
                "state":str(sn.state),
                "subnet_arn":str(sn.subnet_arn),
                "subnet_id":str(sn.subnet_id),
                "tags":str(sn.tags),
            })
        return "subnets",result

```

