### PR TITLE
Issue/5350 agent count metric filter

### DIFF
--- a/changelogs/unreleased/5350-agent-count-metric-filter.yml
+++ b/changelogs/unreleased/5350-agent-count-metric-filter.yml
@@ -1,0 +1,6 @@
+description: For the agent count metric, only count agents that are required for the resources in the latest released model
+issue-nr: 5350
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -26,7 +26,15 @@ from typing import Dict, List, Optional
 
 import asyncpg
 
-from inmanta.data import Agent, Compile, ConfigurationModel, EnvironmentMetricsGauge, EnvironmentMetricsTimer, Resource
+from inmanta.data import (
+    Agent,
+    Compile,
+    ConfigurationModel,
+    Environment,
+    EnvironmentMetricsGauge,
+    EnvironmentMetricsTimer,
+    Resource,
+)
 from inmanta.server import SLICE_DATABASE, SLICE_ENVIRONMENT_METRICS, SLICE_TRANSPORT, protocol
 
 LOGGER = logging.getLogger(__name__)
@@ -83,7 +91,9 @@ LATEST_RELEASED_MODELS_SUBQUERY: str = textwrap.dedent(
         WHERE cm.released = TRUE
         GROUP BY cm.environment
     )
-    """.strip("\n")
+    """.strip(
+        "\n"
+    )
 ).strip()
 """
 Subquery to get the latest released version for each environment. Environments with no released versions are absent.
@@ -99,11 +109,13 @@ LATEST_RELEASED_RESOURCES_SUBQUERY: str = textwrap.dedent(
         INNER JOIN latest_released_models as cm
             ON r.environment = cm.environment AND r.model = cm.version
     )
-    """.strip("\n")
+    """.strip(
+        "\n"
+    )
 ).strip()
 """
-Subquery to get the resources for latest released version for each environment. Environments with no released versions are absent.
-Includes LATEST_RELEASED_MODELS_SUBQUERY.
+Subquery to get the resources for latest released version for each environment. Environments with no released versions are
+absent. Includes LATEST_RELEASED_MODELS_SUBQUERY.
 To be used like f"WITH {LATEST_RELEASED_RESOURCES_SUBQUERY} <main_query>. The main query use the name 'latest_released_models'
 to refer to this table.
 """
@@ -305,7 +317,7 @@ WITH {LATEST_RELEASED_RESOURCES_SUBQUERY}, agent_counts AS (
             ELSE 'down'
         END AS status,
         COUNT(*)
-    FROM public.agent AS a
+    FROM {Agent.table_name()} AS a
     -- only count agents that are relevant for the latest model
     WHERE EXISTS (
         SELECT *

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -277,11 +277,9 @@ class ResourceCountMetricsCollector(MetricsCollector):
         self, start_interval: datetime, end_interval: datetime, connection: asyncpg.connection.Connection
     ) -> Sequence[MetricValue]:
         query: str = f"""
-            WITH {LATEST_RELEASED_MODELS_SUBQUERY}
+            WITH {LATEST_RELEASED_RESOURCES_SUBQUERY}
             SELECT r.environment, r.status, COUNT(*)
-            FROM {Resource.table_name()} AS r
-            INNER JOIN latest_released_models AS cm
-                ON r.environment = cm.environment AND r.model = cm.version
+            FROM latest_released_resources AS r
             GROUP BY r.environment, r.status
             ORDER BY r.environment, r.status
         """

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -277,7 +277,7 @@ class ResourceCountMetricsCollector(MetricsCollector):
             WITH {LATEST_RELEASED_MODELS_SUBQUERY}
             SELECT r.environment, r.status, COUNT(*)
             FROM {Resource.table_name()} AS r
-            INNER JOIN latest_models AS cm
+            INNER JOIN latest_released_models AS cm
                 ON r.environment = cm.environment AND r.model = cm.version
             GROUP BY r.environment, r.status
             ORDER BY r.environment, r.status

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -101,8 +101,10 @@ To be used like f"WITH {LATEST_RELEASED_MODELS_SUBQUERY} <main_query>". The main
 to refer to this table.
 """
 
