### PR TITLE
investigate-flasky-test-cleanup-agent

### DIFF
--- a/changelogs/unreleased/investigate-flaky-test-cleanup-agent.yml
+++ b/changelogs/unreleased/investigate-flaky-test-cleanup-agent.yml
@@ -1,0 +1,3 @@
+description: add asserts to investigate flakiness on the test_cleanup_agent test.
+change-type: patch
+destination-branches: [master]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1446,6 +1446,12 @@ async def test_cleanup_old_agents(server, client, env1_halted, env2_halted):
     await env1.set(data.AUTOSTART_AGENT_MAP, {"agent3": "", "internal": ""})
     await env2.set(data.AUTOSTART_AGENT_MAP, {"agent1": "", "internal": ""})
 
+    agentmap_env1 = await client.get_setting(tid=env1.id, id=data.AUTOSTART_AGENT_MAP)
+    agentmap_env2 = await client.get_setting(tid=env2.id, id=data.AUTOSTART_AGENT_MAP)
+
+    assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
+    assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}
+
     if env1_halted:
         result = await client.halt_environment(env1.id)
         assert result.code == 200
@@ -1518,7 +1524,14 @@ async def test_cleanup_old_agents(server, client, env1_halted, env2_halted):
     agents_before_purge = await data.Agent.get_list()
     assert len(agents_before_purge) == 6
 
+    assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
+    assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}
+
     await server.get_slice(SLICE_ORCHESTRATION)._purge_versions()
+
+    assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
+    assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}
+
     agents_after_purge = [(agent.environment, agent.name) for agent in await data.Agent.get_list()]
     number_agents_env1_after_purge = 4 if env1_halted else 3
     number_agents_env2_after_purge = 2 if env2_halted else 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1446,9 +1446,10 @@ async def test_cleanup_old_agents(server, client, env1_halted, env2_halted):
     await env1.set(data.AUTOSTART_AGENT_MAP, {"agent3": "", "internal": ""})
     await env2.set(data.AUTOSTART_AGENT_MAP, {"agent1": "", "internal": ""})
 
+    # these checks are here to investigate the fact that the test case is flaky and that we have a suspicion
+    # that it is an issue with the agent map
     agentmap_env1 = await client.get_setting(tid=env1.id, id=data.AUTOSTART_AGENT_MAP)
     agentmap_env2 = await client.get_setting(tid=env2.id, id=data.AUTOSTART_AGENT_MAP)
-
     assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
     assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}
 
@@ -1524,17 +1525,19 @@ async def test_cleanup_old_agents(server, client, env1_halted, env2_halted):
     agents_before_purge = await data.Agent.get_list()
     assert len(agents_before_purge) == 6
 
+    # these checks are here to investigate the fact that the test case is flaky and that we have a suspicion
+    # that it is an issue with the agent map
     agentmap_env1 = await client.get_setting(tid=env1.id, id=data.AUTOSTART_AGENT_MAP)
     agentmap_env2 = await client.get_setting(tid=env2.id, id=data.AUTOSTART_AGENT_MAP)
-
     assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
     assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}
 
     await server.get_slice(SLICE_ORCHESTRATION)._purge_versions()
 
+    # these checks are here to investigate the fact that the test case is flaky and that we have a suspicion
+    # that it is an issue with the agent map
     agentmap_env1 = await client.get_setting(tid=env1.id, id=data.AUTOSTART_AGENT_MAP)
     agentmap_env2 = await client.get_setting(tid=env2.id, id=data.AUTOSTART_AGENT_MAP)
-
     assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
     assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1524,10 +1524,16 @@ async def test_cleanup_old_agents(server, client, env1_halted, env2_halted):
     agents_before_purge = await data.Agent.get_list()
     assert len(agents_before_purge) == 6
 
+    agentmap_env1 = await client.get_setting(tid=env1.id, id=data.AUTOSTART_AGENT_MAP)
+    agentmap_env2 = await client.get_setting(tid=env2.id, id=data.AUTOSTART_AGENT_MAP)
+
     assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
     assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}
 
     await server.get_slice(SLICE_ORCHESTRATION)._purge_versions()
+
+    agentmap_env1 = await client.get_setting(tid=env1.id, id=data.AUTOSTART_AGENT_MAP)
+    agentmap_env2 = await client.get_setting(tid=env2.id, id=data.AUTOSTART_AGENT_MAP)
 
     assert agentmap_env1.result["value"] == {"agent3": "", "internal": ""}
     assert agentmap_env2.result["value"] == {"agent1": "", "internal": ""}


### PR DESCRIPTION
# Description

this commit adds additional assert to the test_server.test_cleanup_old_agents test as it is flaky and more info is needed.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
