### PR TITLE
Improved error reporting when an optional list attribute remains unset

### DIFF
--- a/changelogs/unreleased/plain-list-incomplete-error-reporting.yml
+++ b/changelogs/unreleased/plain-list-incomplete-error-reporting.yml
@@ -1,0 +1,8 @@
+description: Improved error reporting when an optional list attribute (not relation) remains unset
+change-type: patch
+sections:
+  minor-improvement: "{{description}}"
+destination-branches:
+  - iso5
+  - iso6
+  - master

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -20,7 +20,7 @@ from typing import List, Optional, Set, Tuple
 
 from inmanta.ast import CompilerException, Locatable, Location, RuntimeException, TypingException
 from inmanta.ast.type import NullableType, TypedList
-from inmanta.execute.runtime import AttributeVariable, ListVariable, OptionVariable, QueueScheduler, ResultVariable
+from inmanta.execute import runtime
 from inmanta.execute.util import Unknown
 from inmanta.stable_api import stable_api
 
@@ -60,7 +60,6 @@ class Attribute(Locatable):
         if nullable:
             self.__type = NullableType(self.__type)
 
-        self.low: int = 0 if nullable else 1
         self.comment = None  # type: Optional[str]
         self.end: Optional[RelationAttribute] = None
 
@@ -107,8 +106,8 @@ class Attribute(Locatable):
             return
         self.type.validate(value)
 
-    def get_new_result_variable(self, instance: "Instance", queue: QueueScheduler) -> ResultVariable:
-        out: ResultVariable[object] = ResultVariable()
+    def get_new_result_variable(self, instance: "Instance", queue: "runtime.QueueScheduler") -> "runtime.ResultVariable":
+        out: runtime.ResultVariable[object] = runtime.ResultVariable()
         out.set_type(self.type)
         return out
 
@@ -170,14 +169,14 @@ class RelationAttribute(Attribute):
         self.low = values[0]
         self.high = values[1]
 
-    def get_new_result_variable(self, instance: "Instance", queue: QueueScheduler) -> ResultVariable:
-        out: ResultVariable
+    def get_new_result_variable(self, instance: "Instance", queue: "runtime.QueueScheduler") -> "runtime.ResultVariable":
+        out: runtime.ResultVariable
         if self.low == 1 and self.high == 1:
-            out = AttributeVariable(self, instance)
+            out = runtime.AttributeVariable(self, instance)
         elif self.low == 0 and self.high == 1:
-            out = OptionVariable(self, instance, queue)
+            out = runtime.OptionVariable(self, instance, queue)
         else:
-            out = ListVariable(self, instance, queue)
+            out = runtime.ListVariable(self, instance, queue)
         out.set_type(self.type)
         return out
 

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -29,8 +29,8 @@ from inmanta.ast import (
     NotFoundException,
     OptionalValueException,
     RuntimeException,
+    attribute,
 )
-from inmanta.ast import attribute
 from inmanta.ast.type import Type
 from inmanta.execute import dataflow, proxy
 from inmanta.execute.dataflow import DataflowGraph

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -18,6 +18,8 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Deque, Dict, Generic, Hashable, List, Optional, Set, TypeVar, Union, cast
 
