### PR TITLE
Fix bug reporting incorrectly length compile queue

### DIFF
--- a/changelogs/unreleased/fix-task-queue-calculation.yml
+++ b/changelogs/unreleased/fix-task-queue-calculation.yml
@@ -1,0 +1,7 @@
+---
+description: Fix bug that causes the `/serverstatus` endpoint to report an incorrect length of the compiler queue.
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-task-queue-calculation.yml
+++ b/changelogs/unreleased/fix-task-queue-calculation.yml
@@ -1,6 +1,5 @@
 ---
 description: Fix bug that causes the `/serverstatus` endpoint to report an incorrect length of the compiler queue.
-issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso6, iso5]
 sections:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3611,11 +3611,11 @@ class Compile(BaseDocument):
         """
         Return the total length of all the compile queues on the Inmanta server.
 
-        :param exclude_started_compiles: True iff don't count compiles started running, but are not finished yet.
+        :param exclude_started_compiles: True iff don't count compiles that started running, but are not finished yet.
         """
         query = f"SELECT count(*) FROM {cls.table_name()} WHERE completed IS NULL"
         if exclude_started_compiles:
-            query += " AND started IS NOT NULL"
+            query += " AND started IS NULL"
         return await cls._fetch_int(query)
 
     @classmethod

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -27,7 +27,6 @@ import traceback
 import uuid
 from asyncio import CancelledError, Task
 from asyncio.subprocess import Process
-from collections import defaultdict
 from collections.abc import Mapping
 from functools import partial
 from itertools import chain
@@ -49,9 +48,9 @@ from inmanta.protocol import encode_token, methods, methods_v2
 from inmanta.protocol.common import ReturnValue
 from inmanta.protocol.exceptions import BadRequest, NotFound
 from inmanta.server import SLICE_COMPILER, SLICE_DATABASE, SLICE_ENVIRONMENT, SLICE_SERVER, SLICE_TRANSPORT
-from inmanta.server.services import environmentservice
 from inmanta.server import config as opt
 from inmanta.server.protocol import ServerSlice
+from inmanta.server.services import environmentservice
 from inmanta.server.validate_filter import InvalidFilter
 from inmanta.types import Apireturn, ArgumentTypes, JsonType, Warnings
 from inmanta.util import TaskMethod, ensure_directory_exist
@@ -912,4 +911,3 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
     async def recalculate_queue_count_cache(self) -> None:
         async with self._queue_count_cache_lock:
             self._queue_count_cache = await data.Compile.get_total_length_of_all_compile_queues()
-

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -885,11 +885,11 @@ class CompilerService(ServerSlice):
             raise NotFound("The compile with the given id does not exist.")
         return details
 
-    def reset_compile_queue_counter_for(self, env: model.Environment) -> None:
+    def reset_compile_queue_counter_for(self, env_id: uuid.UUID) -> None:
         """
         Will be called when the environment is cleared or deleted.
 
         :param env: The environment that is cleared
         """
-        if env.id in self._queue_count_cache:
-            del self._queue_count_cache[env.id]
+        if env_id in self._queue_count_cache:
+            del self._queue_count_cache[env_id]

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -504,7 +504,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         self._global_lock = asyncio.locks.Lock()
         self.listeners: List[CompileStateListener] = []
         self._scheduled_full_compiles: Dict[uuid.UUID, Tuple[TaskMethod, str]] = {}
-        # In-memory cache to keep track of the total length of the compile queue.
+        # In-memory cache to keep track of the total length of all the compile queues on this Inmanta server.
         # This cache is used by the /serverstatus endpoint.
         self._queue_count_cache: int = 0
         self._queue_count_cache_lock = asyncio.locks.Lock()

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -27,8 +27,8 @@ import traceback
 import uuid
 from asyncio import CancelledError, Task
 from asyncio.subprocess import Process
-from collections.abc import Mapping
 from collections import defaultdict
+from collections.abc import Mapping
 from functools import partial
 from itertools import chain
 from logging import Logger

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -486,6 +486,7 @@ class EnvironmentService(protocol.ServerSlice):
 
         self.resource_service.close_resource_action_logger(environment_id)
         await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
+        self.compiler_service.reset_compile_queue_counter_for(env)
 
     @handle(methods_v2.environment_decommission, env="id")
     async def environment_decommission(self, env: data.Environment, metadata: Optional[model.ModelMetadata]) -> int:
@@ -512,6 +513,7 @@ class EnvironmentService(protocol.ServerSlice):
         await env.delete_cascade(only_content=True)
 
         await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
+        self.compiler_service.reset_compile_queue_counter_for(env)
 
         project_dir = os.path.join(self.server_slice._server_storage["environments"], str(env.id))
         if os.path.exists(project_dir):

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -486,7 +486,7 @@ class EnvironmentService(protocol.ServerSlice):
 
         self.resource_service.close_resource_action_logger(environment_id)
         await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
-        self.compiler_service.reset_compile_queue_counter_for(env)
+        self.compiler_service.reset_compile_queue_counter_for(env.id)
 
     @handle(methods_v2.environment_decommission, env="id")
     async def environment_decommission(self, env: data.Environment, metadata: Optional[model.ModelMetadata]) -> int:
@@ -513,7 +513,7 @@ class EnvironmentService(protocol.ServerSlice):
         await env.delete_cascade(only_content=True)
 
         await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
-        self.compiler_service.reset_compile_queue_counter_for(env)
+        self.compiler_service.reset_compile_queue_counter_for(env.id)
 
         project_dir = os.path.join(self.server_slice._server_storage["environments"], str(env.id))
         if os.path.exists(project_dir):

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -150,6 +150,8 @@ class EnvironmentService(protocol.ServerSlice):
         self.compiler_service = cast(compilerservice.CompilerService, server.get_slice(SLICE_COMPILER))
         self.orchestration_service = cast(OrchestrationService, server.get_slice(SLICE_ORCHESTRATION))
         self.resource_service = cast(ResourceService, server.get_slice(SLICE_RESOURCE))
+        # Register the compiler service here to the environment service listener. Registering it within the compiler service
+        # would result in a circular dependency between the environment slice and the compiler service slice.
         self.register_listener_for_multiple_actions(
             self.compiler_service, {EnvironmentAction.cleared, EnvironmentAction.deleted}
         )

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1493,7 +1493,7 @@ async def test_status_compilerservice_task_queue(
     assert await get_length_compiler_queue_from_status_endpoint() == 0
 
     # Add element to compile queue
-    compile_id, _ = await compilerservice.request_recompile(env, force_update=True, do_export=False, remote_id=uuid.uuid4())
+    compile_id, _ = await compilerservice.request_recompile(env, force_update=False, do_export=False, remote_id=uuid.uuid4())
     assert await get_length_compiler_queue_from_status_endpoint() == 1
 
     # Action on environment that empties the compile queue


### PR DESCRIPTION
# Description

Fix bug that causes the `/serverstatus` endpoint to report an incorrect length of the compiler queue.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
