### PR TITLE
[DOC] add changelog

### DIFF
--- a/changelogs/unreleased/bump-std-version-in-v1-tests.yml
+++ b/changelogs/unreleased/bump-std-version-in-v1-tests.yml
@@ -1,0 +1,3 @@
+description: Bump std version to stay compatible with pinned email-validator version
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -974,7 +974,7 @@ import custom_mod_two
         """.strip(),
         python_package_sources=[local_module_package_index],
         project_requires=[
-            module.InmantaModuleRequirement.parse("std~=3.0,<3.0.16"),
+            module.InmantaModuleRequirement.parse("std~=4.1.7,<4.1.8"),
             module.InmantaModuleRequirement.parse("custom_mod_one>0"),
         ],
         python_requires=[
@@ -996,7 +996,7 @@ import custom_mod_two
 +================+======+==========+================+================+=========+
 | custom_mod_one | v2   | no       | 1.0.0          | >0,<999,~=1.0  | yes     |
 | custom_mod_two | v2   | yes      | 1.0.0          | *              | yes     |
-| std            | v1   | yes      | 3.0.15         | 3.0.15         | yes     |
+| std            | v1   | yes      | 4.1.7          | 4.1.7          | yes     |
 +----------------+------+----------+----------------+----------------+---------+
     """.strip()
     )
@@ -1022,7 +1022,7 @@ import custom_mod_two
 +================+======+==========+================+================+=========+
 | custom_mod_one | v2   | no       | 2.0.0          | >0,<999,~=1.0  | no      |
 | custom_mod_two | v2   | yes      | 1.0.0          | *              | yes     |
-| std            | v1   | yes      | 3.0.15         | 3.0.15         | yes     |
+| std            | v1   | yes      | 4.1.7          | 4.1.7          | yes     |
 +----------------+------+----------+----------------+----------------+---------+
     """.strip()
     )
@@ -1079,7 +1079,7 @@ def test_module_install_logging(local_module_package_index: str, snippetcompiler
         python_requires=v2_requirements,
         install_project=False,
         project_requires=[
-            module.InmantaModuleRequirement.parse("std==3.0.0"),
+            module.InmantaModuleRequirement.parse("std==4.1.7"),
         ],
     )
 
@@ -1094,7 +1094,7 @@ def test_module_install_logging(local_module_package_index: str, snippetcompiler
         ("Successfully installed module minimalv2module (v2) version 1.2.3", logging.DEBUG),
         ("Installing module std (v1)", logging.DEBUG),
         (
-            """Successfully installed module std (v1) version 3.0.0 in %s from %s"""
+            """Successfully installed module std (v1) version 4.1.7 in %s from %s"""
             % (os.path.join(project.downloadpath, "std"), "https://github.com/inmanta/std"),
             logging.DEBUG,
         ),
@@ -1511,7 +1511,7 @@ def test_constraints_logging_v1(caplog, snippetcompiler_clean, local_module_pack
         project_requires=[
             module.InmantaModuleRequirement.parse("std>0.0"),
             module.InmantaModuleRequirement.parse("std>=0.0"),
-            module.InmantaModuleRequirement.parse("std==3.0.15"),
+            module.InmantaModuleRequirement.parse("std==4.1.7"),
             module.InmantaModuleRequirement.parse("std<=100.0.0"),
             module.InmantaModuleRequirement.parse("std<100.0.0"),
         ],
@@ -1521,5 +1521,5 @@ def test_constraints_logging_v1(caplog, snippetcompiler_clean, local_module_pack
         caplog,
         "inmanta.module",
         logging.DEBUG,
-        "Installing module std (v1) (with constraints std>0.0 std>=0.0 std==3.0.15 std<=100.0.0 std<100.0.0)",
+        "Installing module std (v1) (with constraints std>0.0 std>=0.0 std==4.1.7 std<=100.0.0 std<100.0.0)",
     )


### PR DESCRIPTION
# Description
Older versions of std (pinning `email_validator~=1.1`)  are no longer compatible with the lock file of core (pinning `email-validator==2.0.0.post1`)

This PR bumps the version of std used in tests testing functionality of v1 modules to a version compatible with lock file of core

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
