### PR TITLE
fixed pip warnings in test_workon

### DIFF
--- a/changelogs/unreleased/fix-workon-test-pip-warnings.yml
+++ b/changelogs/unreleased/fix-workon-test-pip-warnings.yml
@@ -1,0 +1,6 @@
+description: "Disabled pip's version warnings in tests for the inmanta-workon command"
+change-type: patch
+destination-branches:
+  - iso5
+  - iso6
+  - master

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -682,11 +682,13 @@ async def test_workon_compile(
         post_activate=textwrap.dedent(
             """
             declare -F inmanta > /dev/null 2>&1 || exit 1  # check that inmanta is a shell function
-            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) && exit 1  # check that lorem is not installed yet
+            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) \
+                && exit 1  # check that lorem is not installed yet
             echo lorem >> requirements.txt
             # verify that the inmanta command works, accepts options, and is contained within this enviroment
             inmanta project install > /dev/null 2>&1 || exit 1
-            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) || exit 1  # check that lorem is now installed
+            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) \
+                || exit 1  # check that lorem is now installed
             deactivate
             declare -F inmanta > /dev/null 2>&1
             [ "$?" -eq 1 ] # check that inmanta is no longer a shell function

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -682,11 +682,11 @@ async def test_workon_compile(
         post_activate=textwrap.dedent(
             """
             declare -F inmanta > /dev/null 2>&1 || exit 1  # check that inmanta is a shell function
-            (pip list | grep lorem > /dev/null 2>&1) && exit 1  # check that lorem is not installed yet
+            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) && exit 1  # check that lorem is not installed yet
             echo lorem >> requirements.txt
             # verify that the inmanta command works, accepts options, and is contained within this enviroment
             inmanta project install > /dev/null 2>&1 || exit 1
-            (pip list | grep lorem > /dev/null 2>&1) || exit 1  # check that lorem is now installed
+            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) || exit 1  # check that lorem is now installed
             deactivate
             declare -F inmanta > /dev/null 2>&1
             [ "$?" -eq 1 ] # check that inmanta is no longer a shell function


### PR DESCRIPTION
# Description

Fixes [this build issue](https://jenkins.inmanta.com/job/integration-tests/job/pytest/2132/branch=iso6-stable,os=ubuntu-latest/testReport/junit/ubuntu-latest_iso6-stable.tests.server/test_workon/test_workon_compile/)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
