### PR TITLE
Fix typing issue in MethodProperties class

### DIFF
--- a/changelogs/unreleased/fix-typing-issue-method-properties.yml
+++ b/changelogs/unreleased/fix-typing-issue-method-properties.yml
@@ -1,0 +1,4 @@
+---
+description: Fix typing issue in the `MethodProperties.get_description_foreach_http_status_code()` method.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/changelogs/unreleased/fix-typing-issue-method-properties.yml
+++ b/changelogs/unreleased/fix-typing-issue-method-properties.yml
@@ -1,4 +1,4 @@
 ---
 description: Fix typing issue in the `MethodProperties.get_description_foreach_http_status_code()` method.
 change-type: patch
-destination-branches: [master, iso6, iso5, iso4]
+destination-branches: [iso4]

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -733,7 +733,7 @@ class MethodProperties(object):
         for raise_statement in self._parsed_docstring.raises:
             exception_name = raise_statement.type_name
             status_code = self._get_http_status_code_for_exception(exception_name)
-            result[status_code] = raise_statement.description
+            result[status_code] = raise_statement.description if raise_statement.description is not None else ""
 
         return result
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -2156,3 +2156,44 @@ async def test_return_value_with_meta(unused_tcp_port, postgres_db, database_nam
     assert response.result["data"] == "abcd"
     assert response.result["metadata"].get("additionalInfo") is not None
     assert response.result["metadata"].get("warnings") is not None
+
+
+async def test_get_description_foreach_http_status_code() -> None:
+    """
+    Test whether the `MethodProperties.get_description_foreach_http_status_code()` method works as expected.
+    """
+
+    class ProjectServer(ServerSlice):
+        @protocol.typedmethod(path="/test", operation="POST", client_types=[ClientType.api], varkw=True)
+        def test_method1(id: str, **kwargs: object) -> Dict[str, str]:  # NOQA
+            """
+            Create a new project
+
+            :returns: A new project
+            :raises NotFound: The id was not found.
+            :raises 500: A server error.
+            """
+
+        @protocol.typedmethod(path="/test", operation="POST", client_types=[ClientType.api], varkw=True)
+        def test_method2(id: str, **kwargs: object) -> Dict[str, str]:  # NOQA
+            """
+            Create a new project
+
+            :returns:
+            :raises NotFound:
+            :raises 500:
+            """
+
+    method_properties = protocol.common.MethodProperties.methods["test_method1"][0]
+    response_code_to_description: Dict[int, str] = method_properties.get_description_foreach_http_status_code()
+    assert len(response_code_to_description) == 3
+    assert response_code_to_description[200] == "A new project"
+    assert response_code_to_description[404] == "The id was not found."
+    assert response_code_to_description[500] == "A server error."
+
+    method_properties = protocol.common.MethodProperties.methods["test_method2"][0]
+    response_code_to_description: Dict[int, str] = method_properties.get_description_foreach_http_status_code()
+    assert len(response_code_to_description) == 3
+    assert response_code_to_description[200] == ""
+    assert response_code_to_description[404] == ""
+    assert response_code_to_description[500] == ""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -39,6 +39,7 @@ from tornado.httputil import url_concat
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
 from inmanta import config, const, protocol
+from inmanta.const import ClientType
 from inmanta.data.model import BaseModel
 from inmanta.protocol import VersionMatch, exceptions, json_encode
 from inmanta.protocol.common import (


### PR DESCRIPTION
# Description

**Same PR as #5655 but on the iso4 branch due to a merge conflict.**

Fix typing issue in the `MethodProperties.get_description_foreach_http_status_code()` method.)

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
