### PR TITLE
Create asyncio event loops explicitly when starting agent or server

### DIFF
--- a/changelogs/unreleased/app-asyncio-event-loop.yml
+++ b/changelogs/unreleased/app-asyncio-event-loop.yml
@@ -1,0 +1,6 @@
+description: Create asyncio event loops explicitly when starting agent or server
+issue-nr: 5389
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -126,6 +126,8 @@ def start_server(options: argparse.Namespace) -> None:
     if options.config_dir and not os.path.isdir(options.config_dir):
         LOGGER.warning("Config directory %s doesn't exist", options.config_dir)
 
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
     ibl = InmantaBootloader()
     setup_signal_handlers(ibl.stop)
 
@@ -155,6 +157,8 @@ def start_server(options: argparse.Namespace) -> None:
 @command("agent", help_msg="Start the inmanta agent")
 def start_agent(options: argparse.Namespace) -> None:
     from inmanta.agent import agent
+
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
     a = agent.Agent()
     setup_signal_handlers(a.stop)


### PR DESCRIPTION
# Description

Please be critical about this. I think I understand based on the documentation and the cpython + tornado code, but up till two hours ago I knew next to nothing about this.

Very small part of #5389 (easy wins)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
