### PR TITLE
Bump types-python-dateutil from 2.8.19.10 to 2.8.19.11 (#5761)

### DIFF
--- a/changelogs/unreleased/5761-dependabot.yml
+++ b/changelogs/unreleased/5761-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump types-python-dateutil from 2.8.19.10 to 2.8.19.11
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,7 +4,7 @@ openapi_spec_validator==0.5.6
 pip2pi==0.8.2
 sphinxcontrib-contentui==0.2.5
 types-PyYAML==6.0.12.8
-types-python-dateutil==2.8.19.10
+types-python-dateutil==2.8.19.11
 types-setuptools==67.6.0.5
 types-toml==0.10.8.5
 flake8-junit-report==2.1.0


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5761