### PR TITLE
Add support for 4 digit versioning

### DIFF
--- a/changelogs/unreleased/add-four-digit-versioning-module-tool.yml
+++ b/changelogs/unreleased/add-four-digit-versioning-module-tool.yml
@@ -1,5 +1,5 @@
 ---
-description: Add support for four digit versioning for module tool (release).
+description: Add support for four digit versioning for `inmanta module release`.
 change-type: minor
 destination-branches: [master, iso6]
 sections:

--- a/changelogs/unreleased/add-four-digit-versioning-module-tool.yml
+++ b/changelogs/unreleased/add-four-digit-versioning-module-tool.yml
@@ -1,4 +1,6 @@
 ---
-description: Add four digit versioning for module tool (release).
+description: Add support for four digit versioning for module tool (release).
 change-type: minor
 destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/add-four-digit-versioning-module-tool.yml
+++ b/changelogs/unreleased/add-four-digit-versioning-module-tool.yml
@@ -1,0 +1,4 @@
+---
+description: Add four digit versioning for module tool (release).
+change-type: minor
+destination-branches: [master, iso6]

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -103,21 +103,20 @@ def add_deps_check_arguments(parser: argparse.ArgumentParser) -> None:
         dest="no_strict_deps_check",
         action="store_true",
         default=False,
-        help=(
-            "When this option is enabled, only version conflicts in the direct dependencies will result in an error. ",
-             "All other version conflicts will result in a warning. This option is mutually exclusive with the ",
-             "--strict-deps-check option.",
-        ),
+        help="""
+    When this option is enabled, only version conflicts in the direct dependencies will result in an error.
+    All other version conflicts will result in a warning. This option is mutually exclusive with the --strict-deps-check option.
+        """,
     )
     parser.add_argument(
         "--strict-deps-check",
         dest="strict_deps_check",
         action="store_true",
         default=False,
-        help=(
-            "When this option is enabled, a version conflict in any (transitive) dependency will results in an error. ",
-             "This option is mutually exclusive with the --no-strict-deps-check option.",
-        )
+        help="""
+        When this option is enabled, a version conflict in any (transitive) dependency will results in an error.
+        This option is mutually exclusive with the --no-strict-deps-check option.
+        """,
     )
 
 
@@ -247,11 +246,12 @@ class ChangeType(enum.Enum):
             return cls.MINOR
         if high.micro > low.micro:
             return cls.PATCH
-        if len(high.base_version.split('.')) >= 4:
-            high_revision = high.base_version.split('.')[3]
+        if len(high.base_version.split(".")) >= 4:
+            high_revision = high.base_version.split(".")[3]
             # We are switching from 3 digits to 4
-            if len(low.base_version.split('.')) < 4 or \
-                (len(low.base_version.split('.')) >= 4 and high_revision > low.base_version.split('.')[3]):
+            if len(low.base_version.split(".")) < 4 or (
+                len(low.base_version.split(".")) >= 4 and high_revision > low.base_version.split(".")[3]
+            ):
                 return cls.REVISION
         raise Exception("Couldn't determine version change type diff: this state should be unreachable")
 
@@ -292,16 +292,21 @@ class VersionOperation:
             parts[3] = 0
             parts[2] += 1
         if change_type is ChangeType.MINOR:
-            parts[1] += 1
+            parts[3] = 0
             parts[2] = 0
+            parts[1] += 1
         if change_type is ChangeType.MAJOR:
-            parts[0] += 1
+            parts[3] = 0
             parts[1] = 0
             parts[2] = 0
+            parts[0] += 1
 
         # Reset remaining digits to zero
         if len(parts) > 4:
             parts[4:] = [0 for _ in range(len(parts) - 4)]
+
+        while len(parts) > 3 and parts[-1] == 0:
+            parts.pop()
 
         return cls._to_version(parts, version_tag)
 
@@ -338,14 +343,14 @@ class ProjectTool(ModuleLikeTool):
             "-r",
             "--recursive",
             help="Freeze dependencies recursively. If not set, freeze_recursive option in project.yml is used,"
-                 "which defaults to False",
+            "which defaults to False",
             action="store_true",
             default=None,
         )
         freeze.add_argument(
             "--operator",
             help="Comparison operator used to freeze versions, If not set, the freeze_operator option in"
-                 " project.yml is used which defaults to ~=",
+            " project.yml is used which defaults to ~=",
             choices=[o.value for o in FreezeOperator],
             default=None,
         )
