### PR TITLE
Added first POC of type hinting

### DIFF
--- a/changelogs/unreleased/4028-namespace-inference.yml
+++ b/changelogs/unreleased/4028-namespace-inference.yml
@@ -1,0 +1,7 @@
+description: Added namespace inference to nested constructors
+issue-nr: 4028
+change-type: minor
+destination-branches: [master, iso6]
+sections:
+  feature: "{{description}}"
+

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -401,6 +401,56 @@ attribute names as keys and the desired values as values. For example:
     file1_config = {"path": "/opt/1"}
     f1 = File(host=h1, **file1_config)
 
+
+Refering to instances
+++++++++++++++++++++++
+
+When referring to entities in the same module, a parent model or std, short names can be used
+
+Following code blocks are equivalent and both valid
+
+.. code-block:: inmanta
+
+    std::Host("test")
+
+.. code-block:: inmanta
+
+    Host("test")
+
+
+When constructing entities from other modules, the fully qualified name must be used
+
+.. code-block:: inmanta
+
+   import srlinux
+   import srlinux::interface
+
+   interface = srlinux::Interface(
+        subinterface = srlinux::interface::Subinterface(
+        )
+    )
+
+When nesting constructors, short names can be used for the nested constructors, because their types can be inferred
+
+.. code-block:: inmanta
+
+   import srlinux
+   import srlinux::interface
+
+   interface = srlinux::Interface( # This type is qualified
+        subinterface = Subinterface( # This type is inferred
+        )
+    )
+
+However, when relying on type inference,
+1. avoid creating sibling types with the same name, but different fully qualified name, as they may become indistinguishable, breaking the inference on existing models.
+
+    1. if multiple types exist with the same name, and one is in scope, that one is selected (i.e it is defined in this module, a parent module or `std`)
+    2. if multiple types exist with that are all out of scope, inference fails
+
+2. make sure the type you want to infer is imported somewhere in the model. Otherwise the compiler will not find it.
+
+
 Refinements
 ===========
 

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -32,6 +32,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute  # noqa: F401
+    from inmanta.ast.entity import Entity
     from inmanta.ast.statements import Statement  # noqa: F401
     from inmanta.ast.statements.define import DefineEntity, DefineImport  # noqa: F401
     from inmanta.ast.type import NamedType, Type  # noqa: F401
@@ -638,11 +639,12 @@ class TypeNotFoundException(RuntimeException):
 class AmbiguousTypeException(TypeNotFoundException):
     """Exception raised when a type is referenced that does not exist"""
 
-    def __init__(self, type: LocatableString, candidates: List["Type"]) -> None:
+    def __init__(self, type: LocatableString, candidates: List["Entity"]) -> None:
         RuntimeException.__init__(
             self,
             stmt=None,
-            msg="Could not determine namespace for type %s. %d possible candidates exists: [%s]. To resolve this, use the fully qualified name instead of the short name."
+            msg="Could not determine namespace for type %s. %d possible candidates exists: [%s]."
+            " To resolve this, use the fully qualified name instead of the short name."
             % (type, len(candidates), ", ".join(sorted(x.get_full_name() for x in candidates))),
         )
         self.candidates = candidates

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -635,6 +635,21 @@ class TypeNotFoundException(RuntimeException):
         return 20
 
 
+class AmbiguousTypeException(TypeNotFoundException):
+    """Exception raised when a type is referenced that does not exist"""
+
+    def __init__(self, type: LocatableString, candidates: List["Type"]) -> None:
+        RuntimeException.__init__(
+            self,
+            stmt=None,
+            msg="Could not determine namespace for type %s. %d possible candidates exists: [%s]. To resolve this, use the fully qualified name instead of the short name."
+            % (type, len(candidates), ", ".join(sorted(x.get_full_name() for x in candidates))),
+        )
+        self.candidates = candidates
+        self.type = type
+        self.set_location(type.get_location())
+
+
 def stringify_exception(exn: Exception) -> str:
     if isinstance(exn, CompilerException):
         return str(exn)

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -640,12 +640,13 @@ class AmbiguousTypeException(TypeNotFoundException):
     """Exception raised when a type is referenced that does not exist"""
 
     def __init__(self, type: LocatableString, candidates: List["Entity"]) -> None:
