### PR TITLE
Ensure that the test suite stops the agents it starts

### DIFF
--- a/changelogs/unreleased/ensure-agents-are-stopped.yml
+++ b/changelogs/unreleased/ensure-agents-are-stopped.yml
@@ -1,4 +1,4 @@
 ---
 description: Ensure that each test case stops the agents it started.
 change-type: patch
-destination-branches: [master, iso6]
+destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/ensure-agents-are-stopped.yml
+++ b/changelogs/unreleased/ensure-agents-are-stopped.yml
@@ -1,0 +1,4 @@
+---
+description: Ensure that each test case stops the agents it started.
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -1143,7 +1143,9 @@ async def test_multi_instance(resource_container, client, clienthelper, server, 
     await resource_action_consistency_check()
 
 
-async def test_cross_agent_deps(resource_container, server, client, environment, clienthelper, no_agent_backoff, async_finalizer):
+async def test_cross_agent_deps(
+    resource_container, server, client, environment, clienthelper, no_agent_backoff, async_finalizer
+):
     """
     deploy a configuration model with cross host dependency
 
@@ -1970,7 +1972,9 @@ dep_states_reload = [
 
 
 @pytest.mark.parametrize("dep_state", dep_states_reload, ids=lambda x: x.name)
-async def test_reload(server, client, clienthelper, environment, resource_container, dep_state, no_agent_backoff, async_finalizer):
+async def test_reload(
+    server, client, clienthelper, environment, resource_container, dep_state, no_agent_backoff, async_finalizer
+):
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
 
     resource_container.Provider.reset()

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -1143,7 +1143,7 @@ async def test_multi_instance(resource_container, client, clienthelper, server, 
     await resource_action_consistency_check()
 
 
-async def test_cross_agent_deps(resource_container, server, client, environment, clienthelper, no_agent_backoff):
+async def test_cross_agent_deps(resource_container, server, client, environment, clienthelper, no_agent_backoff, async_finalizer):
     """
     deploy a configuration model with cross host dependency
 
@@ -1159,11 +1159,13 @@ async def test_cross_agent_deps(resource_container, server, client, environment,
 
     agent = Agent(hostname="node1", environment=env_id, agent_map={"agent 1": "localhost"}, code_loader=False)
     await agent.add_end_point_name("agent 1")
+    async_finalizer(agent.stop)
     await agent.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     agent2 = Agent(hostname="node2", environment=env_id, agent_map={"agent2": "localhost"}, code_loader=False)
     await agent2.add_end_point_name("agent2")
+    async_finalizer(agent2.stop)
     await agent2.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 2, 10)
 
@@ -1236,9 +1238,6 @@ async def test_cross_agent_deps(resource_container, server, client, environment,
     assert resource_container.Provider.get("agent 1", "key1") == "value1"
     assert resource_container.Provider.get("agent 1", "key2") == "value2"
     assert resource_container.Provider.get("agent2", "key3") == "value3"
-
-    await agent.stop()
-    await agent2.stop()
 
 
 @pytest.mark.parametrize(
@@ -1971,12 +1970,13 @@ dep_states_reload = [
 
 
 @pytest.mark.parametrize("dep_state", dep_states_reload, ids=lambda x: x.name)
-async def test_reload(server, client, clienthelper, environment, resource_container, dep_state, no_agent_backoff):
+async def test_reload(server, client, clienthelper, environment, resource_container, dep_state, no_agent_backoff, async_finalizer):
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
 
     resource_container.Provider.reset()
     agent = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     await agent.add_end_point_name("agent1")
+    async_finalizer(agent.stop)
     await agent.start()
     await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
@@ -2025,7 +2025,6 @@ async def test_reload(server, client, clienthelper, environment, resource_contai
     assert result.result["model"]["done"] == len(resources)
 
     assert dep_state.index == resource_container.Provider.reloadcount("agent1", "key2")
-    await agent.stop()
 
 
 async def test_s_repair_postponed_due_to_running_deploy(
@@ -2602,12 +2601,13 @@ async def test_bad_post_get_facts(
     await agent.stop()
 
 
-async def test_inprogress(resource_container, server, client, clienthelper, environment, no_agent_backoff):
+async def test_inprogress(resource_container, server, client, clienthelper, environment, no_agent_backoff, async_finalizer):
     """
     Test retrieving facts from the agent
     """
     agent = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     await agent.add_end_point_name("agent1")
+    async_finalizer(agent.stop)
     await agent.start()
     await retry_limited(lambda: len(server.get_slice(SLICE_SESSION_MANAGER)._sessions) == 1, 10)
 
@@ -2635,8 +2635,6 @@ async def test_inprogress(resource_container, server, client, clienthelper, envi
     await retry_limited(in_progress, 30)
 
     await resource_container.wait_for_done_with_waiters(client, environment, version)
-
-    await agent.stop()
 
 
 @pytest.mark.parametrize("use_agent_trigger_method_setting", [(True,), (False)])
@@ -3070,7 +3068,7 @@ async def test_deploy_no_code(resource_container, client, clienthelper, environm
     assert "Failed to load handler code " in result["logs"][1]["messages"][0]["msg"]
 
 
-async def test_issue_1662(resource_container, server, client, clienthelper, environment, monkeypatch, request):
+async def test_issue_1662(resource_container, server, client, clienthelper, environment, monkeypatch, async_finalizer):
     agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
     autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
 
@@ -3079,6 +3077,7 @@ async def test_issue_1662(resource_container, server, client, clienthelper, envi
 
     a = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     await a.add_end_point_name("agent1")
+    async_finalizer(a.stop)
     await a.start()
     await retry_limited(lambda: len(agent_manager.sessions) == 1, 10)
 

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -45,7 +45,9 @@ async def environment(environment, client):
     yield environment
 
 
-async def test_purge_on_delete_requires(client: Client, server: Server, environment: str, clienthelper: ClientHelper, async_finalizer):
+async def test_purge_on_delete_requires(
+    client: Client, server: Server, environment: str, clienthelper: ClientHelper, async_finalizer
+):
     """
     Test purge on delete of resources and inversion of requires
     """
@@ -178,7 +180,9 @@ async def test_purge_on_delete_compile_failed_with_compile(
     assert result.result["model"]["total"] == 0
 
 
-async def test_purge_on_delete_compile_failed(client: Client, server: Server, clienthelper: ClientHelper, environment: str, async_finalizer):
+async def test_purge_on_delete_compile_failed(
+    client: Client, server: Server, clienthelper: ClientHelper, environment: str, async_finalizer
+):
     """
     Test purge on delete of resources
     """
@@ -426,7 +430,9 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
     assert not file3["attributes"]["purged"]
 
 
-async def test_purge_on_delete_ignore(client: Client, clienthelper: ClientHelper, server: Server, environment: str, async_finalizer):
+async def test_purge_on_delete_ignore(
+    client: Client, clienthelper: ClientHelper, server: Server, environment: str, async_finalizer
+):
     """
     Test purge on delete behavior for resources that have not longer purged_on_delete set
     """
@@ -558,7 +564,9 @@ async def test_purge_on_delete_ignore(client: Client, clienthelper: ClientHelper
     assert result.result["model"]["total"] == len(resources)
 
 
-async def test_disable_purge_on_delete(client: Client, clienthelper: ClientHelper, server: Server, environment: str, async_finalizer):
+async def test_disable_purge_on_delete(
+    client: Client, clienthelper: ClientHelper, server: Server, environment: str, async_finalizer
+):
     """
     Test disable purge on delete of resources
     """

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -45,7 +45,7 @@ async def environment(environment, client):
     yield environment
 
 
-async def test_purge_on_delete_requires(client: Client, server: Server, environment: str, clienthelper: ClientHelper):
+async def test_purge_on_delete_requires(client: Client, server: Server, environment: str, clienthelper: ClientHelper, async_finalizer):
     """
     Test purge on delete of resources and inversion of requires
     """
@@ -53,6 +53,7 @@ async def test_purge_on_delete_requires(client: Client, server: Server, environm
     config.Config.set("config", "agent-repair-interval", "0")
 
     agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
+    async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
 
@@ -145,7 +146,6 @@ async def test_purge_on_delete_requires(client: Client, server: Server, environm
 
     assert len(file2["attributes"]["requires"]) == 0
     assert file1["id"] in file2["provides"]
-    await agent.stop()
 
 
 async def test_purge_on_delete_compile_failed_with_compile(
@@ -178,7 +178,7 @@ async def test_purge_on_delete_compile_failed_with_compile(
     assert result.result["model"]["total"] == 0
 
 
-async def test_purge_on_delete_compile_failed(client: Client, server: Server, clienthelper: ClientHelper, environment: str):
+async def test_purge_on_delete_compile_failed(client: Client, server: Server, clienthelper: ClientHelper, environment: str, async_finalizer):
     """
     Test purge on delete of resources
     """
@@ -186,6 +186,7 @@ async def test_purge_on_delete_compile_failed(client: Client, server: Server, cl
     config.Config.set("config", "agent-repair-interval", "0")
 
     agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
+    async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
 
@@ -287,7 +288,7 @@ async def test_purge_on_delete_compile_failed(client: Client, server: Server, cl
     assert len(result.result["unknowns"]) == 1
 
 
-async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, server: Server, environment: str):
+async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, server: Server, environment: str, async_finalizer):
     """
     Test purge on delete of resources
     """
@@ -295,6 +296,7 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
     config.Config.set("config", "agent-repair-interval", "0")
 
     agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
+    async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
 
@@ -422,14 +424,14 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
     assert file1["attributes"]["purged"]
     assert file2["attributes"]["purged"]
     assert not file3["attributes"]["purged"]
-    await agent.stop()
 
 
-async def test_purge_on_delete_ignore(client: Client, clienthelper: ClientHelper, server: Server, environment: str):
+async def test_purge_on_delete_ignore(client: Client, clienthelper: ClientHelper, server: Server, environment: str, async_finalizer):
     """
     Test purge on delete behavior for resources that have not longer purged_on_delete set
     """
     agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
+    async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
 
@@ -554,10 +556,9 @@ async def test_purge_on_delete_ignore(client: Client, clienthelper: ClientHelper
     assert result.code == 200
     assert result.result["model"]["version"] == version
     assert result.result["model"]["total"] == len(resources)
-    await agent.stop()
 
 
-async def test_disable_purge_on_delete(client: Client, clienthelper: ClientHelper, server: Server, environment: str):
+async def test_disable_purge_on_delete(client: Client, clienthelper: ClientHelper, server: Server, environment: str, async_finalizer):
     """
     Test disable purge on delete of resources
     """
@@ -565,6 +566,7 @@ async def test_disable_purge_on_delete(client: Client, clienthelper: ClientHelpe
     config.Config.set("config", "agent-repair-interval", "0")
 
     agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
+    async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
     env = await data.Environment.get_by_id(environment)
@@ -627,5 +629,3 @@ async def test_disable_purge_on_delete(client: Client, clienthelper: ClientHelpe
     result = await client.get_version(environment, version)
     assert result.code == 200
     assert result.result["model"]["total"] == 0
-
-    await agent.stop()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -98,6 +98,10 @@ async def async_started_agent(server_config):
     task = asyncio.ensure_future(a.start())
     yield a
     task.cancel()
+    while not task.done():
+        # The CancelledError is only throw on the next invocation of the event loop.
+        # Wait until cancellation has finished.
+        await asyncio.sleep(0)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -99,8 +99,8 @@ async def async_started_agent(server_config):
     yield a
     task.cancel()
     while not task.done():
-        # The CancelledError is only throw on the next invocation of the event loop.
-        # Wait until cancellation has finished.
+        # The CancelledError is only thrown on the next invocation of the event loop.
+        # Wait until the cancellation has finished.
         await asyncio.sleep(0)
 
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -730,8 +730,8 @@ async def test_session_creation_fails(server, environment, async_finalizer, capl
     agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
     a = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     await a.add_end_point_name("agent1")
-    await a.start()
     async_finalizer(a.stop)
+    await a.start()
 
     # Wait until session is created
     await retry_limited(lambda: (env_id, "agent1") in agentmanager.tid_endpoint_to_session, 10)
@@ -763,6 +763,7 @@ async def test_session_creation_fails(server, environment, async_finalizer, capl
     a = Agent(hostname="node1", environment=environment, agent_map={"agent1": "localhost"}, code_loader=False)
     await a.add_end_point_name("agent1")
     await a.start()
+    async_finalizer(a.stop)
 
     # Verify that session creation fails and server state is stays consistent
     await retry_limited(lambda: "Heartbeat failed" in caplog.text, 10)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -308,8 +308,8 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     agent = Agent("localhost", {"nvblah": "localhost"}, environment=environment_multi, code_loader=False)
     await agent.add_end_point_name("vm1.dev.inmanta.com")
     await agent.add_end_point_name("vm2.dev.inmanta.com")
-    await agent.start()
     async_finalizer(agent.stop)
+    await agent.start()
     aclient = agent._client
 
     version = (await client_multi.reserve_version(environment_multi)).result["data"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -301,7 +301,7 @@ async def test_n_versions_env_setting_scope(client, server):
 
 
 @pytest.mark.slowtest
-async def test_get_resource_for_agent(server_multi, client_multi, environment_multi):
+async def test_get_resource_for_agent(server_multi, client_multi, environment_multi, async_finalizer):
     """
     Test the server to manage the updates on a model during agent deploy
     """
@@ -309,6 +309,7 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     await agent.add_end_point_name("vm1.dev.inmanta.com")
     await agent.add_end_point_name("vm2.dev.inmanta.com")
     await agent.start()
+    async_finalizer(agent.stop)
     aclient = agent._client
 
     version = (await client_multi.reserve_version(environment_multi)).result["data"]
@@ -432,7 +433,6 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     result = await client_multi.get_version(environment_multi, version)
     assert result.code == 200
     assert result.result["model"]["done"] == 2
-    await agent.stop()
 
 
 async def test_get_environment(client, clienthelper, server, environment):
@@ -472,11 +472,12 @@ async def test_get_environment(client, clienthelper, server, environment):
     assert len(result.result["environment"]["resources"]) == 9
 
 
-async def test_resource_update(postgresql_client, client, clienthelper, server, environment):
+async def test_resource_update(postgresql_client, client, clienthelper, server, environment, async_finalizer):
     """
     Test updating resources and logging
     """
     agent = Agent("localhost", {"blah": "localhost"}, environment=environment, code_loader=False)
+    async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
 
@@ -569,7 +570,6 @@ async def test_resource_update(postgresql_client, client, clienthelper, server, 
     result = await client.get_version(environment, version)
     assert result.code == 200
     assert result.result["model"]["done"] == 10
-    await agent.stop()
 
 
 async def test_clear_environment(client, server, clienthelper, environment):


### PR DESCRIPTION
# Description

I noticed that some of these tasks are related to the heartbeat of an agent. So I assume this issue is caused by the fact that an agent is not stopped properly. This PR ensure that each test case stops the agents it starts. I will close this ticket after this fix. If the issue pops up again, we can reopen the ticket and investigate this further.

Closes #5332

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~