### PR TITLE
Issue/5466 ensure that api endpoint sort their results in a consisten way

### DIFF
--- a/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
+++ b/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
@@ -1,4 +1,4 @@
 ---
-description: "The following API endpoints now return their results in a meaningful order: methods.list_settings, methods_v2.environment_settings_list, methods.list_params, methods_v2.get_facts, methods.list_projects, methods_v2.project_list, "
+description: "The following API endpoints now return their results in a meaningful order: methods.list_settings, methods_v2.environment_settings_list, methods.list_params, methods_v2.get_facts, methods.list_projects, methods_v2.project_list."
 change-type: patch
 destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
+++ b/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
@@ -1,0 +1,4 @@
+---
+description: "The following API endpoints now return their results in a meaningful order: methods.list_settings, methods_v2.environment_settings_list, methods.list_params, methods_v2.get_facts, methods.list_projects, methods_v2.project_list, "
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
+++ b/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
@@ -2,3 +2,5 @@
 description: "The following API endpoints now return their results in a consistent, meaningful order: methods.list_settings, methods_v2.environment_settings_list, methods.list_params, methods_v2.get_facts, methods.list_projects, methods_v2.project_list, methods.dryrun_list."
 change-type: patch
 destination-branches: [master, iso6, iso5]
+sections:
+    bugfix: "{{description}}"

--- a/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
+++ b/changelogs/unreleased/5466-ensure-that-API-endpoints-sort-their-results-in-a-consistent-way.yml
@@ -1,4 +1,4 @@
 ---
-description: "The following API endpoints now return their results in a meaningful order: methods.list_settings, methods_v2.environment_settings_list, methods.list_params, methods_v2.get_facts, methods.list_projects, methods_v2.project_list."
+description: "The following API endpoints now return their results in a consistent, meaningful order: methods.list_settings, methods_v2.environment_settings_list, methods.list_params, methods_v2.get_facts, methods.list_projects, methods_v2.project_list, methods.dryrun_list."
 change-type: patch
 destination-branches: [master, iso6, iso5]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2887,6 +2887,7 @@ class Parameter(BaseDocument):
             query += " AND metadata @> $" + str(query_param_index) + "::jsonb"
             dict_value = {key: value}
             values.append(cls._get_value(dict_value))
+        query += "ORDER BY id"
         result = await cls.select_query(query, values)
         return result
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2887,7 +2887,7 @@ class Parameter(BaseDocument):
             query += " AND metadata @> $" + str(query_param_index) + "::jsonb"
             dict_value = {key: value}
             values.append(cls._get_value(dict_value))
-        query += "ORDER BY name"
+        query += " ORDER BY name"
         result = await cls.select_query(query, values)
         return result
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2887,7 +2887,7 @@ class Parameter(BaseDocument):
             query += " AND metadata @> $" + str(query_param_index) + "::jsonb"
             dict_value = {key: value}
             values.append(cls._get_value(dict_value))
-        query += "ORDER BY id"
+        query += "ORDER BY name"
         result = await cls.select_query(query, values)
         return result
 

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -94,7 +94,7 @@ def delete_project(id: uuid.UUID):
 @method(path="/project", operation="GET", client_types=[const.ClientType.api])
 def list_projects():
     """
-    Create a list of projects
+    Returns a list of projects ordered alphabetically by name. The environments within each project are also sorted by name.
     """
 
 
@@ -148,7 +148,7 @@ def delete_environment(id: uuid.UUID):
 @method(path="/environment", operation="GET", client_types=[const.ClientType.api])
 def list_environments():
     """
-    Create a list of environments
+    Returns a list of environments. The results are sorted by (project id, environment name, environment id).
     """
 
 
@@ -182,7 +182,7 @@ def get_environment(id: uuid.UUID, versions: int = None, resources: int = None):
 )
 def list_settings(tid: uuid.UUID):
     """
-    List the settings in the current environment
+    List the settings in the current environment ordered by name alphabetically.
     """
 
 
@@ -592,7 +592,7 @@ def dryrun_request(tid: uuid.UUID, id: int):
 @method(path="/dryrun", operation="GET", arg_options=ENV_OPTS, client_types=[const.ClientType.api])
 def dryrun_list(tid: uuid.UUID, version: int = None):
     """
-    Create a list of dry runs
+    Get the list of dry runs for an environment. The results are sorted by dry run id.
 
     :param tid: The id of the environment
     :param version: Only for this version
@@ -751,7 +751,7 @@ def delete_param(tid: uuid.UUID, id: str, resource_id: str = None):
 )
 def list_params(tid: uuid.UUID, query: dict = {}):
     """
-    List/query parameters in this environment
+    List/query parameters in this environment. The results are ordered alphabetically by parameter name.
 
     :param tid: The id of the environment
     :param query: A query to match against metadata
