### PR TITLE
Fix interval first metrics collection after starting the server

### DIFF
--- a/changelogs/unreleased/fix-first-data-collection-interval.yml
+++ b/changelogs/unreleased/fix-first-data-collection-interval.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that we only write metrics to the database after the server has been up for COLLECTION_INTERVAL_IN_SEC seconds.
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -139,7 +139,6 @@ class EnvironmentMetricsService(protocol.ServerSlice):
         self.register_metric_collector(ResourceCountMetricsCollector())
         self.register_metric_collector(AgentCountMetricsCollector())
         self.register_metric_collector(CompileTimeMetricsCollector())
-        self.previous_timestamp = datetime.now()
         self.schedule(
             self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
         )

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -139,7 +139,10 @@ class EnvironmentMetricsService(protocol.ServerSlice):
         self.register_metric_collector(ResourceCountMetricsCollector())
         self.register_metric_collector(AgentCountMetricsCollector())
         self.register_metric_collector(CompileTimeMetricsCollector())
-        self.schedule(self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=0, cancel_on_stop=True)
+        self.previous_timestamp = datetime.now()
+        self.schedule(
+            self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
+        )
 
     def register_metric_collector(self, metrics_collector: MetricsCollector) -> None:
         """


### PR DESCRIPTION
# Description

Ensure that we only write metrics to the database after the server has been up for `COLLECTION_INTERVAL_IN_SEC` seconds.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~