### PR TITLE
Extend functionality openapi type converter

### DIFF
--- a/changelogs/unreleased/extend-openapi-type-converter.yml
+++ b/changelogs/unreleased/extend-openapi-type-converter.yml
@@ -1,0 +1,9 @@
+---
+description: |
+   * Extend functionality OpenAPI type converter.
+   * Bugfix: Ensure OpenAPI enum values always have the type field set.
+   * Bugfix: Ensure that the OpenAPI type reference resolver populates the allOf and oneOf properties of the OpenAPI schema.
+issue-nr: 1169
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/changelogs/unreleased/extend-openapi-type-converter.yml
+++ b/changelogs/unreleased/extend-openapi-type-converter.yml
@@ -1,8 +1,9 @@
 ---
 description: |
-   * Extend functionality OpenAPI type converter.
+   * Extend OpenAPI type converter with features required by lsm extension.
    * Bugfix: Ensure OpenAPI enum values always have the type field set.
-   * Bugfix: Ensure that the OpenAPI type reference resolver populates the allOf and oneOf properties of the OpenAPI schema.
+   * Bugfix: Ensure that the OpenAPI type reference resolver populates the `allOf` and `oneOf` properties of the OpenAPI schema.
+   * Bugfix: Ensure that the OpenApiTypeConverter.get_openapi_type_of_parameter() method populates the default value of a parameter.
 issue-nr: 1169
 issue-repo: inmanta-lsm
 change-type: patch

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -41,6 +41,8 @@ def patch_pydantic_field_type_schema() -> None:
     """
     This ugly patch fixes the serialization of models containing Optional in them.
     https://github.com/samuelcolvin/pydantic/issues/1270
+
+    The fix for this issue will be included in pydantic V2.
     """
 
     def patch_nullable(field: ModelField, **kwargs):

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -182,7 +182,7 @@ class OpenApiTypeConverter:
 
     def _add_type_field_to_enum_value(self, definition: Dict[str, object]) -> Dict[str, object]:
         """
-        When pydantic converts an Python Enum type to its corresponding json schema, it doesn't
+        When pydantic converts a Python Enum type to its corresponding json schema, it doesn't
         populate the type field. This way the rendered API documentation doesn't include all possible
         enum values. This method makes sure that the type attribute of an enum is always populated.
         """

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -15,7 +15,6 @@
 
     Contact: code@inmanta.com
 """
-import enum
 import inspect
 import json
 import re
@@ -44,6 +43,7 @@ from inmanta.protocol.openapi.model import (
     Response,
     Schema,
     Server,
+    OpenApiDataTypes,
 )
 from inmanta.server import config
 from inmanta.server.extensions import FeatureManager
@@ -54,15 +54,6 @@ def openapi_json_encoder(o: object) -> Union[ReturnTypes, util.JSONSerializable]
     if isinstance(o, BaseModel):
         return o.dict(by_alias=True, exclude_none=True)
     return util.api_boundary_json_encoder(o)
-
-
-class OpenApiDataTypes(enum.Enum):
-    STRING = "string"
-    NUMBER = "number"
-    INTEGER = "integer"
-    BOOLEAN = "boolean"
-    ARRAY = "array"
-    OBJECT = "object"
 
 
 class OpenApiConverter:

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -171,8 +171,10 @@ class OpenApiTypeConverter:
         patch_pydantic_field_type_schema()
 
     def get_openapi_type_of_parameter(self, parameter_type: inspect.Parameter) -> Schema:
-        type_annotation = parameter_type.annotation
-        return self.get_openapi_type(type_annotation)
+        schema = self.get_openapi_type(parameter_type.annotation)
+        if parameter_type.default is not inspect.Parameter.empty:
+            schema.default = parameter_type.default
+        return schema
 
     def _handle_pydantic_model(self, type_annotation: Type, by_alias: bool = True) -> Schema:
         # JsonSchema stores the model (and sub-model) definitions at #/definitions,
@@ -215,15 +217,6 @@ class OpenApiTypeConverter:
         pydantic_result = self._handle_pydantic_model(Sub).properties["the_field"]
         pydantic_result.title = None
         return pydantic_result
-
-    def get_openapi_schema_for_python_parameters(self, parameter: inspect.Parameter) -> Schema:
-        """
-        Return the OpenAPI schema for a parameter in a Python function.
-        """
-        schema = self.get_openapi_type(parameter.annotation)
-        if parameter.default is not inspect.Parameter.empty:
-            schema.default = parameter.default
-        return schema
 
     def resolve_reference(self, reference: str) -> Optional[Schema]:
         """

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -21,7 +21,6 @@ import json
 import re
 from typing import Callable, Dict, List, Optional, Type, Union
 
