### PR TITLE
Bump inmanta-dev-dependencies[async,core,pytest,sphinx] from 2.54.0 to 2.55.0 (#5323)

### DIFF
--- a/changelogs/unreleased/5323-dependabot.yml
+++ b/changelogs/unreleased/5323-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: Bump inmanta-dev-dependencies[async,core,pytest,sphinx] from 2.54.0 to
+    2.55.0
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==2.54.0
+inmanta-dev-dependencies[pytest,async,core,sphinx]==2.55.0
 bumpversion==0.6.0
 openapi_spec_validator==0.5.1
 pip2pi==0.8.2


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5323