### PR TITLE
Expose the logging setup through the stable api

### DIFF
--- a/changelogs/unreleased/5815-expose-logging-setup.yml
+++ b/changelogs/unreleased/5815-expose-logging-setup.yml
@@ -1,5 +1,5 @@
 description: Expose the logging setup through the stable api
-issue-nr: 5915
+issue-nr: 5815
 change-type: minor
 destination-branches: [master, iso6, iso5]
 sections:

--- a/changelogs/unreleased/5815-expose-logging-setup.yml
+++ b/changelogs/unreleased/5815-expose-logging-setup.yml
@@ -1,7 +1,7 @@
 description: Expose the logging setup through the stable api
 issue-nr: 5815
 change-type: minor
-destination-branches: [master, iso6, iso5]
+destination-branches: [master, iso6]
 sections:
   feature: "{{description}}"
 

--- a/changelogs/unreleased/5815-expose-logging-setup.yml
+++ b/changelogs/unreleased/5815-expose-logging-setup.yml
@@ -1,0 +1,8 @@
+description: Expose the logging setup through the stable api
+issue-nr: 5915
+change-type: minor
+destination-branches: [master, iso6, iso5]
+sections:
+  feature: "{{description}}"
+
+

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -715,7 +715,7 @@ def app() -> None:
     """
     Run the compiler
     """
-    InmantaLoggerConfig.create_default_handler()
+    log_config = InmantaLoggerConfig.get_instance()
 
     # do an initial load of known config files to build the libdir path
     Config.load_config()
@@ -723,7 +723,7 @@ def app() -> None:
     options, other = parser.parse_known_args()
     options.other = other
 
-    InmantaLoggerConfig.apply_options(options)
+    log_config.apply_options(options)
 
     logging.captureWarnings(True)
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -715,7 +715,7 @@ def app() -> None:
     """
     Run the compiler
     """
-    InmantaLogs.setup_handler()
+    InmantaLogs.create_default_handler()
 
     # do an initial load of known config files to build the libdir path
     Config.load_config()

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -711,13 +711,6 @@ def print_versions_installed_components_and_exit() -> None:
     sys.exit(0)
 
 
-class Options:
-    log_file: str
-    log_file_level: str
-    verbose: int
-    timed: bool
-
-
 def app() -> None:
     """
     Run the compiler

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -61,7 +61,7 @@ from inmanta.compiler import do_compile
 from inmanta.config import Config, Option
 from inmanta.const import EXIT_START_FAILED
 from inmanta.export import cfg_env
-from inmanta.logging import InmantaLogs, _is_on_tty
+from inmanta.logging import InmantaLoggerConfig, _is_on_tty
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
 from inmanta.warnings import WarningsManager
@@ -715,7 +715,7 @@ def app() -> None:
     """
     Run the compiler
     """
-    InmantaLogs.create_default_handler()
+    InmantaLoggerConfig.create_default_handler()
 
     # do an initial load of known config files to build the libdir path
     Config.load_config()
@@ -723,7 +723,7 @@ def app() -> None:
     options, other = parser.parse_known_args()
     options.other = other
 
-    InmantaLogs.apply_options(options)
+    InmantaLoggerConfig.apply_options(options)
 
     logging.captureWarnings(True)
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -711,6 +711,13 @@ def print_versions_installed_components_and_exit() -> None:
     sys.exit(0)
 
 
+class Options:
+    log_file: str
+    log_file_level: str
+    verbose: int
+    timed: bool
+
+
 def app() -> None:
     """
     Run the compiler

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -40,7 +40,6 @@ import sys
 import threading
 import time
 import traceback
-import typing
 from argparse import ArgumentParser
 from asyncio import ensure_future
 from collections import abc
@@ -49,8 +48,6 @@ from threading import Timer
 from types import FrameType
 from typing import Any, Callable, Coroutine, Dict, Optional
 
-import colorlog
-from colorlog.formatter import LogColors
 from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.util import TimeoutError
@@ -64,6 +61,7 @@ from inmanta.compiler import do_compile
 from inmanta.config import Config, Option
 from inmanta.const import EXIT_START_FAILED
 from inmanta.export import cfg_env
+from inmanta.logging import InmantaLogs
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
 from inmanta.warnings import WarningsManager
@@ -74,50 +72,6 @@ except ImportError:
     rpdb = None
 
 LOGGER = logging.getLogger("inmanta")
-
-
-class MultiLineFormatter(colorlog.ColoredFormatter):
-    """Multi-line formatter."""
-
-    def __init__(
-        self,
-        fmt: typing.Optional[str] = None,
-        *,
-        # keep interface minimal: only include fields we actually use
-        log_colors: typing.Optional[LogColors] = None,
-        reset: bool = True,
-        no_color: bool = False,
-    ):
-        super().__init__(fmt, log_colors=log_colors, reset=reset, no_color=no_color)
-        self.fmt = fmt
-
-    def get_header_length(self, record: logging.LogRecord) -> int:
-        """Get the header length of a given record."""
-        # to get the length of the header we want to get the header without the color codes
-        formatter = colorlog.ColoredFormatter(
-            fmt=self.fmt,
-            log_colors=self.log_colors,
-            reset=False,
-            no_color=True,
-        )
-        header = formatter.format(
-            logging.LogRecord(
-                name=record.name,
-                level=record.levelno,
-                pathname=record.pathname,
-                lineno=record.lineno,
-                msg="",
-                args=(),
-                exc_info=None,
-            )
-        )
-        return len(header)
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Format a record with added indentation."""
-        indent: str = " " * self.get_header_length(record)
-        head, *tail = super().format(record).splitlines(True)
-        return head + "".join(indent + line for line in tail)
 
 
 @command("server", help_msg="Start the inmanta server")
@@ -664,23 +618,6 @@ def export(options: argparse.Namespace) -> None:
         conn.release_version(tid, version, True, agent_trigger_method)
 
 
-"""
-This dictionary maps the Inmanta log levels to the corresponding Python log levels
-"""
-log_levels = {
-    "0": logging.ERROR,
-    "1": logging.WARNING,
-    "2": logging.INFO,
-    "3": logging.DEBUG,
-    "4": 2,
-    "ERROR": logging.ERROR,
-    "WARNING": logging.WARNING,
-    "INFO": logging.INFO,
-    "DEBUG": logging.DEBUG,
-    "TRACE": 2,
-}
-
-
 def cmd_parser() -> argparse.ArgumentParser:
     # create the argument compiler
 
@@ -778,94 +715,20 @@ def _is_on_tty() -> bool:
     return (hasattr(sys.stdout, "isatty") and sys.stdout.isatty()) or const.ENVIRON_FORCE_TTY in os.environ
 
 
-def _get_default_stream_handler() -> logging.StreamHandler:
-    stream_handler = logging.StreamHandler(stream=sys.stdout)
-    stream_handler.setLevel(logging.INFO)
-
-    formatter = _get_log_formatter_for_stream_handler(timed=False)
-    stream_handler.setFormatter(formatter)
-
-    return stream_handler
-
-
-def _get_watched_file_handler(options: argparse.Namespace) -> logging.handlers.WatchedFileHandler:
-    if not options.log_file:
-        raise Exception("No logfile was provided.")
-    level = _convert_inmanta_log_level_to_python_log_level(options.log_file_level)
-    formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
-    file_handler = logging.handlers.WatchedFileHandler(filename=options.log_file, mode="a+")
-    file_handler.setFormatter(formatter)
-    file_handler.setLevel(level)
-
-    return file_handler
-
-
-def _convert_inmanta_log_level_to_python_log_level(level: str) -> int:
-    """
-    Converts the Inmanta log level to the Python log level
-    """
-    if level.isdigit() and int(level) > 4:
-        level = "4"
-    return log_levels[level]
-
-
-def _convert_cli_log_level(level: int) -> int:
-    """
-    Converts the number of -v's passed on the CLI to the corresponding Inmanta log level
-    """
-    if level < 1:
-        # The minimal log level on the CLI is always WARNING
-        return logging.WARNING
-    else:
-        return _convert_inmanta_log_level_to_python_log_level(str(level))
-
-
-def _get_log_formatter_for_stream_handler(timed: bool) -> logging.Formatter:
-    log_format = "%(asctime)s " if timed else ""
-    if _is_on_tty():
-        log_format += "%(log_color)s%(name)-25s%(levelname)-8s%(reset)s%(blue)s%(message)s"
-        formatter = MultiLineFormatter(
-            log_format,
-            reset=True,
-            log_colors={"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"},
-        )
-    else:
-        log_format += "%(name)-25s%(levelname)-8s%(message)s"
-        formatter = MultiLineFormatter(
-            log_format,
-            reset=False,
-            no_color=True,
-        )
-    return formatter
-
-
 def app() -> None:
     """
     Run the compiler
     """
     # Send logs to stdout
-    stream_handler = _get_default_stream_handler()
+    handler = InmantaLogs.get_default_handler()
     logging.root.handlers = []
-    logging.root.addHandler(stream_handler)
-    logging.root.setLevel(0)
+    logging.root.addHandler(handler)
 
     # do an initial load of known config files to build the libdir path
     Config.load_config()
     parser = cmd_parser()
     options, other = parser.parse_known_args()
     options.other = other
-
-    # Log everything to a log_file if logfile is provided
-    if options.log_file:
-        watched_file_handler = _get_watched_file_handler(options)
-        logging.root.addHandler(watched_file_handler)
-        logging.root.removeHandler(stream_handler)
-    else:
-        if options.timed:
-            formatter = _get_log_formatter_for_stream_handler(timed=True)
-            stream_handler.setFormatter(formatter)
-        log_level = _convert_cli_log_level(options.verbose)
-        stream_handler.setLevel(log_level)
 
     logging.captureWarnings(True)
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -716,7 +716,7 @@ def app() -> None:
     Run the compiler
     """
     # Send logs to stdout
