### PR TITLE
Issue/5048 mypy strict equality

### DIFF
--- a/changelogs/unreleased/5048-mypy-strict-equality.yml
+++ b/changelogs/unreleased/5048-mypy-strict-equality.yml
@@ -1,0 +1,8 @@
+description: "Enabled mypy's `strict_equality` option"
+change-type: patch
+issue-nr: 5380
+sections:
+  bugfix: Fixed cycle detection in experimental relation precedence policy
+destination-branches:
+  - master
+  - iso6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,33 @@ exclude = '''
 )/
 '''
 
+[tool.mypy]
+plugins = [
+    'pydantic.mypy'
+]
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+follow_imports = 'silent'
+no_implicit_optional = true
+no_implicit_reexport = true
+show_error_codes = true
+strict_optional = true
+strict_equality = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_untyped_fields = true
+
 [tool.irt.build.python]
 hooks = { 'pre' = 'pre-build.sh' }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,30 +40,5 @@ known_first_party=inmanta,inmanta_ext,inmanta_plugins
 known_third_party=pytest,psutil,pydantic,pkg_resources,openapi_spec_validator,docstring_parser,cookiecutter,more_itertools,asyncpg,tornado,pyformance,click,pkg_resources,yaml,texttable,dateutil,importlib_metadata,typing_inspect,jwt,ply,jinja2,pkg_resources,colorlog,execnet,click_plugins,cryptography,netifaces,py
 skip=tests/data
 
-[mypy]
-plugins = pydantic.mypy
-
-check_untyped_defs = True
-disallow_any_generics = True
-disallow_incomplete_defs = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
-disallow_untyped_defs = True
-follow_imports = silent
-no_implicit_optional = True
-no_implicit_reexport = True
-show_error_codes = True
-strict_optional = True
-warn_redundant_casts = True
-warn_return_any = True
-warn_unused_configs = True
-warn_unused_ignores = True
-
-[pydantic-mypy]
-init_forbid_extra=True
-init_typed=True
-warn_untyped_fields=True
-
 [options.extras_require]
 dataflow_graphic = graphviz;

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -25,9 +25,9 @@ import ssl
 import sys
 import uuid
 import warnings
-from collections import defaultdict
+from collections import abc, defaultdict
 from configparser import ConfigParser, Interpolation, SectionProxy
-from typing import Callable, Dict, Generic, List, Optional, TypeVar, Union, cast, overload
+from typing import Callable, Dict, Generic, List, Optional, TypeVar, Union, overload
 from urllib import error, request
 
 from cryptography.hazmat.backends import default_backend
@@ -207,11 +207,14 @@ def is_time(value: str) -> int:
     return int(value)
 
 
-def is_bool(value: str) -> bool:
+def is_bool(value: Union[bool, str]) -> bool:
     """Boolean value, represented as any of true, false, on, off, yes, no, 1, 0. (Case-insensitive)"""
-    if type(value) == bool:
-        return cast(bool, value)
-    return Config._get_instance()._convert_to_boolean(value)
+    if isinstance(value, bool):
+        return value
+    boolean_states: abc.Mapping[str, bool] = Config._get_instance().BOOLEAN_STATES
+    if value.lower() not in boolean_states:
+        raise ValueError('Not a boolean: %s' % value)
+    return boolean_states[value.lower()]
 
 
 def is_list(value: str) -> List[str]:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -213,7 +213,7 @@ def is_bool(value: Union[bool, str]) -> bool:
         return value
     boolean_states: abc.Mapping[str, bool] = Config._get_instance().BOOLEAN_STATES
     if value.lower() not in boolean_states:
-        raise ValueError('Not a boolean: %s' % value)
+        raise ValueError("Not a boolean: %s" % value)
     return boolean_states[value.lower()]
 
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5071,7 +5071,7 @@ class ConfigurationModel(BaseDocument):
                 await cls._execute_query(query, *values, connection=con)
 
     @classmethod