+        candidates = sorted(candidates, key=lambda x: x.get_full_name())
         RuntimeException.__init__(
             self,
             stmt=None,
             msg="Could not determine namespace for type %s. %d possible candidates exists: [%s]."
             " To resolve this, use the fully qualified name instead of the short name."
-            % (type, len(candidates), ", ".join(sorted(x.get_full_name() for x in candidates))),
+            % (type, len(candidates), ", ".join([x.get_full_name() for x in candidates])),
         )
         self.candidates = candidates
         self.type = type

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -215,6 +215,12 @@ class Entity(NamedType):
             parents.extend(entity.get_all_parent_entities())
         return set(parents)
 
+    def get_all_child_entities(self) -> "Set[Entity]":
+        children = [x for x in self.child_entities]
+        for entity in self.child_entities:
+            children.extend(entity.get_all_child_entities())
+        return set(children)
+
     def get_all_attribute_names(self) -> "List[str]":
         """
         Return a list of all attribute names, including parents

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -205,7 +205,7 @@ class RequiresEmitStatement(DynamicStatement):
 class AttributeAssignmentLHS:
     instance: "Reference"
     attribute: str
-    type_hint: Optional["Entity"] = None
+    type_hint: Optional["Type"] = None
 
 
 class ExpressionStatement(RequiresEmitStatement):

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -205,6 +205,7 @@ class RequiresEmitStatement(DynamicStatement):
 class AttributeAssignmentLHS:
     instance: "Reference"
     attribute: str
+    type_hint: Optional["Entity"] = None
 
 
 class ExpressionStatement(RequiresEmitStatement):

--- a/src/inmanta/ast/statements/__init__.py
+++ b/src/inmanta/ast/statements/__init__.py
@@ -48,7 +48,7 @@ from inmanta.execute.runtime import (
 if TYPE_CHECKING:
     from inmanta.ast.assign import SetAttribute  # noqa: F401
     from inmanta.ast.blocks import BasicBlock  # noqa: F401
-    from inmanta.ast.type import NamedType  # noqa: F401
+    from inmanta.ast.type import NamedType, Type  # noqa: F401
     from inmanta.ast.variables import Reference  # noqa: F401
 
 

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -527,14 +527,14 @@ class Constructor(ExpressionStatement):
     def _normalize_rhs(self, index_attributes: abc.Set[str]) -> None:
         assert self.type is not None  # Make mypy happy
         for k, v in self.__attributes.items():
-            # don't notify the rhs for index attributes because it won't be able to resolve the reference
-            # (index attributes need to be resolved before the instance can be constructed)
             attr = self.type.get_attribute(k)
             if attr is None:
                 raise TypingException(
                     self.__attribute_locations[k], "no attribute %s on type %s" % (k, self.type.get_full_name())
                 )
             type_hint = attr.get_type().get_base_type()
+            # don't notify the rhs for index attributes because it won't be able to resolve the reference
+            # (index attributes need to be resolved before the instance can be constructed)
             v.normalize(
                 lhs_attribute=AttributeAssignmentLHS(self._self_ref, k, type_hint) if k not in index_attributes else None
             )

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -610,7 +610,7 @@ class Constructor(ExpressionStatement):
                 raise TypingException(
                     self,
                     f"Can not assign a value of type {self.class_type} "
-                    f"to a variable of type {lhs_attribute.type_hint.type_string()}",
+                    f"to a variable of type {str(lhs_attribute.type_hint)}",
                 )
             elif local_type is not None and local_type.is_subclass(type_hint):
                 # we have a local match, use that to prevent breaking existing code
@@ -637,18 +637,20 @@ class Constructor(ExpressionStatement):
                     else:
                         raise TypingException(
                             self,
-                            f"Can not assign a value of type {local_type.type_string()} "
-                            f"to a variable of type {lhs_attribute.type_hint.type_string()}",
+                            f"Can not assign a value of type {str(local_type)} "
+                            f"to a variable of type {str(lhs_attribute.type_hint)}",
                         )
             else:
                 if local_type is not None:
                     return local_type
                 else:
+                    assert resolver_failure is not None  # make mypy happy
                     raise resolver_failure
         else:
             if local_type is not None:
                 return local_type
             else:
+                assert resolver_failure is not None  # make mypy happy
                 raise resolver_failure
 
     def get_all_eager_promises(self) -> Iterator["StaticEagerPromise"]:

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -531,8 +531,10 @@ class Constructor(ExpressionStatement):
             # (index attributes need to be resolved before the instance can be constructed)
             attr = self.type.get_attribute(k)
             if attr is None:
-                breakpoint()
-            type_hint = self.type.get_attribute(k).get_type().get_base_type()
+                raise TypingException(
+                    self.__attribute_locations[k], "no attribute %s on type %s" % (k, self.type.get_full_name())
+                )
+            type_hint = attr.get_type().get_base_type()
             v.normalize(
                 lhs_attribute=AttributeAssignmentLHS(self._self_ref, k, type_hint) if k not in index_attributes else None
             )

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -581,7 +581,14 @@ class Constructor(ExpressionStatement):
                     mytype = next(iter(candidates))
                 else:
                     # None, pretend nothing happened, reraise original exception
-                    raise
+                    if resolver_failure is not None:
+                        raise resolver_failure
+                    else:
+                        raise TypingException(
+                            self,
+                            f"Can not assign a value of type {local_type.type_string()} "
+                            f"to a variable of type {lhs_attribute.type_hint.type_string()}",
+                        )
         else:
             if local_type is not None:
                 mytype = local_type

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -529,6 +529,9 @@ class Constructor(ExpressionStatement):
         for k, v in self.__attributes.items():
             # don't notify the rhs for index attributes because it won't be able to resolve the reference
             # (index attributes need to be resolved before the instance can be constructed)
+            attr = self.type.get_attribute(k)
+            if attr is None:
+                breakpoint()
             type_hint = self.type.get_attribute(k).get_type().get_base_type()
             v.normalize(
                 lhs_attribute=AttributeAssignmentLHS(self._self_ref, k, type_hint) if k not in index_attributes else None
@@ -589,6 +592,11 @@ class Constructor(ExpressionStatement):
                             f"Can not assign a value of type {local_type.type_string()} "
                             f"to a variable of type {lhs_attribute.type_hint.type_string()}",
                         )
+            else:
+                if local_type is not None:
+                    mytype = local_type
+                else:
+                    raise resolver_failure
         else:
             if local_type is not None:
                 mytype = local_type

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -626,7 +626,7 @@ class Constructor(ExpressionStatement):
                 }
                 if len(candidates) > 1:
                     # To many options, inheritance may cause this to break a working model due to dependency update
-                    raise AmbiguousTypeException(self.class_type, sorted(candidates))
+                    raise AmbiguousTypeException(self.class_type, list(candidates))
                 elif len(candidates) == 1:
                     # One, nice
                     return next(iter(candidates))

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -585,7 +585,7 @@ class Constructor(ExpressionStatement):
             chain.from_iterable(subconstructor.get_all_eager_promises() for subconstructor in self.type.get_sub_constructor())
         )
 
-    def _resolve_type(self, lhs_attribute: Optional[AttributeAssignmentLHS]) -> Entity:
+    def _resolve_type(self, lhs_attribute: Optional[AttributeAssignmentLHS]) -> "Entity":
         """Type hint handling"""
 
         # First normal resolution
@@ -593,7 +593,9 @@ class Constructor(ExpressionStatement):
         local_type: "Optional[Entity]" = None
         try:
             tp = self.namespace.get_type(self.class_type)
-            assert isinstance(tp, Entity), "Should not happen because all entity types start with a capital letter"
+            assert isinstance(
+                tp, inmanta.ast.entity.Entity
+            ), "Should not happen because all entity types start with a capital letter"
             local_type = tp
         except TypeNotFoundException as e:
             resolver_failure = e

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -93,12 +93,12 @@ class Type(Locatable):
         """
         return True
 