-    stream_handler = InmantaLogs.get_basic_stream_handler()
+    stream_handler = InmantaLogs._get_default_stream_handler()
     logging.root.handlers = []
     logging.root.addHandler(stream_handler)
     logging.root.setLevel(0)
@@ -729,14 +729,14 @@ def app() -> None:
 
     # Log everything to a log_file if logfile is provided
     if options.log_file:
-        watched_file_handler = InmantaLogs.get_watched_file_handler(options)
+        watched_file_handler = InmantaLogs._get_watched_file_handler(options)
         logging.root.addHandler(watched_file_handler)
         logging.root.removeHandler(stream_handler)
     else:
         if options.timed:
-            formatter = InmantaLogs.get_log_formatter_for_stream_handler(timed=True)
+            formatter = InmantaLogs._get_log_formatter_for_stream_handler(timed=True)
             stream_handler.setFormatter(formatter)
-        log_level = InmantaLogs.convert_cli_log_level(options.verbose)
+        log_level = InmantaLogs._convert_cli_log_level(options.verbose)
         stream_handler.setLevel(log_level)
 
     logging.captureWarnings(True)

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -715,11 +715,7 @@ def app() -> None:
     """
     Run the compiler
     """
-    # Send logs to stdout
-    stream_handler = InmantaLogs._get_default_stream_handler()
-    logging.root.handlers = []
-    logging.root.addHandler(stream_handler)
-    logging.root.setLevel(0)
+    InmantaLogs.setup_handler()
 
     # do an initial load of known config files to build the libdir path
     Config.load_config()
@@ -727,19 +723,10 @@ def app() -> None:
     options, other = parser.parse_known_args()
     options.other = other
 
-    # Log everything to a log_file if logfile is provided
-    if options.log_file:
-        watched_file_handler = InmantaLogs._get_watched_file_handler(options)
-        logging.root.addHandler(watched_file_handler)
-        logging.root.removeHandler(stream_handler)
-    else:
-        if options.timed:
-            formatter = InmantaLogs._get_log_formatter_for_stream_handler(timed=True)
-            stream_handler.setFormatter(formatter)
-        log_level = InmantaLogs._convert_cli_log_level(options.verbose)
-        stream_handler.setLevel(log_level)
+    InmantaLogs.apply_options(options)
 
     logging.captureWarnings(True)
+
     if options.config_file and not os.path.exists(options.config_file):
         LOGGER.warning("Config file %s doesn't exist", options.config_file)
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -61,7 +61,7 @@ from inmanta.compiler import do_compile
 from inmanta.config import Config, Option
 from inmanta.const import EXIT_START_FAILED
 from inmanta.export import cfg_env
-from inmanta.logging import InmantaLogs
+from inmanta.logging import InmantaLogs, _is_on_tty
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
 from inmanta.warnings import WarningsManager
@@ -709,10 +709,6 @@ def print_versions_installed_components_and_exit() -> None:
     else:
         print("Extensions: No extensions found")
     sys.exit(0)
-
-
-def _is_on_tty() -> bool:
-    return (hasattr(sys.stdout, "isatty") and sys.stdout.isatty()) or const.ENVIRON_FORCE_TTY in os.environ
 
 
 def app() -> None:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2017 Inmanta
+    Copyright 2023 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -14,20 +14,6 @@
     limitations under the License.
 
     Contact: code@inmanta.com
