### PR TITLE
Fix incorrect query composition in get_resource_events()

### DIFF
--- a/changelogs/unreleased/5898-fix-query-get-resource-events.yml
+++ b/changelogs/unreleased/5898-fix-query-get-resource-events.yml
@@ -4,3 +4,5 @@ issue-nr: 5898
 issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso6, iso5]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/5898-fix-query-get-resource-events.yml
+++ b/changelogs/unreleased/5898-fix-query-get-resource-events.yml
@@ -1,5 +1,5 @@
 ---
-description: "Fix bug that makes the handler fail with the exception `PostgresSyntaxError: trailing junk after parameter at or near "$3A"`."
+description: 'Fix bug that makes the handler fail with the exception `PostgresSyntaxError: trailing junk after parameter at or near "$3A"` when running against PostgreSQL 15.'
 issue-nr: 5898
 issue-repo: inmanta-core
 change-type: patch

--- a/changelogs/unreleased/5898-fix-query-get-resource-events.yml
+++ b/changelogs/unreleased/5898-fix-query-get-resource-events.yml
@@ -1,0 +1,8 @@
+---
+description: Fix bug that makes the handler fail with the exception `PostgresSyntaxError: trailing junk after parameter at or near "$3A"`.
+issue-nr: 5898
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6, iso5]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/5898-fix-query-get-resource-events.yml
+++ b/changelogs/unreleased/5898-fix-query-get-resource-events.yml
@@ -4,5 +4,3 @@ issue-nr: 5898
 issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso6, iso5]
-sections:
-  bugfix: "{{description}}"

--- a/changelogs/unreleased/5898-fix-query-get-resource-events.yml
+++ b/changelogs/unreleased/5898-fix-query-get-resource-events.yml
@@ -1,5 +1,5 @@
 ---
-description: Fix bug that makes the handler fail with the exception `PostgresSyntaxError: trailing junk after parameter at or near "$3A"`.
+description: "Fix bug that makes the handler fail with the exception `PostgresSyntaxError: trailing junk after parameter at or near "$3A"`."
 issue-nr: 5898
 issue-repo: inmanta-core
 change-type: patch

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4242,7 +4242,7 @@ class ResourceAction(BaseDocument):
             if last_deploy_start:
                 filter += f" AND ra.started > {arg(last_deploy_start)}"
             if exclude_change:
-                filter += f"AND ra.change <> {arg(exclude_change.value)}"
+                filter += f" AND ra.change <> {arg(exclude_change.value)}"
 
             # then the query around it
             get_all_query = f"""


### PR DESCRIPTION
# Description

When `exclude_change` is provided to the `get_resource_events()`, the method raises the exception `PostgresSyntaxError: trailing junk after parameter at or near "$3A"`. This issue only seems to occur when running against PostgreSQL 15.

closes #5898

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
