### PR TITLE
Fix serialization of ConfigurationModel dao

### DIFF
--- a/changelogs/unreleased/fix-serialization-configurationmodel.yml
+++ b/changelogs/unreleased/fix-serialization-configurationmodel.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug in the serialization of the ConfigurationModel dao.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]
+sections:
+  bugfix: "Fix bug where the 'done' field of a model version returned by the `GET /version` or the `GET /version/<id>` API endpoint decrements when a repair run of an agent changes the state of the resource to deploying again."

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4910,7 +4910,7 @@ class ConfigurationModel(BaseDocument):
     def to_dict(self) -> JsonType:
         dct = BaseDocument.to_dict(self)
         dct["status"] = dict(self._status)
-        dct["done"] = self._done
+        dct["done"] = self.done
         return dct
 
     @classmethod


### PR DESCRIPTION
# Description

Fix bug where the 'done' field of a model version returned by the `GET /version` or the `GET /version/<id>` API endpoint decrements when a repair run of an agent changes the state of the resource to deploying again.

This fix should make the following test case more stable:

```
client = <inmanta.protocol.endpoints.Client object at 0x7f9ab9dd37f0>
agent = <inmanta.agent.agent.Agent object at 0x7f9ab9dd39a0>
clienthelper = <utils.ClientHelper object at 0x7f9ac5e64e20>
environment = 'c8270f38-f6fc-40a1-b4ca-61fdfd9ea051'
resource_container = ResourceContainer(Provider=<class 'conftest.resource_container.<locals>.Provider'>, waiter=<Condition(<unlocked _threa...it_for_condition_with_waiters=<function resource_container.<locals>.wait_for_condition_with_waiters at 0x7f9ac6108670>)
self_state = undefined, dep_state = success
async_finalizer = <conftest.AsyncCleaner object at 0x7f9ac5e88490>
no_agent_backoff = None

    @pytest.mark.parametrize("self_state", self_states, ids=lambda x: x.name)
    @pytest.mark.parametrize("dep_state", dep_states, ids=lambda x: x.name)
    async def test_deploy_and_events(
        client, agent, clienthelper, environment, resource_container, self_state, dep_state, async_finalizer, no_agent_backoff
    ):
        resource_container.Provider.reset()
    
        version = await clienthelper.get_version()
    
        (dep, dep_status) = dep_state.get_resource(resource_container, "agent1", "key2", version, [])
        (own, own_status) = self_state.get_resource(
            resource_container,
            "agent1",
            "key3",
            version,
            ["test::Resource[agent1,key=key2],v=%d" % version, "test::Resource[agent1,key=key1],v=%d" % version],
        )
    
        resources = [
            {
                "key": "key1",
                "value": "value1",
                "id": "test::Resource[agent1,key=key1],v=%d" % version,
                "send_event": True,
                "purged": False,
                "requires": [],
            },
            dep,
            own,
        ]
    
        status = {x[0]: x[1] for x in [dep_status, own_status] if x is not None}
        result = await client.put_version(
            tid=environment,
            version=version,
            resources=resources,
            resource_state=status,
            unknowns=[],
            version_info={},
            compiler_version=get_compiler_version(),
        )
        assert result.code == 200
    
        # do a deploy
        result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
        assert result.code == 200
        assert not result.result["model"]["deployed"]
        assert result.result["model"]["released"]
        assert result.result["model"]["total"] == 3
        assert result.result["model"]["result"] == "deploying"
    
        result = await client.get_version(environment, version)
        assert result.code == 200
    
        await _wait_until_deployment_finishes(client, environment, version)
    
        result = await client.get_version(environment, version)
>       assert result.result["model"]["done"] == len(resources)
E       AssertionError: assert 2 == 3
E        +  where 3 = len([{'id': 'test::Resource[agent1,key=key1],v=1', 'key': 'key1', 'purged': False, 'requires': [], ...}, {'id': 'test::Resource[agent1,key=key2],v=1', 'key': 'key2', 'purged': False, 'requires': [], ...}, {'id': 'test::Resource[agent1,key=key3],v=1', 'key': 'key3', 'purged': False, 'requires': ['test::Resource[agent1,key=key2],v=1', 'test::Resource[agent1,key=key1],v=1'], ...}])

tests/agent_server/test_server_agent.py:1959: AssertionError
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~