### PR TITLE
[FEAT] drop deprecated log_msg method

### DIFF
--- a/changelogs/unreleased/drop-deprecated-log_msg-method.yml
+++ b/changelogs/unreleased/drop-deprecated-log_msg-method.yml
@@ -1,0 +1,4 @@
+description: Drop deprecated log_msg method
+change-type: patch
+destination-branches: [master]
+

--- a/changelogs/unreleased/drop-deprecated-log_msg-method.yml
+++ b/changelogs/unreleased/drop-deprecated-log_msg-method.yml
@@ -1,4 +1,5 @@
-description: Drop deprecated log_msg method
+description: Drop deprecated log_msg method in the handler.
 change-type: patch
 destination-branches: [master]
-
+sections:
+  deprecation-note: "{{description}}"

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -23,7 +23,7 @@ import traceback
 import typing
 import uuid
 from abc import ABC, abstractmethod
-from collections import abc, defaultdict
+from collections import defaultdict
 from concurrent.futures import Future
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast, overload
 
@@ -394,10 +394,6 @@ class HandlerContext(LoggerABC):
     @property
     def changes(self) -> Dict[str, AttributeStateChange]:
         return self._changes
-
-    def log_msg(self, level: int, msg: str, args: abc.Sequence[object], kwargs: abc.MutableMapping[str, object]) -> None:
-        LOGGER.warning("Direct calls to the log_msg method are being deprecated, please use the LoggerABC interface instead.")
-        self._log_msg(level, msg, *args, **kwargs)
 
     def _log_msg(self, level: int, msg: str, *args: object, exc_info: bool = False, **kwargs: object) -> None:
         if len(args) > 0:


### PR DESCRIPTION
# Description

This is a follow-up to this ticket https://github.com/inmanta/inmanta-core/pull/5833, the log_msg method was only kept in iso6 for backwards compatibility.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
