### PR TITLE
Add generic enum migration script

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 8.2.1
+current_version = 8.3.0
 
 [bumpversion:file:setup.py]
 search = version = "{current_version}"

--- a/changelogs/unreleased/add-enum-migration-tool.yml
+++ b/changelogs/unreleased/add-enum-migration-tool.yml
@@ -1,4 +1,4 @@
 ---
 description: Add generic enum migration tool.
-change-type: patch
+change-type: minor
 destination-branches: [master, iso6]

--- a/changelogs/unreleased/add-enum-migration-tool.yml
+++ b/changelogs/unreleased/add-enum-migration-tool.yml
@@ -1,4 +1,4 @@
 ---
 description: Add generic enum migration tool.
 change-type: patch
-destination-branches: [master, iso6, iso5, iso4]
+destination-branches: [master, iso6]

--- a/changelogs/unreleased/add-enum-migration-tool.yml
+++ b/changelogs/unreleased/add-enum-migration-tool.yml
@@ -1,0 +1,4 @@
+---
+description: Add generic enum migration tool.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-version = "8.2.1"
+version = "8.3.0"
 
 setup(
     version=version,

--- a/src/inmanta/db/util.py
+++ b/src/inmanta/db/util.py
@@ -16,10 +16,10 @@
     Contact: code@inmanta.com
 """
 import collections.abc
-from collections import abc
 import logging
-from typing import List, Optional, NamedTuple
+from collections import abc
 from dataclasses import dataclass
+from typing import List, NamedTuple, Optional
 
 from asyncpg import Connection
 

--- a/src/inmanta/db/util.py
+++ b/src/inmanta/db/util.py
@@ -16,8 +16,10 @@
     Contact: code@inmanta.com
 """
 import collections.abc
+from collections import abc
 import logging
-from typing import List, Optional
+from typing import List, Optional, NamedTuple
+from dataclasses import dataclass
 
 from asyncpg import Connection
 
@@ -161,3 +163,72 @@ AND routine_schema = 'public';
         ",".join(type_names),
         ",".join(function_names),
     )
+
+
+class ColumnDefinition(NamedTuple):
+    """
+    :param name: The name of the column.
+    :param is_list: A boolean that indicates whether this column has the type list.
+    :param default: The default value of this column. Or None, when this column doesn't have a default value.
+    """
+
+    name: str
+    is_list: bool = False
+    default: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EnumUpdateDefinition:
+    """
+    A definition on how an existing enum in the database has to be updated.
+
+    :param name: The name of the enumeration.
+    :param values: The values the enum should have after the update.
+    :param deleted_values: A dictionary that indicates which elements are deleted from the existing enum and how
+                           they should be migrated. The key of the dictionary is the name of the removed enum value
+                           and the value of the dictionary is the value it should be replaced with or None if the new value
+                           should be NULL.
+    :param columns: A dictionary that indicates which columns of which tables are using the enum.
+                    The key of the dictionary contains the name of the table.
+    """
+
+    name: str
+    values: abc.Sequence[str]
+    deleted_values: abc.Mapping[str, Optional[str]]  # deleted values mapped to new value if any currently exist
+    columns: abc.Mapping[str, abc.Sequence[ColumnDefinition]]  # columns with defaults
+
+
+async def replace_enum_type(new_type: EnumUpdateDefinition, *, connection: Connection) -> None:
+    """
+    Completely replaces an enum type with a new definition with the same name.
+
+    :param new_type: The definition of the new type. Assumed to be an internal construct, this method is not safe against
+                     injections via this object's attributes.
+    """
+    temp_name: str = f"_old_{new_type.name}"
+    await connection.execute(
+        f"""
+        ALTER TYPE {new_type.name} RENAME TO {temp_name};
+        CREATE TYPE {new_type.name} AS ENUM(%s);
+        """
+        % (", ".join(f"'{v}'" for v in new_type.values))
+    )
+    for table, columns in new_type.columns.items():
+        for column, is_list, default in columns:
+            for old_value, new_value in new_type.deleted_values.items():
+                await connection.execute(f"UPDATE {table} SET {column}=$1 WHERE {column}=$2", new_value, old_value)
+            await connection.execute(f"ALTER TABLE {table} ALTER COLUMN {column} DROP DEFAULT")
+            if is_list:
+                # can't cast directly between enums -> go via varchar
+                await connection.execute(
+                    f"ALTER TABLE {table} ALTER COLUMN {column} TYPE {new_type.name}[]"
+                    f"USING {column}::varchar[]::{new_type.name}[]"
+                )
+            else:
+                # can't cast directly between enums -> go via varchar
+                await connection.execute(
+                    f"ALTER TABLE {table} ALTER COLUMN {column} TYPE {new_type.name} USING {column}::varchar::{new_type.name}"
+                )
+            if default:
+                await connection.execute(f"ALTER TABLE {table} ALTER COLUMN {column} SET DEFAULT '{default}'")
+    await connection.execute(f"DROP TYPE {temp_name}")

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -19,7 +19,7 @@ from os import path
 
 from setuptools import find_namespace_packages, setup
 
-version = "8.2.1"
+version = "8.3.0"
 
 requires = [
     "asyncpg",


### PR DESCRIPTION
# Description

Add generic enum migration script. This is a move from the implementation in https://github.com/inmanta/inmanta-lsm/commit/5ecc0788d050eb7f7d7d8ab96328950c9587b08d#diff-6fd3564394aa7b52de9892fe288c30dbdf214bea67c6c035f428859afdeba5ea to make it reusable in all inmanta-core and the lsm extension.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~