### PR TITLE
Fix backward compatibility LS

### DIFF
--- a/changelogs/unreleased/fix-backward-compatibility-ls.yml
+++ b/changelogs/unreleased/fix-backward-compatibility-ls.yml
@@ -1,0 +1,3 @@
+description: Make it so we have 2 functions that can be called by the LS to stay backward compatible.
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -124,7 +124,7 @@ def anchormap(refs: Optional[abc.Mapping[object, object]] = None) -> Sequence[Tu
 
     (statements, blocks) = compiler.compile()
     sched = scheduler.Scheduler()
-    return sched.anchormap(compiler, statements, blocks)
+    return sched.anchormap_extended(compiler, statements, blocks)
 
 
 def get_types_and_scopes() -> Tuple[Dict[str, inmanta_type.Type], Namespace]:

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -124,7 +124,7 @@ def anchormap(refs: Optional[abc.Mapping[object, object]] = None) -> Sequence[Tu
 
     (statements, blocks) = compiler.compile()
     sched = scheduler.Scheduler()
-    return sched.anchormap_extended(compiler, statements, blocks)
+    return sched.get_anchormap(compiler, statements, blocks)
 
 
 def get_types_and_scopes() -> Tuple[Dict[str, inmanta_type.Type], Namespace]:

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -290,7 +290,10 @@ class Scheduler(object):
 
     def anchormap(
         self, compiler: "Compiler", statements: Sequence["Statement"], blocks: Sequence["BasicBlock"]
-    ) -> Sequence[Tuple[Location, AnchorTarget]]:
+    ) -> Sequence[Tuple[Location, Location]]:
+        """
+        This methode exists for backward compatibility with inmantals
+        """
         range_to_anchor_target = self.anchormap_extended(compiler, statements, blocks)
         range_to_range = [(f, t.location) for f, t in range_to_anchor_target]
 

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -262,7 +262,7 @@ class Scheduler(object):
 
         self.types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
 
-    def anchormap_extended(
+    def get_anchormap(
         self, compiler: "Compiler", statements: Sequence["Statement"], blocks: Sequence["BasicBlock"]
     ) -> Sequence[Tuple[Location, AnchorTarget]]:
         prev = time.time()
@@ -294,7 +294,7 @@ class Scheduler(object):
         """
         This methode exists for backward compatibility with inmantals
         """
-        range_to_anchor_target = self.anchormap_extended(compiler, statements, blocks)
+        range_to_anchor_target = self.get_anchormap(compiler, statements, blocks)
         range_to_range = [(f, t.location) for f, t in range_to_anchor_target]
 
         return range_to_range

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -262,7 +262,7 @@ class Scheduler(object):
 
         self.types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
 
-    def anchormap(
+    def anchormap_extended(
         self, compiler: "Compiler", statements: Sequence["Statement"], blocks: Sequence["BasicBlock"]
     ) -> Sequence[Tuple[Location, AnchorTarget]]:
         prev = time.time()
@@ -280,13 +280,21 @@ class Scheduler(object):
             if anchor is not None
         )
 
-        rangetorange = [(anchor.get_location(), anchor.resolve()) for anchor in anchors]
-        rangetorange = [(f, t) for f, t in rangetorange if t is not None]
+        range_to_anchor_target = [(anchor.get_location(), anchor.resolve()) for anchor in anchors]
+        range_to_anchor_target = [(f, t) for f, t in range_to_anchor_target if t is not None]
 
         now = time.time()
         LOGGER.debug("Anchormap took %f seconds", now - prev)
 
-        return rangetorange
+        return range_to_anchor_target
+
+    def anchormap(
+        self, compiler: "Compiler", statements: Sequence["Statement"], blocks: Sequence["BasicBlock"]
+    ) -> Sequence[Tuple[Location, AnchorTarget]]:
+        range_to_anchor_target = self.anchormap_extended(compiler, statements, blocks)
+        range_to_range = [(f, t.location) for f, t in range_to_anchor_target]
+
+        return range_to_range
 
     def find_wait_cycle(self, attributes_with_precedence_rule: List[RelationAttribute], allwaiters: Set[Waiter]) -> bool:
         """

--- a/tests/test_compiler_entrypoints.py
+++ b/tests/test_compiler_entrypoints.py
@@ -114,6 +114,7 @@ implement Test using a
     anchormap = sched.anchormap(compiler, statements, blocks)
 
     assert len(anchormap) == 9
+    assert all(isinstance(item[0], Range) and isinstance(item[1], Range) for item in anchormap)
 
     checkmap = {(r.lnr, r.start_char, r.end_char): t.lnr for r, t in anchormap}
 

--- a/tests/test_compiler_entrypoints.py
+++ b/tests/test_compiler_entrypoints.py
@@ -287,10 +287,7 @@ implement Test_no_doc using b
 """,
         autostd=False,
     )
-    compiler = Compiler()
-    (statements, blocks) = compiler.compile()
-    sched = scheduler.Scheduler()
-    anchormap = sched.anchormap_extended(compiler, statements, blocks)
+    anchormap = compiler.anchormap()
 
     assert len(anchormap) == 10
 


### PR DESCRIPTION
# Description

Change core to have 2 functions(scheduler_instance.anchormap (old) and scheduler_instance.anchormap_extended (new)) that can be called by the LS to ensure it stays backward compatible.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
