### PR TITLE
Fix race in incremental deploy (iso4)

### DIFF
--- a/changelogs/unreleased/fix-race-in-incremental-deploy-calculation.yml
+++ b/changelogs/unreleased/fix-race-in-incremental-deploy-calculation.yml
@@ -1,0 +1,6 @@
+---
+description: Fix race condition in incremental deploy calculation where a newly released version uses an increment that is calculated from an old model version.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-race-in-incremental-deploy-calculation.yml
+++ b/changelogs/unreleased/fix-race-in-incremental-deploy-calculation.yml
@@ -1,6 +1,6 @@
 ---
 description: Fix race condition in incremental deploy calculation where a newly released version uses an increment that is calculated from an old model version.
 change-type: patch
-destination-branches: [master, iso6, iso5, iso4]
+destination-branches: [iso4]
 sections:
   bugfix: "{{description}}"

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -394,16 +394,6 @@ class OrchestrationService(protocol.ServerSlice):
 
         LOGGER.debug("Successfully stored version %d", version)
 
-    async def _trigger_auto_deploy(
-        self,
-        env: data.Environment,
-        version: int,
-    ) -> None:
-        """
-        Triggers auto-deploy for stored resources. Must be called only after transaction that stores resources has been allowed
-        to commit. If not respected, the auto deploy might work on stale data, likely resulting in resources hanging in the
-        deploying state.
-        """
         auto_deploy = await env.get(data.AUTO_DEPLOY)
         if auto_deploy:
             LOGGER.debug("Auto deploying version %d", version)

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -394,8 +394,16 @@ class OrchestrationService(protocol.ServerSlice):
 
         LOGGER.debug("Successfully stored version %d", version)
 
-        self.resource_service.clear_env_cache(env)
-
+    async def _trigger_auto_deploy(
+        self,
+        env: data.Environment,
+        version: int,
+    ) -> None:
+        """
+        Triggers auto-deploy for stored resources. Must be called only after transaction that stores resources has been allowed
+        to commit. If not respected, the auto deploy might work on stale data, likely resulting in resources hanging in the
+        deploying state.
+        """
         auto_deploy = await env.get(data.AUTO_DEPLOY)
         if auto_deploy:
             LOGGER.debug("Auto deploying version %d", version)

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -116,7 +116,8 @@ class ResourceService(protocol.ServerSlice):
         self._resource_action_loggers: Dict[uuid.UUID, logging.Logger] = {}
         self._resource_action_handlers: Dict[uuid.UUID, logging.Handler] = {}
 
-        self._increment_cache: Dict[uuid.UUID, Optional[Tuple[Set[ResourceVersionIdStr], List[ResourceVersionIdStr]]]] = {}
+        # Dict: environment_id: (model_version, increment, negative_increment)
+        self._increment_cache: Dict[uuid.UUID, Optional[Tuple[int, Set[ResourceVersionIdStr], List[ResourceVersionIdStr]]]] = {}
         # lock to ensure only one inflight request
         self._increment_cache_locks: Dict[uuid.UUID, asyncio.Lock] = defaultdict(lambda: asyncio.Lock())
 
@@ -143,7 +144,6 @@ class ResourceService(protocol.ServerSlice):
     def clear_env_cache(self, env: data.Environment) -> None:
         LOGGER.log(const.LOG_LEVEL_TRACE, "Clearing cache for %s", env.id)
         self._increment_cache[env.id] = None
-        # ??? del self._increment_cache[env.id]
 
     @staticmethod
     def get_resource_action_log_file(environment: uuid.UUID) -> str:

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -320,7 +320,7 @@ class ResourceService(protocol.ServerSlice):
         if version is None:
             return 404, {"message": "No version available"}
 
-        increment_ids, neg_increment = self.get_increment(env, version)
+        increment_ids, neg_increment = await self.get_increment(env, version)
 
         # set already done to deployed
         now = datetime.datetime.now().astimezone()
@@ -428,7 +428,7 @@ class ResourceService(protocol.ServerSlice):
                     increment = await data.ConfigurationModel.get_increment(env.id, version)
                     # Make mypy happy
                     assert increment is not None
-                    self._increment_cache[env.id] = (version, increment[0], list(increment[1]))
+                    self._increment_cache[env.id] = (version, *increment)
         return increment
 
     @protocol.handle(methods.resource_action_update, env="tid")


### PR DESCRIPTION
# Description

**Same PR as #5596 but on iso4 due to a merge conflict**

This PR fixes a race condition in the incremental deploy calculation. The following scenario triggers the race:

* `put_version()` is called for model version N and the increment cache is cleared.
* An agent pulls the resources it has to deploy. This populates the increment cache with an increment relative to version N-1
* The `release_version()` method is called for version N. This call hits the increment cache entry created in the previous bullet point, resulting in an incorrect increment calculation.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
