### PR TITLE
make shutdown more resilient

### DIFF
--- a/changelogs/unreleased/shutdown-stability.yml
+++ b/changelogs/unreleased/shutdown-stability.yml
@@ -1,0 +1,5 @@
+description: Improved exception handling during shutdown
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -370,7 +370,7 @@ class Scheduler(object):
                 # Ignore this, it is ok to leak a cancel here
                 pass
             if isinstance(result, Exception):
-                logging.error("Exception during shutdown", exc_info=result)
+                LOGGER.error("Exception during shutdown", exc_info=result)
 
     def __del__(self) -> None:
         if len(self._scheduled) > 0:


### PR DESCRIPTION
# Description

1. Improve testcase stability by making shutdown more robust
2. It fixes a bug where the first exception breaks the waiting  (see example below)


```python
async def test_a():
    a = []
    async def test1():
        raise Exception()

    async def test2():
        await asyncio.sleep(1)
        a.append("A")

    try:
        await asyncio.gather(test1(), test2())
    except Exception:
        a.append("B")

    assert len(a) == 2
```


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ]~~ No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