-LATEST_RELEASED_RESOURCES_SUBQUERY: str = LATEST_RELEASED_MODELS_SUBQUERY + textwrap.dedent(
-    f"""
+LATEST_RELEASED_RESOURCES_SUBQUERY: str = (
+    LATEST_RELEASED_MODELS_SUBQUERY
+    + textwrap.dedent(
+        f"""
     , latest_released_resources AS (
         SELECT r.*
         FROM {Resource.table_name()} AS r
@@ -110,9 +112,10 @@ LATEST_RELEASED_RESOURCES_SUBQUERY: str = LATEST_RELEASED_MODELS_SUBQUERY + text
             ON r.environment = cm.environment AND r.model = cm.version
     )
     """.strip(
-        "\n"
-    )
-).strip()
+            "\n"
+        )
+    ).strip()
+)
 """
 Subquery to get the resources for latest released version for each environment. Environments with no released versions are
 absent. Includes LATEST_RELEASED_MODELS_SUBQUERY.

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -75,7 +75,6 @@ class MetricValueTimer(MetricValue):
         self.value = value
 
 
-# TODO: version -> latest_version?
 LATEST_RELEASED_MODELS_SUBQUERY: str = textwrap.dedent(
     f"""
     latest_released_models AS (


### PR DESCRIPTION
# Description

- For the agent count metric, only count agents that are required for the resources in the latest released model.
- Fill any gaps in the environment - status matrix with zeros (small part of #5358).

## Subquery reuse

Since some subqueries are now being used for multiple collectors, I extracted them into separate variables. I didn't get it as smooth as I'd hoped, to the point where I'm wondering if it might not be more readable to go for `VIEW` after all. All in all I think it's acceptable as is (if barely). Let me know if you see a better approach or if you think we should go for `VIEW`.

## Performance

The main cost seems to be in the `latest_released_resources` subquery, as can be seen in the bottom-most block in the query plan. The index only scan is performed three times because there are three environments with at least one released model, accounting for the bulk of the execution time. From this I think we can conclude the main potential for a scaling issue is if the number of active environments were to scale up drastically (let's say to 50+, which seems unlikely), or if the number of resources were to scale up drastically, which is a more reasonable scenario. Even so, I think an index only scan is about as efficient as it gets, and we definitely still have 1-2 orders of magnitude of room before performance might start to be an issue so I think we're good on that front.

```
                                                                                            QUERY PLAN                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Merge Left Join  (cost=590.33..592.22 rows=18 width=56) (actual time=6.668..6.685 rows=18 loops=1)
   Merge Cond: ((e.id = a.environment) AND ("*VALUES*".column1 = (CASE WHEN a.paused THEN 'paused'::text WHEN (a.id_primary IS NOT NULL) THEN 'up'::text ELSE 'down'::text END)))
   Buffers: shared hit=4793
   ->  Sort  (cost=2.71..2.75 rows=18 width=48) (actual time=0.030..0.032 rows=18 loops=1)
         Sort Key: e.id, "*VALUES*".column1
         Sort Method: quicksort  Memory: 26kB
         Buffers: shared hit=2
         ->  Nested Loop  (cost=0.00..2.33 rows=18 width=48) (actual time=0.011..0.020 rows=18 loops=1)
               Buffers: shared hit=2
               ->  Seq Scan on environment e  (cost=0.00..2.06 rows=6 width=16) (actual time=0.007..0.010 rows=6 loops=1)
                     Buffers: shared hit=2
               ->  Materialize  (cost=0.00..0.05 rows=3 width=32) (actual time=0.000..0.001 rows=3 loops=6)
                     ->  Values Scan on "*VALUES*"  (cost=0.00..0.04 rows=3 width=32) (actual time=0.001..0.002 rows=3 loops=1)
   ->  GroupAggregate  (cost=587.62..588.62 rows=50 width=56) (actual time=6.636..6.646 rows=3 loops=1)
         Group Key: a.environment, (CASE WHEN a.paused THEN 'paused'::text WHEN (a.id_primary IS NOT NULL) THEN 'up'::text ELSE 'down'::text END)
         Buffers: shared hit=4791
         ->  Sort  (cost=587.62..587.75 rows=50 width=48) (actual time=6.633..6.636 rows=49 loops=1)
               Sort Key: a.environment, (CASE WHEN a.paused THEN 'paused'::text WHEN (a.id_primary IS NOT NULL) THEN 'up'::text ELSE 'down'::text END)
               Sort Method: quicksort  Memory: 28kB
               Buffers: shared hit=4791
               ->  Hash Join  (cost=574.67..586.21 rows=50 width=48) (actual time=6.559..6.621 rows=49 loops=1)
                     Hash Cond: ((a.environment = r.environment) AND ((a.name)::text = (r.agent)::text))
                     Buffers: shared hit=4791
                     ->  Seq Scan on agent a  (cost=0.00..9.92 rows=192 width=60) (actual time=0.002..0.019 rows=192 loops=1)
                           Buffers: shared hit=8
                     ->  Hash  (cost=572.51..572.51 rows=144 width=60) (actual time=6.552..6.553 rows=49 loops=1)
                           Buckets: 1024  Batches: 1  Memory Usage: 13kB
                           Buffers: shared hit=4783
                           ->  HashAggregate  (cost=571.07..572.51 rows=144 width=60) (actual time=6.532..6.542 rows=49 loops=1)
                                 Group Key: r.environment, (r.agent)::text
                                 Batches: 1  Memory Usage: 40kB
                                 Buffers: shared hit=4783
                                 ->  Nested Loop  (cost=21.72..557.91 rows=2633 width=60) (actual time=0.113..5.686 rows=3584 loops=1)
                                       Buffers: shared hit=4783
                                       ->  HashAggregate  (cost=21.30..21.33 rows=3 width=20) (actual time=0.099..0.100 rows=3 loops=1)
                                             Group Key: cm.environment
                                             Batches: 1  Memory Usage: 24kB
                                             Buffers: shared hit=19
                                             ->  Seq Scan on configurationmodel cm  (cost=0.00..20.53 rows=153 width=20) (actual time=0.009..0.070 rows=153 loops=1)
                                                   Filter: released
                                                   Buffers: shared hit=19
                                       ->  Index Only Scan using resource_env_model_agent_index on resource r  (cost=0.42..170.07 rows=878 width=48) (actual time=0.010..1.713 rows=1195 loops=3)
                                             Index Cond: ((environment = cm.environment) AND (model = (max(cm.version))))
                                             Heap Fetches: 9011
                                             Buffers: shared hit=4764
 Planning Time: 0.527 ms
 Execution Time: 6.746 ms
(47 rows)
```

closes #5350

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