-    async def get_increment(cls, environment: uuid.UUID, version: int) -> Tuple[Set[m.ResourceIdStr], Set[m.ResourceIdStr]]:
+    async def get_increment(cls, environment: uuid.UUID, version: int) -> tuple[set[m.ResourceIdStr], set[m.ResourceIdStr]]:
         """
         Find resources incremented by this version compared to deployment state transitions per resource
 

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -691,7 +691,7 @@ class RelationPrecedenceGraph:
         while work:
             node: RelationPrecedenceGraphNode = get_next_ready_item_in_work()
             work.remove(node)
-            if node in result:
+            if node.relation_attribute in result:
                 raise CycleInRelationPrecedencePolicyError()
             result.append(node.relation_attribute)
             work.update(node.dependents)

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -20,7 +20,7 @@ import datetime
 import logging
 import os
 import uuid
-from collections import defaultdict
+from collections import abc, defaultdict
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
 
 from asyncpg.connection import Connection
@@ -103,7 +103,7 @@ class ResourceService(protocol.ServerSlice):
         self._resource_action_loggers: Dict[uuid.UUID, logging.Logger] = {}
         self._resource_action_handlers: Dict[uuid.UUID, logging.Handler] = {}
 
-        self._increment_cache: Dict[uuid.UUID, Optional[Tuple[Set[ResourceVersionIdStr], List[ResourceVersionIdStr]]]] = {}
+        self._increment_cache: Dict[uuid.UUID, Optional[tuple[abc.Set[ResourceIdStr], abc.Set[ResourceIdStr]]]] = {}
         # lock to ensure only one inflight request
         self._increment_cache_locks: Dict[uuid.UUID, asyncio.Lock] = defaultdict(lambda: asyncio.Lock())
 
@@ -307,7 +307,7 @@ class ResourceService(protocol.ServerSlice):
         if version is None:
             return 404, {"message": "No version available"}
 
-        increment = self._increment_cache.get(env.id, None)
+        increment: Optional[tuple[abc.Set[ResourceIdStr], abc.Set[ResourceIdStr]]] = self._increment_cache.get(env.id, None)
         if increment is None:
             lock = self._increment_cache_locks[env.id]
             async with lock:
@@ -321,11 +321,13 @@ class ResourceService(protocol.ServerSlice):
         # set already done to deployed
         now = datetime.datetime.now().astimezone()
 
-        def on_agent(res: ResourceVersionIdStr) -> bool:
+        def on_agent(res: ResourceIdStr) -> bool:
             idr = Id.parse_id(res)
             return idr.get_agent_name() == agent
 
-        neg_increment = [f"{res_id},v={version}" for res_id in neg_increment if on_agent(res_id)]
+        neg_increment_version_ids: list[ResourceVersionIdStr] = [
+            ResourceVersionIdStr(f"{res_id},v={version}") for res_id in neg_increment if on_agent(res_id)
+        ]
 
         logline = {
             "level": "INFO",
@@ -335,7 +337,7 @@ class ResourceService(protocol.ServerSlice):
         }
         await self.resource_action_update(
             env,
-            neg_increment,
+            neg_increment_version_ids,
             action_id=uuid.uuid4(),
             started=now,
             finished=now,

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -21,7 +21,7 @@ import logging
 import os
 import uuid
 from collections import abc, defaultdict
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
 from asyncpg.connection import Connection
 from asyncpg.exceptions import UniqueViolationError

--- a/stubs/pyformance/__init__.pyi
+++ b/stubs/pyformance/__init__.pyi
@@ -1,12 +1,13 @@
-from typing import Callable, Dict, Optional
+from collections import abc
+from typing import Optional
 
 from pyformance.meters import Gauge
 
 
 class MetricsRegistry:
     def __init__(self, clock): ...
-    def dump_metrics(self)-> Dict[str, Dict[str, float]]: ...
+    def dump_metrics(self)-> abc.Mapping[str, abc.Mapping[str, int|float|str]]: ...
 
-global_registry: Callable[[], MetricsRegistry]
+global_registry: abc.Callable[[], MetricsRegistry]
 
 def gauge(key: str, gauge: Optional[Gauge]=None) -> Gauge: ...


### PR DESCRIPTION
# Description

- Moved mypy config to pyproject.toml
- Added `strict_equality = true`
- Fixed fallout
  - small bug in cycle detection for relation precedence policy
  - `inmanta.config.is_bool` used a private library method, I changed it to use equivalent behavior through the public API instead.
  - v1 module finder used deprecated `find_module`. I implemented `find_spec` instead.
  - some incorrect type annotations

Resulting diff below (red is good). There is one new error but I decided not to fix it because it is due to incorrect typing in typeshed, which has already been fixed in the latest mypy nightlies, so it should disappear soon.
```diff
- src/inmanta/config.py:214: error: Returning Any from function declared to return "bool"  [no-any-return]
- src/inmanta/config.py:214: error: "ConfigParser" has no attribute "_convert_to_boolean"  [attr-defined]
- src/inmanta/loader.py:483: error: Argument 1 to "remove" of "list" has incompatible type "PluginModuleFinder"; expected "_MetaPathFinder"  [arg-type]
+ src/inmanta/loader.py:510: error: Argument 2 of "find_spec" is incompatible with supertype "MetaPathFinder"; supertype defines the argument type as "Optional[Sequence[Union[bytes, str]]]"  [override]
+ src/inmanta/loader.py:510: note: This violates the Liskov substitution principle
+ src/inmanta/loader.py:510: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
- src/inmanta/data/__init__.py:5172: error: Argument 1 to "list" has incompatible type "Set[str]"; expected "Iterable[Dict[str, Any]]"  [arg-type]
- src/inmanta/data/__init__.py:5184: error: Invalid index type "Dict[str, Any]" for "Dict[str, List[str]]"; expected type "str"  [index]
- src/inmanta/data/__init__.py:5185: error: Argument 1 to "extend" of "list" has incompatible type "List[str]"; expected "Iterable[Dict[str, Any]]"  [arg-type]
- src/inmanta/data/__init__.py:5189: error: Incompatible return value type (got "Tuple[Set[str], Set[Any]]", expected "Tuple[Set[ResourceIdStr], Set[ResourceIdStr]]")  [return-value]
- src/inmanta/server/services/resourceservice.py:316: error: Incompatible types in assignment (expression has type "Tuple[Set[ResourceIdStr], Set[ResourceIdStr]]", variable has type "Optional[Tuple[Set[ResourceVersionIdStr], List[ResourceVersionIdStr]]]")  [assignment]
- src/inmanta/server/services/resourceservice.py:319: error: "None" object is not iterable  [misc]
```

Closes #5048

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
