### PR TITLE
Fix bug in calculation fact renewal timestamp

### DIFF
--- a/changelogs/unreleased/fix-fact-renewal-timestamp-calculation.yml
+++ b/changelogs/unreleased/fix-fact-renewal-timestamp-calculation.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug that incorrectly calculates the timestamp indicating which facts have to be renewed.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/db/versions/v1.py
+++ b/src/inmanta/db/versions/v1.py
@@ -181,7 +181,7 @@ CREATE TABLE IF NOT EXISTS public.unknownparameter (
 --      * server.get_version()
 CREATE INDEX unknownparameter_env_version_index ON unknownparameter (environment, version);
 -- Used in:
---      * server.renew_expired_facts()
+--      * server.renew_facts()
 CREATE INDEX unknownparameter_resolved_index ON unknownparameter (resolved);
 
 -- Table: public.agentprocess

--- a/src/inmanta/server/services/paramservice.py
+++ b/src/inmanta/server/services/paramservice.py
@@ -68,16 +68,16 @@ class ParameterService(protocol.ServerSlice):
 
     async def renew_expired_facts(self) -> None:
         """
-        Send out requests to renew expired facts
+        Send out requests to renew facts.
         """
-        LOGGER.info("Renewing expired parameters")
+        LOGGER.info("Renewing parameters")
 
-        updated_before = datetime.datetime.now().astimezone() - datetime.timedelta(0, (self._fact_expire - self._fact_renew))
-        expired_params = await data.Parameter.get_updated_before(updated_before)
+        updated_before = datetime.datetime.now().astimezone() - datetime.timedelta(0, self._fact_renew)
+        params_to_renew = await data.Parameter.get_updated_before(updated_before)
 
-        LOGGER.debug("Renewing %d expired parameters" % len(expired_params))
+        LOGGER.debug("Renewing %d parameters", len(params_to_renew))
 
-        for param in expired_params:
+        for param in params_to_renew:
             if param.environment is None:
                 LOGGER.warning(
                     "Found parameter without environment (%s for resource %s). Deleting it.", param.name, param.resource_id
@@ -103,7 +103,7 @@ class ParameterService(protocol.ServerSlice):
                 LOGGER.debug("Requesting value for unknown parameter %s of resource %s in env %s", u.name, u.resource_id, u.id)
                 await self.agentmanager.request_parameter(u.environment, u.resource_id)
 
-        LOGGER.info("Done renewing expired parameters")
+        LOGGER.info("Done renewing parameters")
 
     @handle(methods.get_param, param_id="id", env="tid")
     async def get_param(self, env: data.Environment, param_id: str, resource_id: Optional[str] = None) -> Apireturn:

--- a/src/inmanta/server/services/paramservice.py
+++ b/src/inmanta/server/services/paramservice.py
@@ -63,10 +63,10 @@ class ParameterService(protocol.ServerSlice):
         self.agentmanager = cast(AgentManager, server.get_slice(SLICE_AGENT_MANAGER))
 
     async def start(self) -> None:
-        self.schedule(self.renew_expired_facts, self._fact_renew, cancel_on_stop=False)
+        self.schedule(self.renew_facts, self._fact_renew, cancel_on_stop=False)
         await super().start()
 
-    async def renew_expired_facts(self) -> None:
+    async def renew_facts(self) -> None:
         """
         Send out requests to renew facts.
         """

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -789,7 +789,7 @@ async def test_unkown_parameters(resource_container, environment, client, server
     result = await client.release_version(environment, version, True, const.AgentTriggerMethod.push_full_deploy)
     assert result.code == 200
 
-    await server.get_slice(SLICE_PARAM).renew_expired_facts()
+    await server.get_slice(SLICE_PARAM).renew_facts()
 
     env_id = uuid.UUID(environment)
     params = await data.Parameter.get_list(environment=env_id, resource_id=resource_id_wov)


### PR DESCRIPTION
# Description

Fix bug that incorrectly calculates the timestamp indicating which facts have to be renewed.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
