### PR TITLE
Improve error reporting cross resource set dependencies

### DIFF
--- a/changelogs/unreleased/5705-improve-error-reporting-cross-resource-set-dependencies.yml
+++ b/changelogs/unreleased/5705-improve-error-reporting-cross-resource-set-dependencies.yml
@@ -1,0 +1,6 @@
+---
+description: Improve the error reporting regarding the existance of a cross resource set dependency when a partial compile is done.
+issue-nr: 5705
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]


### PR DESCRIPTION
# Description

Improve the error reporting regarding the existance of a cross resource set dependency when a partial compile is done. The resources that are part of the cross resource set dependency are not reported in the error message.

closes #5705 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