-    def type_string(self) ->str:
+    def type_string(self) -> str:
         """
         Returns the type string as expressed in the Inmanta :term:`DSL`, if this type can be expressed in the :term:`DSL`.
         Otherwise returns None.
         """
-        return None
+        raise NotImplementedError()
 
     def type_string_internal(self) -> str:
         """
@@ -167,9 +167,9 @@ class NullableType(Type):
     def _wrap_type_string(self, string: str) -> str:
         return "%s?" % string
 
-    def type_string(self) -> Optional[str]:
-        base_type_string: Optional[str] = self.element_type.type_string()
-        return None if base_type_string is None else self._wrap_type_string(base_type_string)
+    def type_string(self) -> str:
+        base_type_string: str = self.element_type.type_string()
+        return self._wrap_type_string(base_type_string)
 
     def type_string_internal(self) -> str:
         return self._wrap_type_string(self.element_type.type_string_internal())
@@ -390,6 +390,9 @@ class List(Type):
     def type_string_internal(self) -> str:
         return "List"
 
+    def type_string(self) -> str:
+        return "list"
+
     def get_location(self) -> Location:
         return None
 
@@ -422,9 +425,9 @@ class TypedList(List):
     def _wrap_type_string(self, string: str) -> str:
         return "%s[]" % string
 
-    def type_string(self) -> Optional[str]:
-        element_type_string: Optional[str] = self.element_type.type_string()
-        return None if element_type_string is None else self._wrap_type_string(element_type_string)
+    def type_string(self) -> str:
+        element_type_string: str = self.element_type.type_string()
+        return self._wrap_type_string(element_type_string)
 
     def type_string_internal(self) -> str:
         return self._wrap_type_string(self.element_type.type_string_internal())
@@ -497,6 +500,9 @@ class Dict(Type):
 
     def type_string_internal(self) -> str:
         return "Dict"
+
+    def type_string(self) -> str:
+        return "dict"
 
     def get_location(self) -> Location:
         return None
@@ -573,6 +579,9 @@ class Union(Type):
     def type_string_internal(self) -> str:
         return "Union[%s]" % ",".join((t.type_string_internal() for t in self.types))
 
+    def type_string(self) -> str:
+        return "[" + ", ".join(t.type_string() for t in self.types) + "]"
+
 
 @stable_api
 class Literal(Union):
@@ -586,6 +595,9 @@ class Literal(Union):
 
     def type_string_internal(self) -> str:
         return "Literal"
+
+    def type_string(self) -> str:
+        return "literal"
 
 
 @stable_api

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -590,9 +590,6 @@ class Literal(Union):
     def type_string_internal(self) -> str:
         return "Literal"
 
-    def type_string(self) -> str:
-        return "Literal"
-
 
 @stable_api
 class ConstraintType(NamedType):

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -597,7 +597,7 @@ class Literal(Union):
         return "Literal"
 
     def type_string(self) -> str:
-        return "literal"
+        return "Literal"
 
 
 @stable_api

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -93,7 +93,7 @@ class Type(Locatable):
         """
         return True
 
