### PR TITLE
issue/5359-flaky-test-metrics

### DIFF
--- a/changelogs/unreleased/5359-flaky-test-metrics.yml
+++ b/changelogs/unreleased/5359-flaky-test-metrics.yml
@@ -1,0 +1,6 @@
+description: Fixes some flakiness in the environment metric tests
+issue-nr: 5359
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -181,9 +181,11 @@ class EnvironmentMetricsService(protocol.ServerSlice):
         self.register_metric_collector(CompileWaitingTimeMetricsCollector())
         self.register_metric_collector(AgentCountMetricsCollector())
         self.register_metric_collector(CompileTimeMetricsCollector())
-        self.schedule(
-            self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
-        )
+        if COLLECTION_INTERVAL_IN_SEC != 0:
+            print("OLA")
+            self.schedule(
+                self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
+            )
 
     def register_metric_collector(self, metrics_collector: MetricsCollector) -> None:
         """

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -181,7 +181,7 @@ class EnvironmentMetricsService(protocol.ServerSlice):
         self.register_metric_collector(CompileWaitingTimeMetricsCollector())
         self.register_metric_collector(AgentCountMetricsCollector())
         self.register_metric_collector(CompileTimeMetricsCollector())
-        if COLLECTION_INTERVAL_IN_SEC != 0:
+        if COLLECTION_INTERVAL_IN_SEC > 0:
             self.schedule(
                 self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
             )

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -182,7 +182,6 @@ class EnvironmentMetricsService(protocol.ServerSlice):
         self.register_metric_collector(AgentCountMetricsCollector())
         self.register_metric_collector(CompileTimeMetricsCollector())
         if COLLECTION_INTERVAL_IN_SEC != 0:
-            print("OLA")
             self.schedule(
                 self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
             )

--- a/tests/server/test_environement_metrics.py
+++ b/tests/server/test_environement_metrics.py
@@ -50,7 +50,8 @@ async def env_metrics_service(server_config, init_dataclasses_and_load_schema) -
 
 @pytest.fixture
 def server_pre_start(server_config):
-    """This fixture is called before the server starts to disable the automatic flush_metrics done by the EnvironmentMetricsService"""
+    """This fixture is called before the server starts to disable the automatic flush_metrics done
+    by the EnvironmentMetricsService"""
     previous = environment_metrics_service.COLLECTION_INTERVAL_IN_SEC
     environment_metrics_service.COLLECTION_INTERVAL_IN_SEC = 0
     yield

--- a/tests/server/test_environement_metrics.py
+++ b/tests/server/test_environement_metrics.py
@@ -50,7 +50,7 @@ async def env_metrics_service(server_config, init_dataclasses_and_load_schema) -
 
 @pytest.fixture
 def server_pre_start(server_config):
-    """This fixture is called before the server starts to disable the auotmatical flush_metrics done by the scheduler"""
+    """This fixture is called before the server starts to disable the automatic flush_metrics done by the EnvironmentMetricsService"""
     previous = environment_metrics_service.COLLECTION_INTERVAL_IN_SEC
     environment_metrics_service.COLLECTION_INTERVAL_IN_SEC = 0
     yield

--- a/tests/server/test_environement_metrics.py
+++ b/tests/server/test_environement_metrics.py
@@ -24,6 +24,7 @@ import asyncpg
 import pytest
 
 from inmanta import const, data
+from inmanta.server.services import environment_metrics_service
 from inmanta.server.services.environment_metrics_service import (
     AgentCountMetricsCollector,
     CompileTimeMetricsCollector,
@@ -45,6 +46,15 @@ env_uuid = uuid.uuid4()
 async def env_metrics_service(server_config, init_dataclasses_and_load_schema) -> EnvironmentMetricsService:
     metrics_service = EnvironmentMetricsService()
     yield metrics_service
+
+
+@pytest.fixture
+def server_pre_start(server_config):
+    """This fixture is called before the server starts to disable the auotmatical flush_metrics done by the scheduler"""
+    previous = environment_metrics_service.COLLECTION_INTERVAL_IN_SEC
+    environment_metrics_service.COLLECTION_INTERVAL_IN_SEC = 0
+    yield
+    environment_metrics_service.COLLECTION_INTERVAL_IN_SEC = previous
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

Currently all the test for metric collector do the following steps:

1. starts the server
2. flushes metrics manuall
3. assert that the metrics are collected
This is potentially flaky as the server will also flush at regular intervals. We can never be sure amount the amount of metrics that are present in the metrics tables of the database when the assertions are executed.

this PR disables the automatic flush done at regular intervals

closes #5359

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
