### PR TITLE
Ensure proper agent shutdown in testcases

### DIFF
--- a/changelogs/unreleased/5607-agent-shutdown.yml
+++ b/changelogs/unreleased/5607-agent-shutdown.yml
@@ -1,0 +1,5 @@
+description: Ensure complete agent shutdown in testcases
+issue-nr: 5607
+change-type: patch
+destination-branches: [master, iso6, iso5]
+

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -704,7 +704,18 @@ class nullcontext(contextlib.nullcontext[T], contextlib.AbstractAsyncContextMana
 
 
 async def join_threadpools(threadpools: List[ThreadPoolExecutor]) -> None:
-    # idea borrowed from BaseEventLoop.shutdown_default_executor
+    """
+    Asynchronously join a set of threadpools
+
+    idea borrowed from BaseEventLoop.shutdown_default_executor
+
+    We implemented this method because:
+    1. ThreadPoolExecutor.shutdown(wait=True)` is a blocking call, blocking the ioloop.
+       This doesn't work because we often have back-and-forth between the ioloop and the thread
+       due to our `ResourceHandler.run_sync` method.
+    2.The python sdk has no support for async awaiting threadpool shutdown (except for the default pool)
+    """
+
     loop = asyncio.get_event_loop()
     future = loop.create_future()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -505,6 +505,7 @@ async def test_threadpool_join():
     hanglock = Event()
     done = Queue()
 
+    eventloop = asyncio.get_event_loop()
     async def cor():
         await asyncio.sleep(0.02)
 
@@ -514,7 +515,7 @@ async def test_threadpool_join():
         hanglock.wait()
         print("S1", flush=True)
         # hang on ioloop
-        block = asyncio.get_event_loop().call_soon_threadsafe(cor)
+        block = asyncio.run_coroutine_threadsafe(cor(), loop=eventloop)
         block.result()
         done.put("A")
         print("DONE", flush=True)
@@ -527,7 +528,6 @@ async def test_threadpool_join():
     hanglock.set()
     assert done.qsize() == 0
     await join_threadpool(tp)
-    await asyncio.sleep(10)
     # verify we are done
     tp.shutdown(wait=True)
     assert done.qsize() == 5


### PR DESCRIPTION
# Description

Ensure proper agent shutdown in testcases

closes #5783

The essential issue here was that there is no way to asynchronously join a threadpool 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
