### PR TITLE
Disable cleanup jobs that removes old model version and agent records for tests

### DIFF
--- a/changelogs/unreleased/disable-version-and-agent-cleanup-job.yml
+++ b/changelogs/unreleased/disable-version-and-agent-cleanup-job.yml
@@ -1,0 +1,4 @@
+---
+description: Disable the cleanup job, that removes old model versions and agent records, when the test suite is ran. If this job is enabled, it causes race conditions in test cases that manually create agent records without an associated model.
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,7 @@ from inmanta.protocol import VersionMatch
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_COMPILER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import Server, SliceStartupException
+from inmanta.server.services import orchestrationservice
 from inmanta.server.services.compilerservice import CompilerService, CompileRun
 from inmanta.types import JsonType
 from inmanta.warnings import WarningsManager
@@ -1749,3 +1750,16 @@ def index_with_pkgs_containing_optional_deps() -> str:
                 publish_index=pip_index,
             )
         yield pip_index.url
+
+
+@pytest.fixture(scope="session")
+def disable_version_and_agent_cleanup_job():
+    """
+    Disable the cleanup job ran by the Inmanta server that cleans up old model version and agent records that are no longer
+    used. Enabling this cleanup for the test suite causes race conditions in tests cases that create agent records without an
+    associated model version.
+    """
+    old_perform_cleanup = orchestrationservice.PERFORM_CLEANUP
+    orchestrationservice.PERFORM_CLEANUP = False
+    yield
+    orchestrationservice.PERFORM_CLEANUP = old_perform_cleanup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1752,7 +1752,7 @@ def index_with_pkgs_containing_optional_deps() -> str:
         yield pip_index.url
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def disable_version_and_agent_cleanup_job():
     """
     Disable the cleanup job ran by the Inmanta server that cleans up old model version and agent records that are no longer


### PR DESCRIPTION
# Description

Disable the cleanup job, that removes old model versions and agent records, when the test suite is ran. If this job is enabled, it causes race conditions in test cases that manually create agent records without an associated model.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
