### PR TITLE
Fix for line numbering issue

### DIFF
--- a/changelogs/unreleased/5497-errors-on-attributes.yml
+++ b/changelogs/unreleased/5497-errors-on-attributes.yml
@@ -1,0 +1,6 @@
+description: Improve line numbering when reporting non-existing attributes on constructors
+issue-nr: 5497
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -471,6 +471,7 @@ class Constructor(ExpressionStatement):
     __slots__ = (
         "class_type",
         "__attributes",
+        "__attribute_locations",
         "__wrapped_kwarg_attributes",
         "location",
         "type",
@@ -492,6 +493,7 @@ class Constructor(ExpressionStatement):
         super().__init__()
         self.class_type = class_type
         self.__attributes = {}  # type: Dict[str,ExpressionStatement]
+        self.__attribute_locations: Dict[str, LocatableString] = {}
         self.__wrapped_kwarg_attributes: List[WrappedKwargs] = wrapped_kwargs
         self.location = location
         self.namespace = namespace
@@ -560,7 +562,7 @@ class Constructor(ExpressionStatement):
         for k, v in all_attributes.items():
             attribute = self.type.get_attribute(k)
             if attribute is None:
-                raise TypingException(self, "no attribute %s on type %s" % (k, self.type.get_full_name()))
+                raise TypingException(self.__attribute_locations[k], "no attribute %s on type %s" % (k, self.type.get_full_name()))
             if k not in inindex:
                 self._indirect_attributes[k] = v
             else:
@@ -776,6 +778,7 @@ class Constructor(ExpressionStatement):
         name = str(lname)
         if name not in self.__attributes:
             self.__attributes[name] = value
+            self.__attribute_locations[name] = lname
             self.anchors.append(AttributeReferenceAnchor(lname.get_location(), lname.namespace, self.class_type, name))
             self.anchors.extend(value.get_anchors())
         else:

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -562,7 +562,9 @@ class Constructor(ExpressionStatement):
         for k, v in all_attributes.items():
             attribute = self.type.get_attribute(k)
             if attribute is None:
-                raise TypingException(self.__attribute_locations[k], "no attribute %s on type %s" % (k, self.type.get_full_name()))
+                raise TypingException(
+                    self.__attribute_locations[k], "no attribute %s on type %s" % (k, self.type.get_full_name())
+                )
             if k not in inindex:
                 self._indirect_attributes[k] = v
             else:

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -250,3 +250,25 @@ implement A using std::none
         """,
         """Syntax error: The use of default constructors is no longer supported ({dir}/main.cf:2:9)""",
     )
+
+
+def test_multi_line_constructor(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+entity ManyFields:
+    string a
+    string b
+    string c
+end
+
+implement ManyFields using std::none
+
+ManyFields(
+    a = "A",
+    b = "B",
+    c = "C",
+    d = "D",
+)
+""",
+        """no attribute d on type __config__::ManyFields (reported in d ({dir}/main.cf:14:5))""",  # noqa: E501
+    )


### PR DESCRIPTION
# Description

Fixes #5497 

A few remarks:
1. the error is now reported on the key in the assignment (in the testcase that is `d` in `d = "D"` 
2. @sanderr I added a field to not have to re-wire the whole class, wdyt? 
3. @bartv @sanderr I could also report on the RHS of the assignment, which is easier to implement, but I believe less accurate. What should I report on ? 
4. @sanderr do you recall why locatable str is not in fact a child of locatable? 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
```
+ src/inmanta/ast/statements/generator.py:565: error: Argument 1 to "TypingException" has incompatible type "LocatableString"; expected "Optional[Locatable]"  [arg-type]
```

- [X] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
