### PR TITLE
added small improvement for release command

### DIFF
--- a/changelogs/unreleased/fix_release_command.yml
+++ b/changelogs/unreleased/fix_release_command.yml
@@ -1,6 +1,6 @@
 description: Ensure the `inmanta module release` command never decreases the version number
 change-type: patch
-destination-branches: [master, iso6, iso5]
+destination-branches: [master, iso6]
 sections:
   minor-improvement:  "{{description}}"
 

--- a/changelogs/unreleased/fix_release_command.yml
+++ b/changelogs/unreleased/fix_release_command.yml
@@ -1,6 +1,5 @@
 description: Ensure the `inmanta module release` command never decreases the version number
 change-type: patch
 destination-branches: [master, iso6]
-sections:
-  minor-improvement:  "{{description}}"
+sections: []
 

--- a/changelogs/unreleased/fix_release_command.yml
+++ b/changelogs/unreleased/fix_release_command.yml
@@ -1,0 +1,6 @@
+description: Ensure the `inmanta module release` command never decreases the version number
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  minor-improvement:  "{{description}}"
+

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1122,7 +1122,7 @@ version: 0.0.1dev0"""
         # Determine if we are already sufficiently far ahead
         if current_diff is None or minimal_version_bump_to_prev_release > current_diff:
             LOGGER.debug(
-                "Incrementing version number because we the current difference is smaller than requested difference: %s<%s",
+                "Incrementing version number because the current difference is smaller than requested difference: %s<%s",
                 current_diff,
                 minimal_version_bump_to_prev_release,
             )

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1102,7 +1102,8 @@ version: 0.0.1dev0"""
 
         Invariants:
         1. return a dev version
-        2. this version is at least `minimal_version_bump_to_prev_release` separated from its predecessor in all_existing_stable_version
+        2. this version is at least `minimal_version_bump_to_prev_release`
+            separated from its predecessor in all_existing_stable_version
         3. it is >= the current version
         """
         version_previous_release: Version

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -345,7 +345,7 @@ def test_add_changelog_entry(tmpdir, modules_dir: str, monkeypatch, initial_chan
     v1_module_from_template(
         source_dir=os.path.join(modules_dir, "minimalv1module"),
         dest_dir=path_module,
-        new_version=Version("1.0.1"),
+        new_version=Version("1.0.1.dev"),
         new_name=module_name,
     )
     gitprovider.git_init(repo=path_module)


### PR DESCRIPTION
# Description


1. Added some more docs to the release increment calculation
2. I made it log what it does on DEBUG
3. I made sure we never return a lower version (i.e. adding the `.dev0`  tag is moving to a lower version


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
