### PR TITLE
Improve performance of put_partial endpoint

### DIFF
--- a/changelogs/unreleased/4743-increase-performance-put-partial.yml
+++ b/changelogs/unreleased/4743-increase-performance-put-partial.yml
@@ -1,0 +1,8 @@
+---
+description: Increase the performance of the `put_partial` endpoint by not fetching resources from the database that belong to a resource set that will be removed.
+issue-nr: 4743
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/db/versions/v202301300.py
+++ b/src/inmanta/db/versions/v202301300.py
@@ -1,0 +1,23 @@
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+from asyncpg import Connection
+
+
+async def update(connection: Connection) -> None:
+    await connection.execute("CREATE INDEX ON public.resource (environment, model, resource_set)")

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -229,7 +229,7 @@ class PartialUpdateMerger:
         old_data = await data.Resource.get_resources_for_version(
             environment=self.env.id,
             version=self.base_version,
-            excl=self.removed_resource_sets,
+            exclude_resource_sets=self.removed_resource_sets,
             connection=connection,
         )
         old_resources: Dict[ResourceIdStr, ResourceWithResourceSet] = {}

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -229,7 +229,7 @@ class PartialUpdateMerger:
         old_data = await data.Resource.get_resources_for_version(
             environment=self.env.id,
             version=self.base_version,
-            exclude_resource_sets=self.removed_resource_sets,
+            exclude_resource_sets=set(self.removed_resource_sets),
             connection=connection,
         )
         old_resources: Dict[ResourceIdStr, ResourceWithResourceSet] = {}

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -185,7 +185,7 @@ class PartialUpdateMerger:
         updated_resource_sets = set(s for s in resource_sets.values() if s is not None)
         if updated_resource_sets.intersection(removed_resource_sets):
             raise Exception(
-                "resource_sets contains a resource that belongs to the removed resource set: "
+                "resource_sets contains a resource that belongs to one of the removed_resource_sets: "
                 f"{updated_resource_sets.intersection(removed_resource_sets)}"
             )
         self.partial_updates = partial_updates

