### PR TITLE
added ADR about timezone semantics

### DIFF
--- a/changelogs/unreleased/adr-timezones.yml
+++ b/changelogs/unreleased/adr-timezones.yml
@@ -1,0 +1,5 @@
+description: Added ADR about timezone semantics
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/docs/adr/0001-timezones.md
+++ b/docs/adr/0001-timezones.md
@@ -1,8 +1,8 @@
 # timezones
 
-* Status: proposed
+* Status: accepted
 * Deciders: [Sander, Wouter, Arnaud, Bart]
-* Date: 2023-01-09
+* Date: 2023-01-13
 
 Technical Story: [
     https://github.com/inmanta/inmanta-core/issues/2919,

--- a/docs/adr/XXXX-timezones.md
+++ b/docs/adr/XXXX-timezones.md
@@ -32,9 +32,12 @@ timezone information for these datetime objects?
 
 ## Decision Outcome
 
-Chosen option: option 3 with timezone-aware internal representation, because it is as explicit as we can make (decision driver
-3) it without breaking backwards compatibility. In contrast to option 4, it remains simple: a single contract that applies to
-all API endpoints.
+Chosen option: option 3 with timezone-aware internal representation. Support both timezone aware and naive timestamps as input,
+use timezone-naive timestamps in API return values. Internally, always use timezone-aware timestamps (objects are converted at
+the API boundary). Any timezone-naive timestamps represent a timestamp in UTC.
+
+Rationale: it is as explicit as we can make it (decision driver 3) without breaking backwards compatibility. In contrast to
+option 4, it remains simple: a single contract that applies to all API endpoints.
 
 Option 2 (fully timezone-aware) has a lot of merit and we may want to migrate to it at some point, though that would be a
 breaking change.

--- a/docs/adr/XXXX-timezones.md
+++ b/docs/adr/XXXX-timezones.md
@@ -16,7 +16,7 @@ How do we deal with timezones when it comes to datetime data? This data is passe
 various places in the database and manipulated throughout the code. Which invariants do we uphold with regards to explicit
 timezone information for these datetime objects?
 
-## Decision Drivers <!-- optional -->
+## Decision Drivers
 
 * Behavior should be consistent regardless of the timezone participating hosts (e.g. server, agent, web-console client) live in.
 * Timezone handling over the API is non-trivial: we need to present a clear contract to the end-user.

--- a/docs/adr/XXXX-timezones.md
+++ b/docs/adr/XXXX-timezones.md
@@ -32,9 +32,12 @@ timezone information for these datetime objects?
 
 ## Decision Outcome
 
-Chosen option: option 3 with timezone-aware internal representation. Support both timezone aware and naive timestamps as input,
-use timezone-naive timestamps in API return values. Internally, always use timezone-aware timestamps (objects are converted at
-the API boundary). Any timezone-naive timestamps represent a timestamp in UTC.
+Chosen option: option 3 with timezone-aware internal representation. 
+* Support both timezone aware and naive timestamps as API input,
+* Any timezone-naive timestamps represent a timestamp in UTC.
+* Use timezone-naive timestamps in API return values. 
+* Internally, always use timezone-aware timestamps (objects are converted at
+the API boundary). 
 
 Rationale: it is as explicit as we can make it (decision driver 3) without breaking backwards compatibility. In contrast to
 option 4, it remains simple: a single contract that applies to all API endpoints.

--- a/docs/adr/XXXX-timezones.md
+++ b/docs/adr/XXXX-timezones.md
@@ -36,7 +36,7 @@ Chosen option: option 3 with timezone-aware internal representation.
 * Support both timezone aware and naive timestamps as API input,
 * Any timezone-naive timestamps represent a timestamp in UTC.
 * Use timezone-naive timestamps in API return values. 
-* Internally, always use timezone-aware timestamps (objects are converted at
+* Internally (database + code), always use timezone-aware timestamps (objects are converted at
 the API boundary). 
 
 Rationale: it is as explicit as we can make it (decision driver 3) without breaking backwards compatibility. In contrast to

--- a/docs/adr/XXXX-timezones.md
+++ b/docs/adr/XXXX-timezones.md
@@ -12,13 +12,20 @@ Technical Story: [
 
 ## Context and Problem Statement
 
+In the past (before #2953, May 2021) we didn't really take timezones into account at all. The database, the code and the API
+would all use naive timestamps (timestamps without explicit timezone information), which were generally (not through any
+explicit convention/agreement) interpreted according to the system/library defaults (generally local time). Since local time
+is not necessarily the same for all participating hosts (e.g. server, agent, web-console client) and might even change on a
+single host (e.g. DST), this did not suffice.
+
 How do we deal with timezones when it comes to datetime data? This data is passed in both directions over the API, stored at
 various places in the database and manipulated throughout the code. Which invariants do we uphold with regards to explicit
-timezone information for these datetime objects?
+timezone information for these datetime objects? And how / to what extent do we remain compatible with older API clients, which
+will always send naive timestamps, and might not be able to interpret timezone-aware timestamps in the response?
 
 ## Decision Drivers
 
-1. Behavior should be consistent regardless of the timezone participating hosts (e.g. server, agent, web-console client) live in.
+1. Behavior should be consistent regardless of the timezone participating hosts live in.
 2. Timezone handling over the API is non-trivial: we need to present a clear contract to the end-user.
 3. In the absence of timezone information, there is no single sane interpretation: explicit timezones improve clarity.
 
@@ -32,12 +39,12 @@ timezone information for these datetime objects?
 
 ## Decision Outcome
 
-Chosen option: option 3 with timezone-aware internal representation. 
+Chosen option: option 3 with timezone-aware internal representation.
 * Support both timezone aware and naive timestamps as API input,
 * Any timezone-naive timestamps represent a timestamp in UTC.
-* Use timezone-naive timestamps in API return values. 
+* Use timezone-naive timestamps in API return values.
 * Internally (database + code), always use timezone-aware timestamps (objects are converted at
-the API boundary). 
+the API boundary).
 
 Rationale: it is as explicit as we can make it (decision driver 3) without breaking backwards compatibility. In contrast to
 option 4, it remains simple: a single contract that applies to all API endpoints.

--- a/docs/adr/XXXX-timezones.md
+++ b/docs/adr/XXXX-timezones.md
@@ -18,17 +18,17 @@ timezone information for these datetime objects?
 
 ## Decision Drivers
 
-* Behavior should be consistent regardless of the timezone participating hosts (e.g. server, agent, web-console client) live in.
-* Timezone handling over the API is non-trivial: we need to present a clear contract to the end-user.
-* In the absence of timezone information, there is no single sane interpretation: explicit timezones improve clarity.
+1. Behavior should be consistent regardless of the timezone participating hosts (e.g. server, agent, web-console client) live in.
+2. Timezone handling over the API is non-trivial: we need to present a clear contract to the end-user.
+3. In the absence of timezone information, there is no single sane interpretation: explicit timezones improve clarity.
 
 ## Considered Options
 
-* Use UTC everywhere
-* Use timezone-aware datetimes everywhere
-* Support both timezone aware and naive timestamps as input, return naive timestamps. All naive timestamps are implicitly
+1. Use UTC everywhere
+2. Use timezone-aware datetimes everywhere
+3. Support both timezone aware and naive timestamps as input, return naive timestamps. All naive timestamps are implicitly
     assumed to be in UTC. Internally both a naive and an aware representation are considered.
-* Like the previous (mixed) option but make new end-points (where backwards compatibility is irrelevant) timezone-aware only.
+4. Like the previous (mixed) option but make new end-points (where backwards compatibility is irrelevant) timezone-aware only.
 
 ## Decision Outcome
 

--- a/docs/adr/XXXX-timezones.md
+++ b/docs/adr/XXXX-timezones.md
@@ -1,0 +1,77 @@
+# timezones
+
+* Status: proposed
+* Deciders: [Sander, Wouter, Arnaud, Bart]
+* Date: 2023-01-09
+
+Technical Story: [
+    https://github.com/inmanta/inmanta-core/issues/2919,
+    https://github.com/inmanta/inmanta-core/pull/2953,
+    https://github.com/inmanta/inmanta-lsm/pull/621,
+]
+
+## Context and Problem Statement
+
+How do we deal with timezones when it comes to datetime data? This data is passed in both directions over the API, stored at
+various places in the database and manipulated throughout the code. Which invariants do we uphold with regards to explicit
+timezone information for these datetime objects?
+
+## Decision Drivers <!-- optional -->
+
+* Behavior should be consistent regardless of the timezone participating hosts (e.g. server, agent, web-console client) live in.
+* Timezone handling over the API is non-trivial: we need to present a clear contract to the end-user.
+* In the absence of timezone information, there is no single sane interpretation: explicit timezones improve clarity.
+
+## Considered Options
+
+* Use UTC everywhere
+* Use timezone-aware datetimes everywhere
+* Support both timezone aware and naive timestamps as input, return naive timestamps. All naive timestamps are implicitly
+    assumed to be in UTC. Internally both a naive and an aware representation are considered.
+* Like the previous (mixed) option but make new end-points (where backwards compatibility is irrelevant) timezone-aware only.
+
+## Decision Outcome
+
+Chosen option: option 3 with timezone-aware internal representation, because it is as explicit as we can make (decision driver
+3) it without breaking backwards compatibility. In contrast to option 4, it remains simple: a single contract that applies to
+all API endpoints.
+
+Option 2 (fully timezone-aware) has a lot of merit and we may want to migrate to it at some point, though that would be a
+breaking change.
+
+### Positive Consequences
+
+* Clear contract for the end-user
+* Supports explicit API input
+* Internally (once past the API boundary) datetimes become straightforward to work with: everything is timezone-aware and any
+    complexities resulting from timezone operations are offloaded transparently to the datetime library.
+* Backwards compatible
+* Any remaining naive timestamps are now well defined to be in UTC
+
+### Negative Consequences
+
+* API output must remain timezone-naive
+* Difference between aware/naive on the API boundary vs internally can be confusing
+
+## Pros and Cons of the Options
+
+### option 1: UTC everywhere
+
+* Good, because it presents a clear contract for the end user (all timestamps are implicitly in UTC)
+* Bad, because it doesn't allow for explicit timezones
+* Good, because its semantics are simple and consistent
+* Good, because it is backwards compatible
+
+### option 2: timezone-aware everywhere
+
+* Good, because it presents a clear contract for the end user
+* Good, because it makes all timezones explicit, improving clarity
+* Good, because its semantics are simple and consistent
+* Bad, because it breaks backwards compatibility
+
+### option 4: mixed with timezone-aware only for new endpoints.
+
+* Good, because it presents a clear contract for the end user
+* Good, because it makes timezones as explicit as we can make them without breaking backwards compatibility
+* Good, because it is backwards compatible
+* Bad, because it is more complex to maintain two different semantics for API endpoints


### PR DESCRIPTION
# Description

I decided to add an ADR about this because I was once again confused about the fine points of how we decided to handle timezones.

Additionally, the ADR contains a new decision regarding new API endpoints. Please pay special attention to that. I already violated it in inmanta/designs#113 (before I double checked the current semantics), so I'll need to make minor changes there if this is accepted.

I've added the three of you as decision drivers and therefore reviewers because you were the reviewers of the PR that implemented this back in the day. Feel free to opt out if you like (as long as you don't do so all three of you).


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
