### PR TITLE
fixed bug in namespace lookup breaking import aliases

### DIFF
--- a/changelogs/unreleased/bugfix-namespace-aliases-error.yml
+++ b/changelogs/unreleased/bugfix-namespace-aliases-error.yml
@@ -1,0 +1,5 @@
+description: Fixed error in namespace resolution causing import aliases to break
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -322,16 +322,16 @@ class Namespace(Namespaced):
                 raise DuplicateException(ns, self.visible_namespaces[name], "Two import statements have the same name")
         self.visible_namespaces[name] = ns
 
+    def lookup_namespace(self, name: str) -> Import:
+        if name not in self.visible_namespaces:
+            raise NotFoundException(None, name, f"Namespace {name} not found. Try importing it with `import {name}`")
+        return self.visible_namespaces[name]
+
     def lookup(self, name: str) -> "Union[Type, ResultVariable]":
         if "::" not in name:
             return self.get_scope().direct_lookup(name)
-
         parts = name.rsplit("::", 1)
-
-        if parts[0] not in self.visible_namespaces:
-            raise NotFoundException(None, name, "Namespace %s not found" % parts[0])
-
-        return self.visible_namespaces[parts[0]].target.get_scope().direct_lookup(parts[1])
+        return self.lookup_namespace(parts[0]).target.get_scope().direct_lookup(parts[1])
 
     def get_type(self, typ: LocatableString) -> "Type":
         name: str = str(typ)

--- a/src/inmanta/ast/variables.py
+++ b/src/inmanta/ast/variables.py
@@ -72,12 +72,11 @@ class Reference(ExpressionStatement):
         split: abc.Sequence[str] = self.name.rsplit("::", maxsplit=1)
         if len(split) > 1:
             # fail-fast if namespace does not exist
-            namespace: str = split[0]
-            res = self.namespace.get_root().get_ns_from_string(namespace)
-            if res is None:
-                raise NotFoundException(
-                    self, namespace, f"Could not find namespace {namespace}. Try importing it with `import {namespace}`"
-                )
+            try:
+                self.namespace.lookup_namespace(split[0])
+            except NotFoundException as e:
+                e.set_statement(self)
+                raise
 
     def requires(self) -> List[str]:
         return [self.full_name]

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -333,7 +333,7 @@ def test_namespace_alias(snippetcompiler) -> None:
         import std as alias
 
         alias::x
-        alias::x()
+        alias::count([])
         """,
         install_project=True,
     )


### PR DESCRIPTION
# Description

Fixed error in namespace resolution causing import aliases to break

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
