### PR TITLE
 issue/5693-agent-install-dependency-modules-expert

### DIFF
--- a/changelogs/unreleased/5693-agent-install-dependency-expert.yml
+++ b/changelogs/unreleased/5693-agent-install-dependency-expert.yml
@@ -1,0 +1,7 @@
+description: change agent_install_dependency_modules from experimental feature to expert feature
+issue-nr: 5693
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  feature: "{{description}}"
+

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -133,3 +133,6 @@ Glossary
         computer data centers through machine-readable definition files, rather than physical
         hardware configuration or interactive configuration tools.* Inmanta achieves this by using a
         desired state configuration model that is entirely expressed in code.
+
+    expert feature
+        A feature that is stable, but requires great care and/or knowledge to use properly.

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1552,7 +1552,7 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
         result in an error.
         When a non-strict check is done, only version conflicts in a direct dependency will result in an error.
         All other violations will only result in a warning message.
-    :param agent_install_dependency_modules: [EXPERIMENTAL FEATURE] If true, when a module declares Python dependencies on
+    :param agent_install_dependency_modules: [EXPERT FEATURE] If true, when a module declares Python dependencies on
         other (v2) modules, the agent will install these dependency modules with pip. This option should only be enabled
         if the agent is configured with the appropriate pip related environment variables. The option allows to an extent
         for inter-module dependencies within handler code, even if the dependency module doesn't have any handlers that


### PR DESCRIPTION
# Description

change agent_install_dependency_modules from experimental feature to expert feature
closes #5693 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
