### PR TITLE
Remove ensure internal agent code path from AutostartedAgentManager

### DIFF
--- a/changelogs/unreleased/remove-ensure-internal-agent-code.yml
+++ b/changelogs/unreleased/remove-ensure-internal-agent-code.yml
@@ -1,4 +1,4 @@
 ---
 description: Remove the code in the AutostartedAgentManager that ensure that the internal agent is present in the autostarted_agent_map. This code that safely be removed because a validator was added on the update path of the `autostart_agent_map` in Apr 21, 2020. So this check was included in the initial release of ISO4.
 change-type: patch
-destination-branches: [master, iso6, iso5, iso4]
+destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/remove-ensure-internal-agent-code.yml
+++ b/changelogs/unreleased/remove-ensure-internal-agent-code.yml
@@ -1,0 +1,4 @@
+---
+description: Remove the code in the AutostartedAgentManager that ensure that the internal agent is present in the autostarted_agent_map. This code that safely be removed because a validator was added on the update path of the `autostart_agent_map` in Apr 21, 2020. So this check was included in the initial release of ISO4.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -1013,16 +1013,9 @@ class AutostartedAgentManager(ServerSlice):
         if self._stopping:
             raise ShutdownInProgress()
 
-        agent_map: Dict[str, str]
-        agent_map = cast(
+        agent_map: Dict[str, str] = cast(
             Dict[str, str], await env.get(data.AUTOSTART_AGENT_MAP, connection=connection)
         )  # we know the type of this map
-
-        # The internal agent should always be present in the autostart_agent_map. If it's not, this autostart_agent_map was
-        # set in a previous version of the orchestrator which didn't have this constraint. This code fixes the inconsistency.
-        if "internal" not in agent_map:
-            agent_map["internal"] = "local:"
-            await env.set(data.AUTOSTART_AGENT_MAP, dict(agent_map), connection=connection)
 
         agents = [agent for agent in agents if agent in agent_map]
         needsstart = restart

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1180,35 +1180,6 @@ async def test_failover_doesnt_make_paused_agent_primary(server, client, environ
     assert len(agentmanager.tid_endpoint_to_session) == 0
 
 
-async def test_add_internal_agent_when_missing_in_agent_map(server, environment, postgresql_client):
-    """
-    The internal agent should always be present in the autostart_agent_map. If it is not present, it is added when to
-    auto-started agent is started. This test case verifies this behavior.
-    """
-    # Ensure agent1
-    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
-    env = await data.Environment.get_by_id(UUID(environment))
-    await agentmanager.ensure_agent_registered(env=env, nodename="agent1")
-
-    # Remove the internal agent from the autostart_agent_map
-    query = "UPDATE public.environment SET settings=jsonb_set(settings, $1::text[], to_jsonb($2::jsonb), TRUE)"
-    await postgresql_client.execute(query, [data.AUTOSTART_AGENT_MAP], "{}")
-
-    # Assert internal agent not in autostart_agent_map
-    env = await data.Environment.get_by_id(UUID(environment))
-    autostart_agent_map = await env.get(data.AUTOSTART_AGENT_MAP)
-    assert "internal" not in autostart_agent_map
-
-    # Start autostarted agent1
-    autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
-    await autostarted_agent_manager._ensure_agents(env=env, agents=["agent1"])
-
-    # Verify patch on autostart_agent_map
-    env = await data.Environment.get_by_id(UUID(environment))
-    autostart_agent_map = await env.get(data.AUTOSTART_AGENT_MAP)
-    assert "internal" in autostart_agent_map
-
-
 async def test_error_handling_agent_fork(server, environment, monkeypatch):
     """
     Verifies resolution of issue: inmanta/inmanta-core#2777


### PR DESCRIPTION
# Description

This PR removes the code from the AutostartedAgentManager that ensures that the internal agent is present in the `autostarted_agent_map`. The code is removed because it performs a read-modify-write operation in a non-atomic way, that causes a race condition when the tests perform a call to update the `autostart_agent_map` setting.

The code to ensure that internal agent is present in the `autostart_agent_map` was introduced in [this PR](https://github.com/inmanta/inmanta-core/pull/2103),  because in an old version of the server there wasn't a validator on the update path of the setting that verified this. A [validator](https://github.com/inmanta/inmanta-core/blob/db32611489e71e1064d1c60df7b963200fd31114/src/inmanta/data/__init__.py#L2280) that perform this check was introduced in Apr 21, 2020, so before the initial release of ISO4. As such, we can safely remove this code now.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
