### PR TITLE
Fix race condition test_compileservice_queue test case

### DIFF
--- a/changelogs/unreleased/fix-race-condition-test-compileservice-queue.yml
+++ b/changelogs/unreleased/fix-race-condition-test-compileservice-queue.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in `test_compileservice_queue` test case.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -871,6 +871,9 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     # 5 in the queue, 1 running
     assert compilerslice._queue_count_cache == 5
 
+    async def has_matching_compile_report(first_compile_id: uuid.UUID, second_compile_id: uuid.UUID) -> bool:
+        return await compilerslice.get_report(first_compile_id) == await compilerslice.get_report(second_compile_id)
+
     # finish a compile and wait for service to take on next
     await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
@@ -885,7 +888,9 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     # finish second compile
     await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
-    assert await compilerslice.get_report(compile_id2) == await compilerslice.get_report(compile_id4)
+    # The "halted" field of a compile report is set asynchronously by a background task.
+    # Use try_limited to prevent a race condition.
+    await retry_limited(lambda: has_matching_compile_report(compile_id2, compile_id4), timeout=10)
     # 2 in the queue, 1 running
     assert compilerslice._queue_count_cache == 2
 
@@ -902,8 +907,8 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     while env.id in compilerslice._recompiles:
         await asyncio.sleep(0.2)
 
-    assert await compilerslice.get_report(compile_id3) == await compilerslice.get_report(compile_id5)
-    assert await compilerslice.get_report(compile_id3) == await compilerslice.get_report(compile_id6)
+    await retry_limited(lambda: has_matching_compile_report(compile_id3, compile_id5), timeout=10)
+    await retry_limited(lambda: has_matching_compile_report(compile_id3, compile_id6), timeout=10)
 
     # 0 in the queue, 0 running
     assert compilerslice._queue_count_cache == 0


### PR DESCRIPTION
# Description

Fix race condition in `test_compileservice_queue` test case. When the compile runner finishes its execution, the halted attribute is not yet set on the compile report. This is done outside of the scope of the compile running and in a background task. So the wait condition before the comparison of two compile reports, using the `run_compile_and_wait_until_compile_is_done` method, is not complete because it doesn't wait until the halted attribute is updated. This PR fixes that issue.

Error when halted attribute is not yet updated:

