### PR TITLE
Issue/build master fix flaky tests relying on ordered data

### DIFF
--- a/changelogs/unreleased/build-master-fix-flaky-tests-relying-on-ordered-data.yml
+++ b/changelogs/unreleased/build-master-fix-flaky-tests-relying-on-ordered-data.yml
@@ -1,0 +1,3 @@
+description: Fix flaky tests relying on ordered data
+change-type: minor
+destination-branches: [master, iso6]

--- a/changelogs/unreleased/build-master-fix-flaky-tests-relying-on-ordered-data.yml
+++ b/changelogs/unreleased/build-master-fix-flaky-tests-relying-on-ordered-data.yml
@@ -1,3 +1,3 @@
 description: Fix flaky tests relying on ordered data
 change-type: minor
-destination-branches: [master, iso6]
+destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/build-master-fix-flaky-tests-relying-on-ordered-data.yml
+++ b/changelogs/unreleased/build-master-fix-flaky-tests-relying-on-ordered-data.yml
@@ -1,3 +1,3 @@
 description: Fix flaky tests relying on ordered data
-change-type: minor
+change-type: patch
 destination-branches: [master, iso6, iso5]

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -364,6 +364,8 @@ async def test_put_partial_merge_not_in_resource_set(server, client, environment
 
     assert result.code == 200
     resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
+    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list.sort(key=lambda resource: resource.resource_id)
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=2"
@@ -551,6 +553,8 @@ async def test_put_partial_update_multiple_resource_set(server, client, environm
 
     assert result.code == 200
     resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
+    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list.sort(key=lambda resource: resource.resource_id)
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=2"
@@ -1069,6 +1073,8 @@ async def test_put_partial_different_env(server, client):
     assert version_env1 != version_env2
 
     resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(env_id_1))
+    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list.sort(key=lambda resource: resource.resource_id)
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=2"
@@ -1078,6 +1084,8 @@ async def test_put_partial_different_env(server, client):
         assert r.model == 2
 
     resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(env_id_2))
+    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list.sort(key=lambda resource: resource.resource_id)
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 1
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=1"
@@ -1154,6 +1162,8 @@ async def test_put_partial_removed_rs_in_rs(server, client, environment, clienth
         "that are exported: {'set-b'}"
     )
     resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
+    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list.sort(key=lambda resource: resource.resource_id)
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].attributes == {"key": "key1", "value": "1", "purged": False, "requires": [], "send_event": False}

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -363,9 +363,10 @@ async def test_put_partial_merge_not_in_resource_set(server, client, environment
     )
 
     assert result.code == 200
-    resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
-    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
-    resource_list.sort(key=lambda resource: resource.resource_id)
+    # Explicitly sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list = sorted(
+        await data.Resource.get_resources_in_latest_version(uuid.UUID(environment)), key=lambda resource: resource.resource_id
+    )
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=2"
@@ -552,9 +553,10 @@ async def test_put_partial_update_multiple_resource_set(server, client, environm
     )
 
     assert result.code == 200
-    resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
-    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
-    resource_list.sort(key=lambda resource: resource.resource_id)
+    # Explicitly sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list = sorted(
+        await data.Resource.get_resources_in_latest_version(uuid.UUID(environment)), key=lambda resource: resource.resource_id
+    )
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=2"
@@ -1072,9 +1074,10 @@ async def test_put_partial_different_env(server, client):
 
     assert version_env1 != version_env2
 
-    resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(env_id_1))
-    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
-    resource_list.sort(key=lambda resource: resource.resource_id)
+    # Explicitly sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list = sorted(
+        await data.Resource.get_resources_in_latest_version(uuid.UUID(env_id_1)), key=lambda resource: resource.resource_id
+    )
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=2"
@@ -1083,9 +1086,10 @@ async def test_put_partial_different_env(server, client):
     for r in resource_list:
         assert r.model == 2
 
-    resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(env_id_2))
-    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
-    resource_list.sort(key=lambda resource: resource.resource_id)
+    # Explicitly sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list = sorted(
+        await data.Resource.get_resources_in_latest_version(uuid.UUID(env_id_2)), key=lambda resource: resource.resource_id
+    )
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 1
     assert resource_list[0].resource_version_id == "test::Resource[agent1,key=key1],v=1"
@@ -1161,9 +1165,10 @@ async def test_put_partial_removed_rs_in_rs(server, client, environment, clienth
         "Invalid request: Following resource sets are present in the removed resource sets and in the resources "
         "that are exported: {'set-b'}"
     )
-    resource_list = await data.Resource.get_resources_in_latest_version(uuid.UUID(environment))
-    # Explicitely sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
-    resource_list.sort(key=lambda resource: resource.resource_id)
+    # Explicitly sort the list because postgres gives no guarantee regarding order without explicit ORDER BY clause
+    resource_list = sorted(
+        await data.Resource.get_resources_in_latest_version(uuid.UUID(environment)), key=lambda resource: resource.resource_id
+    )
     resource_sets_from_db = {resource.resource_id: resource.resource_set for resource in resource_list}
     assert len(resource_list) == 2
     assert resource_list[0].attributes == {"key": "key1", "value": "1", "purged": False, "requires": [], "send_event": False}


### PR DESCRIPTION
# Description

This PR fixes flakiness in tests that were implicitly relying on data being ordered.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