@@ -993,5 +993,5 @@ def get_server_status() -> model.StatusResponse:
 )
 def get_compile_queue(tid: uuid.UUID) -> List[model.CompileRun]:
     """
-    Get the current compiler queue on the server
+    Get the current compiler queue on the server, ordered by increasing `requested` timestamp.
     """

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -101,7 +101,7 @@ def project_delete(id: uuid.UUID) -> None:
 @typedmethod(path="/project", operation="GET", client_types=[ClientType.api], api_version=2)
 def project_list(environment_details: bool = False) -> List[model.Project]:
     """
-    Returns a list of projects
+    Returns a list of projects ordered alphabetically by name. The environments within each project are also sorted by name.
     :param environment_details: Whether to include the icon and description of the environments in the results
     """
 
@@ -318,7 +318,7 @@ def environment_create_token(tid: uuid.UUID, client_types: List[str], idempotent
 )
 def environment_settings_list(tid: uuid.UUID) -> model.EnvironmentSettingsReponse:
     """
-    List the settings in the current environment
+    List the settings in the current environment ordered by name alphabetically.
     """
 
 
@@ -818,7 +818,7 @@ def resource_logs(
 )
 def get_facts(tid: uuid.UUID, rid: model.ResourceIdStr) -> List[model.Fact]:
     """
-    Get the facts related to a specific resource
+    Get the facts related to a specific resource. The results are sorted alphabetically by name.
     :param tid: The id of the environment
     :param rid: Id of the resource
     :return: The facts related to this resource

--- a/src/inmanta/server/services/dryrunservice.py
+++ b/src/inmanta/server/services/dryrunservice.py
@@ -163,7 +163,7 @@ class DyrunService(protocol.ServerSlice):
             query_args["model"] = version
 
         dryruns = await data.DryRun.get_list(
-            order_by_column=None, order=None, limit=None, offset=None, no_obj=None, lock=None, connection=None, **query_args
+            order_by_column="id", order=None, limit=None, offset=None, no_obj=None, lock=None, connection=None, **query_args
         )
 
         return (

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -307,7 +307,7 @@ class EnvironmentService(protocol.ServerSlice):
     @handle(methods.list_settings, env="tid")
     async def list_settings(self, env: data.Environment) -> Apireturn:
         settings = {k: env.settings[k] for k in sorted(env.settings.keys()) if k in data.Environment._settings.keys()}
-        return 200, {"settings": settings, "metadata": data.Environment._settings}
+        return 200, {"settings": settings, "metadata": dict(sorted(data.Environment._settings.items()))}
 
     @handle(methods.set_setting, env="tid", key="id")
     async def set_setting(self, env: data.Environment, key: str, value: model.EnvSettingType) -> Apireturn:

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -306,7 +306,7 @@ class EnvironmentService(protocol.ServerSlice):
 
     @handle(methods.list_settings, env="tid")
     async def list_settings(self, env: data.Environment) -> Apireturn:
-        settings = {k: env.settings[k] for k in env.settings.keys() if k in data.Environment._settings.keys()}
+        settings = {k: env.settings[k] for k in sorted(env.settings.keys()) if k in data.Environment._settings.keys()}
         return 200, {"settings": settings, "metadata": data.Environment._settings}
 
     @handle(methods.set_setting, env="tid", key="id")
@@ -532,7 +532,7 @@ class EnvironmentService(protocol.ServerSlice):
     @handle(methods_v2.environment_settings_list, env="tid")
     async def environment_settings_list(self, env: data.Environment) -> model.EnvironmentSettingsReponse:
         return model.EnvironmentSettingsReponse(
-            settings=env.settings, definition={k: v.to_dto() for k, v in data.Environment._settings.items()}
+            settings=dict(sorted(env.settings.items())), definition={k: v.to_dto() for k, v in sorted(data.Environment._settings.items())}
         )
 
     @handle(methods_v2.environment_settings_set, env="tid", key="id")

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -532,7 +532,8 @@ class EnvironmentService(protocol.ServerSlice):
     @handle(methods_v2.environment_settings_list, env="tid")
     async def environment_settings_list(self, env: data.Environment) -> model.EnvironmentSettingsReponse:
         return model.EnvironmentSettingsReponse(
-            settings=dict(sorted(env.settings.items())), definition={k: v.to_dto() for k, v in sorted(data.Environment._settings.items())}
+            settings=dict(sorted(env.settings.items())),
+            definition={k: v.to_dto() for k, v in sorted(data.Environment._settings.items())},
         )
 
     @handle(methods_v2.environment_settings_set, env="tid", key="id")

--- a/src/inmanta/server/services/paramservice.py
+++ b/src/inmanta/server/services/paramservice.py
@@ -280,7 +280,7 @@ class ParameterService(protocol.ServerSlice):
 
     @handle(methods_v2.get_facts, env="tid")
     async def get_facts(self, env: data.Environment, rid: ResourceIdStr) -> List[Fact]:
-        params = await data.Parameter.get_list(environment=env.id, resource_id=rid)
+        params = await data.Parameter.get_list(environment=env.id, resource_id=rid, order_by_column="name")
         dtos = [param.as_fact() for param in params]
         return dtos
 

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -133,10 +133,10 @@ class ProjectService(protocol.ServerSlice):
     async def project_list(self, environment_details: bool = False) -> List[model.Project]:
         project_list = []
 
-        for project in await data.Project.get_list():
+        for project in await data.Project.get_list(order_by_column="id", order="ASC"):
             project_model = project.to_dto()
             project_model.environments = [
-                e.to_dto() for e in await data.Environment.get_list(project=project.id, details=environment_details)
+                e.to_dto() for e in await data.Environment.get_list(project=project.id, details=environment_details, order_by_column="id", order="ASC")
             ]
 
             project_list.append(project_model)

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -133,10 +133,10 @@ class ProjectService(protocol.ServerSlice):
     async def project_list(self, environment_details: bool = False) -> List[model.Project]:
         project_list = []
 
-        for project in await data.Project.get_list(order_by_column="id", order="ASC"):
+        for project in await data.Project.get_list(order_by_column="name", order="ASC"):
             project_model = project.to_dto()
             project_model.environments = [
-                e.to_dto() for e in await data.Environment.get_list(project=project.id, details=environment_details, order_by_column="id", order="ASC")
+                e.to_dto() for e in await data.Environment.get_list(project=project.id, details=environment_details, order_by_column="name", order="ASC")
             ]
 
             project_list.append(project_model)

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -136,7 +136,10 @@ class ProjectService(protocol.ServerSlice):
         for project in await data.Project.get_list(order_by_column="name", order="ASC"):
             project_model = project.to_dto()
             project_model.environments = [
-                e.to_dto() for e in await data.Environment.get_list(project=project.id, details=environment_details, order_by_column="name", order="ASC")
+                e.to_dto()
+                for e in await data.Environment.get_list(
+                    project=project.id, details=environment_details, order_by_column="name", order="ASC"
+                )
             ]
 
             project_list.append(project_model)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -20,7 +20,8 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Dict, cast
+from typing import Dict, cast, List
+from collections import defaultdict
 
 import pytest
 
@@ -78,6 +79,46 @@ async def test_project_api_v1(client):
     # get non existing environment
     response = await client.get_environment(uuid.uuid4())
     assert response.code == 404
+
+async def test_project_api_v2_project_list_ordering(client_v2):
+    """
+    Creates a few projects with several environments each.
+    Check that they are ordered by ascending (project_id, environment_id)
+    """
+
+    project_environments_map: Dict[uuid.UUID, List[uuid.UUID]] = defaultdict(lambda: [])
+
+    for project_n in range(3):
+        result = await client_v2.project_create(f"test-project-{project_n}")
+        assert result.code == 200
+        assert "data" in result.result
+        assert "id" in result.result["data"]
+
+        project_id: uuid.UUID = result.result["data"]["id"]
+        project_environments_map[project_id] = []
+
+        for environment_n in range(3):
+            result = await client_v2.environment_create(project_id=project_id, name=f"test-env-{environment_n}")
+            assert result.code == 200
+            assert "data" in result.result
+            assert "id" in result.result["data"]
+            env_id: uuid.UUID = result.result["data"]["id"]
+            project_environments_map[project_id].append(env_id)
+
+    result = await client_v2.project_list()
+    assert result.code == 200
+    assert "data" in result.result
+    assert len(result.result["data"]) == 3
+    for i in range(3):
+        assert len(result.result["data"][i]["environments"]) == 3
+
+    # Make sure results are sorted according to project id...
+    assert sorted(project_environments_map.keys()) == [result.result["data"][i]["id"] for i in range(3)]
+
+    # ... and according env id within each project
+    for project_n, key_value_pair in enumerate(sorted(project_environments_map.items())):
+        project_id, env_id_list = key_value_pair
+        assert sorted(env_id_list) == [env["id"] for env in result.result["data"][project_n]["environments"]]
 
 
 async def test_project_api_v2(client_v2):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -84,7 +84,7 @@ async def test_project_api_v1(client):
 async def test_project_api_v2_project_list_ordering(client_v2):
     """
     Creates a few projects with several environments each.