```
__________________________ test_compileservice_queue ___________________________

mocked_compiler_service_block = <queue.Queue object at 0x7f5ff51911c0>
server = <inmanta.server.protocol.Server object at 0x7f5ff50985b0>
client = <inmanta.protocol.endpoints.Client object at 0x7f5ff5191730>
environment = 'ddeeb8eb-eef0-4a2c-a647-b91d96db7926'

    async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, server, client, environment):
        """
        Test the inspection of the compile queue. The compile runner is mocked out so the "started" field does not have the
        correct value in this test.
        """
        env = await data.Environment.get_by_id(environment)
        compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
    
        result = await client.get_compile_queue(environment)
        assert len(result.result["queue"]) == 0
        assert result.code == 200
    
        # request a compile
        remote_id1 = uuid.uuid4()
        await compilerslice.request_recompile(
            env=env, force_update=False, do_export=False, remote_id=remote_id1, env_vars={"my_unique_var": "1"}
        )
    
        # api should return one
        result = await client.get_compile_queue(environment)
        assert len(result.result["queue"]) == 1
        assert result.result["queue"][0]["remote_id"] == str(remote_id1)
        assert result.code == 200
        # None in the queue, all running
        assert compilerslice._queue_count_cache == 0
    
        # request a compile
        remote_id2 = uuid.uuid4()
        compile_id2, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=remote_id2)
    
        # api should return two
        result = await client.get_compile_queue(environment)
        assert len(result.result["queue"]) == 2
        assert result.result["queue"][1]["remote_id"] == str(remote_id2)
        assert result.code == 200
        # 1 in the queue, 1 running
        assert compilerslice._queue_count_cache == 1
    
        # request a compile with do_export=True
        remote_id3 = uuid.uuid4()
        compile_id3, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=True, remote_id=remote_id3)
    
        result = await client.get_compile_queue(environment)
        assert len(result.result["queue"]) == 3
        assert result.result["queue"][2]["remote_id"] == str(remote_id3)
        assert result.code == 200
        # 2 in the queue, 1 running
        assert compilerslice._queue_count_cache == 2
    
        # request a compile with do_export=False -> expect merge with compile2
        remote_id4 = uuid.uuid4()
        compile_id4, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=remote_id4)
    
        result = await client.get_compile_queue(environment)
        assert len(result.result["queue"]) == 4
        assert result.result["queue"][3]["remote_id"] == str(remote_id4)
        assert result.code == 200
        # 3 in the queue, 1 running
        assert compilerslice._queue_count_cache == 3
    
        # request a compile with do_export=True -> expect merge with compile3, expect force_update == True for the compile
        remote_id5 = uuid.uuid4()
        compile_id5, _ = await compilerslice.request_recompile(env=env, force_update=True, do_export=True, remote_id=remote_id5)
        remote_id6 = uuid.uuid4()
        compile_id6, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=True, remote_id=remote_id6)
    
        result = await client.get_compile_queue(environment)
        assert len(result.result["queue"]) == 6
        assert result.result["queue"][4]["remote_id"] == str(remote_id5)
        assert result.result["queue"][5]["remote_id"] == str(remote_id6)
        assert result.code == 200
        # 5 in the queue, 1 running
        assert compilerslice._queue_count_cache == 5
    
        # finish a compile and wait for service to take on next
        await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
    
        # api should return five when ready
        result = await client.get_compile_queue(environment)
        assert len(result.result["queue"]) == 5
        assert result.result["queue"][0]["remote_id"] == str(remote_id2)
        assert result.code == 200
        # 4 in the queue, 1 running
        assert compilerslice._queue_count_cache == 4
    
        # finish second compile
        await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
    
>       assert await compilerslice.get_report(compile_id2) == await compilerslice.get_report(compile_id4)
E       AssertionError: assert (200, {'report': {'remote_id': UUID('922246fc-bb8c-410b-9f42-2f27a4647292'), 'requested': datetime.datetime(2023, 2, 10, 1, 29, 19, 795864, tzinfo=datetime.timezone.utc), 'started': None, 'completed': datetime.datetime(2023, 2, 10, 1, 29, 20, 8958, tzinfo=datetime.timezone.utc), 'do_export': False, 'force_update': False, 'metadata': {}, 'environment_variables': {}, 'handled': False, 'version': 1675992560, 'substitute_compile_id': None, 'compile_data': None, 'partial': False, 'removed_resource_sets': [], 'exporter_plugin': None, 'notify_failed_compile': None, 'failed_compile_message': None, 'id': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1'), 'environment': UUID('ddeeb8eb-eef0-4a2c-a647-b91d96db7926'), 'success': False, 'reports': [{'errstream': '', 'outstream': '', 'id': UUID('18f18f41-2a79-4bab-9324-4b2f31ce0b27'), 'started': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'completed': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'command': '', 'name': 'CompileRunnerMock', 'returncode': 1, 'compile': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1')}]}}) == (200, {'report': {'remote_id': UUID('922246fc-bb8c-410b-9f42-2f27a4647292'), 'requested': datetime.datetime(2023, 2, 10, 1, 29, 19, 795864, tzinfo=datetime.timezone.utc), 'started': None, 'completed': datetime.datetime(2023, 2, 10, 1, 29, 20, 8958, tzinfo=datetime.timezone.utc), 'do_export': False, 'force_update': False, 'metadata': {}, 'environment_variables': {}, 'handled': True, 'version': 1675992560, 'substitute_compile_id': None, 'compile_data': None, 'partial': False, 'removed_resource_sets': [], 'exporter_plugin': None, 'notify_failed_compile': None, 'failed_compile_message': None, 'id': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1'), 'environment': UUID('ddeeb8eb-eef0-4a2c-a647-b91d96db7926'), 'success': False, 'reports': [{'errstream': '', 'outstream': '', 'id': UUID('18f18f41-2a79-4bab-9324-4b2f31ce0b27'), 'started': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'completed': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'command': '', 'name': 'CompileRunnerMock', 'returncode': 1, 'compile': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1')}]}})
E         At index 1 diff: {'report': {'remote_id': UUID('922246fc-bb8c-410b-9f42-2f27a4647292'), 'requested': datetime.datetime(2023, 2, 10, 1, 29, 19, 795864, tzinfo=datetime.timezone.utc), 'started': None, 'completed': datetime.datetime(2023, 2, 10, 1, 29, 20, 8958, tzinfo=datetime.timezone.utc), 'do_export': False, 'force_update': False, 'metadata': {}, 'environment_variables': {}, 'handled': False, 'version': 1675992560, 'substitute_compile_id': None, 'compile_data': None, 'partial': False, 'removed_resource_sets': [], 'exporter_plugin': None, 'notify_failed_compile': None, 'failed_compile_message': None, 'id': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1'), 'environment': UUID('ddeeb8eb-eef0-4a2c-a647-b91d96db7926'), 'success': False, 'reports': [{'errstream': '', 'outstream': '', 'id': UUID('18f18f41-2a79-4bab-9324-4b2f31ce0b27'), 'started': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'completed': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'command': '', 'name': 'CompileRunnerMock', 'returncode': 1, 'compile': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1')}]}} != {'report': {'remote_id': UUID('922246fc-bb8c-410b-9f42-2f27a4647292'), 'requested': datetime.datetime(2023, 2, 10, 1, 29, 19, 795864, tzinfo=datetime.timezone.utc), 'started': None, 'completed': datetime.datetime(2023, 2, 10, 1, 29, 20, 8958, tzinfo=datetime.timezone.utc), 'do_export': False, 'force_update': False, 'metadata': {}, 'environment_variables': {}, 'handled': True, 'version': 1675992560, 'substitute_compile_id': None, 'compile_data': None, 'partial': False, 'removed_resource_sets': [], 'exporter_plugin': None, 'notify_failed_compile': None, 'failed_compile_message': None, 'id': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1'), 'environment': UUID('ddeeb8eb-eef0-4a2c-a647-b91d96db7926'), 'success': False, 'reports': [{'errstream': '', 'outstream': '', 'id': UUID('18f18f41-2a79-4bab-9324-4b2f31ce0b27'), 'started': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'completed': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc), 'command': '', 'name': 'CompileRunnerMock', 'returncode': 1, 'compile': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1')}]}}
E         Full diff:
E           (
E            200,
E            {'report': {'compile_data': None,
E                        'completed': datetime.datetime(2023, 2, 10, 1, 29, 20, 8958, tzinfo=datetime.timezone.utc),
E                        'do_export': False,
E                        'environment': UUID('ddeeb8eb-eef0-4a2c-a647-b91d96db7926'),
E                        'environment_variables': {},
E                        'exporter_plugin': None,
E                        'failed_compile_message': None,
E                        'force_update': False,
E         -              'handled': True,
E         ?                         ^^^
E         +              'handled': False,
E         ?                         ^^^^
E                        'id': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1'),
E                        'metadata': {},
E                        'notify_failed_compile': None,
E                        'partial': False,
E                        'remote_id': UUID('922246fc-bb8c-410b-9f42-2f27a4647292'),
E                        'removed_resource_sets': [],
E                        'reports': [{'command': '',
E                                     'compile': UUID('8ee50278-7c22-4323-b879-fd7d3d34abb1'),
E                                     'completed': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc),
E                                     'errstream': '',
E                                     'id': UUID('18f18f41-2a79-4bab-9324-4b2f31ce0b27'),
E                                     'name': 'CompileRunnerMock',
E                                     'outstream': '',
E                                     'returncode': 1,
E                                     'started': datetime.datetime(2023, 2, 10, 1, 29, 19, 906135, tzinfo=datetime.timezone.utc)}],
E                        'requested': datetime.datetime(2023, 2, 10, 1, 29, 19, 795864, tzinfo=datetime.timezone.utc),
E                        'started': None,
E                        'substitute_compile_id': None,
E                        'success': False,
E                        'version': 1675992560}},
E           )
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~