### PR TITLE
Make status endpoint less fragile to timeouts

### DIFF
--- a/changelogs/unreleased/status_endpoint_timeout.yml
+++ b/changelogs/unreleased/status_endpoint_timeout.yml
@@ -1,0 +1,6 @@
+description: Ensure status endpoint returns after 100ms
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"
+

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -133,7 +133,12 @@ class Server(protocol.ServerSlice):
             try:
                 return SliceStatus(name=slice_name, status=await asyncio.wait_for(slice.get_status(), 0.1))
             except TimeoutError:
-                return SliceStatus(name=slice_name, status={"error": f"timeout on data collection for {slice_name}, consult the server log for additional information"})
+                return SliceStatus(
+                    name=slice_name,
+                    status={
+                        "error": f"timeout on data collection for {slice_name}, consult the server log for additional information"
+                    },
+                )
             except Exception:
                 LOGGER.error(
                     f"The following error occured while trying to determine the status of slice {slice_name}",

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -136,7 +136,8 @@ class Server(protocol.ServerSlice):
                 return SliceStatus(
                     name=slice_name,
                     status={
-                        "error": f"timeout on data collection for {slice_name}, consult the server log for additional information"
+                        "error": f"timeout on data collection for {slice_name}, "
+                        "consult the server log for additional information"
                     },
                 )
             except Exception:

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import asyncio
 import json
 import logging
 import os
@@ -128,15 +129,21 @@ class Server(protocol.ServerSlice):
                 "Is inmanta installed? Use setuptools install or setuptools dev to install."
             )
 
-        slices = []
-        for slice_name, slice in self._server.get_slices().items():
+        async def collect_for_slice(slice_name: str, slice: protocol.ServerSlice) -> SliceStatus:
             try:
-                slices.append(SliceStatus(name=slice_name, status=await slice.get_status()))
+                return SliceStatus(name=slice_name, status=await asyncio.wait_for(slice.get_status(), 0.1))
+            except TimeoutError:
+                return SliceStatus(name=slice_name, status={"error": "timeout after 100ms"})
             except Exception:
                 LOGGER.error(
                     f"The following error occured while trying to determine the status of slice {slice_name}",
                     exc_info=True,
                 )
+                return SliceStatus(name=slice_name, status={"error": "An unexpected error occurred, reported to server log"})
+
+        slices = await asyncio.gather(
+            *(collect_for_slice(slice_name, slice) for slice_name, slice in self._server.get_slices().items())
+        )
 
         response = StatusResponse(
             product=product_metadata.product,

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -133,7 +133,7 @@ class Server(protocol.ServerSlice):
             try:
                 return SliceStatus(name=slice_name, status=await asyncio.wait_for(slice.get_status(), 0.1))
             except TimeoutError:
-                return SliceStatus(name=slice_name, status={"error": "timeout after 100ms"})
+                return SliceStatus(name=slice_name, status={"error": f"timeout on data collection for {slice_name}, consult the server log for additional information"})
             except Exception:
                 LOGGER.error(
                     f"The following error occured while trying to determine the status of slice {slice_name}",

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -116,7 +116,7 @@ class DatabaseService(protocol.ServerSlice):
     async def get_connection_status(self) -> bool:
         if self._pool is not None and not self._pool._closing and not self._pool._closed:
             try:
-                async with self._pool.acquire(timeout=10):
+                async with self._pool.acquire(timeout=5):
                     return True
             except Exception:
                 LOGGER.exception("Connection to PostgreSQL failed")

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -116,7 +116,7 @@ class DatabaseService(protocol.ServerSlice):
     async def get_connection_status(self) -> bool:
         if self._pool is not None and not self._pool._closing and not self._pool._closed:
             try:
-                async with self._pool.acquire(timeout=5):
+                async with self._pool.acquire(timeout=10):
                     return True
             except Exception:
                 LOGGER.exception("Connection to PostgreSQL failed")


### PR DESCRIPTION
# Description
Make status endpoint less fragile to timeouts
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