-    def type_string(self) -> Optional[str]:
+    def type_string(self) ->str:
         """
         Returns the type string as expressed in the Inmanta :term:`DSL`, if this type can be expressed in the :term:`DSL`.
         Otherwise returns None.
@@ -143,6 +143,9 @@ class NamedType(Type, Named):
     def get_double_defined_exception(self, other: "NamedType") -> "DuplicateException":
         """produce an error message for this type"""
         raise DuplicateException(self, other, "Type %s is already defined" % (self.get_full_name()))
+
+    def type_string(self) -> str:
+        return self.get_full_name()
 
 
 @stable_api
@@ -642,7 +645,7 @@ class ConstraintType(NamedType):
 
         return True
 
-    def type_string(self):
+    def type_string(self) -> str:
         return "%s::%s" % (self.namespace, self.name)
 
     def type_string_internal(self) -> str:

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -93,11 +93,12 @@ class Type(Locatable):
         """
         return True
 
-    def type_string(self) -> str:
+    def type_string(self) -> Optional[str]:
         """
         Returns the type string as expressed in the Inmanta :term:`DSL`, if this type can be expressed in the :term:`DSL`.
+        Otherwise returns None.
         """
-        raise NotImplementedError()
+        return None
 
     def type_string_internal(self) -> str:
         """
@@ -166,9 +167,9 @@ class NullableType(Type):
     def _wrap_type_string(self, string: str) -> str:
         return "%s?" % string
 
-    def type_string(self) -> str:
-        base_type_string: str = self.element_type.type_string()
-        return self._wrap_type_string(base_type_string)
+    def type_string(self) -> Optional[str]:
+        base_type_string: Optional[str] = self.element_type.type_string()
+        return None if base_type_string is None else self._wrap_type_string(base_type_string)
 
     def type_string_internal(self) -> str:
         return self._wrap_type_string(self.element_type.type_string_internal())
@@ -389,9 +390,6 @@ class List(Type):
     def type_string_internal(self) -> str:
         return "List"
 
-    def type_string(self) -> str:
-        return "list"
-
     def get_location(self) -> Location:
         return None
 
@@ -424,9 +422,9 @@ class TypedList(List):
     def _wrap_type_string(self, string: str) -> str:
         return "%s[]" % string
 
-    def type_string(self) -> str:
-        element_type_string: str = self.element_type.type_string()
-        return self._wrap_type_string(element_type_string)
+    def type_string(self) -> Optional[str]:
+        element_type_string = self.element_type.type_string()
+        return None if element_type_string is None else self._wrap_type_string(element_type_string)
 
     def type_string_internal(self) -> str:
         return self._wrap_type_string(self.element_type.type_string_internal())
@@ -577,9 +575,6 @@ class Union(Type):
 
     def type_string_internal(self) -> str:
         return "Union[%s]" % ",".join((t.type_string_internal() for t in self.types))
-
-    def type_string(self) -> str:
-        return "[" + ", ".join(t.type_string() for t in self.types) + "]"
 
 
 @stable_api

--- a/tests/compiler/test_relations_inverse.py
+++ b/tests/compiler/test_relations_inverse.py
@@ -282,15 +282,7 @@ def test_relation_implicit_inverse_on_plain_attribute(snippetcompiler) -> None:
 
         A(b=B())
         """,
