### PR TITLE
Issue/5842-dont-run-cleanup-jobs-halted-environment-iso5

### DIFF
--- a/changelogs/unreleased/5842-dont-cleanup-halted-env.yml
+++ b/changelogs/unreleased/5842-dont-cleanup-halted-env.yml
@@ -1,0 +1,7 @@
+description: Don't run cleanup jobs on halted environments
+issue-nr: 5842
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  bugfix: "{{description}}"
+

--- a/changelogs/unreleased/5842-dont-cleanup-halted-env.yml
+++ b/changelogs/unreleased/5842-dont-cleanup-halted-env.yml
@@ -1,7 +1,7 @@
 description: Don't run cleanup jobs on halted environments
 issue-nr: 5842
 change-type: patch
-destination-branches: [master, iso6, iso5]
+destination-branches: [iso5]
 sections:
   bugfix: "{{description}}"
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2739,8 +2739,19 @@ class Parameter(BaseDocument):
     metadata: Optional[JsonType] = None
 
     @classmethod
-    async def get_updated_before(cls, updated_before: datetime.datetime) -> List["Parameter"]:
-        query = "SELECT * FROM " + cls.table_name() + " WHERE updated < $1"
+    async def get_updated_before_active_env(cls, updated_before: datetime.datetime) -> List["Parameter"]:
+        """
+        Retrieve the list of parameters that were updated before a specified datetime for environments that are not halted
+        """
+        query = f"""
+         WITH non_halted_envs AS (
+          SELECT id FROM public.environment WHERE NOT halted
+        )
+        SELECT * FROM {cls.table_name()}
+        WHERE environment IN (
+          SELECT id FROM non_halted_envs
+        ) and updated < $1;
+        """
         values = [cls._get_value(updated_before)]
         result = await cls.select_query(query, values)
         return result
@@ -2899,8 +2910,12 @@ class AgentProcess(BaseDocument):
     @classmethod
     async def cleanup(cls, nr_expired_records_to_keep: int) -> None:
         query = f"""
-            DELETE FROM {cls.table_name()} as a1
+            WITH halted_env AS (
+                SELECT id FROM environment WHERE halted = true
+            )
+            DELETE FROM {cls.table_name()} AS a1
             WHERE a1.expired IS NOT NULL AND
+                  a1.environment NOT IN (SELECT id FROM halted_env) AND
                   (
                     -- Take nr_expired_records_to_keep into account
                     SELECT count(*)
@@ -2914,10 +2929,11 @@ class AgentProcess(BaseDocument):
                   -- Agent process only has expired agent instances
                   NOT EXISTS(
                     SELECT 1
-                    FROM {cls.table_name()} as agentprocess INNER JOIN {AgentInstance.table_name()} as agentinstance
-                         ON agentinstance.process = agentprocess.sid
-                    WHERE agentprocess.sid = a1.sid and agentinstance.expired IS NULL
-                  )
+                    FROM {cls.table_name()} AS agentprocess
+                    INNER JOIN {AgentInstance.table_name()} AS agentinstance
+                    ON agentinstance.process = agentprocess.sid
+                    WHERE agentprocess.sid = a1.sid AND agentinstance.expired IS NULL
+                  );
         """
         await cls._execute_query(query, cls._get_value(nr_expired_records_to_keep))
 
@@ -3429,7 +3445,15 @@ class Compile(BaseDocument):
     async def delete_older_than(
         cls, oldest_retained_date: datetime.datetime, connection: Optional[asyncpg.Connection] = None
     ) -> None:
-        query = "DELETE FROM " + cls.table_name() + " WHERE completed <= $1::timestamp with time zone"
+        query = f"""
+        WITH non_halted_envs AS (
+          SELECT id FROM public.environment WHERE NOT halted
+        )
+        DELETE FROM {cls.table_name()}
+        WHERE environment IN (
+          SELECT id FROM non_halted_envs
+        ) AND completed <= $1::timestamp with time zone;
+        """
         await cls._execute_query(query, oldest_retained_date, connection=connection)
 
     @classmethod
@@ -3819,13 +3843,20 @@ class ResourceAction(BaseDocument):
 
     @classmethod
     async def purge_logs(cls) -> None:
