### PR TITLE
Bump types-python-dateutil from 2.8.19.11 to 2.8.19.12 (#5806)

### DIFF
--- a/changelogs/unreleased/5806-dependabot.yml
+++ b/changelogs/unreleased/5806-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump types-python-dateutil from 2.8.19.11 to 2.8.19.12
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,7 +4,7 @@ openapi_spec_validator==0.5.6
 pip2pi==0.8.2
 sphinxcontrib-contentui==0.2.5
 types-PyYAML==6.0.12.9
-types-python-dateutil==2.8.19.11
+types-python-dateutil==2.8.19.12
 types-setuptools==67.6.0.7
 types-toml==0.10.8.6
 flake8-junit-report==2.1.0


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5806