### PR TITLE
Fix typing issue in MethodProperties class

### DIFF
--- a/changelogs/unreleased/fix-typing-issue-method-properties.yml
+++ b/changelogs/unreleased/fix-typing-issue-method-properties.yml
@@ -1,0 +1,4 @@
+---
+description: Fix typing issue in the `MethodProperties.get_description_foreach_http_status_code()` method.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -780,7 +780,7 @@ class MethodProperties(object):
         for raise_statement in self._parsed_docstring.raises:
             exception_name = raise_statement.type_name
             status_code = self._get_http_status_code_for_exception(exception_name)
-            result[status_code] = raise_statement.description
+            result[status_code] = raise_statement.description if raise_statement.description is not None else ""
 
         return result
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2171,7 +2171,7 @@ async def test_kwargs(unused_tcp_port, postgres_db, database_name, async_finaliz
 
 async def test_get_description_foreach_http_status_code() -> None:
     """
-    Test whether the MethodProperties.get_description_foreach_http_status_code works as expected.
+    Test whether the `MethodProperties.get_description_foreach_http_status_code()` method works as expected.
     """
 
     class ProjectServer(ServerSlice):


### PR DESCRIPTION
# Description

Fix typing issue in the `MethodProperties.get_description_foreach_http_status_code()` method.)

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
