### PR TITLE
Issue/5816 inmanta module release output release tag

### DIFF
--- a/changelogs/unreleased/5816-module-release-tag.yml
+++ b/changelogs/unreleased/5816-module-release-tag.yml
@@ -1,5 +1,5 @@
 description: The 'inmanta module release' command now outputs the release tag
-issue-nr: 58116
+issue-nr: 5816
 change-type: patch
 destination-branches: [master, iso6, iso5]
 sections:

--- a/changelogs/unreleased/5816-module-release-tag.yml
+++ b/changelogs/unreleased/5816-module-release-tag.yml
@@ -1,7 +1,7 @@
 description: The 'inmanta module release' command now outputs the release tag
 issue-nr: 5816
 change-type: patch
-destination-branches: [master, iso6, iso5]
+destination-branches: [master, iso6]
 sections:
   minor-improvement: "{{description}}"
 

--- a/changelogs/unreleased/5816-module-release-tag.yml
+++ b/changelogs/unreleased/5816-module-release-tag.yml
@@ -1,0 +1,7 @@
+description: The 'inmanta module release' command now outputs the release tag
+issue-nr: 58116
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  minor-improvement: "{{description}}"
+

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1336,6 +1336,7 @@ version: 0.0.1dev0"""
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
             # bump to the next dev version
             self.release(dev=True, message="Bump version to next development version", patch=True)
+            print(f"The released version has {release_tag} as tag.")
 
 
 class ModuleChangelog:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1334,9 +1334,9 @@ version: 0.0.1dev0"""
                 raise_exc_when_nothing_to_commit=False,
             )
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
+            print(f"Tag created successfully: {release_tag}")
             # bump to the next dev version
             self.release(dev=True, message="Bump version to next development version", patch=True)
-            print(f"Tag created successfully: {release_tag}")
 
 
 class ModuleChangelog:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1336,7 +1336,7 @@ version: 0.0.1dev0"""
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
             # bump to the next dev version
             self.release(dev=True, message="Bump version to next development version", patch=True)
-            print(f"The released version has {release_tag} as tag.")
+            print(f"Tag created successfully: {release_tag}")
 
 
 class ModuleChangelog:

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -511,6 +511,26 @@ def test_too_many_version_bump_arguments() -> None:
     assert "Only one of --revision, --patch, --minor and --major can be set at the same time." in exc_info.value.message
 
 
+def test_output_tag(tmpdir, modules_dir: str, monkeypatch, capsys) -> None:
+    """
+    test that the `inmanta module release` will also output the created tag to stdout
+    """
+    path_module = os.path.join(tmpdir, "mod")
+    v1_module_from_template(
+        source_dir=os.path.join(modules_dir, "minimalv1module"),
+        dest_dir=path_module,
+        new_version=Version("1.2.3"),
+        new_name="mod",
+    )
+    gitprovider.git_init(repo=path_module)
+    gitprovider.commit(repo=path_module, message="Initial commit", add=["*"], commit_all=True)
+    monkeypatch.chdir(path_module)
+    module_tool = ModuleTool()
+    module_tool.release(dev=False, minor=False, major=True, message="Commit changes")
+    (stdout, _) = capsys.readouterr()
+    assert "Tag created successfully: 1.2.4" in stdout
+
+
 def test_epoch_value_larger_than_zero(tmpdir, modules_dir: str, monkeypatch) -> None:
     """
     Ensure that an exception is raised when the epoch value of the module is larger than zero.


### PR DESCRIPTION
# Description

When the inmanta module release command is executed, it doesn't produce any output. That way you have to execute a git log to figure out which Git tag was created. This information is required to push the tag later on using the git push origin <tag> command. Now the release command will output the tag it created.

closes #5816 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
