### PR TITLE
Ensure that the compile_rate by default aggregates to the value 0

### DIFF
--- a/changelogs/unreleased/5452-default-compile-rate-to-zero.yml
+++ b/changelogs/unreleased/5452-default-compile-rate-to-zero.yml
@@ -1,0 +1,6 @@
+---
+description: Ensure that the value of the `compile_rate` metric aggregates to zero instead of None when no compiles were done for that time interval.
+issue-nr: 5452
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -402,7 +402,7 @@ class EnvironmentMetricsService(protocol.ServerSlice):
             {f"UNION ALL ({query_for_compiler_rate})" if "orchestrator.compile_rate" in metrics else ""}
         """.strip()
 
-        # Initialize everything with None values
+        # Initialize everything with default values
         result_metrics: Dict[str, List[Union[float, Dict[str, float], None]]] = {
             m: [0 if m == "orchestrator.compile_rate" else None for _ in range(nb_datapoints)] for m in metrics
         }

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -404,7 +404,7 @@ class EnvironmentMetricsService(protocol.ServerSlice):
 
         # Initialize everything with None values
         result_metrics: Dict[str, List[Union[float, Dict[str, float], None]]] = {
-            m: [None for _ in range(nb_datapoints)] for m in metrics
+            m: [0 if m == "orchestrator.compile_rate" else None for _ in range(nb_datapoints)] for m in metrics
         }
         async with EnvironmentMetricsGauge.get_connection() as con:
             values = [env.id, start_interval, end_interval, nb_datapoints, metrics]

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -1335,6 +1335,7 @@ async def test_compile_rate_metric(
             ),
         ]
     )
+
     start_interval = datetime(year=2023, month=1, day=1, hour=9, minute=0).astimezone()
     end_interval = start_interval + timedelta(hours=1)
     nb_datapoints = 10
@@ -1354,6 +1355,25 @@ async def test_compile_rate_metric(
     assert result.result["data"]["metrics"]["orchestrator.compile_rate"] == [
         sum((i * 6) + j for j in range(6)) * nb_datapoints for i in range(nb_datapoints)
     ]
+
+    # The value 0 should be returned when no data is available
+    start_interval = datetime(year=2023, month=1, day=2, hour=9, minute=0).astimezone()
+    end_interval = start_interval + timedelta(hours=1)
+    nb_datapoints = 10
+    result = await client.get_environment_metrics(
+        tid=env1_id,
+        metrics=["orchestrator.compile_rate"],
+        start_interval=start_interval,
+        end_interval=end_interval,
+        nb_datapoints=nb_datapoints,
+    )
+    assert result.code == 200
+    assert datetime.fromisoformat(result.result["data"]["start"]) == get_as_naive_datetime(start_interval)
+    assert datetime.fromisoformat(result.result["data"]["end"]) == get_as_naive_datetime(end_interval)
+    expected_timestamps = [get_as_naive_datetime(start_interval + timedelta(minutes=(i + 1) * 6)) for i in range(nb_datapoints)]
+    assert [datetime.fromisoformat(timestamp) for timestamp in result.result["data"]["timestamps"]] == expected_timestamps
+    assert len(result.result["data"]["metrics"]) == 1
+    assert all(m == 0 for m in result.result["data"]["metrics"]["orchestrator.compile_rate"])
 
 
 async def test_metric_aggregation_no_date(


### PR DESCRIPTION
# Description

Ensure that the value of the `compile_rate` metric aggregates to zero instead of None when no compiles were done for that time interval.

closes #5452 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~