@@ -557,7 +562,7 @@ class ModuleTool(ModuleLikeTool):
             "add",
             help=add_help_msg,
             description=f"{add_help_msg} When executed on a project, the module is installed as well. "
-                        f"Either --v1 or --v2 has to be set.",
+            f"Either --v1 or --v2 has to be set.",
         )
         add.add_argument(
             "module_req",
@@ -614,7 +619,7 @@ mode.
             "--tag",
             dest="tag",
             help="Create a tag for the commit."
-                 "Tags are not created for dev releases by default, if you want to tag it, specify this flag explicitly",
+            "Tags are not created for dev releases by default, if you want to tag it, specify this flag explicitly",
             action="store_true",
         )
         commit.add_argument("-n", "--no-tag", dest="tag", help="Don't create a tag for the commit", action="store_false")
@@ -637,14 +642,14 @@ mode.
             "-r",
             "--recursive",
             help="Freeze dependencies recursively. If not set, freeze_recursive option in module.yml is used,"
-                 " which defaults to False",
+            " which defaults to False",
             action="store_true",
             default=None,
         )
         freeze.add_argument(
             "--operator",
             help="Comparison operator used to freeze versions, If not set, the freeze_operator option in"
-                 " module.yml is used which defaults to ~=",
+            " module.yml is used which defaults to ~=",
             choices=[o.value for o in FreezeOperator],
             default=None,
         )
@@ -666,7 +671,7 @@ mode.
             "--dev",
             dest="dev_build",
             help="Perform a development build of the module. This adds the build tag `.dev<timestamp>` to the "
-                 "package name. The timestamp has the form %%Y%%m%%d%%H%%M%%S.",
+            "package name. The timestamp has the form %%Y%%m%%d%%H%%M%%S.",
             default=False,
             action="store_true",
         )
@@ -735,7 +740,7 @@ When a development release is done using the --dev option, this command:
             "-c",
             "--changelog-message",
             help="This changelog message will be written to the changelog file. If the -m option is not provided, "
-                 "this message will also be used as the commit message.",
+            "this message will also be used as the commit message.",
         )
         release.add_argument("-a", "--all", dest="commit_all", help="Use commit -a", action="store_true")
 
@@ -1650,7 +1655,7 @@ setup(name="{ModuleV2Source.get_package_name_for(self._module.name)}",
         with zipfile.ZipFile(path_to_wheel) as z:
             dir_prefix = f"{rel_path_namespace_package}/"
             files_in_wheel = set(
-                info.filename[len(dir_prefix):]
+                info.filename[len(dir_prefix) :]
                 for info in z.infolist()
                 if not info.is_dir() and info.filename.startswith(dir_prefix)
             )

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -309,6 +309,9 @@ class VersionOperation:
         )
         parts[bump_index] += 1
 
+        while len(parts) > 3 and parts[-1] == 0:
+            parts.pop()
+
         return cls._to_version(parts, version_tag)
 
     @classmethod

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -105,20 +105,21 @@ def add_deps_check_arguments(parser: argparse.ArgumentParser) -> None:
         dest="no_strict_deps_check",
         action="store_true",
         default=False,
-        help="""
-    When this option is enabled, only version conflicts in the direct dependencies will result in an error.
-    All other version conflicts will result in a warning. This option is mutually exclusive with the --strict-deps-check option.
-        """,
+        help=(
+            "When this option is enabled, only version conflicts in the direct dependencies will result in an error. "
+            "All other version conflicts will result in a warning. This option is mutually exclusive with the "
+            "--strict-deps-check option."
+        ),
     )
     parser.add_argument(
         "--strict-deps-check",
         dest="strict_deps_check",
         action="store_true",
         default=False,
-        help="""
-        When this option is enabled, a version conflict in any (transitive) dependency will results in an error.
-        This option is mutually exclusive with the --no-strict-deps-check option.
-        """,
+        help=(
+            "When this option is enabled, a version conflict in any (transitive) dependency will results in an error. "
+            "This option is mutually exclusive with the --no-strict-deps-check option."
+        ),
     )
 
 
@@ -249,9 +250,9 @@ class ChangeType(enum.Enum):
         if high.micro > low.micro:
             return cls.PATCH
         if len(high.base_version.split(".")) >= 4:
-            high_revision = high.base_version.split(".")[3]
+            high_revision = int(high.base_version.split(".")[3])
             # We are switching from 3 digits to 4
-            if len(low.base_version.split(".")) < 4 or high_revision > low.base_version.split(".")[3]:
+            if len(low.base_version.split(".")) < 4 or high_revision > int(low.base_version.split(".")[3]):
                 return cls.REVISION
         raise Exception("Couldn't determine version change type diff: this state should be unreachable")
 

--- a/tests/moduletool/test_changetype.py
+++ b/tests/moduletool/test_changetype.py
@@ -26,10 +26,6 @@ def test_change_type() -> None:
     assert ChangeType.MINOR.value == "minor"
     assert ChangeType.PATCH.value == "patch"
 
-    assert ChangeType.MAJOR.less() == ChangeType.MINOR
-    assert ChangeType.MINOR.less() == ChangeType.PATCH
-    assert ChangeType.PATCH.less() is None
-
     assert ChangeType.PATCH < ChangeType.MINOR < ChangeType.MAJOR
     assert ChangeType.MAJOR > ChangeType.MINOR > ChangeType.PATCH
 

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -371,7 +371,7 @@ def test_add_changelog_entry(tmpdir, modules_dir: str, monkeypatch, initial_chan
         ("1.0.1.dev0", "1.0.1.dev", "1.1.0.dev", "2.0.0.dev"),
         ("1.1.2.dev0", "1.1.2.dev", "1.1.2.dev", "2.0.0.dev"),
         ("2.0.0.dev", "2.0.0.dev", "2.0.0.dev", "2.0.0.dev"),
-        ("1.0.1.4.6.dev0", "1.0.1.4.6.dev0", "1.1.0.0.0.dev0", "2.0.0.0.0.dev0"),
+        ("1.0.1.4.6.dev0", "1.0.1.4.6.dev0", "1.1.0.dev0", "2.0.0.dev0"),
     ],
 )
 def test_bump_dev_version_distance_already_met(
@@ -417,8 +417,8 @@ def test_bump_dev_version_distance_already_met(
 @pytest.mark.parametrize(
     "initial_version, after_revision_increment, after_patch_increment, after_minor_increment, after_major_increment",
     [
-        ("1.0.1.4", "1.0.1.5.dev0", "1.0.2.0.dev0", "1.1.0.0.dev0", "2.0.0.0.dev0"),
-        ("1.0.1", "1.0.1.1.dev0", "1.0.2.0.dev0", "1.1.0.0.dev0", "2.0.0.0.dev0"),
+        ("1.0.1.4", "1.0.1.5.dev0", "1.0.2.dev0", "1.1.0.dev0", "2.0.0.dev0"),
+        ("1.0.1", "1.0.1.1.dev0", "1.0.2.dev0", "1.1.0.dev0", "2.0.0.dev0"),
     ],
 )
 def test_bump_dev_version_four_digits(
@@ -508,7 +508,7 @@ def test_too_many_version_bump_arguments() -> None:
     module_tool = ModuleTool()
     with pytest.raises(click.UsageError) as exc_info:
         module_tool.release(dev=False, minor=True, major=True, message="Commit changes")
-    assert "Only one of --patch, --minor and --major can be set at the same time." in exc_info.value.message
+    assert "Only one of --revision, --patch, --minor and --major can be set at the same time." in exc_info.value.message
 
 
 def test_epoch_value_larger_than_zero(tmpdir, modules_dir: str, monkeypatch) -> None:

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -371,7 +371,7 @@ def test_add_changelog_entry(tmpdir, modules_dir: str, monkeypatch, initial_chan
         ("1.0.1.dev0", "1.0.1.dev", "1.1.0.dev", "2.0.0.dev"),
         ("1.1.2.dev0", "1.1.2.dev", "1.1.2.dev", "2.0.0.dev"),
         ("2.0.0.dev", "2.0.0.dev", "2.0.0.dev", "2.0.0.dev"),
-        ("1.0.1.4.6.dev0", "1.0.1.4.6.dev0", "1.1.0.dev0", "2.0.0.dev0"),
+        ("1.0.1.4.6.dev0", "1.0.1.4.6.dev0", "1.1.0.0.0.dev0", "2.0.0.0.0.dev0"),
     ],
 )
 def test_bump_dev_version_distance_already_met(
@@ -417,8 +417,8 @@ def test_bump_dev_version_distance_already_met(
 @pytest.mark.parametrize(
     "initial_version, after_revision_increment, after_patch_increment, after_minor_increment, after_major_increment",
     [
-        ("1.0.1.4", "1.0.1.5.dev0", "1.0.2.dev0", "1.1.0.dev0", "2.0.0.dev0"),
-        ("1.0.1", "1.0.1.1.dev0", "1.0.2.dev0", "1.1.0.dev0", "2.0.0.dev0"),
+        ("1.0.1.4", "1.0.1.5.dev0", "1.0.2.0.dev0", "1.1.0.0.dev0", "2.0.0.0.dev0"),
+        ("1.2.3", "1.2.3.1.dev0", "1.2.4.0.dev0", "1.3.0.0.dev0", "2.0.0.0.dev0"),
     ],
 )
 def test_bump_dev_version_four_digits(

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -371,7 +371,7 @@ def test_add_changelog_entry(tmpdir, modules_dir: str, monkeypatch, initial_chan
         ("1.0.1.dev0", "1.0.1.dev", "1.1.0.dev", "2.0.0.dev"),
         ("1.1.2.dev0", "1.1.2.dev", "1.1.2.dev", "2.0.0.dev"),
         ("2.0.0.dev", "2.0.0.dev", "2.0.0.dev", "2.0.0.dev"),
-        ("1.0.1.4.6.dev0", "1.0.1.4.6.dev0", "1.1.0.0.0.dev0", "2.0.0.0.0.dev0"),
+        ("1.0.1.4.6.dev0", "1.0.1.4.6.dev0", "1.1.0.dev0", "2.0.0.dev0"),
     ],
 )
 def test_bump_dev_version_distance_already_met(
@@ -417,8 +417,8 @@ def test_bump_dev_version_distance_already_met(
 @pytest.mark.parametrize(
     "initial_version, after_revision_increment, after_patch_increment, after_minor_increment, after_major_increment",
     [
-        ("1.0.1.4", "1.0.1.5.dev0", "1.0.2.0.dev0", "1.1.0.0.dev0", "2.0.0.0.dev0"),
-        ("1.2.3", "1.2.3.1.dev0", "1.2.4.0.dev0", "1.3.0.0.dev0", "2.0.0.0.dev0"),
+        ("1.0.1.4", "1.0.1.5.dev0", "1.0.2.dev0", "1.1.0.dev0", "2.0.0.dev0"),
+        ("1.2.3", "1.2.3.1.dev0", "1.2.4.dev0", "1.3.0.dev0", "2.0.0.dev0"),
     ],
 )
 def test_bump_dev_version_four_digits(

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -418,6 +418,7 @@ def test_bump_dev_version_distance_already_met(
     "initial_version, after_revision_increment, after_patch_increment, after_minor_increment, after_major_increment",
     [
         ("1.0.1.4", "1.0.1.5.dev0", "1.0.2.0.dev0", "1.1.0.0.dev0", "2.0.0.0.dev0"),
+        ("1.0.1", "1.0.1.1.dev0", "1.0.2.0.dev0", "1.1.0.0.dev0", "2.0.0.0.dev0"),
     ],
 )
 def test_bump_dev_version_four_digits(
@@ -452,15 +453,11 @@ def test_bump_dev_version_four_digits(
     module_tool = ModuleTool()
     module_tool.release(dev=True, revision=True, message="Commit changes")
     assert str(Module.from_path(path_module).version) == str(Version(after_revision_increment))
-    assert str(Module.from_path(path_module).version) == str(Version(after_revision_increment))
     module_tool.release(dev=True, patch=True, message="Commit changes")
-    assert str(Module.from_path(path_module).version) == str(Version(after_patch_increment))
     assert str(Module.from_path(path_module).version) == str(Version(after_patch_increment))
     module_tool.release(dev=True, minor=True, message="Commit changes")
     assert str(Module.from_path(path_module).version) == str(Version(after_minor_increment))
-    assert str(Module.from_path(path_module).version) == str(Version(after_minor_increment))
     module_tool.release(dev=True, major=True, message="Commit changes")
-    assert str(Module.from_path(path_module).version) == str(Version(after_major_increment))
     assert str(Module.from_path(path_module).version) == str(Version(after_major_increment))
 
 


### PR DESCRIPTION
# Description

Added support for 4 digit versioning needed in some repos where we want to follow other products versioning but still able to provide revisions

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