--- a/tests/db/migration_tests/dumps/v202301300.sql
+++ b/tests/db/migration_tests/dumps/v202301300.sql
@@ -1,0 +1,1213 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 13.6
+-- Dumped by pg_dump version 13.6
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: change; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.change AS ENUM (
+    'nochange',
+    'created',
+    'purged',
+    'updated'
+);
+
+
+--
+-- Name: non_deploying_resource_state; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.non_deploying_resource_state AS ENUM (
+    'unavailable',
+    'skipped',
+    'dry',
+    'deployed',
+    'failed',
+    'available',
+    'cancelled',
+    'undefined',
+    'skipped_for_undefined'
+);
+
+
+--
+-- Name: notificationseverity; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.notificationseverity AS ENUM (
+    'message',
+    'info',
+    'success',
+    'warning',
+    'error'
+);
+
+
+--
+-- Name: resource_id_version_pair; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.resource_id_version_pair AS (
+	resource_id character varying,
+	version integer
+);
+
+
+--
+-- Name: resourceaction_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.resourceaction_type AS ENUM (
+    'store',
+    'push',
+    'pull',
+    'deploy',
+    'dryrun',
+    'getfact',
+    'other'
+);
+
+
+--
+-- Name: resourcestate; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.resourcestate AS ENUM (
+    'unavailable',
+    'skipped',
+    'dry',
+    'deployed',
+    'failed',
+    'deploying',
+    'available',
+    'cancelled',
+    'undefined',
+    'skipped_for_undefined'
+);
+
+
+--
+-- Name: versionstate; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.versionstate AS ENUM (
+    'success',
+    'failed',
+    'deploying',
+    'pending'
+);
+
+
+SET default_tablespace = '';
+
+--
+-- Name: agent; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agent (
+    environment uuid NOT NULL,
+    name character varying NOT NULL,
+    last_failover timestamp with time zone,
+    paused boolean DEFAULT false,
+    id_primary uuid,
+    unpause_on_resume boolean
+);
+
+
+--
+-- Name: agentinstance; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agentinstance (
+    id uuid NOT NULL,
+    process uuid NOT NULL,
+    name character varying NOT NULL,
+    expired timestamp with time zone,
+    tid uuid NOT NULL
+);
+
+
+--
+-- Name: agentprocess; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agentprocess (
+    hostname character varying NOT NULL,
+    environment uuid NOT NULL,
+    first_seen timestamp with time zone,
+    last_seen timestamp with time zone,
+    expired timestamp with time zone,
+    sid uuid NOT NULL
+);
+
+
+--
+-- Name: code; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.code (
+    environment uuid NOT NULL,
+    resource character varying NOT NULL,
+    version integer NOT NULL,
+    source_refs jsonb
+);
+
+
+--
+-- Name: compile; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.compile (
+    id uuid NOT NULL,
+    environment uuid NOT NULL,
+    started timestamp with time zone,
+    completed timestamp with time zone,
+    requested timestamp with time zone,
+    metadata jsonb,
+    environment_variables jsonb,
+    do_export boolean,
+    force_update boolean,
+    success boolean,
+    version integer,
+    remote_id uuid,
+    handled boolean,
+    substitute_compile_id uuid,
+    compile_data jsonb,
+    partial boolean DEFAULT false,
+    removed_resource_sets character varying[] DEFAULT ARRAY[]::character varying[],
+    notify_failed_compile boolean,
+    failed_compile_message character varying,
+    exporter_plugin character varying
+);
+
+
+--
+-- Name: configurationmodel; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.configurationmodel (
+    version integer NOT NULL,
+    environment uuid NOT NULL,
+    date timestamp with time zone,
+    released boolean DEFAULT false,
+    deployed boolean DEFAULT false,
+    result public.versionstate DEFAULT 'pending'::public.versionstate,
+    version_info jsonb,
+    total integer DEFAULT 0,
+    undeployable character varying[],
+    skipped_for_undeployable character varying[],
+    partial_base integer
+);
+
+
+--
+-- Name: dryrun; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.dryrun (
+    id uuid NOT NULL,
+    environment uuid NOT NULL,
+    model integer NOT NULL,
+    date timestamp with time zone,
+    total integer DEFAULT 0,
+    todo integer DEFAULT 0,
+    resources jsonb DEFAULT '{}'::jsonb
+);
+
+
+--
+-- Name: environment; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.environment (
+    id uuid NOT NULL,
+    name character varying NOT NULL,
+    project uuid NOT NULL,
+    repo_url character varying DEFAULT ''::character varying,
+    repo_branch character varying DEFAULT ''::character varying,
+    settings jsonb DEFAULT '{}'::jsonb,
+    last_version integer DEFAULT 0,
+    halted boolean DEFAULT false NOT NULL,
+    description character varying(255) DEFAULT ''::character varying,
+    icon character varying(65535) DEFAULT ''::character varying
+);
+
+
+--
+-- Name: environmentmetricsgauge; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.environmentmetricsgauge (
+    environment uuid NOT NULL,
+    metric_name character varying NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    count integer NOT NULL,
+    category character varying DEFAULT '__None__'::character varying NOT NULL
+);
+
+
+--
+-- Name: environmentmetricstimer; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.environmentmetricstimer (
+    environment uuid NOT NULL,
+    metric_name character varying NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    count integer NOT NULL,
+    value double precision NOT NULL,
+    category character varying DEFAULT '__None__'::character varying NOT NULL
+);
+
+
+--
+-- Name: notification; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.notification (
+    id uuid NOT NULL,
+    environment uuid NOT NULL,
+    created timestamp with time zone NOT NULL,
+    title character varying NOT NULL,
+    message character varying NOT NULL,
+    severity public.notificationseverity DEFAULT 'message'::public.notificationseverity,
+    uri character varying NOT NULL,
+    read boolean DEFAULT false NOT NULL,
+    cleared boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: parameter; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.parameter (
+    id uuid NOT NULL,
+    name character varying NOT NULL,
+    value character varying DEFAULT ''::character varying NOT NULL,
+    environment uuid NOT NULL,
+    resource_id character varying DEFAULT ''::character varying,
+    source character varying NOT NULL,
+    updated timestamp with time zone,
+    metadata jsonb
+);
+
+
+--
+-- Name: project; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project (
+    id uuid NOT NULL,
+    name character varying NOT NULL
+);
+
+
+--
+-- Name: report; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.report (
+    id uuid NOT NULL,
+    started timestamp with time zone NOT NULL,
+    completed timestamp with time zone,
+    command character varying NOT NULL,
+    name character varying NOT NULL,
+    errstream character varying DEFAULT ''::character varying,
+    outstream character varying DEFAULT ''::character varying,
+    returncode integer,
+    compile uuid NOT NULL
+);
+
+
+--
+-- Name: resource; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.resource (
+    environment uuid NOT NULL,
+    model integer NOT NULL,
+    resource_id character varying NOT NULL,
+    agent character varying NOT NULL,
+    last_deploy timestamp with time zone,
+    attributes jsonb,
+    attribute_hash character varying,
+    status public.resourcestate DEFAULT 'available'::public.resourcestate,
+    provides character varying[] DEFAULT ARRAY[]::character varying[],
+    resource_type character varying NOT NULL,
+    resource_id_value character varying NOT NULL,
+    last_non_deploying_status public.non_deploying_resource_state DEFAULT 'available'::public.non_deploying_resource_state NOT NULL,
+    resource_set character varying
+);
+
+
+--
+-- Name: resourceaction; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.resourceaction (
+    action_id uuid NOT NULL,
+    action public.resourceaction_type NOT NULL,
+    started timestamp with time zone NOT NULL,
+    finished timestamp with time zone,
+    messages jsonb[],
+    status public.resourcestate DEFAULT 'available'::public.resourcestate,
+    changes jsonb DEFAULT '{}'::jsonb,
+    change public.change,
+    environment uuid NOT NULL,
+    version integer NOT NULL,
+    resource_version_ids character varying[] NOT NULL
+);
+
+
+--
+-- Name: resourceaction_resource; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.resourceaction_resource (
+    environment uuid NOT NULL,
+    resource_action_id uuid NOT NULL,
+    resource_id character varying NOT NULL,
+    resource_version integer NOT NULL
+);
+
+
+--
+-- Name: schemamanager; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schemamanager (
+    name character varying NOT NULL,
+    legacy_version integer,
+    installed_versions integer[]
+);
+
+
+--
+-- Name: unknownparameter; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.unknownparameter (
+    id uuid NOT NULL,
+    name character varying NOT NULL,
+    environment uuid NOT NULL,
+    source character varying NOT NULL,
+    resource_id character varying DEFAULT ''::character varying,
+    version integer NOT NULL,
+    metadata jsonb,
+    resolved boolean DEFAULT false
+);
+
+
+--
+-- Data for Name: agent; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.agent (environment, name, last_failover, paused, id_primary, unpause_on_resume) FROM stdin;
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	localhost	2023-01-30 16:19:09.494191+01	f	83904014-9169-4370-9679-77d902aae42e	\N
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	internal	2023-01-30 16:19:10.912707+01	f	3b83d3e4-85e7-43bb-8633-c61ffdeb7b54	\N
+\.
+
+
+--
+-- Data for Name: agentinstance; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.agentinstance (id, process, name, expired, tid) FROM stdin;
+3b83d3e4-85e7-43bb-8633-c61ffdeb7b54	71a75032-a0b1-11ed-afd4-84144dfe5579	internal	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b
+83904014-9169-4370-9679-77d902aae42e	71a75032-a0b1-11ed-afd4-84144dfe5579	localhost	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b
+8a6b7624-b8b1-470b-bf81-28e840e46307	7145256a-a0b1-11ed-ac66-84144dfe5579	internal	2023-01-30 16:19:10.912707+01	7c2563a6-2a67-4ec0-8c55-77299c7b982b
+\.
+
+
+--
+-- Data for Name: agentprocess; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.agentprocess (hostname, environment, first_seen, last_seen, expired, sid) FROM stdin;
+arnaud-inmanta-laptop	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2023-01-30 16:19:08.850453+01	2023-01-30 16:19:08.911924+01	2023-01-30 16:19:10.912707+01	7145256a-a0b1-11ed-ac66-84144dfe5579
+arnaud-inmanta-laptop	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2023-01-30 16:19:09.494191+01	2023-01-30 16:19:17.767408+01	\N	71a75032-a0b1-11ed-afd4-84144dfe5579
+\.
+
+
+--
+-- Data for Name: code; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.code (environment, resource, version, source_refs) FROM stdin;
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Service	1	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::File	1	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Directory	1	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Package	1	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Symlink	1	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::AgentConfig	1	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Service	2	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::File	2	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Directory	2	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Package	2	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::Symlink	2	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	std::AgentConfig	2	{"db0b95ee005147666e020669ad62de99f657791b": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/resources.py", "inmanta_plugins.std.resources", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]], "e13ad6e395f94b178f8627cbe0b8125d46e7abf0": ["/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std/plugins/__init__.py", "inmanta_plugins.std", ["Jinja2~=3.1", "email_validator~=1.3", "pydantic~=1.10", "dataclasses~=0.7;python_version<'3.7'"]]}
+\.
+
+
+--
+-- Data for Name: compile; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.compile (id, environment, started, completed, requested, metadata, environment_variables, do_export, force_update, success, version, remote_id, handled, substitute_compile_id, compile_data, partial, removed_resource_sets, notify_failed_compile, failed_compile_message, exporter_plugin) FROM stdin;
+c5c047fa-3ad1-4f08-a5a6-28a338886115	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2023-01-30 16:18:58.710719+01	2023-01-30 16:19:08.939917+01	2023-01-30 16:18:58.706157+01	{"type": "api", "message": "Recompile trigger through API call"}	{}	t	t	t	1	3b51c759-0074-417b-84ae-f55dcfa52227	t	\N	{"errors": []}	f	{}	\N	\N	\N
+3819814d-80c1-4a6c-a466-fcac5ba3e141	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2023-01-30 16:19:09.559012+01	2023-01-30 16:19:17.652244+01	2023-01-30 16:19:09.554383+01	{"type": "api", "message": "Recompile trigger through API call"}	{}	t	t	t	2	c66a8e9f-6a94-449b-b70f-74a74287b2d6	t	\N	{"errors": []}	f	{}	\N	\N	\N
+\.
+
+
+--
+-- Data for Name: configurationmodel; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.configurationmodel (version, environment, date, released, deployed, result, version_info, total, undeployable, skipped_for_undeployable, partial_base) FROM stdin;
+1	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2023-01-30 16:19:08.43787+01	t	t	failed	{"export_metadata": {"type": "api", "message": "Recompile trigger through API call", "cli-user": "arnaud", "hostname": "arnaud-inmanta-laptop", "inmanta:compile:state": "success"}}	2	{}	{}	\N
+2	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2023-01-30 16:19:17.565394+01	t	t	deploying	{"export_metadata": {"type": "api", "message": "Recompile trigger through API call", "cli-user": "arnaud", "hostname": "arnaud-inmanta-laptop", "inmanta:compile:state": "success"}}	2	{}	{}	\N
+\.
+
+
+--
+-- Data for Name: dryrun; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.dryrun (id, environment, model, date, total, todo, resources) FROM stdin;
+\.
+
+
+--
+-- Data for Name: environment; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.environment (id, name, project, repo_url, repo_branch, settings, last_version, halted, description, icon) FROM stdin;
+885859ef-db84-4b69-b3cc-307ce629e2f9	dev-2	fc8eec36-a021-49ba-8c24-847023e1c41a			{"auto_full_compile": ""}	0	f		
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	dev-1	fc8eec36-a021-49ba-8c24-847023e1c41a			{"auto_deploy": true, "server_compile": true, "purge_on_delete": false, "auto_full_compile": "", "recompile_backoff": 0.1, "autostart_agent_map": {"internal": "local:", "localhost": "local:"}, "push_on_auto_deploy": true, "autostart_agent_deploy_interval": 0, "autostart_agent_repair_interval": 600, "autostart_agent_deploy_splay_time": 0, "autostart_agent_repair_splay_time": 0, "agent_trigger_method_on_auto_deploy": "push_incremental_deploy"}	2	f		
+\.
+
+
+--
+-- Data for Name: environmentmetricsgauge; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.environmentmetricsgauge (environment, metric_name, "timestamp", count, category) FROM stdin;
+\.
+
+
+--
+-- Data for Name: environmentmetricstimer; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.environmentmetricstimer (environment, metric_name, "timestamp", count, value, category) FROM stdin;
+\.
+
+
+--
+-- Data for Name: notification; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.notification (id, environment, created, title, message, severity, uri, read, cleared) FROM stdin;
+\.
+
+
+--
+-- Data for Name: parameter; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.parameter (id, name, value, environment, resource_id, source, updated, metadata) FROM stdin;
+\.
+
+
+--
+-- Data for Name: project; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.project (id, name) FROM stdin;
+fc8eec36-a021-49ba-8c24-847023e1c41a	project-test-a
+\.
+
+
+--
+-- Data for Name: report; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.report (id, started, completed, command, name, errstream, outstream, returncode, compile) FROM stdin;
+ba5d8691-1165-40f9-8c4c-48e33575f38d	2023-01-30 16:18:58.71104+01	2023-01-30 16:18:58.712152+01		Init		Using extra environment variables during compile \n	0	c5c047fa-3ad1-4f08-a5a6-28a338886115
+bd7ad17a-3293-4adc-9dca-737061ede304	2023-01-30 16:18:58.712455+01	2023-01-30 16:18:58.713313+01		Creating venv			0	c5c047fa-3ad1-4f08-a5a6-28a338886115
+0d83e20c-2b9f-4b57-b33a-6151a023ae19	2023-01-30 16:18:58.718013+01	2023-01-30 16:18:59.001572+01	/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m pip uninstall -y inmanta inmanta-service-orchestrator inmanta-core	Uninstall inmanta packages from the compiler venv	WARNING: Skipping inmanta as it is not installed.\nWARNING: Skipping inmanta-service-orchestrator as it is not installed.\n	Found existing installation: inmanta-core 8.1.0.dev0\nNot uninstalling inmanta-core at /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages, outside environment /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env\nCan't uninstall 'inmanta-core'. No files were found to uninstall.\n	0	c5c047fa-3ad1-4f08-a5a6-28a338886115
+562129ac-01ab-4c54-b84a-12f984f98dc9	2023-01-30 16:18:59.002368+01	2023-01-30 16:19:07.6159+01	/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m inmanta.app -vvv -X project update	Updating modules		inmanta.moduletool       INFO    Performing update attempt 1 of 5\ninmanta.module           DEBUG   Cloning into '/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std'...\ninmanta.module           DEBUG   Installing module std (v1) (with no version constraints).\ninmanta.module           INFO    Checking out 4.1.1 on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.module           DEBUG   Successfully installed module std (v1) version 4.1.1 in /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std from https://github.com/inmanta/std.\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.module           DEBUG   Parsing took 0.000119 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 0 hits and 2 misses (0%)\ninmanta.module           INFO    Performing fetch on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.module           INFO    Checking out 4.1.1 on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.pip              DEBUG   Pip command: /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m pip install --upgrade --upgrade-strategy eager Jinja2~=3.1 email_validator~=1.3 pydantic~=1.10 dataclasses~=0.7; python_version < "3.7" inmanta-core==8.1.0.dev0\ninmanta.pip              DEBUG   Ignoring dataclasses: markers 'python_version < "3.7"' don't match your environment\ninmanta.pip              DEBUG   Requirement already satisfied: Jinja2~=3.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (3.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: email_validator~=1.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (1.3.0)\ninmanta.pip              DEBUG   Collecting email_validator~=1.3\ninmanta.pip              DEBUG   Downloading email_validator-1.3.1-py2.py3-none-any.whl (22 kB)\ninmanta.pip              DEBUG   Requirement already satisfied: pydantic~=1.10 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (1.10.4)\ninmanta.pip              DEBUG   Requirement already satisfied: inmanta-core==8.1.0.dev0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (8.1.0.dev0)\ninmanta.pip              DEBUG   Requirement already satisfied: more-itertools<10,>=8 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (9.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: ply~=3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (3.11)\ninmanta.pip              DEBUG   Requirement already satisfied: python-dateutil~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.8.2)\ninmanta.pip              DEBUG   Requirement already satisfied: cookiecutter<3,>=1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: colorlog~=6.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.7.0)\ninmanta.pip              DEBUG   Requirement already satisfied: click-plugins~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: toml~=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.2)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml~=0.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.17.21)\ninmanta.pip              DEBUG   Requirement already satisfied: PyJWT~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: texttable~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.6.7)\ninmanta.pip              DEBUG   Requirement already satisfied: pip>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (22.3.1)\ninmanta.pip              DEBUG   Requirement already satisfied: packaging<24.0,>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (23.0)\ninmanta.pip              DEBUG   Requirement already satisfied: build~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.0)\ninmanta.pip              DEBUG   Requirement already satisfied: netifaces~=0.11 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.11.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pyyaml~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pyformance~=0.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.4)\ninmanta.pip              DEBUG   Requirement already satisfied: execnet~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.9.0)\ninmanta.pip              DEBUG   Requirement already satisfied: importlib-metadata<7,>=4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: click<8.2,>=8.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (8.1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: docstring-parser<0.16,>=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.15)\ninmanta.pip              DEBUG   Requirement already satisfied: crontab<2.0,>=0.23 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: tornado~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.2)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-inspect~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.8.0)\ninmanta.pip              DEBUG   Requirement already satisfied: cryptography<40,>=36 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (39.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: asyncpg<0.28,~=0.25 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.27.0)\ninmanta.pip              DEBUG   Requirement already satisfied: MarkupSafe>=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from Jinja2~=3.1) (2.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: dnspython>=1.15.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (2.3.0)\ninmanta.pip              DEBUG   Requirement already satisfied: idna>=2.0.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (3.4)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-extensions>=4.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pydantic~=1.10) (4.4.0)\ninmanta.pip              DEBUG   Requirement already satisfied: tomli>=1.1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (2.0.1)\ninmanta.pip              DEBUG   Requirement already satisfied: pyproject_hooks in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: binaryornot>=0.4.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.4.4)\ninmanta.pip              DEBUG   Requirement already satisfied: jinja2-time>=0.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.2.0)\ninmanta.pip              DEBUG   Requirement already satisfied: requests>=2.23.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2.28.2)\ninmanta.pip              DEBUG   Requirement already satisfied: python-slugify>=4.0.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (6.1.2)\ninmanta.pip              DEBUG   Collecting python-slugify>=4.0.0\ninmanta.pip              DEBUG   Downloading python_slugify-8.0.0-py2.py3-none-any.whl (9.5 kB)\ninmanta.pip              DEBUG   Requirement already satisfied: cffi>=1.12 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from cryptography<40,>=36->inmanta-core==8.1.0.dev0) (1.15.1)\ninmanta.pip              DEBUG   Requirement already satisfied: zipp>=0.5 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from importlib-metadata<7,>=4->inmanta-core==8.1.0.dev0) (3.11.0)\ninmanta.pip              DEBUG   Collecting zipp>=0.5\ninmanta.pip              DEBUG   Downloading zipp-3.12.0-py3-none-any.whl (6.6 kB)\ninmanta.pip              DEBUG   Requirement already satisfied: six in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pyformance~=0.4->inmanta-core==8.1.0.dev0) (1.16.0)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml.clib>=0.2.6 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from ruamel.yaml~=0.17->inmanta-core==8.1.0.dev0) (0.2.7)\ninmanta.pip              DEBUG   Requirement already satisfied: mypy-extensions>=0.3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from typing-inspect~=0.7->inmanta-core==8.1.0.dev0) (0.4.3)\ninmanta.pip              DEBUG   Requirement already satisfied: chardet>=3.0.2 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from binaryornot>=0.4.4->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (5.1.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pycparser in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cffi>=1.12->cryptography<40,>=36->inmanta-core==8.1.0.dev0) (2.21)\ninmanta.pip              DEBUG   Requirement already satisfied: arrow in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from jinja2-time>=0.2.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.2.3)\ninmanta.pip              DEBUG   Requirement already satisfied: text-unidecode>=1.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from python-slugify>=4.0.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: charset-normalizer<4,>=2 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (3.0.1)\ninmanta.pip              DEBUG   Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.26.14)\ninmanta.pip              DEBUG   Requirement already satisfied: certifi>=2017.4.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2022.12.7)\ninmanta.pip              DEBUG   Installing collected packages: zipp, python-slugify, email_validator\ninmanta.pip              DEBUG   Attempting uninstall: zipp\ninmanta.pip              DEBUG   Found existing installation: zipp 3.11.0\ninmanta.pip              DEBUG   Not uninstalling zipp at /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages, outside environment /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env\ninmanta.pip              DEBUG   Can't uninstall 'zipp'. No files were found to uninstall.\ninmanta.pip              DEBUG   Attempting uninstall: python-slugify\ninmanta.pip              DEBUG   Found existing installation: python-slugify 6.1.2\ninmanta.pip              DEBUG   Not uninstalling python-slugify at /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages, outside environment /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env\ninmanta.pip              DEBUG   Can't uninstall 'python-slugify'. No files were found to uninstall.\ninmanta.pip              DEBUG   Attempting uninstall: email_validator\ninmanta.pip              DEBUG   Found existing installation: email-validator 1.3.0\ninmanta.pip              DEBUG   Not uninstalling email-validator at /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages, outside environment /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env\ninmanta.pip              DEBUG   Can't uninstall 'email-validator'. No files were found to uninstall.\ninmanta.pip              DEBUG   ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\ninmanta.pip              DEBUG   pyadr 0.19.0 requires python-slugify<7,>=6, but you have python-slugify 8.0.0 which is incompatible.\ninmanta.pip              DEBUG   Successfully installed email_validator-1.3.1 python-slugify-8.0.0 zipp-3.12.0\ninmanta.module           INFO    verifying project\ninmanta.env              WARNING Incompatibility between constraint python-slugify<7,>=6 and installed version 8.0.0 (from pyadr)\ninmanta.moduletool       INFO    Performing update attempt 2 of 5\ninmanta.module           DEBUG   Parsing took 0.000074 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 1 hits and 2 misses (33%)\ninmanta.module           INFO    Performing fetch on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.module           INFO    Checking out 4.1.1 on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.pip              DEBUG   Pip command: /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m pip install --upgrade --upgrade-strategy eager Jinja2~=3.1 email_validator~=1.3 pydantic~=1.10 dataclasses~=0.7; python_version < "3.7" inmanta-core==8.1.0.dev0\ninmanta.pip              DEBUG   Ignoring dataclasses: markers 'python_version < "3.7"' don't match your environment\ninmanta.pip              DEBUG   Requirement already satisfied: Jinja2~=3.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (3.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: email_validator~=1.3 in ./.env/lib/python3.9/site-packages (1.3.1)\ninmanta.pip              DEBUG   Requirement already satisfied: pydantic~=1.10 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (1.10.4)\ninmanta.pip              DEBUG   Requirement already satisfied: inmanta-core==8.1.0.dev0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (8.1.0.dev0)\ninmanta.pip              DEBUG   Requirement already satisfied: PyJWT~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: tornado~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.2)\ninmanta.pip              DEBUG   Requirement already satisfied: asyncpg<0.28,~=0.25 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.27.0)\ninmanta.pip              DEBUG   Requirement already satisfied: packaging<24.0,>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (23.0)\ninmanta.pip              DEBUG   Requirement already satisfied: importlib-metadata<7,>=4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: build~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pyformance~=0.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.4)\ninmanta.pip              DEBUG   Requirement already satisfied: toml~=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.2)\ninmanta.pip              DEBUG   Requirement already satisfied: execnet~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.9.0)\ninmanta.pip              DEBUG   Requirement already satisfied: python-dateutil~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.8.2)\ninmanta.pip              DEBUG   Requirement already satisfied: ply~=3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (3.11)\ninmanta.pip              DEBUG   Requirement already satisfied: cookiecutter<3,>=1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml~=0.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.17.21)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-inspect~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.8.0)\ninmanta.pip              DEBUG   Requirement already satisfied: click<8.2,>=8.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (8.1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: more-itertools<10,>=8 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (9.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: netifaces~=0.11 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.11.0)\ninmanta.pip              DEBUG   Requirement already satisfied: docstring-parser<0.16,>=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.15)\ninmanta.pip              DEBUG   Requirement already satisfied: crontab<2.0,>=0.23 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pip>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (22.3.1)\ninmanta.pip              DEBUG   Requirement already satisfied: colorlog~=6.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.7.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pyyaml~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: cryptography<40,>=36 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (39.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: texttable~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.6.7)\ninmanta.pip              DEBUG   Requirement already satisfied: click-plugins~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: MarkupSafe>=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from Jinja2~=3.1) (2.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: dnspython>=1.15.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (2.3.0)\ninmanta.pip              DEBUG   Requirement already satisfied: idna>=2.0.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (3.4)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-extensions>=4.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pydantic~=1.10) (4.4.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pyproject_hooks in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: tomli>=1.1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (2.0.1)\ninmanta.pip              DEBUG   Requirement already satisfied: jinja2-time>=0.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.2.0)\ninmanta.pip              DEBUG   Requirement already satisfied: python-slugify>=4.0.0 in ./.env/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (8.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: binaryornot>=0.4.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.4.4)\ninmanta.pip              DEBUG   Requirement already satisfied: requests>=2.23.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2.28.2)\ninmanta.pip              DEBUG   Requirement already satisfied: cffi>=1.12 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from cryptography<40,>=36->inmanta-core==8.1.0.dev0) (1.15.1)\ninmanta.pip              DEBUG   Requirement already satisfied: zipp>=0.5 in ./.env/lib/python3.9/site-packages (from importlib-metadata<7,>=4->inmanta-core==8.1.0.dev0) (3.12.0)\ninmanta.pip              DEBUG   Requirement already satisfied: six in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pyformance~=0.4->inmanta-core==8.1.0.dev0) (1.16.0)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml.clib>=0.2.6 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from ruamel.yaml~=0.17->inmanta-core==8.1.0.dev0) (0.2.7)\ninmanta.pip              DEBUG   Requirement already satisfied: mypy-extensions>=0.3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from typing-inspect~=0.7->inmanta-core==8.1.0.dev0) (0.4.3)\ninmanta.pip              DEBUG   Requirement already satisfied: chardet>=3.0.2 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from binaryornot>=0.4.4->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (5.1.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pycparser in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cffi>=1.12->cryptography<40,>=36->inmanta-core==8.1.0.dev0) (2.21)\ninmanta.pip              DEBUG   Requirement already satisfied: arrow in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from jinja2-time>=0.2.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.2.3)\ninmanta.pip              DEBUG   Requirement already satisfied: text-unidecode>=1.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from python-slugify>=4.0.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: certifi>=2017.4.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2022.12.7)\ninmanta.pip              DEBUG   Requirement already satisfied: charset-normalizer<4,>=2 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (3.0.1)\ninmanta.pip              DEBUG   Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.26.14)\ninmanta.module           INFO    verifying project\ninmanta.env              WARNING Incompatibility between constraint python-slugify<7,>=6 and installed version 8.0.0 (from pyadr)\n	0	c5c047fa-3ad1-4f08-a5a6-28a338886115
+b452b83a-8281-42fe-ac18-31abac317383	2023-01-30 16:19:07.617226+01	2023-01-30 16:19:08.938811+01	/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m inmanta.app -vvv export -X -e 7c2563a6-2a67-4ec0-8c55-77299c7b982b --server_address localhost --server_port 51237 --metadata {"type": "api", "message": "Recompile trigger through API call"} --export-compile-data --export-compile-data-file /tmp/tmpa9iabonb --no-ssl	Recompiling configuration model		inmanta.compiler         DEBUG   Starting compile\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.module           DEBUG   Parsing took 0.004205 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 2 hits and 0 misses (100%)\ninmanta.module           INFO    verifying project\ninmanta.env              WARNING Incompatibility between constraint python-slugify<7,>=6 and installed version 8.0.0 (from pyadr)\ninmanta.module           DEBUG   Loading module inmanta_plugins.std.resources\ninmanta.loader           DEBUG   Loading module: inmanta_plugins.std\ninmanta.module           DEBUG   Loading module inmanta_plugins.std\ninmanta.module           DEBUG   Parsing took 0.000094 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 2 hits and 0 misses (100%)\ninmanta.module           INFO    The following modules are currently installed:\ninmanta.module           INFO    V1 modules:\ninmanta.module           INFO      std: 4.1.1\ninmanta.execute.schedulerDEBUG   Iteration 1 (e: 8, w: 0, p: 0, done: 0, time: 0.002309)\ninmanta.execute.schedulerDEBUG   Finishing statements with no waiters\ninmanta.execute.schedulerDEBUG   Iteration 2 (e: 1, w: 0, p: 0, done: 73, time: 0.001914)\ninmanta.execute.schedulerDEBUG   Finishing statements with no waiters\ninmanta.execute.schedulerDEBUG   Iteration 2 (e: 0, w: 0, p: 0, done: 74, time: 0.000250)\ninmanta.execute.schedulerINFO    Total compilation time 0.004623\ninmanta.compiler         DEBUG   Compile done\ninmanta.protocol.endpointsDEBUG   Start transport for client compiler\nasyncio                  DEBUG   Using selector: EpollSelector\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server POST http://localhost:51237/api/v2/reserve_version\ninmanta.protocol.endpointsDEBUG   Start transport for client compiler\ninmanta.export           INFO    Sending resources and handler source to server\ninmanta.export           INFO    Uploading source files\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server POST http://localhost:51237/api/v1/file\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server PUT http://localhost:51237/api/v1/file/db0b95ee005147666e020669ad62de99f657791b\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server PUT http://localhost:51237/api/v1/file/e13ad6e395f94b178f8627cbe0b8125d46e7abf0\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server PUT http://localhost:51237/api/v1/codebatched/1\ninmanta.export           INFO    Uploading 1 files\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server POST http://localhost:51237/api/v1/file\ninmanta.export           INFO    Only 1 files are new and need to be uploaded\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server PUT http://localhost:51237/api/v1/file/7110eda4d09e062aa5e4a390b0a572ac0d2c0220\ninmanta.export           DEBUG   Uploaded file with hash 7110eda4d09e062aa5e4a390b0a572ac0d2c0220\ninmanta.export           INFO    Sending resource updates to server\ninmanta.export           DEBUG     std::File[localhost,path=/tmp/test],v=1\ninmanta.export           DEBUG     std::AgentConfig[internal,agentname=localhost],v=1\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server PUT http://localhost:51237/api/v1/version\ninmanta.export           INFO    Committed resources with version 1\n	0	c5c047fa-3ad1-4f08-a5a6-28a338886115
+2748046c-f5ea-4813-b781-15b14ad480b8	2023-01-30 16:19:09.559409+01	2023-01-30 16:19:09.560422+01		Init		Using extra environment variables during compile \n	0	3819814d-80c1-4a6c-a466-fcac5ba3e141
+6c6a697d-19d7-44c1-9baa-58e0f9f20a79	2023-01-30 16:19:09.565417+01	2023-01-30 16:19:09.820314+01	/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m pip uninstall -y inmanta inmanta-service-orchestrator inmanta-core	Uninstall inmanta packages from the compiler venv	WARNING: Skipping inmanta as it is not installed.\nWARNING: Skipping inmanta-service-orchestrator as it is not installed.\n	Found existing installation: inmanta-core 8.1.0.dev0\nNot uninstalling inmanta-core at /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages, outside environment /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env\nCan't uninstall 'inmanta-core'. No files were found to uninstall.\n	0	3819814d-80c1-4a6c-a466-fcac5ba3e141
+08139de4-e2ea-4e96-987e-a3ddd4f4c112	2023-01-30 16:19:09.821203+01	2023-01-30 16:19:16.774093+01	/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m inmanta.app -vvv -X project update	Updating modules		inmanta.moduletool       INFO    Performing update attempt 1 of 5\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.module           DEBUG   Parsing took 0.000069 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 2 hits and 0 misses (100%)\ninmanta.module           INFO    Performing fetch on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.module           INFO    Checking out 4.1.1 on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.pip              DEBUG   Pip command: /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m pip install --upgrade --upgrade-strategy eager email_validator~=1.3 pydantic~=1.10 Jinja2~=3.1 dataclasses~=0.7; python_version < "3.7" inmanta-core==8.1.0.dev0\ninmanta.pip              DEBUG   Ignoring dataclasses: markers 'python_version < "3.7"' don't match your environment\ninmanta.pip              DEBUG   Requirement already satisfied: email_validator~=1.3 in ./.env/lib/python3.9/site-packages (1.3.1)\ninmanta.pip              DEBUG   Requirement already satisfied: pydantic~=1.10 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (1.10.4)\ninmanta.pip              DEBUG   Requirement already satisfied: Jinja2~=3.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (3.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: inmanta-core==8.1.0.dev0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (8.1.0.dev0)\ninmanta.pip              DEBUG   Requirement already satisfied: more-itertools<10,>=8 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (9.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: build~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.0)\ninmanta.pip              DEBUG   Requirement already satisfied: packaging<24.0,>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (23.0)\ninmanta.pip              DEBUG   Requirement already satisfied: colorlog~=6.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.7.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pip>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (22.3.1)\ninmanta.pip              DEBUG   Requirement already satisfied: pyyaml~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: execnet~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.9.0)\ninmanta.pip              DEBUG   Requirement already satisfied: click-plugins~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: importlib-metadata<7,>=4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-inspect~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.8.0)\ninmanta.pip              DEBUG   Requirement already satisfied: docstring-parser<0.16,>=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.15)\ninmanta.pip              DEBUG   Requirement already satisfied: ply~=3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (3.11)\ninmanta.pip              DEBUG   Requirement already satisfied: toml~=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.2)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml~=0.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.17.21)\ninmanta.pip              DEBUG   Requirement already satisfied: python-dateutil~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.8.2)\ninmanta.pip              DEBUG   Requirement already satisfied: cryptography<40,>=36 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (39.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: netifaces~=0.11 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.11.0)\ninmanta.pip              DEBUG   Requirement already satisfied: asyncpg<0.28,~=0.25 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.27.0)\ninmanta.pip              DEBUG   Requirement already satisfied: texttable~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.6.7)\ninmanta.pip              DEBUG   Requirement already satisfied: click<8.2,>=8.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (8.1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: cookiecutter<3,>=1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: tornado~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.2)\ninmanta.pip              DEBUG   Requirement already satisfied: pyformance~=0.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.4)\ninmanta.pip              DEBUG   Requirement already satisfied: crontab<2.0,>=0.23 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: PyJWT~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: idna>=2.0.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (3.4)\ninmanta.pip              DEBUG   Requirement already satisfied: dnspython>=1.15.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (2.3.0)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-extensions>=4.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pydantic~=1.10) (4.4.0)\ninmanta.pip              DEBUG   Requirement already satisfied: MarkupSafe>=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from Jinja2~=3.1) (2.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: pyproject_hooks in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: tomli>=1.1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (2.0.1)\ninmanta.pip              DEBUG   Requirement already satisfied: requests>=2.23.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2.28.2)\ninmanta.pip              DEBUG   Requirement already satisfied: python-slugify>=4.0.0 in ./.env/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (8.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: jinja2-time>=0.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.2.0)\ninmanta.pip              DEBUG   Requirement already satisfied: binaryornot>=0.4.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.4.4)\ninmanta.pip              DEBUG   Requirement already satisfied: cffi>=1.12 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from cryptography<40,>=36->inmanta-core==8.1.0.dev0) (1.15.1)\ninmanta.pip              DEBUG   Requirement already satisfied: zipp>=0.5 in ./.env/lib/python3.9/site-packages (from importlib-metadata<7,>=4->inmanta-core==8.1.0.dev0) (3.12.0)\ninmanta.pip              DEBUG   Requirement already satisfied: six in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pyformance~=0.4->inmanta-core==8.1.0.dev0) (1.16.0)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml.clib>=0.2.6 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from ruamel.yaml~=0.17->inmanta-core==8.1.0.dev0) (0.2.7)\ninmanta.pip              DEBUG   Requirement already satisfied: mypy-extensions>=0.3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from typing-inspect~=0.7->inmanta-core==8.1.0.dev0) (0.4.3)\ninmanta.pip              DEBUG   Requirement already satisfied: chardet>=3.0.2 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from binaryornot>=0.4.4->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (5.1.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pycparser in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cffi>=1.12->cryptography<40,>=36->inmanta-core==8.1.0.dev0) (2.21)\ninmanta.pip              DEBUG   Requirement already satisfied: arrow in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from jinja2-time>=0.2.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.2.3)\ninmanta.pip              DEBUG   Requirement already satisfied: text-unidecode>=1.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from python-slugify>=4.0.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.26.14)\ninmanta.pip              DEBUG   Requirement already satisfied: charset-normalizer<4,>=2 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (3.0.1)\ninmanta.pip              DEBUG   Requirement already satisfied: certifi>=2017.4.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2022.12.7)\ninmanta.module           INFO    verifying project\ninmanta.env              WARNING Incompatibility between constraint python-slugify<7,>=6 and installed version 8.0.0 (from pyadr)\ninmanta.moduletool       INFO    Performing update attempt 2 of 5\ninmanta.module           DEBUG   Parsing took 0.000083 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 3 hits and 0 misses (100%)\ninmanta.module           INFO    Performing fetch on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.module           INFO    Checking out 4.1.1 on /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/libs/std\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.pip              DEBUG   Pip command: /tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m pip install --upgrade --upgrade-strategy eager email_validator~=1.3 pydantic~=1.10 Jinja2~=3.1 dataclasses~=0.7; python_version < "3.7" inmanta-core==8.1.0.dev0\ninmanta.pip              DEBUG   Ignoring dataclasses: markers 'python_version < "3.7"' don't match your environment\ninmanta.pip              DEBUG   Requirement already satisfied: email_validator~=1.3 in ./.env/lib/python3.9/site-packages (1.3.1)\ninmanta.pip              DEBUG   Requirement already satisfied: pydantic~=1.10 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (1.10.4)\ninmanta.pip              DEBUG   Requirement already satisfied: Jinja2~=3.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (3.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: inmanta-core==8.1.0.dev0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (8.1.0.dev0)\ninmanta.pip              DEBUG   Requirement already satisfied: execnet~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.9.0)\ninmanta.pip              DEBUG   Requirement already satisfied: python-dateutil~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.8.2)\ninmanta.pip              DEBUG   Requirement already satisfied: importlib-metadata<7,>=4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: click<8.2,>=8.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (8.1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: pip>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (22.3.1)\ninmanta.pip              DEBUG   Requirement already satisfied: ply~=3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (3.11)\ninmanta.pip              DEBUG   Requirement already satisfied: toml~=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.2)\ninmanta.pip              DEBUG   Requirement already satisfied: packaging<24.0,>=21.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (23.0)\ninmanta.pip              DEBUG   Requirement already satisfied: netifaces~=0.11 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.11.0)\ninmanta.pip              DEBUG   Requirement already satisfied: asyncpg<0.28,~=0.25 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.27.0)\ninmanta.pip              DEBUG   Requirement already satisfied: cryptography<40,>=36 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (39.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pyformance~=0.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.4)\ninmanta.pip              DEBUG   Requirement already satisfied: texttable~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.6.7)\ninmanta.pip              DEBUG   Requirement already satisfied: crontab<2.0,>=0.23 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: more-itertools<10,>=8 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (9.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: docstring-parser<0.16,>=0.10 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.15)\ninmanta.pip              DEBUG   Requirement already satisfied: tornado~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.2)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml~=0.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.17.21)\ninmanta.pip              DEBUG   Requirement already satisfied: cookiecutter<3,>=1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: colorlog~=6.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.7.0)\ninmanta.pip              DEBUG   Requirement already satisfied: PyJWT~=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (2.6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: click-plugins~=1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (1.1.1)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-inspect~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.8.0)\ninmanta.pip              DEBUG   Requirement already satisfied: build~=0.7 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (0.10.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pyyaml~=6.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from inmanta-core==8.1.0.dev0) (6.0)\ninmanta.pip              DEBUG   Requirement already satisfied: idna>=2.0.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (3.4)\ninmanta.pip              DEBUG   Requirement already satisfied: dnspython>=1.15.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from email_validator~=1.3) (2.3.0)\ninmanta.pip              DEBUG   Requirement already satisfied: typing-extensions>=4.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pydantic~=1.10) (4.4.0)\ninmanta.pip              DEBUG   Requirement already satisfied: MarkupSafe>=2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from Jinja2~=3.1) (2.1.2)\ninmanta.pip              DEBUG   Requirement already satisfied: tomli>=1.1.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (2.0.1)\ninmanta.pip              DEBUG   Requirement already satisfied: pyproject_hooks in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from build~=0.7->inmanta-core==8.1.0.dev0) (1.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: requests>=2.23.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2.28.2)\ninmanta.pip              DEBUG   Requirement already satisfied: jinja2-time>=0.2.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.2.0)\ninmanta.pip              DEBUG   Requirement already satisfied: python-slugify>=4.0.0 in ./.env/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (8.0.0)\ninmanta.pip              DEBUG   Requirement already satisfied: binaryornot>=0.4.4 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (0.4.4)\ninmanta.pip              DEBUG   Requirement already satisfied: cffi>=1.12 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from cryptography<40,>=36->inmanta-core==8.1.0.dev0) (1.15.1)\ninmanta.pip              DEBUG   Requirement already satisfied: zipp>=0.5 in ./.env/lib/python3.9/site-packages (from importlib-metadata<7,>=4->inmanta-core==8.1.0.dev0) (3.12.0)\ninmanta.pip              DEBUG   Requirement already satisfied: six in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from pyformance~=0.4->inmanta-core==8.1.0.dev0) (1.16.0)\ninmanta.pip              DEBUG   Requirement already satisfied: ruamel.yaml.clib>=0.2.6 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from ruamel.yaml~=0.17->inmanta-core==8.1.0.dev0) (0.2.7)\ninmanta.pip              DEBUG   Requirement already satisfied: mypy-extensions>=0.3.0 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from typing-inspect~=0.7->inmanta-core==8.1.0.dev0) (0.4.3)\ninmanta.pip              DEBUG   Requirement already satisfied: chardet>=3.0.2 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from binaryornot>=0.4.4->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (5.1.0)\ninmanta.pip              DEBUG   Requirement already satisfied: pycparser in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from cffi>=1.12->cryptography<40,>=36->inmanta-core==8.1.0.dev0) (2.21)\ninmanta.pip              DEBUG   Requirement already satisfied: arrow in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from jinja2-time>=0.2.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.2.3)\ninmanta.pip              DEBUG   Requirement already satisfied: text-unidecode>=1.3 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from python-slugify>=4.0.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.3)\ninmanta.pip              DEBUG   Requirement already satisfied: certifi>=2017.4.17 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (2022.12.7)\ninmanta.pip              DEBUG   Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/arnaud/.virtualenvs/inmanta-core/lib/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (1.26.14)\ninmanta.pip              DEBUG   Requirement already satisfied: charset-normalizer<4,>=2 in /home/arnaud/.virtualenvs/inmanta-core/lib64/python3.9/site-packages (from requests>=2.23.0->cookiecutter<3,>=1->inmanta-core==8.1.0.dev0) (3.0.1)\ninmanta.module           INFO    verifying project\ninmanta.env              WARNING Incompatibility between constraint python-slugify<7,>=6 and installed version 8.0.0 (from pyadr)\n	0	3819814d-80c1-4a6c-a466-fcac5ba3e141
+e50b0f5e-ca0e-4336-8cab-d522039fee0d	2023-01-30 16:19:16.775056+01	2023-01-30 16:19:17.651522+01	/tmp/tmpcaf0ggj3/server/environments/7c2563a6-2a67-4ec0-8c55-77299c7b982b/.env/bin/python -m inmanta.app -vvv export -X -e 7c2563a6-2a67-4ec0-8c55-77299c7b982b --server_address localhost --server_port 51237 --metadata {"type": "api", "message": "Recompile trigger through API call"} --export-compile-data --export-compile-data-file /tmp/tmptm5q2x7c --no-ssl	Recompiling configuration model		inmanta.compiler         DEBUG   Starting compile\ninmanta.warnings         WARNING InmantaWarning: Loaded V1 module std. The use of V1 modules is deprecated. Use the equivalent V2 module instead.\ninmanta.module           DEBUG   Parsing took 0.003977 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 2 hits and 0 misses (100%)\ninmanta.module           INFO    verifying project\ninmanta.env              WARNING Incompatibility between constraint python-slugify<7,>=6 and installed version 8.0.0 (from pyadr)\ninmanta.module           DEBUG   Loading module inmanta_plugins.std.resources\ninmanta.loader           DEBUG   Loading module: inmanta_plugins.std\ninmanta.module           DEBUG   Loading module inmanta_plugins.std\ninmanta.module           DEBUG   Parsing took 0.000088 seconds\ninmanta.parser.cache     DEBUG   Compiler cache observed 2 hits and 0 misses (100%)\ninmanta.module           INFO    The following modules are currently installed:\ninmanta.module           INFO    V1 modules:\ninmanta.module           INFO      std: 4.1.1\ninmanta.execute.schedulerDEBUG   Iteration 1 (e: 8, w: 0, p: 0, done: 0, time: 0.002133)\ninmanta.execute.schedulerDEBUG   Finishing statements with no waiters\ninmanta.execute.schedulerDEBUG   Iteration 2 (e: 1, w: 0, p: 0, done: 73, time: 0.001778)\ninmanta.execute.schedulerDEBUG   Finishing statements with no waiters\ninmanta.execute.schedulerDEBUG   Iteration 2 (e: 0, w: 0, p: 0, done: 74, time: 0.000223)\ninmanta.execute.schedulerINFO    Total compilation time 0.004272\ninmanta.compiler         DEBUG   Compile done\ninmanta.protocol.endpointsDEBUG   Start transport for client compiler\nasyncio                  DEBUG   Using selector: EpollSelector\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server POST http://localhost:51237/api/v2/reserve_version\ninmanta.protocol.endpointsDEBUG   Start transport for client compiler\ninmanta.export           INFO    Sending resources and handler source to server\ninmanta.export           INFO    Uploading source files\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server POST http://localhost:51237/api/v1/file\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server PUT http://localhost:51237/api/v1/codebatched/2\ninmanta.export           INFO    Uploading 1 files\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server POST http://localhost:51237/api/v1/file\ninmanta.export           INFO    Only 0 files are new and need to be uploaded\ninmanta.export           INFO    Sending resource updates to server\ninmanta.export           DEBUG     std::File[localhost,path=/tmp/test],v=2\ninmanta.export           DEBUG     std::AgentConfig[internal,agentname=localhost],v=2\ninmanta.protocol.rest.clientDEBUG   Getting config in section compiler_rest_transport\ninmanta.protocol.rest.clientDEBUG   Calling server PUT http://localhost:51237/api/v1/version\ninmanta.export           INFO    Committed resources with version 2\n	0	3819814d-80c1-4a6c-a466-fcac5ba3e141
+\.
+
+
+--
+-- Data for Name: resource; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.resource (environment, model, resource_id, agent, last_deploy, attributes, attribute_hash, status, provides, resource_type, resource_id_value, last_non_deploying_status, resource_set) FROM stdin;
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	std::File[localhost,path=/tmp/test]	localhost	2023-01-30 16:19:09.540535+01	{"hash": "7110eda4d09e062aa5e4a390b0a572ac0d2c0220", "path": "/tmp/test", "group": "root", "owner": "root", "purged": false, "reload": false, "version": 1, "requires": ["std::AgentConfig[internal,agentname=localhost]"], "send_event": false, "permissions": 644, "purge_on_delete": false}	af78dd949dae28f78c1acf515ca0beec	failed	{}	std::File	/tmp/test	failed	\N
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	std::AgentConfig[internal,agentname=localhost]	internal	2023-01-30 16:19:10.944762+01	{"uri": "local:", "purged": false, "version": 1, "requires": [], "agentname": "localhost", "autostart": true, "send_event": false, "purge_on_delete": false}	57a3c0cc2657fc65ab59ca7c97f52d80	deployed	{"std::File[localhost,path=/tmp/test]"}	std::AgentConfig	localhost	deployed	\N
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	std::AgentConfig[internal,agentname=localhost]	internal	2023-01-30 16:19:17.579705+01	{"uri": "local:", "purged": false, "version": 2, "requires": [], "agentname": "localhost", "autostart": true, "send_event": false, "purge_on_delete": false}	57a3c0cc2657fc65ab59ca7c97f52d80	deployed	{"std::File[localhost,path=/tmp/test]"}	std::AgentConfig	localhost	deployed	\N
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	std::File[localhost,path=/tmp/test]	localhost	2023-01-30 16:19:17.609346+01	{"hash": "7110eda4d09e062aa5e4a390b0a572ac0d2c0220", "path": "/tmp/test", "group": "root", "owner": "root", "purged": false, "reload": false, "version": 2, "requires": ["std::AgentConfig[internal,agentname=localhost]"], "send_event": false, "permissions": 644, "purge_on_delete": false}	af78dd949dae28f78c1acf515ca0beec	failed	{}	std::File	/tmp/test	failed	\N
+\.
+
+
+--
+-- Data for Name: resourceaction; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.resourceaction (action_id, action, started, finished, messages, status, changes, change, environment, version, resource_version_ids) FROM stdin;
+eac5d17c-0e56-4b39-981f-5c45fe35a86f	store	2023-01-30 16:19:08.437271+01	2023-01-30 16:19:08.443265+01	{"{\\"msg\\": \\"Successfully stored version 1\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"version\\": 1}, \\"timestamp\\": \\"2023-01-30T16:19:08.443274+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	{"std::File[localhost,path=/tmp/test],v=1","std::AgentConfig[internal,agentname=localhost],v=1"}
+725ac5d7-a88f-4c64-9d50-b8535bc26db7	pull	2023-01-30 16:19:08.859814+01	2023-01-30 16:19:08.86638+01	{"{\\"msg\\": \\"Resource version pulled by client for agent internal state\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"agent\\": \\"internal\\"}, \\"timestamp\\": \\"2023-01-30T16:19:08.866392+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	{"std::AgentConfig[internal,agentname=localhost],v=1"}
+2522dd18-0ee3-48aa-9ee5-3eec041a7a6d	deploy	2023-01-30 16:19:08.895668+01	2023-01-30 16:19:08.910831+01	{"{\\"msg\\": \\"Start run for resource std::AgentConfig[internal,agentname=localhost],v=1 because Repair run started at 2023-01-30 16:19:08+0100\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"agent\\": \\"internal\\", \\"reason\\": \\"Repair run started at 2023-01-30 16:19:08+0100\\", \\"resource\\": \\"std::AgentConfig[internal,agentname=localhost],v=1\\", \\"deploy_id\\": \\"6baf038b-ce9d-46e6-8a69-1f7968029d14\\"}, \\"timestamp\\": \\"2023-01-30T16:19:08.892291+01:00\\"}","{\\"msg\\": \\"Start deploy 6baf038b-ce9d-46e6-8a69-1f7968029d14 of resource std::AgentConfig[internal,agentname=localhost],v=1\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"deploy_id\\": \\"6baf038b-ce9d-46e6-8a69-1f7968029d14\\", \\"resource_id\\": {\\"version\\": 1, \\"attribute\\": \\"agentname\\", \\"agent_name\\": \\"internal\\", \\"entity_type\\": \\"std::AgentConfig\\", \\"attribute_value\\": \\"localhost\\"}}, \\"timestamp\\": \\"2023-01-30T16:19:08.897316+01:00\\"}","{\\"msg\\": \\"Calling read_resource\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {}, \\"timestamp\\": \\"2023-01-30T16:19:08.898386+01:00\\"}","{\\"msg\\": \\"Calling create_resource\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {}, \\"timestamp\\": \\"2023-01-30T16:19:08.901911+01:00\\"}","{\\"msg\\": \\"End run for resource std::AgentConfig[internal,agentname=localhost],v=1 in deploy 6baf038b-ce9d-46e6-8a69-1f7968029d14\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"resource\\": \\"std::AgentConfig[internal,agentname=localhost],v=1\\", \\"deploy_id\\": \\"6baf038b-ce9d-46e6-8a69-1f7968029d14\\"}, \\"timestamp\\": \\"2023-01-30T16:19:08.905160+01:00\\"}"}	deployed	{"std::AgentConfig[internal,agentname=localhost],v=1": {"std::AgentConfig[internal,agentname=localhost],v=1": {"current": null, "desired": null}}}	nochange	7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	{"std::AgentConfig[internal,agentname=localhost],v=1"}
+4155fd76-5a2b-44b6-829f-c28e772733c8	pull	2023-01-30 16:19:09.502369+01	2023-01-30 16:19:09.508246+01	{"{\\"msg\\": \\"Resource version pulled by client for agent localhost state\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"agent\\": \\"localhost\\"}, \\"timestamp\\": \\"2023-01-30T16:19:09.508259+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	{"std::File[localhost,path=/tmp/test],v=1"}
+d968c57b-c10f-4fa1-9912-2cc2af61bdb0	deploy	2023-01-30 16:19:09.531883+01	2023-01-30 16:19:09.540535+01	{"{\\"msg\\": \\"Start run for resource std::File[localhost,path=/tmp/test],v=1 because Repair run started at 2023-01-30 16:19:09+0100\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"agent\\": \\"localhost\\", \\"reason\\": \\"Repair run started at 2023-01-30 16:19:09+0100\\", \\"resource\\": \\"std::File[localhost,path=/tmp/test],v=1\\", \\"deploy_id\\": \\"9a46daf8-3ede-45e7-ade2-3c7920e64eee\\"}, \\"timestamp\\": \\"2023-01-30T16:19:09.529894+01:00\\"}","{\\"msg\\": \\"Start deploy 9a46daf8-3ede-45e7-ade2-3c7920e64eee of resource std::File[localhost,path=/tmp/test],v=1\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"deploy_id\\": \\"9a46daf8-3ede-45e7-ade2-3c7920e64eee\\", \\"resource_id\\": {\\"version\\": 1, \\"attribute\\": \\"path\\", \\"agent_name\\": \\"localhost\\", \\"entity_type\\": \\"std::File\\", \\"attribute_value\\": \\"/tmp/test\\"}}, \\"timestamp\\": \\"2023-01-30T16:19:09.533266+01:00\\"}","{\\"msg\\": \\"Calling read_resource\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {}, \\"timestamp\\": \\"2023-01-30T16:19:09.534249+01:00\\"}","{\\"msg\\": \\"Calling create_resource\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {}, \\"timestamp\\": \\"2023-01-30T16:19:09.534325+01:00\\"}","{\\"msg\\": \\"An error occurred during deployment of std::File[localhost,path=/tmp/test],v=1 (exception: PermissionError('[Errno 1] Operation not permitted: '/tmp/test''))\\", \\"args\\": [], \\"level\\": \\"ERROR\\", \\"kwargs\\": {\\"exc_info\\": true, \\"exception\\": \\"PermissionError('[Errno 1] Operation not permitted: '/tmp/test'')\\", \\"traceback\\": \\"Traceback (most recent call last):\\\\n  File \\\\\\"/home/arnaud/Documents/projects/inmanta-core/src/inmanta/agent/handler.py\\\\\\", line 929, in execute\\\\n    self.create_resource(ctx, desired)\\\\n  File \\\\\\"/tmp/tmpcaf0ggj3/7c2563a6-2a67-4ec0-8c55-77299c7b982b/agent/code/modules/std/plugins/resources/__init__.py\\\\\\", line 193, in create_resource\\\\n    self._io.chown(resource.path, resource.owner, resource.group)\\\\n  File \\\\\\"/home/arnaud/Documents/projects/inmanta-core/src/inmanta/agent/io/local.py\\\\\\", line 605, in chown\\\\n    os.chown(path, _user, _group)\\\\nPermissionError: [Errno 1] Operation not permitted: '/tmp/test'\\\\n\\", \\"resource_id\\": {\\"version\\": 1, \\"attribute\\": \\"path\\", \\"agent_name\\": \\"localhost\\", \\"entity_type\\": \\"std::File\\", \\"attribute_value\\": \\"/tmp/test\\"}}, \\"timestamp\\": \\"2023-01-30T16:19:09.536513+01:00\\"}","{\\"msg\\": \\"End run for resource std::File[localhost,path=/tmp/test],v=1 in deploy 9a46daf8-3ede-45e7-ade2-3c7920e64eee\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"resource\\": \\"std::File[localhost,path=/tmp/test],v=1\\", \\"deploy_id\\": \\"9a46daf8-3ede-45e7-ade2-3c7920e64eee\\"}, \\"timestamp\\": \\"2023-01-30T16:19:09.536721+01:00\\"}"}	failed	{"std::File[localhost,path=/tmp/test],v=1": {"std::File[localhost,path=/tmp/test],v=1": {"current": null, "desired": null}}}	nochange	7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	{"std::File[localhost,path=/tmp/test],v=1"}
+ad79cdc9-3573-4731-8fac-96dd44b9a04c	pull	2023-01-30 16:19:10.920443+01	2023-01-30 16:19:10.921606+01	{"{\\"msg\\": \\"Resource version pulled by client for agent internal state\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"agent\\": \\"internal\\"}, \\"timestamp\\": \\"2023-01-30T16:19:10.921616+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	{"std::AgentConfig[internal,agentname=localhost],v=1"}
+b0b626e4-ce36-45a7-af4c-2611d1cd47ff	deploy	2023-01-30 16:19:10.936433+01	2023-01-30 16:19:10.944762+01	{"{\\"msg\\": \\"Start run for resource std::AgentConfig[internal,agentname=localhost],v=1 because Repair run started at 2023-01-30 16:19:10+0100\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"agent\\": \\"internal\\", \\"reason\\": \\"Repair run started at 2023-01-30 16:19:10+0100\\", \\"resource\\": \\"std::AgentConfig[internal,agentname=localhost],v=1\\", \\"deploy_id\\": \\"0875e11f-8344-4c76-8f82-34d22b027cf9\\"}, \\"timestamp\\": \\"2023-01-30T16:19:10.933280+01:00\\"}","{\\"msg\\": \\"Start deploy 0875e11f-8344-4c76-8f82-34d22b027cf9 of resource std::AgentConfig[internal,agentname=localhost],v=1\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"deploy_id\\": \\"0875e11f-8344-4c76-8f82-34d22b027cf9\\", \\"resource_id\\": {\\"version\\": 1, \\"attribute\\": \\"agentname\\", \\"agent_name\\": \\"internal\\", \\"entity_type\\": \\"std::AgentConfig\\", \\"attribute_value\\": \\"localhost\\"}}, \\"timestamp\\": \\"2023-01-30T16:19:10.937937+01:00\\"}","{\\"msg\\": \\"Calling read_resource\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {}, \\"timestamp\\": \\"2023-01-30T16:19:10.938980+01:00\\"}","{\\"msg\\": \\"End run for resource std::AgentConfig[internal,agentname=localhost],v=1 in deploy 0875e11f-8344-4c76-8f82-34d22b027cf9\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"resource\\": \\"std::AgentConfig[internal,agentname=localhost],v=1\\", \\"deploy_id\\": \\"0875e11f-8344-4c76-8f82-34d22b027cf9\\"}, \\"timestamp\\": \\"2023-01-30T16:19:10.942332+01:00\\"}"}	deployed	{"std::AgentConfig[internal,agentname=localhost],v=1": {"std::AgentConfig[internal,agentname=localhost],v=1": {"current": null, "desired": null}}}	nochange	7c2563a6-2a67-4ec0-8c55-77299c7b982b	1	{"std::AgentConfig[internal,agentname=localhost],v=1"}
+0b5b10de-5a77-4eb7-bf89-5c8e5063e058	store	2023-01-30 16:19:17.565212+01	2023-01-30 16:19:17.566783+01	{"{\\"msg\\": \\"Successfully stored version 2\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"version\\": 2}, \\"timestamp\\": \\"2023-01-30T16:19:17.566795+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	{"std::File[localhost,path=/tmp/test],v=2","std::AgentConfig[internal,agentname=localhost],v=2"}
+ec1408a4-1dba-4f12-8ad0-529a6dc3c3eb	deploy	2023-01-30 16:19:17.579705+01	2023-01-30 16:19:17.579705+01	{"{\\"msg\\": \\"Setting deployed due to known good status\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"timestamp\\": \\"2023-01-30T15:19:17.579705+00:00\\"}"}	deployed	\N	nochange	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	{"std::AgentConfig[internal,agentname=localhost],v=2"}
+de6f31f6-dfe7-419f-817e-fd9085a5111d	pull	2023-01-30 16:19:17.578247+01	2023-01-30 16:19:17.579863+01	{"{\\"msg\\": \\"Resource version pulled by client for agent localhost state\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"agent\\": \\"localhost\\"}, \\"timestamp\\": \\"2023-01-30T16:19:17.580956+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	{"std::File[localhost,path=/tmp/test],v=2"}
+82667bb0-7cc2-4d94-b9f8-21d301e916cc	pull	2023-01-30 16:19:17.767165+01	2023-01-30 16:19:17.768715+01	{"{\\"msg\\": \\"Resource version pulled by client for agent internal state\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"agent\\": \\"internal\\"}, \\"timestamp\\": \\"2023-01-30T16:19:17.768726+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	{"std::AgentConfig[internal,agentname=localhost],v=2"}
+eab8585b-feac-408d-82a3-d43aaec91bcf	deploy	2023-01-30 16:19:17.601432+01	2023-01-30 16:19:17.609346+01	{"{\\"msg\\": \\"Start run for resource std::File[localhost,path=/tmp/test],v=2 because call to trigger_update\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"agent\\": \\"localhost\\", \\"reason\\": \\"call to trigger_update\\", \\"resource\\": \\"std::File[localhost,path=/tmp/test],v=2\\", \\"deploy_id\\": \\"7d2d9199-facc-4bff-a227-07adca076d4b\\"}, \\"timestamp\\": \\"2023-01-30T16:19:17.598986+01:00\\"}","{\\"msg\\": \\"Start deploy 7d2d9199-facc-4bff-a227-07adca076d4b of resource std::File[localhost,path=/tmp/test],v=2\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"deploy_id\\": \\"7d2d9199-facc-4bff-a227-07adca076d4b\\", \\"resource_id\\": {\\"version\\": 2, \\"attribute\\": \\"path\\", \\"agent_name\\": \\"localhost\\", \\"entity_type\\": \\"std::File\\", \\"attribute_value\\": \\"/tmp/test\\"}}, \\"timestamp\\": \\"2023-01-30T16:19:17.603058+01:00\\"}","{\\"msg\\": \\"Calling read_resource\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {}, \\"timestamp\\": \\"2023-01-30T16:19:17.603481+01:00\\"}","{\\"msg\\": \\"Calling update_resource\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"changes\\": {\\"group\\": {\\"current\\": \\"arnaud\\", \\"desired\\": \\"root\\"}, \\"owner\\": {\\"current\\": \\"arnaud\\", \\"desired\\": \\"root\\"}}}, \\"timestamp\\": \\"2023-01-30T16:19:17.605765+01:00\\"}","{\\"msg\\": \\"An error occurred during deployment of std::File[localhost,path=/tmp/test],v=2 (exception: PermissionError('[Errno 1] Operation not permitted: '/tmp/test''))\\", \\"args\\": [], \\"level\\": \\"ERROR\\", \\"kwargs\\": {\\"exc_info\\": true, \\"exception\\": \\"PermissionError('[Errno 1] Operation not permitted: '/tmp/test'')\\", \\"traceback\\": \\"Traceback (most recent call last):\\\\n  File \\\\\\"/home/arnaud/Documents/projects/inmanta-core/src/inmanta/agent/handler.py\\\\\\", line 936, in execute\\\\n    self.update_resource(ctx, dict(changes), desired)\\\\n  File \\\\\\"/tmp/tmpcaf0ggj3/7c2563a6-2a67-4ec0-8c55-77299c7b982b/agent/code/modules/std/plugins/resources/__init__.py\\\\\\", line 221, in update_resource\\\\n    self._io.chown(resource.path, resource.owner, resource.group)\\\\n  File \\\\\\"/home/arnaud/Documents/projects/inmanta-core/src/inmanta/agent/io/local.py\\\\\\", line 605, in chown\\\\n    os.chown(path, _user, _group)\\\\nPermissionError: [Errno 1] Operation not permitted: '/tmp/test'\\\\n\\", \\"resource_id\\": {\\"version\\": 2, \\"attribute\\": \\"path\\", \\"agent_name\\": \\"localhost\\", \\"entity_type\\": \\"std::File\\", \\"attribute_value\\": \\"/tmp/test\\"}}, \\"timestamp\\": \\"2023-01-30T16:19:17.606290+01:00\\"}","{\\"msg\\": \\"End run for resource std::File[localhost,path=/tmp/test],v=2 in deploy 7d2d9199-facc-4bff-a227-07adca076d4b\\", \\"args\\": [], \\"level\\": \\"DEBUG\\", \\"kwargs\\": {\\"resource\\": \\"std::File[localhost,path=/tmp/test],v=2\\", \\"deploy_id\\": \\"7d2d9199-facc-4bff-a227-07adca076d4b\\"}, \\"timestamp\\": \\"2023-01-30T16:19:17.606682+01:00\\"}"}	failed	{"std::File[localhost,path=/tmp/test],v=2": {"std::File[localhost,path=/tmp/test],v=2": {"current": null, "desired": null}}}	nochange	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	{"std::File[localhost,path=/tmp/test],v=2"}
+6dddb21c-3662-46ce-b54e-aa3fa7d4c4e0	pull	2023-01-30 16:19:17.767667+01	2023-01-30 16:19:17.769426+01	{"{\\"msg\\": \\"Resource version pulled by client for agent localhost state\\", \\"args\\": [], \\"level\\": \\"INFO\\", \\"kwargs\\": {\\"agent\\": \\"localhost\\"}, \\"timestamp\\": \\"2023-01-30T16:19:17.769432+01:00\\"}"}	\N	\N	\N	7c2563a6-2a67-4ec0-8c55-77299c7b982b	2	{"std::File[localhost,path=/tmp/test],v=2"}
+\.
+
+
+--
+-- Data for Name: resourceaction_resource; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.resourceaction_resource (environment, resource_action_id, resource_id, resource_version) FROM stdin;
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	eac5d17c-0e56-4b39-981f-5c45fe35a86f	std::File[localhost,path=/tmp/test]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	eac5d17c-0e56-4b39-981f-5c45fe35a86f	std::AgentConfig[internal,agentname=localhost]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	725ac5d7-a88f-4c64-9d50-b8535bc26db7	std::AgentConfig[internal,agentname=localhost]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	2522dd18-0ee3-48aa-9ee5-3eec041a7a6d	std::AgentConfig[internal,agentname=localhost]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	4155fd76-5a2b-44b6-829f-c28e772733c8	std::File[localhost,path=/tmp/test]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	d968c57b-c10f-4fa1-9912-2cc2af61bdb0	std::File[localhost,path=/tmp/test]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	ad79cdc9-3573-4731-8fac-96dd44b9a04c	std::AgentConfig[internal,agentname=localhost]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	b0b626e4-ce36-45a7-af4c-2611d1cd47ff	std::AgentConfig[internal,agentname=localhost]	1
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	0b5b10de-5a77-4eb7-bf89-5c8e5063e058	std::File[localhost,path=/tmp/test]	2
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	0b5b10de-5a77-4eb7-bf89-5c8e5063e058	std::AgentConfig[internal,agentname=localhost]	2
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	de6f31f6-dfe7-419f-817e-fd9085a5111d	std::File[localhost,path=/tmp/test]	2
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	ec1408a4-1dba-4f12-8ad0-529a6dc3c3eb	std::AgentConfig[internal,agentname=localhost]	2
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	eab8585b-feac-408d-82a3-d43aaec91bcf	std::File[localhost,path=/tmp/test]	2
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	82667bb0-7cc2-4d94-b9f8-21d301e916cc	std::AgentConfig[internal,agentname=localhost]	2
+7c2563a6-2a67-4ec0-8c55-77299c7b982b	6dddb21c-3662-46ce-b54e-aa3fa7d4c4e0	std::File[localhost,path=/tmp/test]	2
+\.
+
+
+--
+-- Data for Name: schemamanager; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.schemamanager (name, legacy_version, installed_versions) FROM stdin;
+core	\N	{1,2,3,4,5,6,7,17,202105170,202106080,202106210,202109100,202111260,202203140,202203160,202205250,202206290,202208180,202208190,202209090,202209130,202209160,202211230,202212010,202301100,202301110,202301120,202301160,202301170,202301190,202301300}
+\.
+
+
+--
+-- Data for Name: unknownparameter; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.unknownparameter (id, name, environment, source, resource_id, version, metadata, resolved) FROM stdin;
+\.
+
+
+--
+-- Name: agent agent_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent
+    ADD CONSTRAINT agent_pkey PRIMARY KEY (environment, name);
+
+
+--
+-- Name: agentinstance agentinstance_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agentinstance
+    ADD CONSTRAINT agentinstance_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agentinstance agentinstance_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agentinstance
+    ADD CONSTRAINT agentinstance_unique UNIQUE (tid, process, name);
+
+
+--
+-- Name: agentprocess agentprocess_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agentprocess
+    ADD CONSTRAINT agentprocess_pkey PRIMARY KEY (sid);
+
+
+--
+-- Name: code code_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.code
+    ADD CONSTRAINT code_pkey PRIMARY KEY (environment, version, resource);
+
+
+--
+-- Name: compile compile_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.compile
+    ADD CONSTRAINT compile_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: configurationmodel configurationmodel_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configurationmodel
+    ADD CONSTRAINT configurationmodel_pkey PRIMARY KEY (environment, version);
+
+
+--
+-- Name: dryrun dryrun_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dryrun
+    ADD CONSTRAINT dryrun_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: environment environment_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.environment
+    ADD CONSTRAINT environment_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: environmentmetricsgauge environmentmetricsgauge_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.environmentmetricsgauge
+    ADD CONSTRAINT environmentmetricsgauge_pkey PRIMARY KEY (environment, "timestamp", metric_name, category);
+
+
+--
+-- Name: environmentmetricstimer environmentmetricstimer_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.environmentmetricstimer
+    ADD CONSTRAINT environmentmetricstimer_pkey PRIMARY KEY (environment, "timestamp", metric_name, category);
+
+
+--
+-- Name: notification notification_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification
+    ADD CONSTRAINT notification_pkey PRIMARY KEY (environment, id);
+
+
+--
+-- Name: parameter parameter_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.parameter
+    ADD CONSTRAINT parameter_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project project_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project
+    ADD CONSTRAINT project_name_key UNIQUE (name);
+
+
+--
+-- Name: project project_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project
+    ADD CONSTRAINT project_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: report report_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.report
+    ADD CONSTRAINT report_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: resource resource_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.resource
+    ADD CONSTRAINT resource_pkey PRIMARY KEY (environment, model, resource_id);
+
+
+--
+-- Name: resourceaction resourceaction_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.resourceaction
+    ADD CONSTRAINT resourceaction_pkey PRIMARY KEY (action_id);
+
+
+--
+-- Name: resourceaction_resource resourceaction_resource_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.resourceaction_resource
+    ADD CONSTRAINT resourceaction_resource_pkey PRIMARY KEY (environment, resource_id, resource_version, resource_action_id);
+
+
+--
+-- Name: schemamanager schemamanager_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schemamanager
+    ADD CONSTRAINT schemamanager_pkey PRIMARY KEY (name);
+
+
+--
+-- Name: unknownparameter unknownparameter_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.unknownparameter
+    ADD CONSTRAINT unknownparameter_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agent_id_primary_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agent_id_primary_index ON public.agent USING btree (id_primary) WHERE (id_primary IS NULL);
+
+
+--
+-- Name: agentinstance_expired_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agentinstance_expired_index ON public.agentinstance USING btree (expired) WHERE (expired IS NULL);
+
+
+--
+-- Name: agentinstance_expired_tid_endpoint_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agentinstance_expired_tid_endpoint_index ON public.agentinstance USING btree (tid, name, expired);
+
+
+--
+-- Name: agentinstance_process_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agentinstance_process_index ON public.agentinstance USING btree (process);
+
+
+--
+-- Name: agentprocess_env_expired_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agentprocess_env_expired_index ON public.agentprocess USING btree (environment, expired);
+
+
+--
+-- Name: agentprocess_env_hostname_expired_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agentprocess_env_hostname_expired_index ON public.agentprocess USING btree (environment, hostname, expired);
+
+
+--
+-- Name: agentprocess_expired_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agentprocess_expired_index ON public.agentprocess USING btree (expired) WHERE (expired IS NULL);
+
+
+--
+-- Name: agentprocess_sid_expired_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX agentprocess_sid_expired_index ON public.agentprocess USING btree (sid, expired);
+
+
+--
+-- Name: compile_completed_environment_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX compile_completed_environment_idx ON public.compile USING btree (completed, environment);
+
+
+--
+-- Name: compile_env_remote_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX compile_env_remote_id_index ON public.compile USING btree (environment, remote_id);
+
+
+--
+-- Name: compile_env_requested_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX compile_env_requested_index ON public.compile USING btree (environment, requested);
+
+
+--
+-- Name: compile_env_started_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX compile_env_started_index ON public.compile USING btree (environment, started DESC);
+
+
+--
+-- Name: configurationmodel_env_released_version_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX configurationmodel_env_released_version_index ON public.configurationmodel USING btree (environment, released, version DESC);
+
+
+--
+-- Name: configurationmodel_env_version_total_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX configurationmodel_env_version_total_index ON public.configurationmodel USING btree (environment, version DESC, total);
+
+
+--
+-- Name: dryrun_env_model_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX dryrun_env_model_index ON public.dryrun USING btree (environment, model);
+
+
+--
+-- Name: environment_name_project_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX environment_name_project_index ON public.environment USING btree (project, name);
+
+
+--
+-- Name: notification_env_created_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX notification_env_created_id_index ON public.notification USING btree (environment, created DESC, id);
+
+
+--
+-- Name: parameter_env_name_resource_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX parameter_env_name_resource_id_index ON public.parameter USING btree (environment, name, resource_id);
+
+
+--
+-- Name: parameter_metadata_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX parameter_metadata_index ON public.parameter USING gin (metadata jsonb_path_ops);
+
+
+--
+-- Name: parameter_updated_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX parameter_updated_index ON public.parameter USING btree (updated);
+
+
+--
+-- Name: report_compile_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX report_compile_index ON public.report USING btree (compile);
+
+
+--
+-- Name: resource_attributes_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resource_attributes_index ON public.resource USING gin (attributes jsonb_path_ops);
+
+
+--
+-- Name: resource_env_attr_hash_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resource_env_attr_hash_index ON public.resource USING btree (environment, attribute_hash);
+
+
+--
+-- Name: resource_env_model_agent_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resource_env_model_agent_index ON public.resource USING btree (environment, model, agent);
+
+
+--
+-- Name: resource_env_resourceid_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX resource_env_resourceid_index ON public.resource USING btree (environment, resource_id, model DESC);
+
+
+--
+-- Name: resource_environment_model_resource_set_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resource_environment_model_resource_set_idx ON public.resource USING btree (environment, model, resource_set);
+
+
+--
+-- Name: resource_environment_resource_id_value_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resource_environment_resource_id_value_index ON public.resource USING btree (environment, resource_id_value);
+
+
+--
+-- Name: resource_environment_resource_type_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resource_environment_resource_type_index ON public.resource USING btree (environment, resource_type);
+
+
+--
+-- Name: resource_environment_status_model_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resource_environment_status_model_idx ON public.resource USING btree (environment, status, model DESC);
+
+
+--
+-- Name: resourceaction_environment_action_started_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resourceaction_environment_action_started_index ON public.resourceaction USING btree (environment, action, started DESC);
+
+
+--
+-- Name: resourceaction_environment_version_started_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resourceaction_environment_version_started_index ON public.resourceaction USING btree (environment, version, started DESC);
+
+
+--
+-- Name: resourceaction_started_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX resourceaction_started_index ON public.resourceaction USING btree (started);
+
+
+--
+-- Name: unknownparameter_env_version_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX unknownparameter_env_version_index ON public.unknownparameter USING btree (environment, version);
+
+
+--
+-- Name: unknownparameter_resolved_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX unknownparameter_resolved_index ON public.unknownparameter USING btree (resolved);
+
+
+--
+-- Name: agent agent_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent
+    ADD CONSTRAINT agent_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: agent agent_id_primary_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent
+    ADD CONSTRAINT agent_id_primary_fkey FOREIGN KEY (id_primary) REFERENCES public.agentinstance(id) ON DELETE RESTRICT;
+
+
+--
+-- Name: agentinstance agentinstance_process_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agentinstance
+    ADD CONSTRAINT agentinstance_process_fkey FOREIGN KEY (process) REFERENCES public.agentprocess(sid) ON DELETE CASCADE;
+
+
+--
+-- Name: agentprocess agentprocess_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agentprocess
+    ADD CONSTRAINT agentprocess_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: code code_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.code
+    ADD CONSTRAINT code_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: compile compile_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.compile
+    ADD CONSTRAINT compile_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: compile compile_substitute_compile_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.compile
+    ADD CONSTRAINT compile_substitute_compile_id_fkey FOREIGN KEY (substitute_compile_id) REFERENCES public.compile(id) ON DELETE CASCADE;
+
+
+--
+-- Name: configurationmodel configurationmodel_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.configurationmodel
+    ADD CONSTRAINT configurationmodel_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: dryrun dryrun_environment_model_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dryrun
+    ADD CONSTRAINT dryrun_environment_model_fkey FOREIGN KEY (environment, model) REFERENCES public.configurationmodel(environment, version) ON DELETE CASCADE;
+
+
+--
+-- Name: environment environment_project_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.environment
+    ADD CONSTRAINT environment_project_fkey FOREIGN KEY (project) REFERENCES public.project(id) ON DELETE CASCADE;
+
+
+--
+-- Name: environmentmetricsgauge environmentmetricsgauge_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.environmentmetricsgauge
+    ADD CONSTRAINT environmentmetricsgauge_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: environmentmetricstimer environmentmetricstimer_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.environmentmetricstimer
+    ADD CONSTRAINT environmentmetricstimer_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: notification notification_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification
+    ADD CONSTRAINT notification_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: parameter parameter_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.parameter
+    ADD CONSTRAINT parameter_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: report report_compile_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.report
+    ADD CONSTRAINT report_compile_fkey FOREIGN KEY (compile) REFERENCES public.compile(id) ON DELETE CASCADE;
+
+
+--
+-- Name: resource resource_environment_model_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.resource
+    ADD CONSTRAINT resource_environment_model_fkey FOREIGN KEY (environment, model) REFERENCES public.configurationmodel(environment, version) ON DELETE CASCADE;
+
+
+--
+-- Name: resourceaction resourceaction_environment_version_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.resourceaction
+    ADD CONSTRAINT resourceaction_environment_version_fkey FOREIGN KEY (environment, version) REFERENCES public.configurationmodel(environment, version) ON DELETE CASCADE;
+
+
+--
+-- Name: resourceaction_resource resourceaction_resource_environment_resource_id_resource_v_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.resourceaction_resource
+    ADD CONSTRAINT resourceaction_resource_environment_resource_id_resource_v_fkey FOREIGN KEY (environment, resource_id, resource_version) REFERENCES public.resource(environment, resource_id, model) ON DELETE CASCADE;
+
+
+--
+-- Name: resourceaction_resource resourceaction_resource_resource_action_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.resourceaction_resource
+    ADD CONSTRAINT resourceaction_resource_resource_action_id_fkey FOREIGN KEY (resource_action_id) REFERENCES public.resourceaction(action_id) ON DELETE CASCADE;
+
+
+--
+-- Name: unknownparameter unknownparameter_environment_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.unknownparameter
+    ADD CONSTRAINT unknownparameter_environment_fkey FOREIGN KEY (environment) REFERENCES public.environment(id) ON DELETE CASCADE;
+
+
+--
+-- Name: unknownparameter unknownparameter_environment_version_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.unknownparameter
+    ADD CONSTRAINT unknownparameter_environment_version_fkey FOREIGN KEY (environment, version) REFERENCES public.configurationmodel(environment, version) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/tests/db/migration_tests/test_v202301190_to_v202301300.py
+++ b/tests/db/migration_tests/test_v202301190_to_v202301300.py
@@ -1,0 +1,31 @@
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import os
+from collections import abc
+
+import pytest
+
+
+@pytest.mark.db_restore_dump(os.path.join(os.path.dirname(__file__), "dumps/v202301190.sql"))
+async def test_migration(
+    migrate_db_from: abc.Callable[[], abc.Awaitable[None]],
+) -> None:
+    """
+    Only added an index: make sure the migration script applies.
+    """
+    await migrate_db_from()


### PR DESCRIPTION
# Description

Increase the performance of the `put_partial` endpoint by not fetching resources from the database that belong to a resource set that will be removed.

closes #4743 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~