### PR TITLE
Improve documentation of get_resource() endpoint

### DIFF
--- a/changelogs/unreleased/improve-doc-get-resource-endpoint.yml
+++ b/changelogs/unreleased/improve-doc-get-resource-endpoint.yml
@@ -1,0 +1,5 @@
+---
+description: Improve the documentation of the `api/v1/resource/<id>` endpoint and return a clear error message if the given id is not a valid resource version id.
+change-type: patch
+destination-branches: [master, iso6, iso5]
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/improve-doc-get-resource-endpoint.yml
+++ b/changelogs/unreleased/improve-doc-get-resource-endpoint.yml
@@ -2,4 +2,5 @@
 description: Improve the documentation of the `api/v1/resource/<id>` endpoint and return a clear error message if the given id is not a valid resource version id.
 change-type: patch
 destination-branches: [master, iso6, iso5]
+sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -393,7 +393,7 @@ def get_resource(
     Return a resource with the given id.
 
     :param tid: The id of the environment this resource belongs to
-    :param id: Get the resource with the given id
+    :param id: Get the resource with the given resource version id
     :param logs: Include the logs in the response
     :param status: Only return the status of the resource
     :param log_action: The log action to include, leave empty/none for all actions. Valid actions are one of

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -224,8 +224,8 @@ class ResourceService(protocol.ServerSlice):
         # Validate resource version id
         try:
             Id.parse_resource_version_id(resource_id)
-        except ValueError as exc:
-            return 404, {"message": str(exc)}
+        except ValueError:
+            return 400, {"message": f"{resource_id} is not a valid resource version id"}
 
         resv = await data.Resource.get(env.id, resource_id)
         if resv is None:

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -221,6 +221,12 @@ class ResourceService(protocol.ServerSlice):
         log_action: const.ResourceAction,
         log_limit: int,
     ) -> Apireturn:
+        # Validate resource version id
+        try:
+            Id.parse_resource_version_id(resource_id)
+        except ValueError as exc:
+            return 404, {"message": str(exc)}
+
         resv = await data.Resource.get(env.id, resource_id)
         if resv is None:
             return 404, {"message": "The resource with the given id does not exist in the given environment"}
@@ -240,7 +246,7 @@ class ResourceService(protocol.ServerSlice):
 
         return 200, {"resource": resv, "logs": actions}
 
-    # This endpoint does't have a method associated yet.
+    # This endpoint doesn't have a method associated yet.
     # Intended for use by other slices
     async def get_resources_in_latest_version(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -572,6 +572,17 @@ async def test_resource_update(postgresql_client, client, clienthelper, server, 
     assert result.result["model"]["done"] == 10
 
 
+async def test_get_resource_on_invalid_resource_id(server, client, environment) -> None:
+    """
+    Verify that a clear error message is returned when the resource version id passed to the
+    get_resource() endpoint has an invalid structure.
+    """
+    invalid_resource_version_id = "invalid resource version id"
+    result = await client.get_resource(tid=environment, id=invalid_resource_version_id)
+    assert result.code == 400
+    assert f"{invalid_resource_version_id} is not a valid resource version id" in result.result["message"]
+
+
 async def test_clear_environment(client, server, clienthelper, environment):
     """
     Test clearing out an environment


### PR DESCRIPTION
# Description

Improve the documentation of the `api/v1/resource/<id>` endpoint and return a clear error message if the given id is not a valid resource version id.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~