### PR TITLE
Issue/5543 resource file upload should ignore identical files

### DIFF
--- a/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
+++ b/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
@@ -5,4 +5,4 @@ destination-branches:
   - iso6
   - iso5
 sections:
-  bugfix: "{{description}}"
+  bugfix: "Fix issue that may cause the first export for an environment to fail when files with identical content are present."

--- a/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
+++ b/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
@@ -1,4 +1,4 @@
-description: The stat_file API endpoint now returns a set of files instead of a list.
+description: The stat_file API endpoint now returns a list with no duplicates.
 change-type: patch
 destination-branches:
   - master

--- a/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
+++ b/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
@@ -4,3 +4,5 @@ destination-branches:
   - master
   - iso6
   - iso5
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
+++ b/changelogs/unreleased/5543-resource-file-upload-should-ignore-identical-files.yml
@@ -1,0 +1,6 @@
+description: The stat_file API endpoint now returns a set of files instead of a list.
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -131,7 +131,9 @@ class FileService(protocol.ServerSlice):
         """
         Return which files in the list don't exist on the server
         """
-        response: Dict[str, object] = {}
+        # A dict is used here instead of a set to have efficient set-like behaviour while preserving insertion order. Only its
+        # keys are relevant.
+        response: dict[str, object] = {}
 
         for f in files:
             f_path = os.path.join(self.server_slice._server_storage["files"], f)

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -19,7 +19,7 @@ import base64
 import difflib
 import logging
 import os
-from typing import Iterable, List, cast, Set
+from typing import Iterable, List, Set, cast
 
 from inmanta.protocol import handle, methods
 from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -19,7 +19,7 @@ import base64
 import difflib
 import logging
 import os
-from typing import Iterable, List, Set, cast
+from typing import Dict, Iterable, List, cast
 
 from inmanta.protocol import handle, methods
 from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError
@@ -127,18 +127,18 @@ class FileService(protocol.ServerSlice):
         """
         return 200, {"files": self.stat_file_internal(files)}
 
-    def stat_file_internal(self, files: Iterable[str]) -> Set[str]:
+    def stat_file_internal(self, files: Iterable[str]) -> List[str]:
         """
         Return which files in the list don't exist on the server
         """
-        response: Set[str] = set()
+        response: Dict[str, object] = {}
 
         for f in files:
             f_path = os.path.join(self.server_slice._server_storage["files"], f)
             if not os.path.exists(f_path):
-                response.add(f)
+                response[f] = None
 
-        return response
+        return list(response.keys())
 
     @handle(methods.diff)
     async def file_diff(self, a: str, b: str) -> Apireturn:

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -19,7 +19,7 @@ import base64
 import difflib
 import logging
 import os
-from typing import Dict, Iterable, List, cast
+from typing import Iterable, List, cast
 
 from inmanta.protocol import handle, methods
 from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -19,7 +19,7 @@ import base64
 import difflib
 import logging
 import os
-from typing import Iterable, List, cast
+from typing import Iterable, List, cast, Set
 
 from inmanta.protocol import handle, methods
 from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError
@@ -127,15 +127,16 @@ class FileService(protocol.ServerSlice):
         """
         return 200, {"files": self.stat_file_internal(files)}
 
-    def stat_file_internal(self, files: Iterable[str]) -> List[str]:
+    def stat_file_internal(self, files: Iterable[str]) -> Set[str]:
         """
         Return which files in the list don't exist on the server
         """
-        response: List[str] = []
+        response: Set[str] = set()
+
         for f in files:
             f_path = os.path.join(self.server_slice._server_storage["files"], f)
             if not os.path.exists(f_path):
-                response.append(f)
+                response.add(f)
 
         return response
 


### PR DESCRIPTION
# Description

The stat_file API endpoint now returns a set of files instead of a list.

closes #5543  

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