-    Check that they are ordered by ascending (project_id, environment_id)
+    Check that they are ordered by ascending (project_name, environment_name)
     """
 
     project_environments_map: Dict[str, List[str]] = defaultdict(lambda: [])

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -112,10 +112,10 @@ async def test_project_api_v2_project_list_ordering(client_v2):
     for i in range(3):
         assert len(result.result["data"][i]["environments"]) == 3
 
-    # Make sure results are sorted according to project id...
+    # Make sure results are sorted according to project name...
     assert sorted(project_environments_map.keys()) == [result.result["data"][i]["name"] for i in range(3)]
 
-    # ... and according env id within each project
+    # ... and according to env name within each project
     for project_n, key_value_pair in enumerate(sorted(project_environments_map.items())):
         project_id, env_id_list = key_value_pair
         assert sorted(env_id_list) == [env["name"] for env in result.result["data"][project_n]["environments"]]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -87,24 +87,23 @@ async def test_project_api_v2_project_list_ordering(client_v2):
     Check that they are ordered by ascending (project_id, environment_id)
     """
 
-    project_environments_map: Dict[uuid.UUID, List[uuid.UUID]] = defaultdict(lambda: [])
+    project_environments_map: Dict[str, List[str]] = defaultdict(lambda: [])
 
     for project_n in range(3):
