### PR TITLE
constructor namespace inference: always prefer local types

### DIFF
--- a/changelogs/unreleased/type-hint-fix.yml
+++ b/changelogs/unreleased/type-hint-fix.yml
@@ -1,0 +1,5 @@
+description: Changed the behavior of constructor namespace inference to always prefer local types
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -302,12 +302,14 @@ class Entity(NamedType, WithComment):
         self.add_instance(out)
         return out
 
-    def is_subclass(self, subclass_candidate: "Entity") -> bool:
+    def is_subclass(self, subclass_candidate: "Entity", *, strict: bool = True) -> bool:
         """
         Check if the given subclass_candidate entity is a subclass of this class.
-        Does not consider entities a subclass of themselves.
+        Does not consider entities a subclass of themselves in strict mode (the default).
+
+        :param strict: Only return True for entities that are a strict subtype, i.e. not of the same type.
         """
-        return subclass_candidate.is_parent(self)
+        return not strict and subclass_candidate == self or subclass_candidate.is_parent(self)
 
     def validate(self, value: object) -> bool:
         """

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -309,7 +309,7 @@ class Entity(NamedType, WithComment):
 
         :param strict: Only return True for entities that are a strict subtype, i.e. not of the same type.
         """
-        return not strict and subclass_candidate == self or subclass_candidate.is_parent(self)
+        return (not strict and subclass_candidate == self) or subclass_candidate.is_parent(self)
 
     def validate(self, value: object) -> bool:
         """

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -615,7 +615,7 @@ class Constructor(ExpressionStatement):
                 )
             elif local_type is not None:
                 # always prefer local type, raise an exception if it is of an incorrect type
-                if not local_type.is_parent(type_hint):
+                if not type_hint.is_subclass(local_type, strict=False):
                     raise TypingException(
                         self,
                         f"Can not assign a value of type {str(local_type)} "

--- a/tests/compiler/test_type_hinting.py
+++ b/tests/compiler/test_type_hinting.py
@@ -63,7 +63,10 @@ implement One using std::none
 
 
 def test_basic_type_hint_name_collision(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
+    """
+    Verify that local types are preferred, even if they do not match the type, resulting in an appropriate exception.
+    """
+    snippetcompiler.setup_for_error(
         """
 import elaboratev1module
 
@@ -79,8 +82,11 @@ implement elaboratev1module::A using std::none
 implement A using std::none
 
         """,
+        (
+            "Can not assign a value of type __config__::A to a variable of type elaboratev1module::A"
+            " (reported in Construct(A) ({dir}/main.cf:10))"
+        ),
     )
-    (_, scopes) = compiler.do_compile()
 
 
 def test_basic_type_hint_attribute_collision(snippetcompiler):


### PR DESCRIPTION
# Description

Changes the behavior of constructor namespace inference to always prefer local types even if it is of an incorrect type for the relation. (See [Slack](https://inmanta.slack.com/archives/CKRF0C8R3/p1680612216840569?thread_ts=1680592889.609999&cid=CKRF0C8R3))

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