-import pydantic
 from pydantic.networks import AnyUrl
 from pydantic.schema import model_schema
 from pydantic.typing import NoneType
@@ -55,6 +54,7 @@ def openapi_json_encoder(o: object) -> Union[ReturnTypes, util.JSONSerializable]
     if isinstance(o, BaseModel):
         return o.dict(by_alias=True, exclude_none=True)
     return util.api_boundary_json_encoder(o)
+
 
 class OpenApiDataTypes(enum.Enum):
     STRING = "string"

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -34,6 +34,7 @@ from inmanta.protocol.openapi.model import (
     Info,
     MediaType,
     OpenAPI,
+    OpenApiDataTypes,
     Operation,
     Parameter,
     ParameterType,
@@ -43,7 +44,6 @@ from inmanta.protocol.openapi.model import (
     Response,
     Schema,
     Server,
-    OpenApiDataTypes,
 )
 from inmanta.server import config
 from inmanta.server.extensions import FeatureManager

--- a/src/inmanta/protocol/openapi/model.py
+++ b/src/inmanta/protocol/openapi/model.py
@@ -70,7 +70,6 @@ class Schema(BaseModel):
     oneOf: Optional[Sequence["Schema"]] = None
     enum: Optional[List[str]] = None
 
-
     def resolve(self, ref_prefix: str, known_schemas: Dict[str, "Schema"]) -> "Schema":
         """
         Returns this object or the one this object is refering to.
@@ -111,7 +110,6 @@ class Schema(BaseModel):
 
         # We only do a deepcopy if the parameter says so AND this object has not been newly built
         deep = deep and schema is not self
-
 
         # Duplicate the schema, and update some of its values
         duplicate = schema.copy(update=update, deep=deep)

--- a/src/inmanta/protocol/openapi/model.py
+++ b/src/inmanta/protocol/openapi/model.py
@@ -251,3 +251,12 @@ class OpenAPI(BaseModel):
     servers: Optional[List[Server]] = None
     paths: Dict[str, PathItem]
     components: Optional[Components] = None
+
+
+class OpenApiDataTypes(Enum):
+    STRING = "string"
+    NUMBER = "number"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+    ARRAY = "array"
+    OBJECT = "object"

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import enum
 import inspect
 import json
 from datetime import datetime
@@ -25,7 +26,7 @@ import pytest
 from openapi_spec_validator import openapi_v30_spec_validator
 from pydantic.networks import AnyHttpUrl, AnyUrl, PostgresDsn
 
-from inmanta.const import ResourceAction
+from inmanta.const import ResourceAction, ClientType
 from inmanta.data import model
 from inmanta.data.model import EnvironmentSetting
 from inmanta.protocol import method
@@ -37,7 +38,7 @@ from inmanta.protocol.openapi.converter import (
     OpenApiTypeConverter,
     OperationHandler,
 )
-from inmanta.protocol.openapi.model import MediaType, Schema
+from inmanta.protocol.openapi.model import MediaType, Schema, ParameterType, OpenApiDataTypes
 from inmanta.server import SLICE_SERVER
 from inmanta.server.extensions import FeatureManager
 from inmanta.server.protocol import Server
@@ -55,11 +56,11 @@ def feature_manager(server: Server) -> FeatureManager:
 
 @pytest.fixture(scope="function")
 def api_methods_fixture(clean_reset):
-    @method(path="/simpleoperation", client_types=["api", "agent"], envelope=True)
+    @method(path="/simpleoperation", client_types=[ClientType.api, ClientType.agent], envelope=True)
     def post_method() -> str:
         return ""
 
-    @method(path="/simpleoperation", client_types=["agent"], operation="GET")
+    @method(path="/simpleoperation", client_types=[ClientType.agent], operation="GET")
     def get_method():
         pass
 
@@ -68,7 +69,7 @@ def api_methods_fixture(clean_reset):
         "non_header": ArgOption(getter=lambda x, y: "test"),
     }
 
-    @method(path="/operation/<id>", client_types=["api", "agent"], envelope=True, arg_options=arg_options)
+    @method(path="/operation/<id>", client_types=[ClientType.api, ClientType.agent], envelope=True, arg_options=arg_options)
     def dummy_post_with_parameters(header: str, non_header: str, param: int, id: UUID) -> str:
         """
         This is a brief description.
@@ -86,7 +87,13 @@ def api_methods_fixture(clean_reset):
         """
         return ""
 
-    @method(path="/operation/<id>", client_types=["api", "agent"], envelope=True, arg_options=arg_options, operation="GET")
+    @method(
+        path="/operation/<id>",
+        client_types=[ClientType.api, ClientType.agent],
+        envelope=True,
+        arg_options=arg_options,
+        operation="GET",
+    )
     def dummy_get_with_parameters(header: str, non_header: str, param: int, id: UUID) -> str:
         """
         This is a brief description.
@@ -104,11 +111,17 @@ def api_methods_fixture(clean_reset):
         """
         return ""
 
-    @method(path="/operation/<id>", client_types=["api", "agent"], envelope=True, arg_options=arg_options)
+    @method(path="/operation/<id>", client_types=[ClientType.api, ClientType.agent], envelope=True, arg_options=arg_options)
     def dummy_post_with_parameters_no_docstring(header: str, non_header: str, param: int, id: UUID) -> str:
         return ""
 
-    @method(path="/operation/<id>", client_types=["api", "agent"], envelope=True, arg_options=arg_options, operation="GET")
+    @method(
+        path="/operation/<id>",
+        client_types=[ClientType.api, ClientType.agent],
+        envelope=True,
+        arg_options=arg_options,
+        operation="GET",
+    )
     def dummy_get_with_parameters_no_docstring(header: str, non_header: str, param: int, id: UUID) -> str:
         return ""
 
@@ -119,7 +132,7 @@ def api_methods_fixture(clean_reset):
 
     @method(
         path="/operation/<id_doc>/<id_no_doc>",
-        client_types=["api", "agent"],
+        client_types=[ClientType.api, ClientType.agent],
         envelope=True,
         arg_options=arg_options_partial_doc,
     )
@@ -137,7 +150,7 @@ def api_methods_fixture(clean_reset):
 
     @method(
         path="/operation/<id_doc>/<id_no_doc>",
-        client_types=["api", "agent"],
+        client_types=[ClientType.api, ClientType.agent],
         envelope=True,
         arg_options=arg_options_partial_doc,
         operation="GET",
@@ -152,6 +165,17 @@ def api_methods_fixture(clean_reset):
         :param param_doc: A parameter.
         :param id_doc: The id of the resource.
         """
+        return ""
+
+    @method(
+        path="/default/<id>",
+        client_types=[ClientType.api],
+        envelope=True,
+        operation="GET",
+    )
+    def dummy_get_with_default_values(
+        no_def: int, id: int = 5, param: str = "test", fl: float = 0.1, opt: Optional[str] = None
+    ) -> str:
         return ""
 
 
@@ -722,3 +746,76 @@ def test_openapi_schema() -> None:
     assert not Schema(**{"$ref": ref_prefix + "person"}).recursive_resolve(ref_prefix, schemas, update={}) == person_schema
     person_schema.properties["address"] = schemas["address"]
     assert Schema(**{"$ref": ref_prefix + "person"}).recursive_resolve(ref_prefix, schemas, update={}) == person_schema
+
+
+def test_get_openapi_parameter_type_for(api_methods_fixture: None) -> None:
+    """
+    Verify whether the MethodProperties.get_openapi_parameter_type_for() method works as expected.
+    """
+    assert len(MethodProperties.methods["dummy_post_with_parameters_no_docstring"]) == 1
+    method_properties = MethodProperties.methods["dummy_post_with_parameters_no_docstring"][0]
+    assert method_properties.get_openapi_parameter_type_for("id") is ParameterType.path
+    assert method_properties.get_openapi_parameter_type_for("header") is ParameterType.header
+    assert method_properties.get_openapi_parameter_type_for("non_header") is None
+    assert method_properties.get_openapi_parameter_type_for("param") is None
+
+    assert len(MethodProperties.methods["dummy_get_with_parameters_no_docstring"]) == 1
+    method_properties = MethodProperties.methods["dummy_get_with_parameters_no_docstring"][0]
+    assert method_properties.get_openapi_parameter_type_for("id") is ParameterType.path
+    assert method_properties.get_openapi_parameter_type_for("header") is ParameterType.header
+    assert method_properties.get_openapi_parameter_type_for("non_header") is ParameterType.query
+    assert method_properties.get_openapi_parameter_type_for("param") is ParameterType.query
+
+
+def test_get_openapi_type_of_parameter(api_methods_fixture: None) -> None:
+    """
+    Verify whether the OpenApiTypeConverter.get_openapi_type_of_parameter() method works as expected.
+    """
+    type_converter = OpenApiTypeConverter()
+    assert len(MethodProperties.methods["dummy_get_with_default_values"]) == 1
+    method_properties = MethodProperties.methods["dummy_get_with_default_values"][0]
+    param_dct = inspect.signature(method_properties.function).parameters
+    for param_name, data_type, default_value, nullable in [
+        ("no_def", OpenApiDataTypes.INTEGER.value, None, False),
+        ("id", OpenApiDataTypes.INTEGER.value, 5, False),
+        ("param", OpenApiDataTypes.STRING.value, "test", False),
+        ("fl", OpenApiDataTypes.NUMBER.value, 0.1, False),
+        ("opt", OpenApiDataTypes.STRING.value, None, True),
+    ]:
+        schema = type_converter.get_openapi_type_of_parameter(param_dct[param_name])
+        assert schema.type == data_type
+        assert schema.default == default_value
+        assert schema.nullable if nullable else not schema.nullable
+
+
+def test_get_openapi_type_for_on_enum() -> None:
+    """
+    Ensure that the type field is populated correctly when OpenApiTypeConverter.get_openapi_type() is called on an Enum.
+    """
+    class StrValEnum(enum.Enum):
+        A = "a"
+        B = "b"
+
+    class IntValEnum(enum.Enum):
+        A = 1
+        B = 2
+
+    class FloatValEnum(enum.Enum):
+        A = 1
+        B = 2.0
+
+    class BoolValEnum(enum.Enum):
+        A = True
+        B = False
+
+    openapi_type_converter = OpenApiTypeConverter()
+
+    for python_type, openapi_type in [
+        (StrValEnum, OpenApiDataTypes.STRING.value),
+        (IntValEnum, OpenApiDataTypes.INTEGER.value),
+        (FloatValEnum, OpenApiDataTypes.NUMBER.value),
+        (BoolValEnum, OpenApiDataTypes.BOOLEAN.value),
+    ]:
+        schema = openapi_type_converter.get_openapi_type(python_type)
+        resolved_schema = schema.resolve(openapi_type_converter.ref_prefix, openapi_type_converter.components.schemas)
+        assert resolved_schema.type == openapi_type

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -26,7 +26,7 @@ import pytest
 from openapi_spec_validator import openapi_v30_spec_validator
 from pydantic.networks import AnyHttpUrl, AnyUrl, PostgresDsn
 
-from inmanta.const import ResourceAction, ClientType
+from inmanta.const import ClientType, ResourceAction
 from inmanta.data import model
 from inmanta.data.model import EnvironmentSetting
 from inmanta.protocol import method
@@ -38,7 +38,7 @@ from inmanta.protocol.openapi.converter import (
     OpenApiTypeConverter,
     OperationHandler,
 )
-from inmanta.protocol.openapi.model import MediaType, Schema, ParameterType, OpenApiDataTypes
+from inmanta.protocol.openapi.model import MediaType, OpenApiDataTypes, ParameterType, Schema
 from inmanta.server import SLICE_SERVER
 from inmanta.server.extensions import FeatureManager
 from inmanta.server.protocol import Server
@@ -792,6 +792,7 @@ def test_get_openapi_type_for_on_enum() -> None:
     """
     Ensure that the type field is populated correctly when OpenApiTypeConverter.get_openapi_type() is called on an Enum.
     """
+
     class StrValEnum(enum.Enum):
         A = "a"
         B = "b"


### PR DESCRIPTION
# Description

This PR:

* Extend OpenAPI type converter with features required by lsm extension.
* Bugfix: Ensure OpenAPI enum values always have the type field set.
* Bugfix: Ensure that the OpenAPI type reference resolver populates the `allOf` and `oneOf` properties of the OpenAPI schema.
* Bugfix: Ensure that the OpenApiTypeConverter.get_openapi_type_of_parameter() method populates the default value of a parameter.

Part of inmanta/inmanta-lsm#1169

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
