### PR TITLE
Use latest tag in docker install documentation

### DIFF
--- a/changelogs/unreleased/reference-oss-container-with-latest-tag.yml
+++ b/changelogs/unreleased/reference-oss-container-with-latest-tag.yml
@@ -1,0 +1,4 @@
+---
+description: Make sure that the `Install Inmanta with Docker` documentation uses the latest tag instead of a specific version tag for the OSS container.
+change-type: patch
+destination-branches: [master]

--- a/changelogs/unreleased/reference-oss-container-with-latest-tag.yml
+++ b/changelogs/unreleased/reference-oss-container-with-latest-tag.yml
@@ -1,4 +1,4 @@
 ---
 description: Make sure that the `Install Inmanta with Docker` documentation uses the latest tag instead of a specific version tag for the OSS container.
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso6]

--- a/docs/install/2-install-server-with-docker.rst
+++ b/docs/install/2-install-server-with-docker.rst
@@ -15,7 +15,7 @@ Pull the image
 
     .. code-block:: sh
 
-        docker pull ghcr.io/inmanta/orchestrator:2022
+        docker pull ghcr.io/inmanta/orchestrator:latest
 
 
     This command will pull the latest version of the Inmanta OSS Orchestrator image.
@@ -77,7 +77,7 @@ Here is a minimalistic docker-compose file content that can be used to deploy th
 
             inmanta-server:
                 container_name: inmanta_orchestrator
-                image: ghcr.io/inmanta/orchestrator:2022
+                image: ghcr.io/inmanta/orchestrator:latest
                 ports:
                     - 8888:8888
                 networks:
@@ -190,7 +190,7 @@ If you use docker-compose, you can simply update this section of the example abo
 
         inmanta-server:
             container_name: inmanta_orchestrator
-            image: ghcr.io/inmanta/orchestrator:2022
+            image: ghcr.io/inmanta/orchestrator:latest
             ports:
                 - 8888:8888
             volumes:
@@ -270,7 +270,7 @@ There are two ways you can achieve this:
 
         inmanta-server:
             container_name: inmanta_orchestrator
-            image: ghcr.io/inmanta/orchestrator:2022
+            image: ghcr.io/inmanta/orchestrator:latest
             ports:
                 - 8888:8888
             volumes:


### PR DESCRIPTION
# Description

Make sure that the `Install Inmanta with Docker` documentation uses the latest tag instead of a specific version tag for the OSS container.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