+import inmanta.ast.attribute  # noqa: F401 (pep8 does not recognize partially qualified access ast.attribute)
+from inmanta import ast
 from inmanta.ast import (
     AttributeException,
     CompilerException,
@@ -29,7 +31,6 @@ from inmanta.ast import (
     NotFoundException,
     OptionalValueException,
     RuntimeException,
-    attribute,
 )
 from inmanta.ast.type import Type
 from inmanta.execute import dataflow, proxy
@@ -365,8 +366,8 @@ class AttributeVariable(ResultVariable["Instance"], RelationAttributeVariable):
 
     __slots__ = ("attribute", "myself")
 
-    def __init__(self, attribute: "attribute.RelationAttribute", instance: "Instance"):
-        self.attribute: attribute.RelationAttribute = attribute
+    def __init__(self, attribute: "ast.attribute.RelationAttribute", instance: "Instance"):
+        self.attribute: ast.attribute.RelationAttribute = attribute
         self.myself: "Instance" = instance
         ResultVariable.__init__(self)
 
@@ -629,8 +630,8 @@ class ListVariable(BaseListVariable, RelationAttributeVariable):
 
     __slots__ = ("attribute", "myself")
 
-    def __init__(self, attribute: "attribute.RelationAttribute", instance: "Instance", queue: "QueueScheduler") -> None:
-        self.attribute: attribute.RelationAttribute = attribute
+    def __init__(self, attribute: "ast.attribute.RelationAttribute", instance: "Instance", queue: "QueueScheduler") -> None:
+        self.attribute: ast.attribute.RelationAttribute = attribute
         self.myself: "Instance" = instance
         BaseListVariable.__init__(self, queue)
 
@@ -693,9 +694,9 @@ class OptionVariable(DelayedResultVariable["Instance"], RelationAttributeVariabl
 
     __slots__ = ("attribute", "myself", "location")
 
-    def __init__(self, attribute: "attribute.Attribute", instance: "Instance", queue: "QueueScheduler") -> None:
+    def __init__(self, attribute: "ast.attribute.Attribute", instance: "Instance", queue: "QueueScheduler") -> None:
         self.value = None
-        self.attribute: attribute.RelationAttribute = attribute
+        self.attribute: ast.attribute.RelationAttribute = attribute
         self.myself: "Instance" = instance
         self.location = None
         # Only call super after initialization of the above-mentioned attributes
@@ -1248,7 +1249,7 @@ class Instance(ExecutionContext):
                 else:
                     attr = self.type.get_attribute(k)
                     assert attr is not None  # Make mypy happy
-                    if isinstance(attr, attribute.RelationAttribute) and attr.is_multi():
+                    if isinstance(attr, ast.attribute.RelationAttribute) and attr.is_multi():
                         low = attr.low
                         # none for list attributes
                         # list for n-ary relations

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -30,6 +30,7 @@ from inmanta.ast import (
     OptionalValueException,
     RuntimeException,
 )
+from inmanta.ast.attribute import Attribute, RelationAttribute
 from inmanta.ast.type import Type
 from inmanta.execute import dataflow, proxy
 from inmanta.execute.dataflow import DataflowGraph
@@ -37,7 +38,6 @@ from inmanta.execute.tracking import Tracker
 from inmanta.execute.util import NoneValue, Unknown
 
 if TYPE_CHECKING:
-    from inmanta.ast.attribute import Attribute, RelationAttribute
     from inmanta.ast.blocks import BasicBlock
     from inmanta.ast.entity import Entity, Implementation
     from inmanta.ast.statements import RawResumer, RequiresEmitStatement, Resumer, Statement
@@ -365,8 +365,8 @@ class AttributeVariable(ResultVariable["Instance"], RelationAttributeVariable):
 
     __slots__ = ("attribute", "myself")
 
-    def __init__(self, attribute: "RelationAttribute", instance: "Instance"):
-        self.attribute: "RelationAttribute" = attribute
+    def __init__(self, attribute: RelationAttribute, instance: "Instance"):
+        self.attribute: RelationAttribute = attribute
         self.myself: "Instance" = instance
         ResultVariable.__init__(self)
 
@@ -629,8 +629,8 @@ class ListVariable(BaseListVariable, RelationAttributeVariable):
 
     __slots__ = ("attribute", "myself")
 
-    def __init__(self, attribute: "RelationAttribute", instance: "Instance", queue: "QueueScheduler") -> None:
-        self.attribute: "RelationAttribute" = attribute
+    def __init__(self, attribute: RelationAttribute, instance: "Instance", queue: "QueueScheduler") -> None:
+        self.attribute: RelationAttribute = attribute
         self.myself: "Instance" = instance
         BaseListVariable.__init__(self, queue)
 
@@ -693,9 +693,9 @@ class OptionVariable(DelayedResultVariable["Instance"], RelationAttributeVariabl
 
     __slots__ = ("attribute", "myself", "location")
 
-    def __init__(self, attribute: "Attribute", instance: "Instance", queue: "QueueScheduler") -> None:
+    def __init__(self, attribute: Attribute, instance: "Instance", queue: "QueueScheduler") -> None:
         self.value = None
-        self.attribute: "RelationAttribute" = attribute
+        self.attribute: RelationAttribute = attribute
         self.myself: "Instance" = instance
         self.location = None
         # Only call super after initialization of the above-mentioned attributes
@@ -1248,7 +1248,7 @@ class Instance(ExecutionContext):
                 else:
                     attr = self.type.get_attribute(k)
                     assert attr is not None  # Make mypy happy
-                    if attr.is_multi():
+                    if isinstance(attr, RelationAttribute) and attr.is_multi():
                         low = attr.low
                         # none for list attributes
                         # list for n-ary relations

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -30,7 +30,7 @@ from inmanta.ast import (
     OptionalValueException,
     RuntimeException,
 )
-from inmanta.ast.attribute import Attribute, RelationAttribute
+from inmanta.ast import attribute
 from inmanta.ast.type import Type
 from inmanta.execute import dataflow, proxy
 from inmanta.execute.dataflow import DataflowGraph
@@ -365,8 +365,8 @@ class AttributeVariable(ResultVariable["Instance"], RelationAttributeVariable):
 
     __slots__ = ("attribute", "myself")
 
-    def __init__(self, attribute: RelationAttribute, instance: "Instance"):
-        self.attribute: RelationAttribute = attribute
+    def __init__(self, attribute: "attribute.RelationAttribute", instance: "Instance"):
+        self.attribute: attribute.RelationAttribute = attribute
         self.myself: "Instance" = instance
         ResultVariable.__init__(self)
 
@@ -629,8 +629,8 @@ class ListVariable(BaseListVariable, RelationAttributeVariable):
 
     __slots__ = ("attribute", "myself")
 
-    def __init__(self, attribute: RelationAttribute, instance: "Instance", queue: "QueueScheduler") -> None:
-        self.attribute: RelationAttribute = attribute
+    def __init__(self, attribute: "attribute.RelationAttribute", instance: "Instance", queue: "QueueScheduler") -> None:
+        self.attribute: attribute.RelationAttribute = attribute
         self.myself: "Instance" = instance
         BaseListVariable.__init__(self, queue)
 
@@ -693,9 +693,9 @@ class OptionVariable(DelayedResultVariable["Instance"], RelationAttributeVariabl
 
     __slots__ = ("attribute", "myself", "location")
 
-    def __init__(self, attribute: Attribute, instance: "Instance", queue: "QueueScheduler") -> None:
+    def __init__(self, attribute: "attribute.Attribute", instance: "Instance", queue: "QueueScheduler") -> None:
         self.value = None
-        self.attribute: RelationAttribute = attribute
+        self.attribute: attribute.RelationAttribute = attribute
         self.myself: "Instance" = instance
         self.location = None
         # Only call super after initialization of the above-mentioned attributes
@@ -1248,7 +1248,7 @@ class Instance(ExecutionContext):
                 else:
                     attr = self.type.get_attribute(k)
                     assert attr is not None  # Make mypy happy
-                    if isinstance(attr, RelationAttribute) and attr.is_multi():
+                    if isinstance(attr, attribute.RelationAttribute) and attr.is_multi():
                         low = attr.low
                         # none for list attributes
                         # list for n-ary relations

--- a/tests/compiler/test_list.py
+++ b/tests/compiler/test_list.py
@@ -418,9 +418,7 @@ def test_emptylists(snippetcompiler):
     compiler.do_compile()
 
 
-@pytest.mark.parametrize_any(
-    "type", ["[]", "[]?"]
-)
+@pytest.mark.parametrize_any("type", ["[]", "[]?"])
 def test_653_list_attribute_unset(snippetcompiler, type: str):
     snippetcompiler.setup_for_error(
         f"""

--- a/tests/compiler/test_list.py
+++ b/tests/compiler/test_list.py
@@ -418,11 +418,14 @@ def test_emptylists(snippetcompiler):
     compiler.do_compile()
 
 
-def test_653_list_attribute_unset(snippetcompiler):
+@pytest.mark.parametrize_any(
+    "type", ["[]", "[]?"]
+)
+def test_653_list_attribute_unset(snippetcompiler, type: str):
     snippetcompiler.setup_for_error(
-        """
+        f"""
         entity Test:
-            string[] bla
+            string{type} bla
         end
 
         Test()
@@ -430,7 +433,7 @@ def test_653_list_attribute_unset(snippetcompiler):
         implement Test using std::none
         """,
         "The object __config__::Test (instantiated at {dir}/main.cf:6) is not complete:"
-        " attribute bla ({dir}/main.cf:3:22) requires 1 values but only 0 are set",
+        f" attribute bla ({{dir}}/main.cf:3:{20 + len(type)}) is not set",
     )
 
 


### PR DESCRIPTION
# Description

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