-        textwrap.dedent(
-            """
-            Could not set attribute `b` on instance `__config__::A (instantiated at {dir}/main.cf:12)` (reported in Construct(A) ({dir}/main.cf:12))
-            caused by:
-              Attempting to assign constructor of type __config__::B to attribute that is not a relation attribute: b on __config__::A (instantiated at {dir}/main.cf:12) (reported in Construct(B) ({dir}/main.cf:12))
-            """.lstrip(  # noqa: E501
-                "\n"
-            ).rstrip()
-        ),
+        "Can not assign a value of type B to a variable of type int (reported in Construct(B) ({dir}/main.cf:12))",
     )
 
 
@@ -314,16 +306,8 @@ def test_relation_implicit_inverse_on_different_entity_type(snippetcompiler) -> 
 
         A(b=B())
         """,
-        textwrap.dedent(
-            """
-            Could not set attribute `b` on instance `__config__::A (instantiated at {dir}/main.cf:13)` (reported in Construct(A) ({dir}/main.cf:13))
-            caused by:
-              Invalid Constructor call:
-            \t* Missing relation 'a'. The relation __config__::B.a is part of an index. (reported in Construct(B) ({dir}/main.cf:13))
-            """.lstrip(  # noqa: E501
-                "\n"
-            ).rstrip()
-        ),
+        "Can not assign a value of type __config__::B to a variable "
+        "of type __config__::C (reported in Construct(B) ({dir}/main.cf:13))",
     )
 
 

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -62,3 +62,22 @@ implement One using std::none
         """,
     )
     (_, scopes) = compiler.do_compile()
+
+
+
+def test_basic_type_hint_attribute_collision(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import elaboratev1module
+
+entity A:
+    int ref
+end
+
+One(ref=A())
+
+implement elaboratev1module::A using std::none
+implement One using std::none
+        """,
+    )
+    (_, scopes) = compiler.do_compile()

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -21,6 +21,28 @@ implement One using std::none
     (_, scopes) = compiler.do_compile()
 
 
+def test_inheriting_type_hint(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import elaboratev1module
+import elaboratev1module::submod
+
+entity One:
+
+end
+
+One.ref [1] -- elaboratev1module::A
+
+One(ref=B())
+
+implement elaboratev1module::A using std::none
+implement elaboratev1module::submod::B using std::none
+
+implement One using std::none
+        """,
+    )
+    (_, scopes) = compiler.do_compile()
+
 
 def test_basic_type_hint_name_collision(snippetcompiler):
     snippetcompiler.setup_for_snippet(

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -1,0 +1,42 @@
+from inmanta import compiler
+
+
+def test_basic_type_hint(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import elaboratev1module
+
+entity One:
+
+end
+
+One.ref [1] -- elaboratev1module::A
+
+One(ref=A())
+
+implement elaboratev1module::A using std::none
+implement One using std::none
+        """,
+    )
+    (_, scopes) = compiler.do_compile()
+
+
+
+def test_basic_type_hint_name_collision(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import elaboratev1module
+
+entity A:
+
+end
+
+A.ref [1] -- elaboratev1module::A
+
+One(ref=A())
+
+implement elaboratev1module::A using std::none
+implement One using std::none
+        """,
+    )
+    (_, scopes) = compiler.do_compile()

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -1,7 +1,22 @@
-import pytest
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 
 from inmanta import compiler
-from inmanta.ast import AmbiguousTypeException, TypeNotFoundException
 
 
 def test_basic_type_hint(snippetcompiler):
@@ -106,7 +121,7 @@ implement elaboratev1module::A using std::none
 implement One using std::none
 
         """,
-        "Can not assign a value of type A to a variable of type int (reported in Construct(A) ({dir}/main.cf:8))"
+        "Can not assign a value of type A to a variable of type int (reported in Construct(A) ({dir}/main.cf:8))",
     )
 
     snippetcompiler.reset()
@@ -123,5 +138,5 @@ A(ref=A())
 implement A using std::none
 
         """,
-    "Can not assign a value of type A to a variable of type int (reported in Construct(A) ({dir}/main.cf:8))"
+        "Can not assign a value of type A to a variable of type int (reported in Construct(A) ({dir}/main.cf:8))",
     )

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -1,4 +1,7 @@
+import pytest
+
 from inmanta import compiler
