### PR TITLE
Issue/5790 type inference uses is subclass in wrong direction

### DIFF
--- a/changelogs/unreleased/fix-type-inference-using-is-subclass-in-wrong-direction.yml
+++ b/changelogs/unreleased/fix-type-inference-using-is-subclass-in-wrong-direction.yml
@@ -1,0 +1,3 @@
+description: Type inference uses is_subclass in wrong direction
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -304,7 +304,7 @@ class Entity(NamedType, WithComment):
 
     def is_subclass(self, subclass_candidate: "Entity") -> bool:
         """
-        Check if the given sub_class_candidate entity is a subclass of this class.
+        Check if the given subclass_candidate entity is a subclass of this class.
         Does not consider entities a subclass of themselves.
         """
         return subclass_candidate.is_parent(self)

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -186,15 +186,15 @@ class Entity(NamedType, WithComment):
 
     attributes: "Dict[str,Attribute]" = property(get_attributes, set_attributes, None, None)
 
-    def is_parent(self, entity: "Entity") -> bool:
+    def is_parent(self, parent_candidate: "Entity") -> bool:
         """
-        Check if the given entity is a parent of this entity. Does not consider an entity its own parent.
+        Check if the given parent_candidate entity is a parent of this entity. Does not consider an entity its own parent.
         """
-        if entity in self.parent_entities:
+        if parent_candidate in self.parent_entities:
             return True
         else:
             for parent in self.parent_entities:
-                if parent.is_parent(entity):
+                if parent.is_parent(parent_candidate):
                     return True
         return False
 
@@ -302,11 +302,12 @@ class Entity(NamedType, WithComment):
         self.add_instance(out)
         return out
 
-    def is_subclass(self, cls: "Entity") -> bool:
+    def is_subclass(self, sub_class_candidate: "Entity") -> bool:
         """
-        Is the given class a subclass of this class. Does not consider entities a subclass of themselves.
+        Check if the given sub_class_candidate entity is a subclass of this class.
+        Does not consider entities a subclass of themselves.
         """
-        return cls.is_parent(self)
+        return sub_class_candidate.is_parent(self)
 
     def validate(self, value: object) -> bool:
         """

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -302,12 +302,12 @@ class Entity(NamedType, WithComment):
         self.add_instance(out)
         return out
 
-    def is_subclass(self, sub_class_candidate: "Entity") -> bool:
+    def is_subclass(self, subclass_candidate: "Entity") -> bool:
         """
         Check if the given sub_class_candidate entity is a subclass of this class.
         Does not consider entities a subclass of themselves.
         """
-        return sub_class_candidate.is_parent(self)
+        return subclass_candidate.is_parent(self)
 
     def validate(self, value: object) -> bool:
         """

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -613,7 +613,7 @@ class Constructor(ExpressionStatement):
                     f"Can not assign a value of type {self.class_type} "
                     f"to a variable of type {str(lhs_attribute.type_hint)}",
                 )
-            elif local_type is not None and local_type.is_subclass(type_hint):
+            elif local_type is not None and local_type.is_parent(type_hint):
                 # we have a local match, use that to prevent breaking existing code
                 return local_type
             elif "::" not in str(self.class_type):
@@ -738,7 +738,7 @@ class Constructor(ExpressionStatement):
             if (
                 inverse is not None
                 and inverse.name not in self._direct_attributes
-                # in case of a double set, prefer kwargs: double set will be raised when the bidirictional relation is set by
+                # in case of a double set, prefer kwargs: double set will be raised when the bidirectional relation is set by
                 # the LHS
                 and inverse.name not in kwarg_attrs
                 and inverse.name in chain.from_iterable(type_class.get_indices())

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -165,12 +165,3 @@ n = a.b.n
     (_, scopes) = compiler.do_compile()
     root = scopes.get_child("__config__")
     assert 1 == root.lookup("n").get_value()
-
-
-# mymod:
-
-
-# main.cf
-
-# assert
-# n = 1

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -140,3 +140,37 @@ implement A using std::none
         """,
         "Can not assign a value of type A to a variable of type int (reported in Construct(A) ({dir}/main.cf:8))",
     )
+
+
+def test_type_inference_is_subclass_right_direction_5790(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import test_5790
+
+entity A extends test_5790::A:
+end
+
+entity B extends test_5790::B:
+    int n = 1
+end
+
+implement A using std::none
+implement B using std::none
+
+
+a = A(b=B())
+n = a.b.n
+        """,
+    )
+    (_, scopes) = compiler.do_compile()
+    root = scopes.get_child("__config__")
+    assert 1 == root.lookup("n").get_value()
+
+
+# mymod:
+
+
+# main.cf
+
+# assert
+# n = 1

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -83,29 +83,6 @@ implement A using std::none
     (_, scopes) = compiler.do_compile()
 
 
-def test_advanced_type_hint_name_collision(snippetcompiler):
-    snippetcompiler.setup_for_error(
-        """
-import elaboratev1module
-
-entity A extends elaboratev1module::A:
-
-end
-
-A.ref [1] -- elaboratev1module::A
-
-A(ref=A())
-
-implement elaboratev1module::A using std::none
-implement A using std::none
-
-        """,
-        "Could not determine namespace for type A. 2 possible candidates exists: [__config__::A, elaboratev1module::A]. "
-        "To resolve this, use the fully qualified name instead of the short name. "
-        "(reported in Construct(A) ({dir}/main.cf:10:7))",
-    )
-
-
 def test_basic_type_hint_attribute_collision(snippetcompiler):
     snippetcompiler.setup_for_error(
         """

--- a/tests/data/modules/test_5790/model/_init.cf
+++ b/tests/data/modules/test_5790/model/_init.cf
@@ -1,0 +1,8 @@
+entity A:
+end
+
+entity B:
+    int n = 0
+end
+
+A.b [1] -- B

--- a/tests/data/modules/test_5790/module.yml
+++ b/tests/data/modules/test_5790/module.yml
@@ -1,0 +1,3 @@
+name: test_5790
+license: Apache 2.0
+version: 1.0


### PR DESCRIPTION
# Description


closes https://github.com/inmanta/inmanta-core/issues/5790

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