-        environments = await Environment.get_list()
-        for env in environments:
-            time_to_retain_logs = await env.get(RESOURCE_ACTION_LOGS_RETENTION)
-            keep_logs_until = datetime.datetime.now().astimezone() - datetime.timedelta(days=time_to_retain_logs)
-            query = "DELETE FROM " + cls.table_name() + " WHERE environment=$1 AND started < $2"
-            value = cls._get_value(keep_logs_until)
-            await cls._execute_query(query, env.id, value)
+        default_retention_time = Environment._settings[RESOURCE_ACTION_LOGS_RETENTION].default
+
+        query = f"""
+            WITH non_halted_envs AS (
+                SELECT id, (COALESCE((settings->>'resource_action_logs_retention')::int, $1)) AS retention_days
+                FROM {Environment.table_name()}
+                WHERE NOT halted
+            )
+            DELETE FROM {cls.table_name()}
+            USING non_halted_envs
+            WHERE environment = non_halted_envs.id
+                AND started < now() AT TIME ZONE 'UTC' - make_interval(days => non_halted_envs.retention_days)
+        """
+        await cls._execute_query(query, default_retention_time)
 
     @classmethod
     async def query_resource_actions(
@@ -5260,15 +5291,20 @@ class Notification(BaseDocument):
 
     @classmethod
     async def clean_up_notifications(cls) -> None:
-        environments = await Environment.get_list()
-        for env in environments:
-            time_to_retain_logs = await env.get(NOTIFICATION_RETENTION)
-            keep_notifications_until = datetime.datetime.now().astimezone() - datetime.timedelta(days=time_to_retain_logs)
-            LOGGER.info(
-                "Cleaning up notifications in environment %s that are older than %s", env.name, keep_notifications_until
-            )
-            query = f"DELETE FROM {cls.table_name()} WHERE created < $1 AND environment = $2"
-            await cls._execute_query(query, cls._get_value(keep_notifications_until), cls._get_value(env.id))
+        default_retention_time = Environment._settings[NOTIFICATION_RETENTION].default
+        LOGGER.info("Cleaning up notifications")
+        query = f"""
+                   WITH non_halted_envs AS (
+                       SELECT id, (COALESCE((settings->>'notification_retention')::int, $1)) AS retention_days
+                       FROM {Environment.table_name()}
+                       WHERE NOT halted
+                   )
+                   DELETE FROM {cls.table_name()}
+                   USING non_halted_envs
+                   WHERE environment = non_halted_envs.id
+                       AND created < now() AT TIME ZONE 'UTC' - make_interval(days => non_halted_envs.retention_days)
+               """
+        await cls._execute_query(query, default_retention_time)
 
     def to_dto(self) -> m.Notification:
         return m.Notification(

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -28,7 +28,6 @@ import uuid
 from asyncio import CancelledError, Task
 from asyncio.subprocess import Process
 from collections.abc import Mapping
-from functools import partial
 from itertools import chain
 from logging import Logger
 from tempfile import NamedTemporaryFile
@@ -561,11 +560,27 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
                 "type": "schedule",
                 "message": "Full recompile triggered by AUTO_FULL_COMPILE cron schedule",
             }
-            recompile: TaskMethod = partial(
-                self.request_recompile, env, force_update=False, do_export=True, remote_id=uuid.uuid4(), metadata=metadata
-            )
-            self.schedule_cron(recompile, schedule_cron, cancel_on_stop=False)
-            self._scheduled_full_compiles[env.id] = (recompile, schedule_cron)
+
+            async def _request_recompile_task() -> Tuple[Optional[uuid.UUID], Warnings]:
+                """
+                Creates a new task for the full compile schedule.
+                If the environment is halted, the task does nothing.
+                Otherwise, it requests a recompile.
+                """
+                latest_env = await data.Environment.get_by_id(env.id)
+                if not latest_env or latest_env.halted:
+                    return None, []
+
+                return await self.request_recompile(
+                    env,
+                    force_update=False,
+                    do_export=True,
+                    remote_id=uuid.uuid4(),
+                    metadata=metadata,
+                )
+
+            self.schedule_cron(_request_recompile_task, schedule_cron, cancel_on_stop=False)
+            self._scheduled_full_compiles[env.id] = (_request_recompile_task, schedule_cron)
 
     async def request_recompile(
         self,

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -369,7 +369,7 @@ class OrchestrationService(protocol.ServerSlice):
         Purge versions from the database
         """
         # TODO: move to data and use queries for delete
-        envs = await data.Environment.get_list()
+        envs = await data.Environment.get_list(halted=False)
         for env_item in envs:
             # get available versions
             n_versions = await env_item.get(AVAILABLE_VERSIONS_TO_KEEP)

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -757,10 +757,15 @@ async def test_register_setting(environment, client, server, caplog):
     assert result.result["value"] is False
 
 
-async def test_unkown_parameters(resource_container, environment, client, server, clienthelper, agent, no_agent_backoff):
+@pytest.mark.parametrize("halted", [True, False])
+async def test_unknown_parameters(
+    resource_container, environment, client, server, clienthelper, agent, no_agent_backoff, halted, caplog
+):
     """
     Test retrieving facts from the agent
     """
+
+    caplog.set_level(logging.DEBUG)
     resource_container.Provider.reset()
     await client.set_setting(environment, data.SERVER_COMPILE, False)
 
@@ -774,6 +779,11 @@ async def test_unkown_parameters(resource_container, environment, client, server
     resources = [{"key": "key", "value": "value", "id": resource_id, "requires": [], "purged": False, "send_event": False}]
 
     unknowns = [{"resource": resource_id_wov, "parameter": "length", "source": "fact"}]
+
+    if halted:
+        result = await client.halt_environment(environment)
+        assert result.code == 200
+
     result = await client.put_version(
         tid=environment,
         version=version,
@@ -790,13 +800,23 @@ async def test_unkown_parameters(resource_container, environment, client, server
     await server.get_slice(SLICE_PARAM).renew_facts()
 
     env_id = uuid.UUID(environment)
-    params = await data.Parameter.get_list(environment=env_id, resource_id=resource_id_wov)
-    while len(params) < 3:
+    if not halted:
         params = await data.Parameter.get_list(environment=env_id, resource_id=resource_id_wov)
-        await asyncio.sleep(0.1)
+        while len(params) < 3:
+            params = await data.Parameter.get_list(environment=env_id, resource_id=resource_id_wov)
+            await asyncio.sleep(0.1)
 
-    result = await client.get_param(env_id, "length", resource_id_wov)
-    assert result.code == 200
+        result = await client.get_param(env_id, "length", resource_id_wov)
+        assert result.code == 200
+        msg = f"Requesting value for unknown parameter length of resource test::Resource[agent1,key=key] in env {environment}"
+        log_contains(caplog, "inmanta.server.services.paramservice", logging.DEBUG, msg)
+
+    else:
+        msg = (
+            "Not Requesting value for unknown parameter length of resource test::Resource[agent1,key=key] "
+            f"in env {environment} as the env is halted"
+        )
+        log_contains(caplog, "inmanta.server.services.paramservice", logging.DEBUG, msg)
 
 
 async def test_fail(resource_container, client, agent, environment, clienthelper, async_finalizer, no_agent_backoff):

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1068,6 +1068,59 @@ async def test_compileservice_cleanup(
     assert len(result.result["reports"]) == 1
 
 
+@pytest.mark.parametrize("halted", [True, False])
+async def test_compileservice_cleanup_halted(server, client, environment, halted):
+    """
+    Test that the cleanup process of the CompileService works correctly when the environment is halted.
+
+    This test creates two compiles and inserts them into the database.
+    If the 'halted' parameter is true, it halts the environment and checks that both compiles remain after cleanup.
+    Otherwise, it checks that only one compile remains after cleanup (the new latest one).
+    """
+
+    if halted:
+        result = await client.halt_environment(environment)
+        assert result.code == 200
+
+    now = datetime.datetime.now()
+    time_of_old_compile = now - datetime.timedelta(days=30)
+    compile_id_old = uuid.UUID("c00cc33f-f70f-4800-ad01-ff042f67118f")
+    old_compile = {
+        "id": compile_id_old,
+        "remote_id": uuid.UUID("c9a10da1-9bf6-4152-8461-98adc02c4cee"),
+        "environment": uuid.UUID(environment),
+        "requested": time_of_old_compile,
+        "started": time_of_old_compile,
+        "completed": time_of_old_compile,
+        "do_export": True,
+        "force_update": True,
+        "metadata": {"type": "api", "message": "Recompile trigger through API call"},
+        "environment_variables": {},
+        "success": True,
+        "handled": True,
+        "version": 1,
+    }
+    compile_id_new = uuid.uuid4()
+    new_compile = {**old_compile, "id": compile_id_new, "requested": now, "started": now, "completed": now}
+
+    # insert compiles and reports into the database
+    async with Compile.get_connection() as con:
+        async with con.transaction():
+            await Compile(**old_compile).insert(connection=con)
+            await Compile(**new_compile).insert(connection=con)
+
+    compiles = await data.Compile.get_list()
+    assert len(compiles) == 2
+
+    oldest_retained_date = datetime.datetime.now().astimezone() - datetime.timedelta(seconds=50)
+
+    await data.Compile.delete_older_than(oldest_retained_date)
+
+    compiles = await data.Compile.get_list()
+    # if halted, nothing should be cleaned up, otherwise only the old compile should be cleaned up
+    assert len(compiles) == (2 if halted else 1)
+
+
 async def test_issue_2361(environment_factory: EnvironmentFactory, server, client, tmpdir):
     env = await environment_factory.create_environment(main="")
 

--- a/tests/server/test_notifications.py
+++ b/tests/server/test_notifications.py
@@ -34,12 +34,12 @@ from inmanta.server.services.notificationservice import NotificationService
 from utils import retry_limited
 
 
-@pytest.fixture
-async def environment_with_notifications(server, environment: str):
-    env_id = uuid.UUID(environment)
-
+async def add_notifications_with_timestamp(env_id: uuid.UUID, days_old: int):
+    """
+    Adds 8 notifications to the database, each with a creation date `days_old` days in the past.
+    """
     for i in range(8):
-        created = (datetime.datetime.now().astimezone() - datetime.timedelta(days=1)).replace(hour=i)
+        created = (datetime.datetime.now().astimezone() - datetime.timedelta(days=days_old)).replace(hour=i)
         await data.Notification(
             title="Notification" if i % 2 else "Error",
             message="Something happened" if i % 2 else "Something bad happened",
@@ -51,6 +51,30 @@ async def environment_with_notifications(server, environment: str):
             cleared=i in {4, 5},
         ).insert()
 
+
+@pytest.fixture
+async def environment_with_notifications(environment: str):
+    """
+    A fixture that sets up a new environment with notifications for testing.
+    """
+    environment = uuid.UUID(environment)
+    await add_notifications_with_timestamp(
+        environment, days_old=1
+    )  # add notifications with timestamp 1 day before current time
+    yield environment
+
+
+@pytest.fixture
+async def halted_env_with_old_notifications(server, client, environment: str):
+    """
+    A fixture that sets up a halted environment with notifications older than 365 days for testing.
+    """
+    environment = uuid.UUID(environment)
+    result = await client.halt_environment(environment)
+    assert result.code == 200
+    await add_notifications_with_timestamp(
+        environment, days_old=500
+    )  # add notifications with timestamp 500 day before current time
     yield environment
 
 
@@ -385,3 +409,22 @@ async def test_notification_cleanup_on_start(init_dataclasses_and_load_schema, a
     # Only the latest one is kept
     assert len(short_retention_notifications) == 1
     assert short_retention_notifications[0].created == timestamps[2]
+
+
+@pytest.mark.parametrize("halted", [True, False])
+async def test_cleanup_notifications(server, client, halted_env_with_old_notifications, halted):
+    # test that the notifications are only cleaned up if the env is not halted
+    env_id = halted_env_with_old_notifications
+    result = await client.list_notifications(env_id)
+    assert result.code == 200
+    assert len(result.result["data"]) == 8
+
+    if not halted:
+        result = await client.resume_environment(env_id)
+        assert result.code == 200
+
+    await data.Notification.clean_up_notifications()
+
+    result = await client.list_notifications(env_id)
+    assert result.code == 200
+    assert len(result.result["data"]) == (8 if halted else 0)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -459,7 +459,11 @@ async def test_agent_process(init_dataclasses_and_load_schema):
     assert (await data.AgentInstance.get_by_id(agi2.id)) is None
 
 
-async def test_agentprocess_cleanup(init_dataclasses_and_load_schema, postgresql_client):
+@pytest.mark.parametrize("env1_halted", [True, False])
+@pytest.mark.parametrize("env2_halted", [True, False])
+async def test_agentprocess_cleanup(init_dataclasses_and_load_schema, postgresql_client, env1_halted, env2_halted):
+    # tests the agent process cleanup function with different combinations of halted environments
+
     project = data.Project(name="test")
     await project.insert()
 
@@ -504,14 +508,23 @@ async def test_agentprocess_cleanup(init_dataclasses_and_load_schema, postgresql
     await insert_agent_proc_and_instances(env2.id, "proc2", datetime.datetime(2020, 1, 1, 2, 0), [now, now])
     await insert_agent_proc_and_instances(env2.id, "proc2", datetime.datetime(2020, 1, 1, 3, 0), [now])
 
+    if env1_halted:
+        await env1.update_fields(halted=True)
+    if env2_halted:
+        await env2.update_fields(halted=True)
+
     # Run cleanup twice to verify stability
     for i in range(2):
         # Perform cleanup
         await data.AgentProcess.cleanup(nr_expired_records_to_keep=1)
         # Assert outcome
+        # Halting env1 has no impact on the cleanup: an expired instance will be kept in both cases
+        # Halting env2 has an impact on the cleanup: if it's halted 5 expired instances in 2 processes will not be removed.
         await verify_nr_of_records(env1.id, hostname="proc1", expected_nr_procs=2, expected_nr_instances=2)
         await verify_nr_of_records(env1.id, hostname="proc2", expected_nr_procs=1, expected_nr_instances=1)
-        await verify_nr_of_records(env2.id, hostname="proc2", expected_nr_procs=2, expected_nr_instances=3)
+        await verify_nr_of_records(
+            env2.id, hostname="proc2", expected_nr_procs=4 if env2_halted else 2, expected_nr_instances=8 if env2_halted else 3
+        )
         # Assert records are deleted in the correct order
         query = """
             SELECT expired
@@ -519,8 +532,10 @@ async def test_agentprocess_cleanup(init_dataclasses_and_load_schema, postgresql
             WHERE environment=$1 AND hostname=$2 AND expired IS NOT NULL
         """
         result = await postgresql_client.fetch(query, env2.id, "proc2")
-        assert len(result) == 1
-        assert result[0]["expired"] == datetime.datetime(2020, 1, 1, 3, 0).astimezone()
+        assert len(result) == 3 if env2_halted else 1
+        if len(result) == 1:
+            # if the cleanup was done (env2 not halted), verify the expired record that was kept is the right one.
+            assert result[0]["expired"] == datetime.datetime(2020, 1, 1, 3, 0).astimezone()
 
 
 async def test_delete_agentinstance_which_is_primary(init_dataclasses_and_load_schema):
@@ -2060,12 +2075,17 @@ async def test_code(init_dataclasses_and_load_schema):
     assert len(await data.Code.get_versions(env.id, code3.version + 1)) == 1
 
 
-async def test_parameter(init_dataclasses_and_load_schema):
+@pytest.mark.parametrize("halted", [True, False])
+async def test_parameter(init_dataclasses_and_load_schema, halted):
+    # verify the call to "get_updated_before". If the env is halted it shouldn't return any result
     project = data.Project(name="test")
     await project.insert()
 
     env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
     await env.insert()
+
+    if halted:
+        await env.update_fields(halted=True)
 
     time1 = datetime.datetime(2018, 7, 14, 12, 30)
     time2 = datetime.datetime(2018, 7, 16, 12, 30)
@@ -2080,16 +2100,18 @@ async def test_parameter(init_dataclasses_and_load_schema):
         parameters.append(parameter)
         await parameter.insert()
 
-    updated_before = await data.Parameter.get_updated_before(datetime.datetime(2018, 7, 12, 12, 30))
+    updated_before = await data.Parameter.get_updated_before_active_env(datetime.datetime(2018, 7, 12, 12, 30))
     assert len(updated_before) == 0
-    updated_before = await data.Parameter.get_updated_before(datetime.datetime(2018, 7, 14, 12, 30))
-    assert len(updated_before) == 1
-    assert (updated_before[0].environment, updated_before[0].name) == (parameters[2].environment, parameters[2].name)
-    updated_before = await data.Parameter.get_updated_before(datetime.datetime(2018, 7, 15, 12, 30))
+    updated_before = await data.Parameter.get_updated_before_active_env(datetime.datetime(2018, 7, 14, 12, 30))
+    assert len(updated_before) == (0 if halted else 1)
+    if not halted:
+        assert (updated_before[0].environment, updated_before[0].name) == (parameters[2].environment, parameters[2].name)
+    updated_before = await data.Parameter.get_updated_before_active_env(datetime.datetime(2018, 7, 15, 12, 30))
     list_of_ids = [(x.environment, x.name) for x in updated_before]
-    assert len(updated_before) == 2
-    assert (parameters[0].environment, parameters[0].name) in list_of_ids
-    assert (parameters[2].environment, parameters[2].name) in list_of_ids
+    assert len(updated_before) == (0 if halted else 2)
+    if not halted:
+        assert (parameters[0].environment, parameters[0].name) in list_of_ids
+        assert (parameters[2].environment, parameters[2].name) in list_of_ids
 
 
 async def test_parameter_list_parameters(init_dataclasses_and_load_schema):
@@ -2333,7 +2355,9 @@ async def test_match_tables_in_db_against_table_definitions_in_orm(
         assert item in table_names_in_database
 
 
-async def test_purgelog_test(init_dataclasses_and_load_schema):
+@pytest.mark.parametrize("env1_halted", [True, False])
+@pytest.mark.parametrize("env2_halted", [True, False])
+async def test_purgelog_test(init_dataclasses_and_load_schema, env1_halted, env2_halted):
     project = data.Project(name="test")
     await project.insert()
 
@@ -2408,15 +2432,25 @@ async def test_purgelog_test(init_dataclasses_and_load_schema):
         )
         await ra2.insert()
 
+    if env1_halted:
+        await envs[0].update_fields(halted=True)
+    if env2_halted:
+        await envs[1].update_fields(halted=True)
+
     # Make the retention time for the second environment shorter than the default 7 days
     await envs[1].set(data.RESOURCE_ACTION_LOGS_RETENTION, value=2)
 
     assert len(await data.ResourceAction.get_list()) == 4  # Two ra's in each environment
     await data.ResourceAction.purge_logs()
-    assert len(await data.ResourceAction.get_list()) == 1  # One ra in the first environment and none in the second environment
+    number_ra_env1 = 2 if env1_halted else 1  # if not halted one is cleaned up
+    number_ra_env2 = 2 if env2_halted else 0  # if not halted both are cleaned up
+    assert len(await data.ResourceAction.get_list()) == number_ra_env1 + number_ra_env2
     remaining_resource_action = (await data.ResourceAction.get_list())[0]
-    assert remaining_resource_action.environment == envs[0].id
-    assert remaining_resource_action.started == timestamp_six_days_ago
+
+    # verify that after a cleanup (without halted envs) the remaining record is the right one.
+    if not (env1_halted or env2_halted):
+        assert remaining_resource_action.environment == envs[0].id
+        assert remaining_resource_action.started == timestamp_six_days_ago
 
 
 async def test_insert_many(init_dataclasses_and_load_schema, postgresql_client):


### PR DESCRIPTION
The server runs many cleanup jobs in the background. This issue should make sure that no cleanup jobs are run on halted environments.

Closes https://github.com/inmanta/inmanta-core/issues/5842

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [ ] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [x] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
