### PR TITLE
Namespace lookup fail fast

### DIFF
--- a/changelogs/unreleased/namespace-lookup-fail-fast.yml
+++ b/changelogs/unreleased/namespace-lookup-fail-fast.yml
@@ -1,0 +1,7 @@
+description: Raise namespace lookup exception earlier (normalization phase) for improved diagnostics
+change-type: patch
+sections:
+  minor-improvement: "{{description}}"
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -329,7 +329,7 @@ class Namespace(Namespaced):
         parts = name.rsplit("::", 1)
 
         if parts[0] not in self.visible_namespaces:
-            raise NotFoundException(None, name, "Variable %s not found" % parts[0])
+            raise NotFoundException(None, name, "Namespace %s not found" % parts[0])
 
         return self.visible_namespaces[parts[0]].target.get_scope().direct_lookup(parts[1])
 

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -17,6 +17,7 @@
 """
 
 import logging
+from collections import abc
 from typing import Dict, Generic, List, Optional, TypeVar
 
 import inmanta.execute.dataflow as dataflow
@@ -68,7 +69,15 @@ class Reference(ExpressionStatement):
         self.full_name = str(name)
 
     def normalize(self, *, lhs_attribute: Optional[AttributeAssignmentLHS] = None) -> None:
-        pass
+        split: abc.Sequence[str] = self.name.rsplit("::", maxsplit=1)
+        if len(split) > 1:
+            # fail-fast if namespace does not exist
+            namespace: str = split[0]
+            res = self.namespace.get_root().get_ns_from_string(namespace)
+            if res is None:
+                raise NotFoundException(
+                    self, namespace, f"Could not find namespace {namespace}. Try importing it with `import {namespace}`"
+                )
 
     def requires(self) -> List[str]:
         return [self.full_name]

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -60,8 +60,6 @@ def do_compile(refs: Optional[abc.Mapping[object, object]] = None) -> tuple[dict
     :param refs: Datastructure used to pass on mocking information to the compiler. Supported options:
                     * key="facts"; value=Dict with the following structure: {"<resource_id": {"<fact_name>": "<fact_value"}}
     """
-    if refs is None:
-        refs = {}
     compiler = Compiler(refs=refs)
 
     LOGGER.debug("Starting compile")
@@ -110,7 +108,7 @@ def show_dataflow_graphic(scheduler: scheduler.Scheduler, compiler: "Compiler") 
     )
 
 
-def anchormap(refs: Dict[Any, Any] = {}) -> Sequence[Tuple[Location, Location]]:
+def anchormap(refs: Optional[abc.Mapping[object, object]] = None) -> Sequence[Tuple[Location, Location]]:
     """
     Return all lexical references
 
@@ -148,11 +146,11 @@ class Compiler(object):
                     * key="facts"; value=Dict with the following structure: {"<resource_id": {"<fact_name>": "<fact_value"}}
     """
 
-    def __init__(self, cf_file: str = "main.cf", refs: Dict[Any, Any] = {}) -> None:
+    def __init__(self, cf_file: str = "main.cf", refs: Optional[abc.Mapping[object, object]] = None) -> None:
         self.__root_ns: Optional[Namespace] = None
         self._data: CompileData = CompileData()
         self.plugins: Dict[str, Plugin] = {}
-        self.refs = refs
+        self.refs = refs if refs is not None else {}
 
     def get_plugins(self) -> Dict[str, Plugin]:
         return self.plugins

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -53,13 +53,15 @@ if TYPE_CHECKING:
     from inmanta.ast import BasicBlock, Statement  # noqa: F401
 
 
-def do_compile(refs: Dict[Any, Any] = {}) -> Tuple[Dict[str, inmanta_type.Type], Namespace]:
+def do_compile(refs: Optional[abc.Mapping[object, object]] = None) -> tuple[dict[str, inmanta_type.Type], Namespace]:
     """
     Perform a complete compilation run for the current project (as returned by :py:meth:`inmanta.module.Project.get`)
 
     :param refs: Datastructure used to pass on mocking information to the compiler. Supported options:
                     * key="facts"; value=Dict with the following structure: {"<resource_id": {"<fact_name>": "<fact_value"}}
     """
+    if refs is None:
+        refs = {}
     compiler = Compiler(refs=refs)
 
     LOGGER.debug("Starting compile")

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -19,7 +19,7 @@ import logging
 import sys
 from collections import abc
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set, Tuple
 
 import inmanta.ast.type as inmanta_type
 import inmanta.execute.dataflow as dataflow

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -292,8 +292,7 @@ def test_reference_nonexisting_namespace(snippetcompiler, namespace: str) -> Non
             f"Could not find namespace {namespace}. Try importing it with `import {namespace}`"
             f" (reported in {namespace}::x ({snippetcompiler.project_dir}/main.cf:1:1))"
         ),
-    ) as exc_info:
-        project: module.Project = snippetcompiler.project
+    ):
         comp: compiler.Compiler = compiler.Compiler()
         sched: scheduler.Scheduler = scheduler.Scheduler()
 


### PR DESCRIPTION
# Description

Raise namespace lookup exception earlier (normalization phase) for improved diagnostics. 

E.g. language server (latest stable release):

https://user-images.githubusercontent.com/7672159/222155958-015879f3-498f-4c72-89f6-02c1ddcc85bc.mp4

strangely, the video doesn't seem to play in the browser. Downloading it works though.

@arnaudsjs I added you purely for review of the behavior, not the implementation.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
