### PR TITLE
Improve logging on exceptions in api requests

### DIFF
--- a/changelogs/unreleased/improve-request-error-logging.yml
+++ b/changelogs/unreleased/improve-request-error-logging.yml
@@ -1,0 +1,4 @@
+---
+description: Improve the logging of exceptions in API requests
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -158,7 +158,7 @@ class RESTHandler(tornado.web.RequestHandler):
                 self.respond({"message": "Unable to decode request body"}, {}, 400)
 
             except exceptions.BaseHttpException as e:
-                LOGGER.warning("Got %d status code: %s", e.to_status(), e.to_body())
+                LOGGER.warning("Received an exception with status code %d and message %s", e.to_status(), e.to_body())
                 self.respond(e.to_body(), {}, e.to_status())
 
             except CancelledError:

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -158,6 +158,7 @@ class RESTHandler(tornado.web.RequestHandler):
                 self.respond({"message": "Unable to decode request body"}, {}, 400)
 
             except exceptions.BaseHttpException as e:
+                LOGGER.warning("Got %d status code: %s", e.to_status(), e.to_body())
                 self.respond(e.to_body(), {}, e.to_status())
 
             except CancelledError:


### PR DESCRIPTION
# Description

When we get an http exception during an API request we send the message to the client without logging.

When this error causes a redirect loop in your browser you do not even see the message. This PR also adds it to the logs of the server.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
