### PR TITLE
Increase performance delete old metrics query

### DIFF
--- a/changelogs/unreleased/increase-performance-delete-old-metrics-query.yml
+++ b/changelogs/unreleased/increase-performance-delete-old-metrics-query.yml
@@ -1,0 +1,6 @@
+---
+description: Increase the performance of the query to delete old metrics.
+issue-nr: 5130
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -219,18 +219,12 @@ class EnvironmentMetricsService(protocol.ServerSlice):
                 WHERE e.retention_time_in_hours > 0
             ), delete_gauge AS (
                 DELETE FROM {EnvironmentMetricsGauge.table_name()} AS emg
-                WHERE EXISTS(
-                   SELECT *
-                   FROM env_and_delete_before_timestamp AS e_to_dt
-                   WHERE emg.environment=e_to_dt.id AND emg.timestamp < e_to_dt.delete_before_timestamp
-                )
+                USING env_and_delete_before_timestamp as e_to_dt
+                WHERE emg.environment=e_to_dt.id AND emg.timestamp < e_to_dt.delete_before_timestamp
             )
             DELETE FROM {EnvironmentMetricsTimer.table_name()} AS emt
-            WHERE EXISTS(
-                SELECT *
-                FROM env_and_delete_before_timestamp AS e_to_dt
-                WHERE emt.environment=e_to_dt.id AND emt.timestamp < e_to_dt.delete_before_timestamp
-            )
+            USING env_and_delete_before_timestamp AS e_to_dt
+            WHERE emt.environment=e_to_dt.id AND emt.timestamp < e_to_dt.delete_before_timestamp
             """
             environment_metrics_retention_setting: Setting = Environment.get_setting_definition(ENVIRONMENT_METRICS_RETENTION)
             values = [


### PR DESCRIPTION
# Description

Increase the performance of the query to delete old metrics.

Query plan old query:

```
 Delete on environmentmetricstimer emt  (cost=7824.81..7835.77 rows=1 width=54) (actual time=0.258..0.260 rows=0 loops=1)
   CTE env_and_delete_before_timestamp
     ->  Seq Scan on environment e  (cost=0.00..1.15 rows=1 width=24) (actual time=0.012..0.085 rows=5 loops=1)
           Filter: ((halted IS FALSE) AND (CASE WHEN (settings ? 'environment_metrics_retention'::text) THEN ((settings ->> 'environment_metrics_retention'::text))::integer ELSE 8760 END > 0))
           Rows Removed by Filter: 1
   CTE delete_gauge
     ->  Delete on environmentmetricsgauge emg  (cost=0.03..7823.62 rows=547 width=54) (actual time=53.992..53.992 rows=0 loops=1)
           ->  Hash Semi Join  (cost=0.03..7823.62 rows=547 width=54) (actual time=53.991..53.991 rows=0 loops=1)
                 Hash Cond: (emg.environment = e_to_dt_1.id)
                 Join Filter: (emg."timestamp" < e_to_dt_1.delete_before_timestamp)
                 Rows Removed by Join Filter: 252914
                 ->  Seq Scan on environmentmetricsgauge emg  (cost=0.00..6954.07 rows=328407 width=30) (actual time=0.009..31.551 rows=328407 loops=1)
                 ->  Hash  (cost=0.02..0.02 rows=1 width=72) (actual time=0.004..0.004 rows=5 loops=1)
                       ->  CTE Scan on env_and_delete_before_timestamp e_to_dt_1  (cost=0.00..0.02 rows=1 width=72) (actual time=0.001..0.001 rows=5 loops=1)
   ->  Hash Semi Join  (cost=0.03..11.00 rows=1 width=54) (actual time=0.257..0.258 rows=0 loops=1)
         Hash Cond: (emt.environment = e_to_dt.id)
         Join Filter: (emt."timestamp" < e_to_dt.delete_before_timestamp)
         Rows Removed by Join Filter: 392
         ->  Seq Scan on environmentmetricstimer emt  (cost=0.00..9.92 rows=392 width=30) (actual time=0.029..0.086 rows=392 loops=1)
         ->  Hash  (cost=0.02..0.02 rows=1 width=72) (actual time=0.111..0.111 rows=5 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 9kB
               ->  CTE Scan on env_and_delete_before_timestamp e_to_dt  (cost=0.00..0.02 rows=1 width=72) (actual time=0.032..0.106 rows=5 loops=1)
 Planning Time: 0.741 ms
 Execution Time: 54.337 ms
```

Query plan new query:

```
 Delete on environmentmetricstimer emt  (cost=1514.80..1522.85 rows=1 width=54) (actual time=0.133..0.134 rows=0 loops=1)
   CTE env_and_delete_before_timestamp
     ->  Seq Scan on environment e  (cost=0.00..1.15 rows=1 width=24) (actual time=0.010..0.099 rows=5 loops=1)
           Filter: ((halted IS FALSE) AND (CASE WHEN (settings ? 'environment_metrics_retention'::text) THEN ((settings ->> 'environment_metrics_retention'::text))::integer ELSE 8760 END > 0))
           Rows Removed by Filter: 1
   CTE delete_gauge
     ->  Delete on environmentmetricsgauge emg  (cost=30.03..1513.37 rows=547 width=54) (actual time=0.066..0.066 rows=0 loops=1)
           ->  Nested Loop  (cost=30.03..1513.37 rows=547 width=54) (actual time=0.066..0.066 rows=0 loops=1)
                 ->  CTE Scan on env_and_delete_before_timestamp e_to_dt_1  (cost=0.00..0.02 rows=1 width=72) (actual time=0.001..0.002 rows=5 loops=1)
                 ->  Bitmap Heap Scan on environmentmetricsgauge emg  (cost=30.03..1507.88 rows=547 width=30) (actual time=0.012..0.012 rows=0 loops=5)
                       Recheck Cond: ((environment = e_to_dt_1.id) AND ("timestamp" < e_to_dt_1.delete_before_timestamp))
                       ->  Bitmap Index Scan on environmentmetricsgauge_pkey  (cost=0.00..29.89 rows=547 width=0) (actual time=0.012..0.012 rows=0 loops=5)
                             Index Cond: ((environment = e_to_dt_1.id) AND ("timestamp" < e_to_dt_1.delete_before_timestamp))
   ->  Nested Loop  (cost=0.27..8.32 rows=1 width=54) (actual time=0.132..0.132 rows=0 loops=1)
         ->  CTE Scan on env_and_delete_before_timestamp e_to_dt  (cost=0.00..0.02 rows=1 width=72) (actual time=0.019..0.109 rows=5 loops=1)
         ->  Index Scan using environmentmetricstimer_pkey on environmentmetricstimer emt  (cost=0.27..8.29 rows=1 width=30) (actual time=0.004..0.004 rows=0 loops=5)
               Index Cond: ((environment = e_to_dt.id) AND ("timestamp" < e_to_dt.delete_before_timestamp))
 Planning Time: 0.721 ms
 Execution Time: 0.290 ms
```

closes #5130

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~