### PR TITLE
Fix bug in resource action cleanup job (iso4)

### DIFF
--- a/changelogs/unreleased/bugfix-resource-action-cleanup.yml
+++ b/changelogs/unreleased/bugfix-resource-action-cleanup.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the shortest interval used for the `resource_action_logs_retention` environment setting across all environments was applied on all environments.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/bugfix-resource-action-cleanup.yml
+++ b/changelogs/unreleased/bugfix-resource-action-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 description: Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the shortest interval used for the `resource_action_logs_retention` environment setting across all environments was applied on all environments.
 change-type: patch
-destination-branches: [master, iso6, iso5, iso4]
+destination-branches: [iso4]
 sections:
   bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3448,9 +3448,9 @@ class ResourceAction(BaseDocument):
         for env in environments:
             time_to_retain_logs = await env.get(RESOURCE_ACTION_LOGS_RETENTION)
             keep_logs_until = datetime.datetime.now().astimezone() - datetime.timedelta(days=time_to_retain_logs)
-            query = "DELETE FROM " + cls.table_name() + " WHERE started < $1"
+            query = "DELETE FROM " + cls.table_name() + " WHERE environment=$1 AND started < $2"
             value = cls._get_value(keep_logs_until)
-            await cls._execute_query(query, value)
+            await cls._execute_query(query, env.id, value)
 
     @classmethod
     async def query_resource_actions(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2317,35 +2317,35 @@ async def test_purgelog_test(init_dataclasses_and_load_schema):
         )
         await cm.insert()
 
-    # ResourceAction 1
-    log_line_ra1 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=1)
-    action_id = uuid.uuid4()
-    ra1 = data.ResourceAction(
-        environment=env.id,
-        version=version,
-        resource_version_ids=["id1"],
-        action_id=action_id,
-        action=const.ResourceAction.store,
-        started=timestamp_eight_days_ago,
-        finished=datetime.datetime.now(),
-        messages=[log_line_ra1],
-    )
-    await ra1.insert()
+        # ResourceAction 1
+        log_line_ra1 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=1)
+        action_id = uuid.uuid4()
+        ra1 = data.ResourceAction(
+            environment=env.id,
+            version=version,
+            resource_version_ids=["id1"],
+            action_id=action_id,
+            action=const.ResourceAction.store,
+            started=timestamp_eight_days_ago,
+            finished=datetime.datetime.now(),
+            messages=[log_line_ra1],
+        )
+        await ra1.insert()
 
-    # ResourceAction 2
-    log_line_ra2 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=2)
-    action_id = uuid.uuid4()
-    ra2 = data.ResourceAction(
-        environment=env.id,
-        version=version,
-        resource_version_ids=["id2"],
-        action_id=action_id,
-        action=const.ResourceAction.store,
-        started=timestamp_six_days_ago,
-        finished=datetime.datetime.now(),
-        messages=[log_line_ra2],
-    )
-    await ra2.insert()
+        # ResourceAction 2
+        log_line_ra2 = data.LogLine.log(logging.INFO, "Successfully stored version %(version)d", version=2)
+        action_id = uuid.uuid4()
+        ra2 = data.ResourceAction(
+            environment=env.id,
+            version=version,
+            resource_version_ids=["id2"],
+            action_id=action_id,
+            action=const.ResourceAction.store,
+            started=timestamp_six_days_ago,
+            finished=datetime.datetime.now(),
+            messages=[log_line_ra2],
+        )
+        await ra2.insert()
 
     # Make the retention time for the second environment shorter than the default 7 days
     await envs[1].set(data.RESOURCE_ACTION_LOGS_RETENTION, value=2)


### PR DESCRIPTION
# Description

**Same PR as #5855 but scoped to the iso4 branch due to a merge conflict**

Fix bug where the cleanup job, that removes old resource actions, ignores the environment scope of the `resource_action_logs_retention` setting. This way the most restrictive value of the `resource_action_logs_retention` setting across all environments was applied on all environments.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
