### PR TITLE
Fix log line regarding agent backoff

### DIFF
--- a/changelogs/unreleased/fix-log-line-agent-backoff.yml
+++ b/changelogs/unreleased/fix-log-line-agent-backoff.yml
@@ -1,0 +1,6 @@
+---
+description: Make sure that the log line, that reports the time required for an agent to fetch its resources from the server, is reported as a floating point number instead of an integer.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -681,7 +681,7 @@ class AgentInstance(object):
             return False
         if time.time() < self._get_resource_timeout:
             self.logger.info(
-                "Attempting to get resources during backoff %g seconds left, last download took %d seconds",
+                "Attempting to get resources during backoff %g seconds left, last download took %f seconds",
                 self._get_resource_timeout - time.time(),
                 self._get_resource_duration,
             )


### PR DESCRIPTION
# Description

Make sure that the log line, that reports the time required for an agent to fetch its resources from the server, is reported as a floating point number instead of an integer.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