-        result = await client_v2.project_create(f"test-project-{project_n}")
+        project_name: str = f"test-project-{project_n}"
+        result = await client_v2.project_create(project_name)
         assert result.code == 200
         assert "data" in result.result
         assert "id" in result.result["data"]
 
         project_id: uuid.UUID = result.result["data"]["id"]
-        project_environments_map[project_id] = []
+        project_environments_map[project_name] = []
 
         for environment_n in range(3):
-            result = await client_v2.environment_create(project_id=project_id, name=f"test-env-{environment_n}")
+            env_name: str = f"test-env-{environment_n}"
+            result = await client_v2.environment_create(project_id=project_id, name=env_name)
             assert result.code == 200
-            assert "data" in result.result
-            assert "id" in result.result["data"]
-            env_id: uuid.UUID = result.result["data"]["id"]
-            project_environments_map[project_id].append(env_id)
+            project_environments_map[project_name].append(env_name)
 
     result = await client_v2.project_list()
     assert result.code == 200
@@ -114,12 +113,12 @@ async def test_project_api_v2_project_list_ordering(client_v2):
         assert len(result.result["data"][i]["environments"]) == 3
 
     # Make sure results are sorted according to project id...
-    assert sorted(project_environments_map.keys()) == [result.result["data"][i]["id"] for i in range(3)]
+    assert sorted(project_environments_map.keys()) == [result.result["data"][i]["name"] for i in range(3)]
 
     # ... and according env id within each project
     for project_n, key_value_pair in enumerate(sorted(project_environments_map.items())):
         project_id, env_id_list = key_value_pair
-        assert sorted(env_id_list) == [env["id"] for env in result.result["data"][project_n]["environments"]]
+        assert sorted(env_id_list) == [env["name"] for env in result.result["data"][project_n]["environments"]]
 
 
 async def test_project_api_v2(client_v2):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -19,9 +19,9 @@ import base64
 import logging
 import os
 import uuid
-from pathlib import Path
-from typing import Dict, cast, List
 from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, cast
 
 import pytest
 
@@ -79,6 +79,7 @@ async def test_project_api_v1(client):
     # get non existing environment
     response = await client.get_environment(uuid.uuid4())
     assert response.code == 404
+
 
 async def test_project_api_v2_project_list_ordering(client_v2):
     """


### PR DESCRIPTION
# Description

Tasks:

- [x] The [`project_list` endpoint](https://github.com/inmanta/inmanta-core/blob/b781ed5a27137b0372f5471f0ec60fb341f58faf/src/inmanta/server/services/projectservice.py#L133) doesn't sort the returned projects and environments in a specific way. This issue should ensure a proper sorting order.
- [x] Similar issues may exists in other endpoints in inmanta-core and its extensions. This issue should make sure that all other endpoints sort their results in a consistent and meaningful way. Focus on the simple methods in `protocol/server/services/`.

----

Ordering already in place:
- methods.get_compile_queue -> ORDER BY requested ASC
- methods.list_environments -> sort by primary column in SQL, then do full sort in Python, cheap because mostly sorted already by this point
- methods_v2.get_resource_events -> ORDER BY started DESC

Added in this PR
- methods.list_settings -> added python default sorting on dict keys
- methods_v2.environment_settings_list -> added python default sorting on dict keys
- methods.list_params -> added ORDER BY name
- methods_v2.get_facts -> added ORDER BY name
- methods_v2.project_list -> add order by project name and then by env name
- methods.list_projects -> uses v2 endpoint logic
- methods.dryrun_list -> added ORDER BY id


----

closes #5466 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
