### PR TITLE
Produce no warning about download path if it is not used

### DIFF
--- a/changelogs/unreleased/5507-download-path.yml
+++ b/changelogs/unreleased/5507-download-path.yml
@@ -1,0 +1,6 @@
+description: Produce no warning about download path if it is not used
+issue-nr: 5507
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -960,7 +960,7 @@ class ModuleRepo:
 
     def is_empty(self) -> bool:
         """
-        return true of this repo will never produce any repo
+        Return true if this repo will never produce any repo.
 
         Used to distinguish an empty compose repo from a non-empty one
         """

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -21,6 +21,7 @@ import enum
 import glob
 import importlib
 import logging
+import operator
 import os
 import re
 import subprocess
@@ -34,6 +35,7 @@ from abc import ABC, abstractmethod
 from collections import abc, defaultdict
 from configparser import ConfigParser
 from dataclasses import dataclass
+from functools import reduce
 from importlib.abc import Loader
 from io import BytesIO, TextIOBase
 from itertools import chain
@@ -956,6 +958,14 @@ class ModuleRepo:
         # same class is used for search path and remote repos, perhaps not optimal
         raise NotImplementedError("Abstract method")
 
+    def is_empty(self) -> bool:
+        """
+        return true of this repo will never produce any repo
+
+        Used to distinguish an empty compose repo from a non-empty one
+        """
+        return False
+
 
 class CompositeModuleRepo(ModuleRepo):
     def __init__(self, children: List[ModuleRepo]) -> None:
@@ -973,6 +983,9 @@ class CompositeModuleRepo(ModuleRepo):
             if result is not None:
                 return result
         return None
+
+    def is_empty(self) -> bool:
+        return reduce(operator.and_, (child.is_empty() for child in self.children), True)
 
 
 class LocalFileRepo(ModuleRepo):
@@ -996,6 +1009,10 @@ class LocalFileRepo(ModuleRepo):
             return path
         return None
 
+    def is_empty(self) -> bool:
+        # May have or receive items
+        return False
+
 
 class RemoteRepo(ModuleRepo):
     def __init__(self, baseurl: str) -> None:
@@ -1016,6 +1033,10 @@ class RemoteRepo(ModuleRepo):
 
     def path_for(self, name: str) -> Optional[str]:
         raise NotImplementedError("Should only be called on local repos")
+
+    def is_empty(self) -> bool:
+        # May have or receive items
+        return False
 
 
 def make_repo(path: str, root: Optional[str] = None) -> Union[LocalFileRepo, RemoteRepo]:
@@ -1900,13 +1921,15 @@ class Project(ModuleLike[ProjectMetadata], ModuleLikeWithYmlMetadataFile):
             ),
         )
 
-        if self._metadata.downloadpath is not None:
-            self._metadata.downloadpath = os.path.abspath(os.path.join(path, self._metadata.downloadpath))
-            if self._metadata.downloadpath not in self._metadata.modulepath:
-                LOGGER.warning("Downloadpath is not in module path! Module install will not work as expected")
+        if not self.module_source_v1.remote_repo.is_empty():
+            # This is only relevant if we have a V1 module source
+            if self._metadata.downloadpath is not None:
+                self._metadata.downloadpath = os.path.abspath(os.path.join(path, self._metadata.downloadpath))
+                if self._metadata.downloadpath not in self._metadata.modulepath:
+                    LOGGER.warning("Downloadpath is not in module path! Module install will not work as expected")
 
-            if not os.path.exists(self._metadata.downloadpath):
-                os.mkdir(self._metadata.downloadpath)
+                if not os.path.exists(self._metadata.downloadpath):
+                    os.mkdir(self._metadata.downloadpath)
 
         self.virtualenv: env.ActiveEnv
         if venv_path is None:

--- a/tests/moduletool/test_repos.py
+++ b/tests/moduletool/test_repos.py
@@ -20,7 +20,7 @@ import subprocess
 
 import pytest
 
-from inmanta.module import InvalidMetadata, LocalFileRepo, RemoteRepo, UntrackedFilesMode, gitprovider
+from inmanta.module import CompositeModuleRepo, InvalidMetadata, LocalFileRepo, RemoteRepo, UntrackedFilesMode, gitprovider
 
 
 def test_file_co(git_modules_dir, modules_repo):
@@ -54,6 +54,7 @@ def test_remote_repo_good2(tmpdir, modules_repo):
     result = repo.clone("test-repository", coroot)
     assert result
     assert os.path.exists(os.path.join(coroot, "test-repository", "README"))
+    assert not repo.is_empty()
 
 
 def test_remote_repo_bad(tmpdir, modules_repo):
@@ -64,6 +65,7 @@ def test_remote_repo_bad(tmpdir, modules_repo):
         assert not result
     msg = e.value.msg
     assert msg == "Wrong repo path at https://github.com/{}/{} : should only contain at most one {} pair"
+    assert not repo.is_empty()
 
 
 def test_local_repo_bad(tmpdir, modules_repo):
@@ -147,3 +149,19 @@ def test_commit_raise_exc_when_nothing_to_commit(tmpdir, modules_repo: str) -> N
     assert "" != gitprovider.status(repo=git_repo_clone)
     gitprovider.commit(repo=git_repo_clone, message="test", commit_all=True, raise_exc_when_nothing_to_commit=False)
     assert "" != gitprovider.status(repo=git_repo_clone)
+
+
+def test_composite_repo_empty():
+    repo = LocalFileRepo("test")
+
+    empty = CompositeModuleRepo([])
+    assert empty.is_empty()
+
+    also_empty = CompositeModuleRepo([empty])
+    assert also_empty.is_empty()
+
+    composed = CompositeModuleRepo([repo])
+    assert not composed.is_empty()
+
+    composed = CompositeModuleRepo([repo, empty])
+    assert not composed.is_empty()

--- a/tests/test_projectmetadata.py
+++ b/tests/test_projectmetadata.py
@@ -15,11 +15,13 @@
 
     Contact: code@inmanta.com
 """
+import logging
 from typing import List, Optional
 
 import pytest
 
-from inmanta.module import ModuleRepoType, ProjectMetadata, RelationPrecedenceRule
+from inmanta.module import ModuleRepoType, Project, ProjectMetadata, RelationPrecedenceRule
+from utils import assert_no_warning
 
 
 @pytest.mark.parametrize(
@@ -79,3 +81,20 @@ def test_relation_precedence_policy_parsing(
     else:
         with pytest.raises(ValueError):
             ProjectMetadata(name="test", relation_precedence_policy=[precedence_rule])
+
+
+def test_no_module_path(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING):
+        with (tmp_path / "project.yml").open("w") as fh:
+            fh.write(
+                """
+    name: testproject
+    downloadpath: libs
+    repo:
+        - url: https://pypi.org/simple
+          type: package
+    """
+            )
+
+        Project(tmp_path, autostd=False)
+    assert_no_warning(caplog)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -237,7 +237,7 @@ def assert_no_warning(caplog, loggers_to_allow: list[str] = NOISY_LOGGERS):
     Assert there are no warning, except from the list of loggers to allow
     """
     for record in caplog.records:
-        assert record.levelname != "WARNING" or (record.name in loggers_to_allow)
+        assert record.levelname != "WARNING" or (record.name in loggers_to_allow), record
 
 
 def configure(unused_tcp_port, database_name, database_port):


### PR DESCRIPTION
# Description

Produce no warning about download path if it is not used

closes #5507 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
