### PR TITLE
added iso6 to dependabot config after branch divergence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
   allow:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
+- target-branch: iso6
+  package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  allow:
+    # Allow both direct and indirect updates for all packages
+    - dependency-type: "all"

--- a/changelogs/unreleased/dependabot-divergence.yml
+++ b/changelogs/unreleased/dependabot-divergence.yml
@@ -1,0 +1,4 @@
+description: Added iso6 to dependabot config after divergence
+change-type: patch
+destination-branches:
+  - master


### PR DESCRIPTION
See [internal docs](https://internal.inmanta.com/general/general-how-to/dependabot.html#when-to-update).