+from inmanta.ast import AmbiguousTypeException, TypeNotFoundException
 
 
 def test_basic_type_hint(snippetcompiler):
@@ -55,22 +58,45 @@ end
 
 A.ref [1] -- elaboratev1module::A
 
-One(ref=A())
+A(ref=A())
 
 implement elaboratev1module::A using std::none
-implement One using std::none
+implement A using std::none
+
         """,
     )
     (_, scopes) = compiler.do_compile()
 
 
-
-def test_basic_type_hint_attribute_collision(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
+def test_advanced_type_hint_name_collision(snippetcompiler):
+    snippetcompiler.setup_for_error(
         """
 import elaboratev1module
 
-entity A:
+entity A extends elaboratev1module::A:
+
+end
+
+A.ref [1] -- elaboratev1module::A
+
+A(ref=A())
+
+implement elaboratev1module::A using std::none
+implement A using std::none
+
+        """,
+        "Could not determine namespace for type A. 2 possible candidates exists: [__config__::A, elaboratev1module::A]. "
+        "To resolve this, use the fully qualified name instead of the short name. "
+        "(reported in Construct(A) ({dir}/main.cf:10:7))",
+    )
+
+
+def test_basic_type_hint_attribute_collision(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+import elaboratev1module
+
+entity One:
     int ref
 end
 
@@ -78,6 +104,24 @@ One(ref=A())
 
 implement elaboratev1module::A using std::none
 implement One using std::none
+
         """,
+        "Can not assign a value of type A to a variable of type int (reported in Construct(A) ({dir}/main.cf:8))"
     )
-    (_, scopes) = compiler.do_compile()
+
+    snippetcompiler.reset()
+    snippetcompiler.setup_for_error(
+        """
+import elaboratev1module
+
+entity A:
+    int ref
+end
+
+A(ref=A())
+
+implement A using std::none
+
+        """,
+    "Can not assign a value of type A to a variable of type int (reported in Construct(A) ({dir}/main.cf:8))"
+    )

--- a/tests/data/modules/elaboratev1module/model/_init.cf
+++ b/tests/data/modules/elaboratev1module/model/_init.cf
@@ -2,3 +2,7 @@ import mod1
 import std
 
 std::print("Hello world")
+
+entity A:
+
+end

--- a/tests/data/modules/elaboratev1module/model/other.cf
+++ b/tests/data/modules/elaboratev1module/model/other.cf
@@ -1,1 +1,7 @@
 import mod2
+
+
+entity B extends A:
+
+end
+

--- a/tests/data/modules/elaboratev1module/model/other.cf
+++ b/tests/data/modules/elaboratev1module/model/other.cf
@@ -1,7 +1,1 @@
 import mod2
-
-
-entity B extends A:
-
-end
-

--- a/tests/data/modules/elaboratev1module/model/submod.cf
+++ b/tests/data/modules/elaboratev1module/model/submod.cf
@@ -1,0 +1,3 @@
+entity B extends A:
+
+end


### PR DESCRIPTION
# Description

First very raw POC of type hinting. 

Turns out the most difficult wiring is done by the constructor trees. 

This cuts off all corners, but it does show we should be able to do it easily 

closes  #4028 

- [x]  docs
- [x]  changelog file

# TBD

 - ~~this makes it possible to break a model by importing a subtype with the same name as a super type in a different namespace. This is a very dangerous thing.~~  -> resolved: local resolution takes precedence 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
