### PR TITLE
Fix bug in resource action cleanup job

### DIFF
--- a/changelogs/unreleased/bugfix-resource-action-cleanup.yml
+++ b/changelogs/unreleased/bugfix-resource-action-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 description: Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the most restrictive value of the `resource_action_logs_retention` setting across all environments was applied on all environments.
 change-type: patch
-destination-branches: [master, iso6]
+destination-branches: [master, iso6, iso5, iso4]
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/bugfix-resource-action-cleanup.yml
+++ b/changelogs/unreleased/bugfix-resource-action-cleanup.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the most restrictive value of the `resource_action_logs_retention` setting across all environments was applied on all environments.
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/bugfix-resource-action-cleanup.yml
+++ b/changelogs/unreleased/bugfix-resource-action-cleanup.yml
@@ -1,5 +1,5 @@
 ---
-description: Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the most restrictive value of the `resource_action_logs_retention` setting across all environments was applied on all environments.
+description: Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the shortest interval used for the `resource_action_logs_retention` environment setting across all environments was applied on all environments.
 change-type: patch
 destination-branches: [master, iso6, iso5, iso4]
 sections:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4015,9 +4015,9 @@ class ResourceAction(BaseDocument):
         for env in environments:
             time_to_retain_logs = await env.get(RESOURCE_ACTION_LOGS_RETENTION)
             keep_logs_until = datetime.datetime.now().astimezone() - datetime.timedelta(days=time_to_retain_logs)
-            query = "DELETE FROM " + cls.table_name() + " WHERE started < $1"
+            query = "DELETE FROM " + cls.table_name() + " WHERE environment=$1 AND started < $2"
             value = cls._get_value(keep_logs_until)
-            await cls._execute_query(query, value)
+            await cls._execute_query(query, env.id, value)
 
     @classmethod
     async def query_resource_actions(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2336,77 +2336,87 @@ async def test_purgelog_test(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()
 
-    env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
-    await env.insert()
+    envs = []
 
-    version = 1
-    cm = data.ConfigurationModel(
-        environment=env.id,
-        version=version,
-        date=datetime.datetime.now(),
-        total=1,
-        version_info={},
-        released=True,
-        deployed=True,
-        is_suitable_for_partial_compiles=False,
-    )
-    await cm.insert()
+    timestamp_eight_days_ago = datetime.datetime.now().astimezone() - datetime.timedelta(days=8)
+    timestamp_six_days_ago = datetime.datetime.now().astimezone() - datetime.timedelta(days=6)
 
-    res1 = data.Resource.new(
-        environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/file1],v=1",
-        status=const.ResourceState.deployed,
-        last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
-        attributes={"path": "/etc/file2"},
-    )
-    await res1.insert()
+    for i in range(2):
+        env = data.Environment(name=f"dev-{i}", project=project.id, repo_url="", repo_branch="")
+        await env.insert()
+        envs.append(env)
 
-    # ResourceAction 1
-    timestamp_ra1 = datetime.datetime.now() - datetime.timedelta(days=8)
-    log_line_ra1 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=1)
-    action_id = uuid.uuid4()
-    ra1 = data.ResourceAction(
-        environment=env.id,
-        version=version,
-        resource_version_ids=[res1.resource_version_id],
-        action_id=action_id,
-        action=const.ResourceAction.store,
-        started=timestamp_ra1,
-        finished=datetime.datetime.now(),
-        messages=[log_line_ra1],
-    )
-    await ra1.insert()
+        version = 1
+        cm = data.ConfigurationModel(
+            environment=env.id,
+            version=version,
+            date=datetime.datetime.now(),
+            total=1,
+            version_info={},
+            released=True,
+            deployed=True,
+            is_suitable_for_partial_compiles=False,
+        )
+        await cm.insert()
 
-    res2 = data.Resource.new(
-        environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/file2],v=1",
-        status=const.ResourceState.deployed,
-        last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
-        attributes={"path": "/etc/file2"},
-    )
-    await res2.insert()
+        res1 = data.Resource.new(
+            environment=env.id,
+            resource_version_id="std::File[agent1,path=/etc/file1],v=1",
+            status=const.ResourceState.deployed,
+            last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
+            attributes={"path": "/etc/file2"},
+        )
+        await res1.insert()
 
-    # ResourceAction 2
-    timestamp_ra2 = datetime.datetime.now() - datetime.timedelta(days=6)
-    log_line_ra2 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=2)
-    action_id = uuid.uuid4()
-    ra2 = data.ResourceAction(
-        environment=env.id,
-        version=version,
-        resource_version_ids=[res2.resource_version_id],
-        action_id=action_id,
-        action=const.ResourceAction.store,
-        started=timestamp_ra2,
-        finished=datetime.datetime.now(),
-        messages=[log_line_ra2],
-    )
-    await ra2.insert()
+        # ResourceAction 1
 
-    assert len(await data.ResourceAction.get_list()) == 2
+        log_line_ra1 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=1)
+        action_id = uuid.uuid4()
+        ra1 = data.ResourceAction(
+            environment=env.id,
+            version=version,
+            resource_version_ids=[res1.resource_version_id],
+            action_id=action_id,
+            action=const.ResourceAction.store,
+            started=timestamp_eight_days_ago,
+            finished=datetime.datetime.now(),
+            messages=[log_line_ra1],
+        )
+        await ra1.insert()
+
+        res2 = data.Resource.new(
+            environment=env.id,
+            resource_version_id="std::File[agent1,path=/etc/file2],v=1",
+            status=const.ResourceState.deployed,
+            last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
+            attributes={"path": "/etc/file2"},
+        )
+        await res2.insert()
+
+        # ResourceAction 2
+        log_line_ra2 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=2)
+        action_id = uuid.uuid4()
+        ra2 = data.ResourceAction(
+            environment=env.id,
+            version=version,
+            resource_version_ids=[res2.resource_version_id],
+            action_id=action_id,
+            action=const.ResourceAction.store,
+            started=timestamp_six_days_ago,
+            finished=datetime.datetime.now(),
+            messages=[log_line_ra2],
+        )
+        await ra2.insert()
+
+    # Make the retention time for the second environment shorter than the default 7 days
+    await envs[1].set(data.RESOURCE_ACTION_LOGS_RETENTION, value=2)
+
+    assert len(await data.ResourceAction.get_list()) == 4  # Two ra's in each environment
     await data.ResourceAction.purge_logs()
-    assert len(await data.ResourceAction.get_list()) == 1
+    assert len(await data.ResourceAction.get_list()) == 1  # One ra in the first environment and none in the second environment
     remaining_resource_action = (await data.ResourceAction.get_list())[0]
-    assert remaining_resource_action.action_id == ra2.action_id
+    assert remaining_resource_action.environment == envs[0].id
+    assert remaining_resource_action.started == timestamp_six_days_ago
 
 
 async def test_insert_many(init_dataclasses_and_load_schema, postgresql_client):


### PR DESCRIPTION
# Description

Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the most restrictive value of the `resource_action_logs_retention` setting across all environments was applied on all environments.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
