### PR TITLE
added assertion for better visibility on flaky test

### DIFF
--- a/changelogs/unreleased/test-failure-visibility.yml
+++ b/changelogs/unreleased/test-failure-visibility.yml
@@ -1,0 +1,7 @@
+description: Added assertion for better visibility on flaky test
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5
+  - iso4

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -146,6 +146,7 @@ async def test_2way_protocol(unused_tcp_port, no_tid_check, postgres_db, databas
 async def check_sessions(sessions):
     for s in sessions:
         a = await s.client.get_agent_status_x("X")
+        assert a.code == 200, a.result
         result = a.get_result()
         assert result["status"] == "ok", result
 


### PR DESCRIPTION
This test failed tonight but I can't seem to reproduce it. Since there is not sufficient data to really investigate I added an initial assertion that should cover the same case and fail with a better message.