### PR TITLE
Force srlinux image to latest version in quickstart

### DIFF
--- a/changelogs/unreleased/force-update-srlinux-image.yml
+++ b/changelogs/unreleased/force-update-srlinux-image.yml
@@ -1,0 +1,4 @@
+---
+description: Add step to the quickstart documentation that forces the srlinux image to the latest version.
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -95,6 +95,7 @@ Go to the `SR Linux` folder and then `containerlab` to spin-up the containers:
 .. code-block:: sh
 
     cd examples/Networking/SR\ Linux/containerlab
+    sudo docker pull ghcr.io/nokia/srlinux:latest
     sudo clab deploy -t topology.yml
 
 `Containerlab` will spin-up:


### PR DESCRIPTION
# Description

Add step to the quickstart documentation that forces the srlinux image to the latest version.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation