### PR TITLE
Removed unused field in Server class

### DIFF
--- a/changelogs/unreleased/server-token.yml
+++ b/changelogs/unreleased/server-token.yml
@@ -1,0 +1,7 @@
+description: Removed unused field in Server class
+change-type: patch
+sections:
+  bugfix: "The server no longer incorrectly logs a warning about server_rest_transport.token missing from the config"
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -28,7 +28,6 @@ from tornado import gen, queues, routing, web
 from tornado.ioloop import IOLoop
 
 import inmanta.protocol.endpoints
-from inmanta import config as inmanta_config
 from inmanta.data.model import ExtensionStatus
 from inmanta.protocol import Client, common, endpoints, handle, methods
 from inmanta.protocol.exceptions import ShutdownInProgress
@@ -99,7 +98,6 @@ class Server(endpoints.Endpoint):
         self._slices: Dict[str, ServerSlice] = {}
         self._slice_sequence: Optional[List[ServerSlice]] = None
         self._handlers: List[routing.Rule] = []
-        self.token: Optional[str] = inmanta_config.Config.get(self.id, "token", None)
         self.connection_timout = connection_timout
         self.sessions_handler = SessionManager()
         self.add_slice(self.sessions_handler)


### PR DESCRIPTION
# Description

The server used to log `WARNING Config name token not defined in section server_rest_transport` because this line tried to access it for no apparent reason. This PR removes the line entirely.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
