### PR TITLE
Fix incorrect cron expression in test case test_server_recompile

### DIFF
--- a/changelogs/unreleased/fix-cron-expression-in-test-case.yml
+++ b/changelogs/unreleased/fix-cron-expression-in-test-case.yml
@@ -1,0 +1,5 @@
+---
+description: "Fix bug in cron expression of test case `test_server_recompile`"
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/fix-cron-expression-in-test-case.yml
+++ b/changelogs/unreleased/fix-cron-expression-in-test-case.yml
@@ -1,5 +1,4 @@
 ---
 description: "Fix bug in cron expression of test case `test_server_recompile`"
-issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso6, iso5]


### PR DESCRIPTION
# Description

This test case replaces the cron expression:

`"%d %d %d * * *" % (recent.second, recent.minute, recent.hour)`
with
`"%d %d %d * * * *" % (recent.second, recent.minute, recent.hour)`

If there are only 6 items are defined in the cron expression, the crontab library assumes that the seconds are not specified on the cron expression. That way we can end up with an invalid cron expression, because `recent.minutes` will be interpreted as hours. The range of minutes is [0, 59] and the range of hours is [0, 23]. If the minutes go above 23, the cron expression is rejected because the hours part of the cron expression has an invalid range.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
