### PR TITLE
agent count metric: include retired agents

### DIFF
--- a/changelogs/unreleased/agent-count-metric-include-retired.yml
+++ b/changelogs/unreleased/agent-count-metric-include-retired.yml
@@ -1,0 +1,5 @@
+description: Revert exclusion of retired agents in the agent count metric
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -115,13 +115,13 @@ LATEST_RELEASED_RESOURCES_SUBQUERY: str = (
     LATEST_RELEASED_MODELS_SUBQUERY
     + textwrap.dedent(
         f"""
-    , latest_released_resources AS (
-        SELECT r.*
-        FROM {Resource.table_name()} AS r
-        INNER JOIN latest_released_models as cm
-            ON r.environment = cm.environment AND r.model = cm.version
-    )
-    """.strip(
+        , latest_released_resources AS (
+            SELECT r.*
+            FROM {Resource.table_name()} AS r
+            INNER JOIN latest_released_models as cm
+                ON r.environment = cm.environment AND r.model = cm.version
+        )
+        """.strip(
             "\n"
         )
     ).strip()
@@ -492,7 +492,7 @@ class AgentCountMetricsCollector(MetricsCollector):
     ) -> Sequence[MetricValue]:
         query: str = f"""
 -- fetch actual counts
-WITH {LATEST_RELEASED_RESOURCES_SUBQUERY}, agent_counts AS (
+WITH agent_counts AS (
     SELECT
         environment,
         CASE
@@ -502,12 +502,6 @@ WITH {LATEST_RELEASED_RESOURCES_SUBQUERY}, agent_counts AS (
         END AS status,
         COUNT(*)
     FROM {Agent.table_name()} AS a
-    -- only count agents that are relevant for the latest model
-    WHERE EXISTS (
-        SELECT *
-        FROM latest_released_resources AS r
-        WHERE r.environment = a.environment AND r.agent = a.name
-    )
     GROUP BY environment, status
 )
 -- inject zeroes for missing values in the environment - status matrix

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -706,9 +706,9 @@ async def test_agent_count_metric(clienthelper, client, server):
     assert all(statuses.keys() == {"paused", "up", "down"} for _, statuses in gauges_by_status.items())
     # verify counts
     assert gauges_by_status[env1.id]["paused"].count == 1
-    assert gauges_by_status[env2.id]["paused"].count == 1  # agent3 is not used by any resource so it should not be counted
+    assert gauges_by_status[env2.id]["paused"].count == 2  # agent3 is not used by any resource but it should still be counted
     # verify that all other counts are 0
-    assert sum(abs(gauge.count) for gauge in result_gauge) == 2
+    assert sum(abs(gauge.count) for gauge in result_gauge) == 3
 
 
 async def test_agent_count_metric_empty_datapoint(client, server):


### PR DESCRIPTION
# Description

For improved consistency with the agents page, revert exclusion of retired (not used by latest released version) agents in the agent count metric. Increases relevance of #5349.

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
