### PR TITLE
added fix for attribute hash stability

### DIFF
--- a/changelogs/unreleased/5306-improved-attribute-hash.yml
+++ b/changelogs/unreleased/5306-improved-attribute-hash.yml
@@ -1,0 +1,9 @@
+description: Improve stability of incremental deploy for resources containing dicts
+issue-nr: 5306
+sections:
+  feature: "{{description}"
+  upgrade-note: "The first recompile after this upgrade will always perform a full deploy"
+change-type: minor
+destination-branches:
+  - iso6
+  - master

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -69,6 +69,7 @@ from inmanta.const import DONE_STATES, UNDEPLOYABLE_NAMES, AgentStatus, LogLevel
 from inmanta.data import model as m
 from inmanta.data import schema
 from inmanta.data.model import PagingBoundaries, ResourceIdStr, api_boundary_datetime_normalizer
+from inmanta.protocol.common import custom_json_encoder
 from inmanta.protocol.exceptions import BadRequest, NotFound
 from inmanta.server import config
 from inmanta.stable_api import stable_api
@@ -4222,12 +4223,14 @@ class Resource(BaseDocument):
         return {r["resource_id"] + ",v=" + str(r["model"]): const.ResourceState(r["last_non_deploying_status"]) for r in result}
 
     def make_hash(self) -> None:
-        character = "|".join(
-            sorted([str(k) + "||" + str(v) for k, v in self.attributes.items() if k not in ["requires", "provides", "version"]])
+        character = json.dumps(
+            {k: v for k, v in self.attributes.items() if k not in ["requires", "provides", "version"]},
+            default=custom_json_encoder,
+            sort_keys=True,
         )
         m = hashlib.md5()
-        m.update(self.resource_id.encode())
-        m.update(character.encode())
+        m.update(self.resource_id.encode("utf-8"))
+        m.update(character.encode("utf-8"))
         self.attribute_hash = m.hexdigest()
 
     @classmethod

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4226,7 +4226,7 @@ class Resource(BaseDocument):
         character = json.dumps(
             {k: v for k, v in self.attributes.items() if k not in ["requires", "provides", "version"]},
             default=custom_json_encoder,
-            sort_keys=True,
+            sort_keys=True,  # sort the keys for stable hashes when using dicts, see #5306
         )
         m = hashlib.md5()
         m.update(self.resource_id.encode("utf-8"))

--- a/tests/server/test_attribute_hash.py
+++ b/tests/server/test_attribute_hash.py
@@ -1,0 +1,58 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import uuid
+
+from inmanta.data import Resource
+
+
+def test_attribute_hash():
+    """
+    Increment calculation requires an attribute hash.
+
+    This testcase verifies the basic correctness of this hash
+
+    see issue 5306
+    """
+    base_resource = {
+        "a": [1, 2, 3],
+        "b": {"a": "b", "c": "d"},
+        "X": "z",
+    }
+
+    reordered_same = {
+        "X": "z",
+        "b": {"c": "d", "a": "b"},
+        "a": [1, 2, 3],
+    }
+
+    other = {
+        "X": "z",
+        "b": {"c": "d", "a": []},
+        "a": [1, 2, 3],
+    }
+
+    env = uuid.uuid4()
+
+    def get_hash(attributes) -> str:
+        r = Resource.new(environment=env, resource_version_id="test::Test[a,b=c],v=3", attributes=attributes)
+        r.make_hash()
+        return r.attribute_hash
+
+    assert get_hash(base_resource) == get_hash(reordered_same)
+
+    assert get_hash(base_resource) != get_hash(other)


### PR DESCRIPTION
# Description

Fixes an unstability in the increment calculation when resources contain dicts. 

closes #5306 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
