### PR TITLE
Usage inmanta module freeze command on v2 module

### DIFF
--- a/changelogs/unreleased/5631-module-freeze-command.yml
+++ b/changelogs/unreleased/5631-module-freeze-command.yml
@@ -1,0 +1,7 @@
+---
+description: Show a clear error message when the `inmanta module freeze` command is executed on a v2 module. This is not supported.
+issue-nr: 5631
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/5631-module-freeze-command.yml
+++ b/changelogs/unreleased/5631-module-freeze-command.yml
@@ -2,6 +2,6 @@
 description: Show a clear error message when the `inmanta module freeze` command is executed on a v2 module. This is not supported.
 issue-nr: 5631
 change-type: patch
-destination-branches: [master, iso6, iso5]
+destination-branches: [iso5]
 sections:
   bugfix: "{{description}}"

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -528,7 +528,10 @@ mode.
             "--v1", dest="v1", help="Create a v1 module. By default a v2 module is created.", action="store_true"
         )
 
-        freeze = subparser.add_parser("freeze", help="Set all version numbers in module.yml")
+        freeze = subparser.add_parser(
+            "freeze",
+            help="Freeze all version numbers in module.yml. This command is only supported on v1 modules. On v2 modules use"
+            " the pip freeze command instead.")
         freeze.add_argument(
             "-o",
             "--outfile",
@@ -921,6 +924,11 @@ version: 0.0.1dev0"""
         """
         !!! Big Side-effect !!! sets yaml parser to be order preserving
         """
+        if (module and ModuleV2.from_path(module)) or ModuleV2.from_path(os.curdir):
+            raise CLIException(
+                "The `inmanta module freeze` command is not supported on V2 modules. Use the `pip freeze` command instead.",
+                exitcode=1,
+            )
 
         # find module
         module_obj = self.get_module(module)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -531,7 +531,8 @@ mode.
         freeze = subparser.add_parser(
             "freeze",
             help="Freeze all version numbers in module.yml. This command is only supported on v1 modules. On v2 modules use"
-            " the pip freeze command instead.")
+            " the pip freeze command instead.",
+        )
         freeze.add_argument(
             "-o",
             "--outfile",


### PR DESCRIPTION
# Description

**Same PR as  #5874 but on the iso5 branch due to a merge conflict.**

Show a clear error message when the `inmanta module freeze` command executed on a v2 module. This is not supported.

closes #5631 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
