### PR TITLE
Fix real_time_logging test case

### DIFF
--- a/changelogs/unreleased/fix-real-time-logging-test-case-part2.yml
+++ b/changelogs/unreleased/fix-real-time-logging-test-case-part2.yml
@@ -1,0 +1,4 @@
+---
+description: Make the test case test_real_time_logging more robust
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -1133,7 +1133,7 @@ def test_real_time_logging(caplog):
     # "two" should be logged at least one second after "one"
     delta: float = (last_log_line_time - first_log_line_time).total_seconds()
     expected_delta = 1
-    fault_tolerance = 0.01
+    fault_tolerance = 0.1
     assert abs(delta - expected_delta) <= fault_tolerance
 
 


### PR DESCRIPTION
# Description

This test case failed with the following exception:

```
04:58:32     @pytest.mark.slowtest
04:58:32     def test_real_time_logging(caplog):
04:58:32         """
04:58:32         Make sure the logging in run_command_and_stream_output happens in real time
04:58:32         """
04:58:32         caplog.set_level(logging.DEBUG)
04:58:32     
04:58:32         cmd: List[str] = ["sh -c 'echo one && sleep 1 && echo two'"]
04:58:32         return_code: int
04:58:32         output: List[str]
04:58:32         return_code, output = CommandRunner(LOGGER).run_command_and_stream_output(cmd, shell=True)
04:58:32         assert return_code == 0
04:58:32     
04:58:32         assert "one" in caplog.records[0].message
04:58:32         assert "one" in output[0]
04:58:32         first_log_line_time: datetime = datetime.fromtimestamp(caplog.records[0].created)
04:58:32     
04:58:32         assert "two" in caplog.records[-1].message
04:58:32         assert "two" in output[-1]
04:58:32         last_log_line_time: datetime = datetime.fromtimestamp(caplog.records[-1].created)
04:58:32     
04:58:32         # "two" should be logged at least one second after "one"
04:58:32         delta: float = (last_log_line_time - first_log_line_time).total_seconds()
04:58:32         expected_delta = 1
04:58:32         fault_tolerance = 0.01
04:58:32 >       assert abs(delta - expected_delta) <= fault_tolerance
04:58:32 E       assert 0.011795 <= 0.01
04:58:32 E        +  where 0.011795 = abs((1.011795 - 1))
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~