### PR TITLE
Added documentation regarding inter-resource set dependency constraints

### DIFF
--- a/changelogs/unreleased/5679-doc-inter-resource-set-deps.yml
+++ b/changelogs/unreleased/5679-doc-inter-resource-set-deps.yml
@@ -1,0 +1,8 @@
+---
+description: Added diagrams to the documentation that explain the limitations regarding inter-resource set dependencies when partial compiles are enabled.
+issue-nr: 5679
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  minor-improvement: "{{description}}"

--- a/docs/model_developers/resource_sets.rst
+++ b/docs/model_developers/resource_sets.rst
@@ -483,10 +483,12 @@ Inter-resource set dependencies
 -------------------------------
 
 Resources within a resource set can only depend on resources within the same resource set or on shared resources.
-The diagram below provides an example where the resource dependency graph satisfies this requirement.
+Shared resources on the other hand can have dependencies on any resource in the model. The diagram below provides
+an example where the resource dependency graph satisfies these requirements. The arrows in the diagram show the
+requires relationship between entities/resources.
 
 .. digraph:: resource_sets_example_valid_dependencies
-    :caption: Two resource sets satisfying the dependency constraint
+    :caption: Two resource sets satisfying the dependency constraints
 
     subgraph cluster_shared {
         AgentConfig;
@@ -528,7 +530,7 @@ The diagram below provides an example where the resource dependency graph satisf
 In the diagram below, resource ``Host(id=269)`` that belongs to resource set 0 depends on resource ``Host(id=31)`` that belongs to resource set 1. This inter-resource set dependency is not allowed.
 
 .. digraph:: resource_sets_example_invalid_dependencies
-    :caption: Two resource sets violating the dependency constraint
+    :caption: Two resource sets violating the dependency constraints
 
     subgraph cluster_shared {
         AgentConfig;

--- a/docs/model_developers/resource_sets.rst
+++ b/docs/model_developers/resource_sets.rst
@@ -84,8 +84,7 @@ When using partial compiles, the following rules have to be followed:
 * Resources cannot be migrated using a partial compile to a different resource set. A full compile is necessary for this process.
 * A resource set that is contained in a partial export must be complete, meaning that all of its resources must be present.
 * Resources that weren't assigned to a specific resource set can never be updated or removed by a partial build. Although, adding resources is allowed.
-* The new version of the model that emerges from a partial compilation should have a dependency graph that is closed within the resource sets that were exported.
-  i.e., it should not depend on any resource sets other than those that were exported.
+* Resources within a resource set cannot depend on resources in another resource set. Dependencies on shared resources are allowed.
 * Multiple resource sets may be updated simultaneously via a partial build.
 
 For a guide on how to design a model in order to take these into account, see `Modeling guidelines`_.
@@ -478,6 +477,96 @@ behavior because the allocator guarantees uniqueness for the host id:
 
     # force rendering on multiple ranks
     {"Host(id=694)" "Host(id=269)" "Host(id=712)" "Host(id=31)"} -> "AgentConfig";
+
+
+Inter-resource set dependencies
+-------------------------------
+
+Resources within a resource set can only depend on resources within the same resource set or on shared resources.
+The diagram below provides an example where the resource dependency graph satisfies this requirement.
+
+.. digraph:: resource_sets_example_valid_dependencies
+    :caption: Two resource sets satisfying the dependency constraint
+
+    subgraph cluster_shared {
+        AgentConfig;
+        color = "green";
+        fontcolor = "grey";
+        label = "Shared resources";
+        labelloc = "bottom";
+    }
+
+    subgraph cluster_service0 {
+        "Network(id=0)" [shape=rectangle];
+        "Network(id=0)" -> subgraph cluster_resources0 {
+            "Host(id=269)";
+            color = "grey";
+            fontcolor = "grey";
+            label = "Resource set 0";
+            labelloc = "bottom";
+        }
+        color = "green";
+        label = "service 0";
+        labelloc = "top";
+    }
+    subgraph cluster_service1 {
+        "Network(id=1)" [shape=rectangle];
+        "Network(id=1)" -> subgraph cluster_resources1 {
+            "Host(id=31)";
+            color = "grey";
+            fontcolor = "grey";
+            label = "Resource set 1";
+            labelloc = "bottom";
+        }
+        color = "green";
+        label = "service 1";
+        labelloc = "top";
+    }
+
+    {"Host(id=269)" "Host(id=31)"} -> "AgentConfig";
+
+In the diagram below, resource ``Host(id=269)`` that belongs to resource set 0 depends on resource ``Host(id=31)`` that belongs to resource set 1. This inter-resource set dependency is not allowed.
+
+.. digraph:: resource_sets_example_invalid_dependencies
+    :caption: Two resource sets violating the dependency constraint
+
+    subgraph cluster_shared {
+        AgentConfig;
+        color = "green";
+        fontcolor = "grey";
+        label = "Shared resources";
+        labelloc = "bottom";
+    }
+
+    subgraph cluster_service0 {
+        "Network(id=0)" [shape=rectangle];
+        "Network(id=0)" -> subgraph cluster_resources0 {
+            "Host(id=269)";
+            color = "grey";
+            fontcolor = "grey";
+            label = "Resource set 0";
+            labelloc = "bottom";
+        }
+        color = "green";
+        label = "service 0";
+        labelloc = "top";
+    }
+    subgraph cluster_service1 {
+        "Network(id=1)" [shape=rectangle];
+        "Network(id=1)" -> subgraph cluster_resources1 {
+            "Host(id=31)";
+            color = "grey";
+            fontcolor = "grey";
+            label = "Resource set 1";
+            labelloc = "bottom";
+        }
+        color = "green";
+        label = "service 1";
+        labelloc = "top";
+    }
+
+    {"Host(id=269)" "Host(id=31)"} -> "AgentConfig";
+    {"Host(id=269)"} -> "Host(id=31)" [color=red];
 
 
 Testing


### PR DESCRIPTION
# Description

Added diagrams to the documentation that explain the limitations regarding inter-resource set dependencies when partial compiles are enabled.

closes #5679

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