-
-
-    Command line development guidelines
-    ###################################
-
-    do's and don'ts
-    ----------------
-    MUST NOT: sys.exit => use command.CLIException
-    SHOULD NOT: print( => use logger for messages, only print for final output
-
-
-    Entry points
-    ------------
-    @command annotation to register new command
 """
 import logging
 import sys
@@ -106,11 +92,11 @@ class InmantaLogs:
             handler = logging.handlers.WatchedFileHandler(filename=options.log_file, mode="a+")
         else:
             handler = logging.StreamHandler(stream)
-        cls._set_format(options, handler)
-        cls._set_log_level(options, handler)
+        cls._set_default_format(options, handler)
+        cls._set_default_log_level(options, handler)
 
     @classmethod
-    def _set_format(cls, options, handler):
+    def _set_default_format(cls, options, handler):
         if options.log_file:
             formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
         else:
@@ -119,7 +105,7 @@ class InmantaLogs:
         handler.setFormatter(formatter)
 
     @classmethod
-    def _set_log_level(cls, options, stream_handler):
+    def _set_default_log_level(cls, options, stream_handler):
         if options.log_file:
             level = cls._convert_inmanta_log_level_to_python_log_level(options.log_file_level)
         else:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -19,7 +19,6 @@ import logging
 import os
 import sys
 from argparse import Namespace
-from logging.handlers import WatchedFileHandler
 from typing import Optional, TextIO
 
 import colorlog
@@ -63,12 +62,12 @@ class InmantaLoggerConfig:
     A class that provides logging functionality for Inmanta projects.
 
     Usage:
-    To use this class, you first need to call the `create_default_handler` method to configure the logging handler. This method
-    takes a `stream` argument that specifies where the log messages should be sent to. If no `stream` is provided,
+    To use this class, you first need to call the `get_instance`. This method takes a `stream` argument
+    that specifies where the log messages should be sent to. If no `stream` is provided,
     the log messages will be sent to standard output.
 
     You can then call the `apply_options` method to configure the logging options. This method takes an `options`
-    argument that should be an object with the following attributes:
+    argument that should be an Option object with the following attributes:
     - `log_file`: if this attribute is set, the logs will be written to the specified file instead of the stream
       specified in `create_default_handler`.
     - `log_file_level`: the logging level for the file handler (if `log_file` is set).
@@ -102,6 +101,7 @@ class InmantaLoggerConfig:
         logging.root.setLevel(0)
 
     @classmethod
+    @stable_api
     def get_instance(cls, stream: TextIO = sys.stdout) -> "InmantaLoggerConfig":
         """
         This method should be used to obtain an instance of this class, because this class is a singleton.
@@ -111,6 +111,18 @@ class InmantaLoggerConfig:
         if not cls._instance:
             cls._instance = cls(stream)
         return cls._instance
+
+    @classmethod
+    @stable_api
+    def clean_instance(cls) -> "InmantaLoggerConfig":
+        """
+        This method should be used to obtain an instance of this class, because this class is a singleton.
+
+        :param stream: The stream to send log messages to. Default is standard output (sys.stdout)
+        """
+        if cls._instance and cls._instance._handler:
+            cls._instance._handler.close()
+        cls._instance = None
 
     @stable_api
     def apply_options(self, options: Options) -> None:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -115,13 +115,12 @@ class InmantaLoggerConfig:
 
         :param stream: The stream to send log messages to. Default is standard output (sys.stdout)
         """
-        if (
-            cls._instance
-            and not isinstance(cls._instance._handler, logging.StreamHandler)
-            or cls._instance._handler.stream != stream
-        ):
-            raise Exception("Instance already exists with a different stream handler")
-        if not cls._instance:
+        if cls._instance:
+            if not isinstance(cls._instance._handler, logging.StreamHandler):
+                raise Exception("Instance already exists with a different handler")
+            elif isinstance(cls._instance._handler, logging.StreamHandler) and cls._instance._handler.stream != stream:
+                raise Exception("Instance already exists with a different stream")
+        else:
             cls._instance = cls(stream)
         return cls._instance
 

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -96,7 +96,7 @@ class InmantaLogs:
         """
         if not cls._handler:
             raise Exception(
-                "No handler to apply options to. Please use the create_default_handler method before calling this " "one"
+                "No handler to apply options to. Please use the create_default_handler method before calling this one"
             )
         if options.log_file:
             cls.set_logfile_location(options.log_file)
@@ -120,7 +120,7 @@ class InmantaLogs:
         """
         if not cls._handler:
             raise Exception(
-                "No handler to apply options to. Please use the create_default_handler method before calling this " "one"
+                "No handler to apply options to. Please use the create_default_handler method before calling this one"
             )
         cls._handler.setLevel(log_level)
 
@@ -133,7 +133,7 @@ class InmantaLogs:
         """
         if not cls._handler:
             raise Exception(
-                "No handler to apply options to. Please use the create_default_handler method before calling this " "one"
+                "No handler to apply options to. Please use the create_default_handler method before calling this one"
             )
         cls._handler.setFormatter(formatter)
 

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -16,13 +16,19 @@
     Contact: code@inmanta.com
 """
 import logging
+import os
 import sys
 import typing
 
 import colorlog
 from colorlog.formatter import LogColors
 
-from inmanta.app import _is_on_tty
+from inmanta import const
+
+
+def _is_on_tty() -> bool:
+    return (hasattr(sys.stdout, "isatty") and sys.stdout.isatty()) or const.ENVIRON_FORCE_TTY in os.environ
+
 
 """
 This dictionary maps the Inmanta log levels to the corresponding Python log levels

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -129,7 +129,7 @@ class InmantaLoggerConfig:
         """
         Apply the logging options to the current handler. A handler should have been created before
 
-        :param options: the option object coming from the command line. This function use the following
+        :param options: The Option object coming from the command line. This function uses the following
             attributes: log_file, log_file_level, verbose, timed
         """
         if not self._handler:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -63,15 +63,15 @@ class InmantaLogs:
       specified in `setup_handler`.
     - `log_file_level`: the logging level for the file handler (if `log_file` is set).
     - `verbose`: the verbosity level of the log messages.
-    - 'timed': if true,  adds the time to the formatter in the log lines.
+    - `timed`: if true,  adds the time to the formatter in the log lines.
 
     The setup is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
     the 'final' logger with apply_options.
 
     for more fine-grained configuration the following functions can be used aswell:
-        - set_log_level
-        - set_log_formatter
-        - set_logfile_location
+        - `set_log_level`
+        - `set_log_formatter`
+        - `set_logfile_location`
     """
 
     _handler: Optional[logging.Handler] = None

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -30,14 +30,12 @@
     @command annotation to register new command
 """
 import logging
-import os
 import sys
 import typing
 
 import colorlog
 from colorlog.formatter import LogColors
 
-from inmanta import const
 from inmanta.app import _is_on_tty
 
 """

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -104,6 +104,7 @@ class InmantaLoggerConfig:
             cls._instance.__init__(stream)
         return cls._instance
 
+    @stable_api
     def apply_options(self, options: object) -> None:
         """
         Apply the logging options to the current handler. A handler should have been created before
@@ -112,9 +113,7 @@ class InmantaLoggerConfig:
             attributes: log_file, log_file_level, verbose, timed
         """
         if not self._handler:
-            raise Exception(
-                "No handler to apply options to. Please use the create_default_handler method before calling this one"
-            )
+            raise Exception("No handler to apply options to. Please use the get_instance method before calling this one")
         if options.log_file:
             self.set_logfile_location(options.log_file)
             formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
@@ -126,6 +125,7 @@ class InmantaLoggerConfig:
                 self.set_log_formatter(formatter)
             self.set_log_level(str(options.verbose))
 
+    @stable_api
     def set_log_level(self, inmanta_log_level: str, cli: bool = True) -> None:
         """
         Set the logging level. A handler should have been created before
@@ -145,9 +145,7 @@ class InmantaLoggerConfig:
         :param cli: True if the logs will be outputed to the CLI.
         """
         if not self._handler:
-            raise Exception(
-                "No handler to apply options to. Please use the create_default_handler method before calling this one"
-            )
+            raise Exception("No handler to apply options to. Please use the get_instance method before calling this one")
         # maximum of 4 v's
         if inmanta_log_level.isdigit() and int(inmanta_log_level) > 4:
             inmanta_log_level = "4"
@@ -160,6 +158,7 @@ class InmantaLoggerConfig:
         python_log_level = log_levels[inmanta_log_level]
         self._handler.setLevel(python_log_level)
 
+    @stable_api
     def set_log_formatter(self, formatter: logging.Formatter) -> None:
         """
         Set the log formatter. A handler should have been created before
@@ -167,11 +166,10 @@ class InmantaLoggerConfig:
         :param formatter: The log formatter.
         """
         if not self._handler:
-            raise Exception(
-                "No handler to apply options to. Please use the create_default_handler method before calling this one"
-            )
+            raise Exception("No handler to apply options to. Please use the get_instance method before calling this one")
         self._handler.setFormatter(formatter)
 
+    @stable_api
     def set_logfile_location(self, location: str) -> None:
         """
         Set the location of the log file. Be careful that this function will replace the current handler with a new one
@@ -185,6 +183,7 @@ class InmantaLoggerConfig:
         self._handler = file_handler
         logging.root.addHandler(self._handler)
 
+    @stable_api
     def get_handler(self) -> Optional[logging.Handler]:
         """
         Get the logging handler
@@ -192,9 +191,7 @@ class InmantaLoggerConfig:
         :return: The logging handler
         """
         if not self._handler:
-            raise Exception(
-                "No handler to apply options to. Please use the create_default_handler method before calling this one"
-            )
+            raise Exception("No handler to apply options to. Please use the get_instance method before calling this one")
         return self._handler
 
     def _get_log_formatter_for_stream_handler(self, timed: bool) -> logging.Formatter:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -96,8 +96,8 @@ class InmantaLogs:
     _handler: logging.Handler
 
     @classmethod
-    def setup_handler(cls) -> logging.StreamHandler:
-        cls._handler = logging.StreamHandler(stream=sys.stdout)
+    def setup_handler(cls, stream=sys.stdout) -> logging.StreamHandler:
+        cls._handler = logging.StreamHandler(stream=stream)
         cls.set_log_level(logging.INFO)
         formatter = cls._get_log_formatter_for_stream_handler(timed=False)
         cls.set_log_formatter(formatter)
@@ -147,7 +147,7 @@ class InmantaLogs:
             # The minimal log level on the CLI is always WARNING
             return logging.WARNING
         else:
-            return cls.convert_inmanta_log_level_to_python_log_level(str(level))
+            return cls._convert_inmanta_log_level_to_python_log_level(str(level))
 
     @classmethod
     def _convert_inmanta_log_level_to_python_log_level(cls, level: str) -> int:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -67,6 +67,11 @@ class InmantaLogs:
 
     The setup is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
     the 'final' logger with apply_options.
+
+    for more fine_grained configuration the following functions can be used aswell:
+        - set_log_level
+        - set_log_formatter
+        - set_logfile_location
     """
 
     _handler: Optional[logging.Handler] = None

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -68,7 +68,7 @@ class InmantaLogs:
     The setup is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
     the 'final' logger with `apply_options`.
 
-    for more fine-grained configuration the following functions can be used aswell:
+    for more fine-grained configuration the following functions can be used as well:
         - `set_log_level`
         - `set_log_formatter`
         - `set_logfile_location`

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -89,7 +89,8 @@ class InmantaLogs:
     @classmethod
     def apply_options(cls, options, stream: Optional[str] = sys.stdout) -> None:
         """
-        Apply the logging options to the current handler. If no handler yet, first start on with setup_handler
+        Apply the logging options to the current handler. If there is no handler yet, this function starts one
+        with setup_handler
 
         :param options: the option object coming from the command line. This function use the following
             attribute: log_file, log_file_level, verbose, timed

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -15,10 +15,11 @@
 
     Contact: code@inmanta.com
 """
+import argparse
 import logging
 import os
 import sys
-from typing import Optional
+from typing import Optional, TextIO
 
 import colorlog
 from colorlog.formatter import LogColors
@@ -71,7 +72,7 @@ class InmantaLogs:
     _handler: Optional[logging.Handler] = None
 
     @classmethod
-    def create_default_handler(cls, stream: Optional[str] = sys.stdout) -> None:
+    def create_default_handler(cls, stream: TextIO = sys.stdout) -> None:
         """
         Set up the logging handler for Inmanta.
 
@@ -87,12 +88,12 @@ class InmantaLogs:
         logging.root.setLevel(0)
 
     @classmethod
-    def apply_options(cls, options) -> None:
+    def apply_options(cls, options: object) -> None:
         """
         Apply the logging options to the current handler. A handler should have been created before
 
         :param options: the option object coming from the command line. This function use the following
-            attribute: log_file, log_file_level, verbose, timed
+            attributes: log_file, log_file_level, verbose, timed
         """
         if not cls._handler:
             raise Exception(
@@ -110,7 +111,7 @@ class InmantaLogs:
             cls.set_log_level(str(options.verbose))
 
     @classmethod
-    def set_log_level(cls, inmanta_log_level: str, cli=True) -> None:
+    def set_log_level(cls, inmanta_log_level: str, cli: bool = True) -> None:
         """
         Set the logging level. A handler should have been created before
         below the supported inmanta log levels and there equivalent in python logging:
@@ -172,7 +173,7 @@ class InmantaLogs:
         logging.root.addHandler(cls._handler)
 
     @classmethod
-    def get_handler(cls) -> logging.Handler:
+    def get_handler(cls) -> Optional[logging.Handler]:
         """
         Get the logging handler
 

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -89,12 +89,15 @@ class InmantaLogs:
     @classmethod
     def apply_options(cls, options) -> None:
         """
-        Apply the logging options to the current handler. If there is no handler yet, this function starts one
-        with setup_handler
+        Apply the logging options to the current handler. A handler should have been created before
 
         :param options: the option object coming from the command line. This function use the following
             attribute: log_file, log_file_level, verbose, timed
         """
+        if not cls._handler:
+            raise Exception(
+                "No handler to apply options to. Please use the create_default_handler method before calling this " "one"
+            )
         if options.log_file:
             cls.set_logfile_location(options.log_file)
             formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
@@ -111,27 +114,34 @@ class InmantaLogs:
     @classmethod
     def set_log_level(cls, log_level: int) -> None:
         """
-        Set the logging level.
+        Set the logging level. A handler should have been created before
 
         :param log_level: The logging level.
         """
+        if not cls._handler:
+            raise Exception(
+                "No handler to apply options to. Please use the create_default_handler method before calling this " "one"
+            )
         cls._handler.setLevel(log_level)
 
     @classmethod
     def set_log_formatter(cls, formatter: logging.Formatter) -> None:
         """
-        Set the log formatter.
+        Set the log formatter. A handler should have been created before
 
         :param formatter: The log formatter.
         """
+        if not cls._handler:
+            raise Exception(
+                "No handler to apply options to. Please use the create_default_handler method before calling this " "one"
+            )
         cls._handler.setFormatter(formatter)
 
     @classmethod
     def set_logfile_location(cls, location: str) -> None:
         """
-        Set the location of the log file. Be carefull taht this function will replace the current handler with a new one
-        This means that configurations done on the previous handler will be lost. It might be a good idea to
-        call this function first.
+        Set the location of the log file. Be careful that this function will replace the current handler with a new one
+        This means that configurations done on the previous handler will be lost.
 
         :param location: The location of the log file.
         """
@@ -143,9 +153,9 @@ class InmantaLogs:
     @classmethod
     def get_handler(cls) -> logging.Handler:
         """
-        Get the logging handler instance used by this class
+        Get the logging handler
 
-        :return: The logging handler instance used by this class
+        :return: The logging handler
         """
         return cls._handler
 

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -93,38 +93,28 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
 
 
 class InmantaLogs:
-    _handler: logging.Handler = logging.StreamHandler(sys.stdout)
-
-    @classmethod
-    def get_basic_stream_handler(cls, stream=sys.stdout) -> logging.StreamHandler:
-        stream_handler = logging.StreamHandler(stream)
+    def _get_default_stream_handler(cls) -> logging.StreamHandler:
+        stream_handler = logging.StreamHandler(stream=sys.stdout)
         stream_handler.setLevel(logging.INFO)
-        formatter = cls.get_log_formatter_for_stream_handler(timed=False)
+
+        formatter = cls._get_log_formatter_for_stream_handler(timed=False)
         stream_handler.setFormatter(formatter)
 
         return stream_handler
 
-    @classmethod
-    def apply_options(cls, options: argparse.Namespace) -> None:
-        return
-
-    @classmethod
-    def set_log_location(cls, options):
-        if options.log_file:
-            file_handler = logging.handlers.WatchedFileHandler(filename=options.log_file, mode="a+")
-
-    @classmethod
-    def get_watched_file_handler(cls, options: argparse.Namespace) -> logging.handlers.WatchedFileHandler:
+    def _get_watched_file_handler(cls, options: argparse.Namespace) -> logging.handlers.WatchedFileHandler:
         if not options.log_file:
             raise Exception("No logfile was provided.")
-        level = cls.convert_inmanta_log_level_to_python_log_level(options.log_file_level)
+        level = cls._convert_inmanta_log_level_to_python_log_level(options.log_file_level)
         formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
         file_handler = logging.handlers.WatchedFileHandler(filename=options.log_file, mode="a+")
         file_handler.setFormatter(formatter)
         file_handler.setLevel(level)
 
+        return file_handler
+
     @classmethod
-    def convert_cli_log_level(cls, level: int) -> int:
+    def _convert_cli_log_level(cls, level: int) -> int:
         """
         Converts the number of -v's passed on the CLI to the corresponding Inmanta log level
         """

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -1,0 +1,168 @@
+"""
+    Copyright 2017 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+
+
+    Command line development guidelines
+    ###################################
+
+    do's and don'ts
+    ----------------
+    MUST NOT: sys.exit => use command.CLIException
+    SHOULD NOT: print( => use logger for messages, only print for final output
+
+
+    Entry points
+    ------------
+    @command annotation to register new command
+"""
+import logging
+import os
+import sys
+import typing
+
+import colorlog
+from colorlog.formatter import LogColors
+
+from inmanta import const
+from inmanta.app import _is_on_tty
+
+"""
+This dictionary maps the Inmanta log levels to the corresponding Python log levels
+"""
+log_levels = {
+    "0": logging.ERROR,
+    "1": logging.WARNING,
+    "2": logging.INFO,
+    "3": logging.DEBUG,
+    "4": 2,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "TRACE": 2,
+}
+
+
+class MultiLineFormatter(colorlog.ColoredFormatter):
+    """Multi-line formatter."""
+
+    def __init__(
+        self,
+        fmt: typing.Optional[str] = None,
+        *,
+        # keep interface minimal: only include fields we actually use
+        log_colors: typing.Optional[LogColors] = None,
+        reset: bool = True,
+        no_color: bool = False,
+    ):
+        super().__init__(fmt, log_colors=log_colors, reset=reset, no_color=no_color)
+        self.fmt = fmt
+
+    def get_header_length(self, record: logging.LogRecord) -> int:
+        """Get the header length of a given record."""
+        # to get the length of the header we want to get the header without the color codes
+        formatter = colorlog.ColoredFormatter(
+            fmt=self.fmt,
+            log_colors=self.log_colors,
+            reset=False,
+            no_color=True,
+        )
+        header = formatter.format(
+            logging.LogRecord(
+                name=record.name,
+                level=record.levelno,
+                pathname=record.pathname,
+                lineno=record.lineno,
+                msg="",
+                args=(),
+                exc_info=None,
+            )
+        )
+        return len(header)
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format a record with added indentation."""
+        indent: str = " " * self.get_header_length(record)
+        head, *tail = super().format(record).splitlines(True)
+        return head + "".join(indent + line for line in tail)
+
+
+class InmantaLogs:
+    @classmethod
+    def get_default_handler(cls, options, stream=sys.stdout) -> logging.Handler:
+        if options.log_file:
+            handler = logging.handlers.WatchedFileHandler(filename=options.log_file, mode="a+")
+        else:
+            handler = logging.StreamHandler(stream)
+        cls._set_format(options, handler)
+        cls._set_log_level(options, handler)
+
+    @classmethod
+    def _set_format(cls, options, handler):
+        if options.log_file:
+            formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
+        else:
+            timed = options.timed if options.timed else False
+            formatter = cls._get_log_formatter_for_stream_handler(timed=timed)
+        handler.setFormatter(formatter)
+
+    @classmethod
+    def _set_log_level(cls, options, stream_handler):
+        if options.log_file:
+            level = cls._convert_inmanta_log_level_to_python_log_level(options.log_file_level)
+        else:
+            level = cls._convert_cli_log_level(options.verbose)
+        stream_handler.setLevel(level)
+
+    @classmethod
+    def _convert_cli_log_level(cls, level: int) -> int:
+        """
+        Converts the number of -v's passed on the CLI to the corresponding Inmanta log level
+        """
+        if level < 1:
+            # The minimal log level on the CLI is always WARNING
+            return logging.WARNING
+        else:
+            return cls._convert_inmanta_log_level_to_python_log_level(str(level))
+
+    @classmethod
+    def _convert_inmanta_log_level_to_python_log_level(cls, level: str) -> int:
+        """
+        Converts the Inmanta log level to the Python log level
+        """
+        if level.isdigit() and int(level) > 4:
+            level = "4"
+        return log_levels[level]
+
+    @classmethod
+    def _get_log_formatter_for_stream_handler(cls, timed: bool) -> logging.Formatter:
+        log_format = "%(asctime)s " if timed else ""
+        if _is_on_tty():
+            log_format += "%(log_color)s%(name)-25s%(levelname)-8s%(reset)s%(blue)s%(message)s"
+            formatter = MultiLineFormatter(
+                log_format,
+                reset=True,
+                log_colors={"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"},
+            )
+        else:
+            log_format += "%(name)-25s%(levelname)-8s%(message)s"
+            formatter = MultiLineFormatter(
+                log_format,
+                reset=False,
+                no_color=True,
+            )
+        return formatter

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -140,11 +140,10 @@ class InmantaLoggerConfig:
 
     @classmethod
     @stable_api
-    def clean_instance(cls) -> "InmantaLoggerConfig":
+    def clean_instance(cls) -> None:
         """
-        This method should be used to obtain an instance of this class, because this class is a singleton.
+        This method should be used to clean up an instance of this class
 
-        :param stream: The stream to send log messages to. Default is standard output (sys.stdout)
         """
         if cls._instance and cls._instance._handler:
             cls._instance._handler.close()

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -162,7 +162,7 @@ class InmantaLoggerConfig:
             "TRACE": 2,
 
         :param inmanta_log_level: The inmanta logging level
-        :param cli: True if the logs will be outputed to the CLI.
+        :param cli: True if the logs will be outputted to the CLI.
         """
         if not self._handler:
             raise Exception("No handler to apply options to. Please use the get_instance method before calling this one")

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -162,7 +162,8 @@ class InmantaLoggerConfig:
     def set_log_level(self, inmanta_log_level: str, cli: bool = True) -> None:
         """
         Set the logging level. A handler should have been created before.
-        The possible inmanta log levels and their associated python log level are defined in the inmanta.logging.log_levels dictionary.
+        The possible inmanta log levels and their associated python log level
+        are defined in the inmanta.logging.log_levels dictionary.
 
         :param inmanta_log_level: The inmanta logging level
         :param cli: True if the logs will be outputted to the CLI.

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -146,7 +146,8 @@ class InmantaLogs:
         :param location: The location of the log file.
         """
         file_handler = logging.handlers.WatchedFileHandler(filename=location, mode="a+")
-        logging.root.removeHandler(cls._handler)
+        if cls._handler:
+            logging.root.removeHandler(cls._handler)
         cls._handler = file_handler
         logging.root.addHandler(cls._handler)
 

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -66,7 +66,7 @@ class InmantaLogs:
     - `timed`: if true,  adds the time to the formatter in the log lines.
 
     The setup is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
-    the 'final' logger with apply_options.
+    the 'final' logger with `apply_options`.
 
     for more fine-grained configuration the following functions can be used aswell:
         - `set_log_level`

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -171,7 +171,7 @@ class InmantaLoggerConfig:
             inmanta_log_level = "4"
 
         # The minimal log level on the CLI is always WARNING
-        if cli and inmanta_log_level == "ERROR" or (inmanta_log_level.isdigit() and int(inmanta_log_level) < 1):
+        if cli and (inmanta_log_level == "ERROR" or (inmanta_log_level.isdigit() and int(inmanta_log_level) < 1)):
             inmanta_log_level = "WARNING"
 
         # Converts the Inmanta log level to the Python log level

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -62,9 +62,9 @@ class InmantaLogs:
       specified in `setup_handler`.
     - `log_file_level`: the logging level for the file handler (if `log_file` is set).
     - `verbose`: the verbosity level of the log messages.
-    - 'timed':if true,  adds the time to the formatter in the log lines.
+    - 'timed': if true,  adds the time to the formatter in the log lines.
 
-    This is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
+    The setup is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
     the 'final' logger with apply_options.
     """
 
@@ -87,18 +87,14 @@ class InmantaLogs:
         logging.root.setLevel(0)
 
     @classmethod
-    def apply_options(cls, options, stream: Optional[str] = sys.stdout) -> None:
+    def apply_options(cls, options) -> None:
         """
         Apply the logging options to the current handler. If there is no handler yet, this function starts one
         with setup_handler
 
         :param options: the option object coming from the command line. This function use the following
             attribute: log_file, log_file_level, verbose, timed
-        :param stream: The stream to send log messages to. Default is standard output (sys.stdout). This is only used
-            if a handler needs to be setup. If there is already a handler this param is ignored.
         """
-        if cls._handler is None:
-            cls.create_default_handler(stream=stream)
         if options.log_file:
             cls.set_logfile_location(options.log_file)
             formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -148,8 +148,8 @@ class InmantaLoggerConfig:
     @stable_api
     def set_log_level(self, inmanta_log_level: str, cli: bool = True) -> None:
         """
-        Set the logging level. A handler should have been created before
-        below the supported inmanta log levels and there equivalent in python logging:
+        Set the logging level. A handler should have been created before.
+        Below the supported Inmanta log levels and there equivalent and their equivalent Python log levels are shown:
             "0": logging.ERROR,
             "1": logging.WARNING,
             "2": logging.INFO,

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -132,10 +132,12 @@ class InmantaLoggerConfig:
 
         :param stream: The stream to send log messages to. Default is standard output (sys.stdout)
         """
-        if cls._instance and not (
-            isinstance(cls._instance.handler, logging.StreamHandler) and cls._instance._handler.stream != stream
+        if (
+            cls._instance
+            and not isinstance(cls._instance._handler, logging.StreamHandler)
+            or cls._instance._handler.stream != stream
         ):
-            raise Exception("Instance already exists: cannot set the stream argument")
+            raise Exception("Instance already exists with a different stream handler")
         if not cls._instance:
             cls._instance = cls(stream)
         return cls._instance

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -53,7 +53,7 @@ class Options(Namespace):
     """
     The Options class provides a way to configure the InmantaLoggerConfig with the following attributes:
     - `log_file`: if this attribute is set, the logs will be written to the specified file instead of the stream
-      specified in `create_default_handler`.
+      specified in `get_instance`.
     - `log_file_level`: the Inmanta logging level for the file handler (if `log_file` is set).
         The possible inmanta logging levels and their associated python log level are the following ones:
             "0": logging.ERROR,
@@ -92,7 +92,7 @@ class InmantaLoggerConfig:
     You can then call the `apply_options` method to configure the logging options. This method takes an `options`
     argument that should be an Option object with the following attributes:
     - `log_file`: if this attribute is set, the logs will be written to the specified file instead of the stream
-      specified in `create_default_handler`.
+      specified in `get_instance`.
     - `log_file_level`: the logging level for the file handler (if `log_file` is set).
     - `verbose`: the verbosity level of the log messages.
     - `timed`: if true,  adds the time to the formatter in the log lines.
@@ -132,7 +132,9 @@ class InmantaLoggerConfig:
 
         :param stream: The stream to send log messages to. Default is standard output (sys.stdout)
         """
-        if cls._instance and stream != sys.stdout:
+        if cls._instance and not (
+            isinstance(cls._instance.handler, logging.StreamHandler) and cls._instance._handler.stream != stream
+        ):
             raise Exception("Instance already exists: cannot set the stream argument")
         if not cls._instance:
             cls._instance = cls(stream)

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -68,7 +68,7 @@ class InmantaLogs:
     The setup is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
     the 'final' logger with apply_options.
 
-    for more fine_grained configuration the following functions can be used aswell:
+    for more fine-grained configuration the following functions can be used aswell:
         - set_log_level
         - set_log_formatter
         - set_logfile_location

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -204,7 +204,7 @@ class InmantaLoggerConfig:
         logging.root.addHandler(self._handler)
 
     @stable_api
-    def get_handler(self) -> Optional[logging.Handler]:
+    def get_handler(self) -> logging.Handler:
         """
         Get the logging handler
 

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -15,7 +15,6 @@
 
     Contact: code@inmanta.com
 """
-import argparse
 import logging
 import os
 import sys

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -55,7 +55,8 @@ class Options(Namespace):
     - `log_file`: if this attribute is set, the logs will be written to the specified file instead of the stream
       specified in `get_instance`.
     - `log_file_level`: the Inmanta logging level for the file handler (if `log_file` is set).
-        The possible inmanta log levels and their associated python log level are defined in the inmanta.logging.log_levels dictionary.
+        The possible inmanta log levels and their associated python log level are defined in the
+        inmanta.logging.log_levels dictionary.
     - `verbose`: the verbosity level of the log messages. can be a number from 0 to 4.
         if a bigger number is provided, 4 will be used. Refer to log_file_level for the explanation of each level.
         default is 1 (WARNING)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -516,6 +516,7 @@ def reset_all_objects():
     V2ModuleBuilder.DISABLE_ISOLATED_ENV_BUILDER_CACHE = False
     compiler.Finalizers.reset_finalizers()
     AuthJWTConfig.reset()
+    InmantaLoggerConfig.clean_instance()
 
 
 @pytest.fixture()
@@ -1764,9 +1765,3 @@ def disable_version_and_agent_cleanup_job():
     orchestrationservice.PERFORM_CLEANUP = False
     yield
     orchestrationservice.PERFORM_CLEANUP = old_perform_cleanup
-
-
-@pytest.fixture(scope="function")
-async def cleanup_log_instance():
-    InmantaLoggerConfig.clean_instance()
-    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ import warnings
 
 import toml
 from inmanta.config import AuthJWTConfig
+from inmanta.logging import InmantaLoggerConfig
 
 """
 About the use of @parametrize_any and @slowtest:
@@ -1763,3 +1764,9 @@ def disable_version_and_agent_cleanup_job():
     orchestrationservice.PERFORM_CLEANUP = False
     yield
     orchestrationservice.PERFORM_CLEANUP = old_perform_cleanup
+
+
+@pytest.fixture(scope="function")
+async def cleanup_log_instance():
+    InmantaLoggerConfig.clean_instance()
+    yield

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -116,7 +116,7 @@ def test_set_logfile_location(
 
 @pytest.mark.parametrize_any(
     "log_file, log_file_level, verbose",
-    [(None, "INFO", "1"), (None, "ERROR", "4"), ("test.log", "WARNING", "4"), ("test.log", "DEBUG", "4")],
+    [(None, "INFO", 1), (None, "ERROR", 4), ("test.log", "WARNING", 4), ("test.log", "DEBUG", 4)],
 )
 def test_apply_options(tmpdir, log_file, log_file_level, verbose):
     stream = StringIO()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -47,7 +47,7 @@ def test_setup_instance_2_times():
 
     with pytest.raises(Exception) as e:
         InmantaLoggerConfig.get_instance(sys.stdout)
-    message = "Instance already exists: cannot set the stream argument"
+    message = "Instance already exists with a different stream"
     assert message in str(e.value)
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -32,6 +32,25 @@ def test_setup_instance():
     assert handler.level == logging.INFO
 
 
+def test_setup_instance_2_times():
+    inmanta_logger = InmantaLoggerConfig.get_instance(sys.stderr)
+    handler = inmanta_logger.get_handler()
+    assert handler.stream == sys.stderr
+    assert isinstance(handler.formatter, MultiLineFormatter)
+    assert handler.level == logging.INFO
+
+    inmanta_logger = InmantaLoggerConfig.get_instance(sys.stderr)
+    handler = inmanta_logger.get_handler()
+    assert handler.stream == sys.stderr
+    assert isinstance(handler.formatter, MultiLineFormatter)
+    assert handler.level == logging.INFO
+
+    with pytest.raises(Exception) as e:
+        InmantaLoggerConfig.get_instance(sys.stdout)
+    message = "Instance already exists: cannot set the stream argument"
+    assert message in str(e.value)
+
+
 def test_setup_instance_with_stream():
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -59,7 +59,7 @@ def test_set_log_level():
     assert expected_output not in log_output
 
     # change the log_level and verify the log is visible this time.
-    InmantaLogs.set_log_level(logging.DEBUG)
+    InmantaLogs.set_log_level("DEBUG")
     logger.debug("This is a test message")
     log_output = stream.getvalue().strip()
     assert expected_output in log_output
@@ -123,7 +123,7 @@ def test_apply_options(tmpdir):
 
     # test that with if no log_file is given, the stream will be used with the specified verbose option
     # For verbose level 1, WARNINGs are shown INFOs not
-    options1 = Options(log_file=None, log_file_level="INFO", verbose=1)
+    options1 = Options(log_file=None, log_file_level="INFO", verbose="1")
     InmantaLogs.apply_options(options1)
     logger.info("info: This is the first test")
     logger.warning("warning: This is the second test")
@@ -133,7 +133,7 @@ def test_apply_options(tmpdir):
 
     # test that with if no log_file is given, the stream will be used with the specified verbose option
     # For verbose level 4, WARNINGs and INFOs are shown
-    options2 = Options(log_file=None, log_file_level="INFO", verbose=4)
+    options2 = Options(log_file=None, log_file_level="INFO", verbose="4")
     InmantaLogs.apply_options(options2)
     logger.warning("warning: This is the third test")
     logger.info("info: This is the forth test")
@@ -145,7 +145,7 @@ def test_apply_options(tmpdir):
 
     # test that with if a log_file is given, the logfile will be used will be used with the specified log_file_level
     # Here WARNINGs are shown INFOs not
-    options3 = Options(log_file=log_file, log_file_level="WARNING", verbose=4)
+    options3 = Options(log_file=log_file, log_file_level="WARNING", verbose="4")
     InmantaLogs.apply_options(options3)
     logger.info("info: This is the first test")
     logger.warning("warning: This is the second test")
@@ -156,7 +156,7 @@ def test_apply_options(tmpdir):
 
     # test that with if a log_file is given, the logfile will be used will be used with the specified log_file_level
     # Here both WARNINGs and INFOs are shown
-    options4 = Options(log_file=log_file, log_file_level="DEBUG", verbose=4)
+    options4 = Options(log_file=log_file, log_file_level="DEBUG", verbose="4")
     InmantaLogs.apply_options(options4)
     logger.warning("warning: This is the third test")
     logger.info("info: This is the forth test")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,19 +19,19 @@ import logging
 import sys
 from io import StringIO
 
-from inmanta.logging import InmantaLogs, MultiLineFormatter
+from inmanta.logging import InmantaLoggerConfig, MultiLineFormatter
 
 
 def test_setup_handler():
-    InmantaLogs.create_default_handler()
-    handler = InmantaLogs.get_handler()
+    InmantaLoggerConfig.create_default_handler()
+    handler = InmantaLoggerConfig.get_handler()
     assert handler.stream == sys.stdout
     assert isinstance(handler.formatter, MultiLineFormatter)
     assert handler.level == logging.INFO
 
     stream = StringIO()
-    InmantaLogs.create_default_handler(stream=stream)
-    handler = InmantaLogs.get_handler()
+    InmantaLoggerConfig.create_default_handler(stream=stream)
+    handler = InmantaLoggerConfig.get_handler()
     assert handler.stream == stream
     assert isinstance(handler.formatter, MultiLineFormatter)
     assert handler.level == logging.INFO
@@ -46,8 +46,8 @@ def test_setup_handler():
 
 def test_set_log_level():
     stream = StringIO()
-    InmantaLogs.create_default_handler(stream=stream)
-    handler = InmantaLogs.get_handler()
+    InmantaLoggerConfig.create_default_handler(stream=stream)
+    handler = InmantaLoggerConfig.get_handler()
     assert handler.level == logging.INFO
 
     logger = logging.getLogger("test_logger")
@@ -59,7 +59,7 @@ def test_set_log_level():
     assert expected_output not in log_output
 
     # change the log_level and verify the log is visible this time.
-    InmantaLogs.set_log_level("DEBUG")
+    InmantaLoggerConfig.set_log_level("DEBUG")
     logger.debug("This is a test message")
     log_output = stream.getvalue().strip()
     assert expected_output in log_output
@@ -67,8 +67,8 @@ def test_set_log_level():
 
 def test_set_log_formatter():
     stream = StringIO()
-    InmantaLogs.create_default_handler(stream=stream)
-    handler = InmantaLogs.get_handler()
+    InmantaLoggerConfig.create_default_handler(stream=stream)
+    handler = InmantaLoggerConfig.get_handler()
     assert isinstance(handler.formatter, MultiLineFormatter)
 
     logger = logging.getLogger("test_logger")
@@ -82,8 +82,8 @@ def test_set_log_formatter():
 
     # change the formatter and verify the output is different
     formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-    InmantaLogs.set_log_formatter(formatter)
-    assert InmantaLogs.get_handler().formatter == formatter
+    InmantaLoggerConfig.set_log_formatter(formatter)
+    assert InmantaLoggerConfig.get_handler().formatter == formatter
 
     logger.info("This is a test message")
     log_output = stream.getvalue().strip()
@@ -92,9 +92,9 @@ def test_set_log_formatter():
 
 def test_set_logfile_location(tmpdir):
     log_file = tmpdir.join("test.log")
-    InmantaLogs.create_default_handler()
-    InmantaLogs.set_logfile_location(str(log_file))
-    handler = InmantaLogs.get_handler()
+    InmantaLoggerConfig.create_default_handler()
+    InmantaLoggerConfig.set_logfile_location(str(log_file))
+    handler = InmantaLoggerConfig.get_handler()
     assert isinstance(handler, logging.handlers.WatchedFileHandler)
     assert handler.baseFilename == str(log_file)
 
@@ -118,13 +118,13 @@ class Options:
 
 def test_apply_options(tmpdir):
     stream = StringIO()
-    InmantaLogs.create_default_handler(stream=stream)
+    InmantaLoggerConfig.create_default_handler(stream=stream)
     logger = logging.getLogger("test_logger")
 
     # test that with if no log_file is given, the stream will be used with the specified verbose option
     # For verbose level 1, WARNINGs are shown INFOs not
     options1 = Options(log_file=None, log_file_level="INFO", verbose="1")
-    InmantaLogs.apply_options(options1)
+    InmantaLoggerConfig.apply_options(options1)
     logger.info("info: This is the first test")
     logger.warning("warning: This is the second test")
     log_output = stream.getvalue().strip()
@@ -134,7 +134,7 @@ def test_apply_options(tmpdir):
     # test that with if no log_file is given, the stream will be used with the specified verbose option
     # For verbose level 4, WARNINGs and INFOs are shown
     options2 = Options(log_file=None, log_file_level="INFO", verbose="4")
-    InmantaLogs.apply_options(options2)
+    InmantaLoggerConfig.apply_options(options2)
     logger.warning("warning: This is the third test")
     logger.info("info: This is the forth test")
     log_output = stream.getvalue().strip()
@@ -146,7 +146,7 @@ def test_apply_options(tmpdir):
     # test that with if a log_file is given, the logfile will be used will be used with the specified log_file_level
     # Here WARNINGs are shown INFOs not
     options3 = Options(log_file=log_file, log_file_level="WARNING", verbose="4")
-    InmantaLogs.apply_options(options3)
+    InmantaLoggerConfig.apply_options(options3)
     logger.info("info: This is the first test")
     logger.warning("warning: This is the second test")
     with open(str(log_file), "r") as f:
@@ -157,7 +157,7 @@ def test_apply_options(tmpdir):
     # test that with if a log_file is given, the logfile will be used will be used with the specified log_file_level
     # Here both WARNINGs and INFOs are shown
     options4 = Options(log_file=log_file, log_file_level="DEBUG", verbose="4")
-    InmantaLogs.apply_options(options4)
+    InmantaLoggerConfig.apply_options(options4)
     logger.warning("warning: This is the third test")
     logger.info("info: This is the forth test")
     with open(str(log_file), "r") as f:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -22,7 +22,7 @@ from io import StringIO
 from inmanta.logging import InmantaLoggerConfig, MultiLineFormatter, Options
 
 
-def test_setup_instance():
+def test_setup_instance(cleanup_log_instance):
     inmanta_logger = InmantaLoggerConfig.get_instance()
     handler = inmanta_logger.get_handler()
     assert handler.stream == sys.stdout
@@ -30,7 +30,7 @@ def test_setup_instance():
     assert handler.level == logging.INFO
 
 
-def test_setup_instance_with_stream():
+def test_setup_instance_with_stream(cleanup_log_instance):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -46,7 +46,7 @@ def test_setup_instance_with_stream():
     assert log_output == expected_output
 
 
-def test_set_log_level():
+def test_set_log_level(cleanup_log_instance):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -67,7 +67,7 @@ def test_set_log_level():
     assert expected_output in log_output
 
 
-def test_set_log_formatter():
+def test_set_log_formatter(cleanup_log_instance):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -92,7 +92,7 @@ def test_set_log_formatter():
     assert expected_output_format2 in log_output
 
 
-def test_set_logfile_location(tmpdir):
+def test_set_logfile_location(tmpdir, cleanup_log_instance):
     log_file = tmpdir.join("test.log")
     inmanta_logger = InmantaLoggerConfig.get_instance()
     inmanta_logger.set_logfile_location(str(log_file))
@@ -110,7 +110,7 @@ def test_set_logfile_location(tmpdir):
         assert "This is a test message" in contents
 
 
-def test_apply_options(tmpdir):
+def test_apply_options(tmpdir, cleanup_log_instance):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     logger = logging.getLogger("test_logger")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,7 +19,7 @@ import logging
 import sys
 from io import StringIO
 
-from inmanta.logging import InmantaLoggerConfig, MultiLineFormatter
+from inmanta.logging import InmantaLoggerConfig, MultiLineFormatter, Options
 
 
 def test_setup_instance():
@@ -108,14 +108,6 @@ def test_set_logfile_location(tmpdir):
     with open(str(log_file), "r") as f:
         contents = f.read()
         assert "This is a test message" in contents
-
-
-class Options:
-    def __init__(self, log_file=None, log_file_level=None, verbose=None):
-        self.log_file = log_file
-        self.log_file_level = log_file_level
-        self.verbose = verbose
-        self.timed = False
 
 
 def test_apply_options(tmpdir):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,166 @@
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import logging
+import sys
+from io import StringIO
+
+from inmanta.logging import InmantaLogs, MultiLineFormatter
+
+
+def test_setup_handler():
+    InmantaLogs.create_default_handler()
+    handler = InmantaLogs.get_handler()
+    assert handler.stream == sys.stdout
+    assert isinstance(handler.formatter, MultiLineFormatter)
+    assert handler.level == logging.INFO
+
+    stream = StringIO()
+    InmantaLogs.create_default_handler(stream=stream)
+    handler = InmantaLogs.get_handler()
+    assert handler.stream == stream
+    assert isinstance(handler.formatter, MultiLineFormatter)
+    assert handler.level == logging.INFO
+
+    # Log a message
+    logger = logging.getLogger("test_logger")
+    logger.info("This is a test message")
+    log_output = stream.getvalue().strip()
+    expected_output = "test_logger              INFO    This is a test message"
+    assert log_output == expected_output
+
+
+def test_set_log_level():
+    stream = StringIO()
+    InmantaLogs.create_default_handler(stream=stream)
+    handler = InmantaLogs.get_handler()
+    assert handler.level == logging.INFO
+
+    logger = logging.getLogger("test_logger")
+    expected_output = "test_logger              DEBUG   This is a test message"
+
+    # Log a message and verify that it is not logged as the log level is too high
+    logger.debug("This is a test message")
+    log_output = stream.getvalue().strip()
+    assert expected_output not in log_output
+
+    # change the log_level and verify the log is visible this time.
+    InmantaLogs.set_log_level(logging.DEBUG)
+    logger.debug("This is a test message")
+    log_output = stream.getvalue().strip()
+    assert expected_output in log_output
+
+
+def test_set_log_formatter():
+    stream = StringIO()
+    InmantaLogs.create_default_handler(stream=stream)
+    handler = InmantaLogs.get_handler()
+    assert isinstance(handler.formatter, MultiLineFormatter)
+
+    logger = logging.getLogger("test_logger")
+    expected_output_format1 = "test_logger              INFO    This is a test message"
+    expected_output_format2 = "test_logger - INFO - This is a test message"
+
+    # Log a message with the default formatter
+    logger.info("This is a test message")
+    log_output = stream.getvalue().strip()
+    assert expected_output_format1 in log_output
+
+    # change the formatter and verify the output is different
+    formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+    InmantaLogs.set_log_formatter(formatter)
+    assert InmantaLogs.get_handler().formatter == formatter
+
+    logger.info("This is a test message")
+    log_output = stream.getvalue().strip()
+    assert expected_output_format2 in log_output
+
+
+def test_set_logfile_location(tmpdir):
+    log_file = tmpdir.join("test.log")
+    InmantaLogs.create_default_handler()
+    InmantaLogs.set_logfile_location(str(log_file))
+    handler = InmantaLogs.get_handler()
+    assert isinstance(handler, logging.handlers.WatchedFileHandler)
+    assert handler.baseFilename == str(log_file)
+
+    # Log a message
+    logger = logging.getLogger("test_logger")
+    logger.info("This is a test message")
+
+    # Verify the message was written to the log file
+    with open(str(log_file), "r") as f:
+        contents = f.read()
+        assert "This is a test message" in contents
+
+
+class Options:
+    def __init__(self, log_file=None, log_file_level=None, verbose=None):
+        self.log_file = log_file
+        self.log_file_level = log_file_level
+        self.verbose = verbose
+        self.timed = False
+
+
+def test_apply_options(tmpdir):
+    stream = StringIO()
+    InmantaLogs.create_default_handler(stream=stream)
+    logger = logging.getLogger("test_logger")
+
+    # test that with if no log_file is given, the stream will be used with the specified verbose option
+    # For verbose level 1, WARNINGs are shown INFOs not
+    options1 = Options(log_file=None, log_file_level="INFO", verbose=1)
+    InmantaLogs.apply_options(options1)
+    logger.info("info: This is the first test")
+    logger.warning("warning: This is the second test")
+    log_output = stream.getvalue().strip()
+    "INFO     test_logger info: This is the first test" not in log_output
+    "WARNING  test_logger warning: This is the second test" in log_output
+
+    # test that with if no log_file is given, the stream will be used with the specified verbose option
+    # For verbose level 4, WARNINGs and INFOs are shown
+    options2 = Options(log_file=None, log_file_level="INFO", verbose=4)
+    InmantaLogs.apply_options(options2)
+    logger.warning("warning: This is the third test")
+    logger.info("info: This is the forth test")
+    log_output = stream.getvalue().strip()
+    "INFO     test_logger info: This is the forth test" in log_output
+    "WARNING  test_logger warning: This is the third test" in log_output
+
+    log_file = tmpdir.join("test.log")
+
+    # test that with if a log_file is given, the logfile will be used will be used with the specified log_file_level
+    # Here WARNINGs are shown INFOs not
+    options3 = Options(log_file=log_file, log_file_level="WARNING", verbose=4)
+    InmantaLogs.apply_options(options3)
+    logger.info("info: This is the first test")
+    logger.warning("warning: This is the second test")
+    with open(str(log_file), "r") as f:
+        contents = f.read()
+        assert "INFO     test_logger info: This is the first test" not in contents
+        assert "WARNING  test_logger warning: This is the second test" in contents
+
+    # test that with if a log_file is given, the logfile will be used will be used with the specified log_file_level
+    # Here both WARNINGs and INFOs are shown
+    options4 = Options(log_file=log_file, log_file_level="DEBUG", verbose=4)
+    InmantaLogs.apply_options(options4)
+    logger.warning("warning: This is the third test")
+    logger.info("info: This is the forth test")
+    with open(str(log_file), "r") as f:
+        contents = f.read()
+        assert "WARNING  test_logger warning: This is the third test" in contents
+        assert "INFO     test_logger info: This is the forth test" in contents

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -167,6 +167,8 @@ def test_apply_options(tmpdir):
 
 
 def test_logging_cleaned_after_apply_options(tmpdir):
+    # verifies that when changing the stream with apply_option, the old stream is properly cleaned up
+    # and not user anymore.
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     logger = logging.getLogger("test_logger")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -137,7 +137,7 @@ def test_apply_options(tmpdir, log_file, log_file_level, verbose):
         debug_in_output = "test_logger              DEBUG   debug: This is the first test" in log_output
         info_in_output = "test_logger              INFO    info: This is the second test" in log_output
         warning_in_output = "test_logger              WARNING warning: This is the third test" in log_output
-        error_in_output = "test_logger              ERROR   error: This is the forth test" in log_output
+        error_in_output = "test_logger              ERROR   error: This is the fourth test" in log_output
         assert debug_in_output if int(verbose) >= 3 else not debug_in_output
         assert info_in_output if int(verbose) >= 2 else not info_in_output
         assert warning_in_output if int(verbose) >= 1 else not warning_in_output
@@ -149,7 +149,7 @@ def test_apply_options(tmpdir, log_file, log_file_level, verbose):
             debug_in_output = "DEBUG    test_logger debug: This is the first test" in log_output
             info_in_output = "INFO     test_logger info: This is the second test" in log_output
             warning_in_output = "WARNING  test_logger warning: This is the third test" in log_output
-            error_in_output = "ERROR    test_logger error: This is the forth test" in log_output
+            error_in_output = "ERROR    test_logger error: This is the fourth test" in log_output
             assert debug_in_output if log_file_level in ["DEBUG"] else not debug_in_output
             assert info_in_output if log_file_level in ["DEBUG", "INFO"] else not info_in_output
             assert warning_in_output if log_file_level in ["WARNING", "INFO", "DEBUG"] else not warning_in_output

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -22,7 +22,7 @@ from io import StringIO
 from inmanta.logging import InmantaLoggerConfig, MultiLineFormatter, Options
 
 
-def test_setup_instance(cleanup_log_instance):
+def test_setup_instance():
     inmanta_logger = InmantaLoggerConfig.get_instance()
     handler = inmanta_logger.get_handler()
     assert handler.stream == sys.stdout
@@ -30,7 +30,7 @@ def test_setup_instance(cleanup_log_instance):
     assert handler.level == logging.INFO
 
 
-def test_setup_instance_with_stream(cleanup_log_instance):
+def test_setup_instance_with_stream():
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -46,7 +46,7 @@ def test_setup_instance_with_stream(cleanup_log_instance):
     assert log_output == expected_output
 
 
-def test_set_log_level(cleanup_log_instance):
+def test_set_log_level():
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -67,7 +67,7 @@ def test_set_log_level(cleanup_log_instance):
     assert expected_output in log_output
 
 
-def test_set_log_formatter(cleanup_log_instance):
+def test_set_log_formatter():
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -92,7 +92,9 @@ def test_set_log_formatter(cleanup_log_instance):
     assert expected_output_format2 in log_output
 
 
-def test_set_logfile_location(tmpdir, cleanup_log_instance):
+def test_set_logfile_location(
+    tmpdir,
+):
     log_file = tmpdir.join("test.log")
     inmanta_logger = InmantaLoggerConfig.get_instance()
     inmanta_logger.set_logfile_location(str(log_file))
@@ -110,7 +112,7 @@ def test_set_logfile_location(tmpdir, cleanup_log_instance):
         assert "This is a test message" in contents
 
 
-def test_apply_options(tmpdir, cleanup_log_instance):
+def test_apply_options(tmpdir):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     logger = logging.getLogger("test_logger")
@@ -162,3 +164,27 @@ def test_apply_options(tmpdir, cleanup_log_instance):
         assert "WARNING  test_logger warning: This is the forth test" in contents
         assert "INFO     test_logger info: This is the fifth test" in contents
         assert "DEBUG    test_logger debug: This is the sixth test" in contents
+
+
+def test_logging_cleaned_after_apply_options(tmpdir):
+    stream = StringIO()
+    inmanta_logger = InmantaLoggerConfig.get_instance(stream)
+    logger = logging.getLogger("test_logger")
+
+    logger.info("This is a test message")
+    log_output = stream.getvalue().strip()
+    expected_output = "test_logger              INFO    This is a test message"
+    assert log_output == expected_output
+
+    log_file = tmpdir.join("test.log")
+
+    options3 = Options(log_file=log_file, log_file_level="WARNING", verbose="4")
+    inmanta_logger.apply_options(options3)
+    logger.warning("warning: This is the second test")
+    with open(str(log_file), "r") as f:
+        contents = f.read()
+        assert "WARNING  test_logger warning: This is the second test" in contents
+
+    log_output = stream.getvalue().strip()
+    expected_output = "test_logger              INFO    This is a test message"
+    assert log_output == expected_output


### PR DESCRIPTION
# Description

Expose core logging setup through the stable api

closes #5815

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
