### PR TITLE
Fix race in incremental deploy

### DIFF
--- a/changelogs/unreleased/fix-race-in-incremental-deploy-calculation.yml
+++ b/changelogs/unreleased/fix-race-in-incremental-deploy-calculation.yml
@@ -1,0 +1,6 @@
+---
+description: Fix race condition in incremental deploy calculation where a newly released version uses an increment that is calculated from an old model version.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -687,8 +687,6 @@ class OrchestrationService(protocol.ServerSlice):
 
         LOGGER.debug("Successfully stored version %d", version)
 
-        self.resource_service.clear_env_cache(env)
-
     async def _trigger_auto_deploy(
         self,
         env: data.Environment,

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -408,6 +408,7 @@ class ResourceService(protocol.ServerSlice):
         :param env: The environment to consider.
         :parma version: The version of the model to consider.
         """
+
         def _get_cache_entry() -> Optional[tuple[abc.Set[ResourceIdStr], abc.Set[ResourceIdStr]]]:
             """
             Returns a tuple (increment, negative_increment) if a cache entry exists for the given environment and version


### PR DESCRIPTION
# Description

This PR fixes a race condition in the incremental deploy calculation. The following scenario triggers the race:

* `put_version()` is called for model version N and the increment cache is cleared.
* An agent pulls the resources it has to deploy. This populates the increment cache with an increment relative to version N-1
* The `release_version()` method is called for version N. This call hits the increment cache entry created in the previous bullet point, resulting in an incorrect increment calculation.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
