### PR TITLE
Add support for compile request inside a database transaction

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 8.3.1
+current_version = 8.4.0
 
 [bumpversion:file:setup.py]
 search = version = "{current_version}"

--- a/changelogs/unreleased/1249-fix-race-condition-compile-requests.yml
+++ b/changelogs/unreleased/1249-fix-race-condition-compile-requests.yml
@@ -1,0 +1,8 @@
+---
+description: Add support to the compilerservice to request a compile that is part of a database transaction.
+issue-nr: 1249
+issue-repo: inmanta-lsm
+change-type: minor
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/1249-fix-race-condition-compile-requests.yml
+++ b/changelogs/unreleased/1249-fix-race-condition-compile-requests.yml
@@ -3,6 +3,6 @@ description: Add support to the compilerservice to request a compile that is par
 issue-nr: 1249
 issue-repo: inmanta-lsm
 change-type: minor
-destination-branches: [master]
+destination-branches: [iso6]
 sections:
   minor-improvement: "{{description}}"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-version = "8.3.1"
+version = "8.4.0"
 
 setup(
     version=version,

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -520,17 +520,39 @@ async def test_compilerservice_compile_data(environment_factory: EnvironmentFact
     assert error.message == "value set twice:\n\told value: 0\n\t\tset at ./main.cf:1\n\tnew value: 1\n\t\tset at ./main.cf:1\n"
 
 
-async def test_e2e_recompile_failure(compilerservice: CompilerService):
+@pytest.mark.parametrize("use_trx_based_api", [True, False])
+async def test_e2e_recompile_failure(compilerservice: CompilerService, use_trx_based_api: bool):
     project = data.Project(name="test")
     await project.insert()
 
     env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
     await env.insert()
 
+    async def request_compile(remote_id: uuid.UUID, env_vars: dict[str, str]) -> None:
+        if use_trx_based_api:
+            async with data.Environment.get_connection() as connection:
+                async with connection.transaction():
+                    compile_id, warnings = await compilerservice.request_recompile(
+                        env=env,
+                        force_update=False,
+                        do_export=False,
+                        remote_id=remote_id,
+                        env_vars=env_vars,
+                        connection=connection,
+                        in_db_transaction=True,
+                    )
+                assert compile_id is not None, warnings
+            await compilerservice.notify_compile_request_committed(compile_id)
+        else:
+            await compilerservice.request_recompile(
+                env=env, force_update=False, do_export=False, remote_id=remote_id, env_vars=env_vars
+            )
+
     u1 = uuid.uuid4()
-    await compilerservice.request_recompile(env, False, False, u1, env_vars={"my_unique_var": str(u1)})
+    await request_compile(remote_id=u1, env_vars={"my_unique_var": str(u1)})
+
     u2 = uuid.uuid4()
-    await compilerservice.request_recompile(env, False, False, u2, env_vars={"my_unique_var": str(u2)})
+    await request_compile(remote_id=u2, env_vars={"my_unique_var": str(u2)})
 
     assert await compilerservice.is_compiling(env.id) == 200
 
@@ -540,6 +562,8 @@ async def test_e2e_recompile_failure(compilerservice: CompilerService):
         return res == 204
 
     await retry_limited(compile_done, 10)
+    # All compiles are finished. The queue should be empty
+    assert compilerservice._queue_count_cache == 0
 
     _, all_compiles = await compilerservice.get_reports(env)
     all_reports = {i["remote_id"]: await compilerservice.get_report(i["id"]) for i in all_compiles["reports"]}
@@ -950,6 +974,37 @@ async def test_compilerservice_halt(mocked_compiler_service_block, server, clien
     await client.resume_environment(environment)
     result = await client.is_compiling(environment)
     assert result.code == 200
+
+
+async def test_compileservice_queue_count_on_trx_based_api(mocked_compiler_service_block, server, client, environment):
+    """
+    Verify that the `_queue_count_cache` is not incremented and that the compile is not scheduled until the
+    `notify_compile_request_committed()` method is called.
+    """
+    env = await data.Environment.get_by_id(environment)
+    compiler_service: CompilerService = server.get_slice(SLICE_COMPILER)
+
+    async with data.Environment.get_connection() as connection:
+        async with connection.transaction():
+            remote_id1 = uuid.uuid4()
+            compile_id, warnings = await compiler_service.request_recompile(
+                env=env,
+                force_update=False,
+                do_export=False,
+                remote_id=remote_id1,
+                connection=connection,
+                in_db_transaction=True,
+            )
+            assert compile_id is not None, warnings
+            assert compiler_service._queue_count_cache == 0
+            assert len(compiler_service._recompiles) == 0
+    # Transaction committed
+    await compiler_service.notify_compile_request_committed(compile_id)
+    assert compiler_service._queue_count_cache == 1
+    assert len(compiler_service._recompiles) == 1
+
+    await run_compile_and_wait_until_compile_is_done(compiler_service, mocked_compiler_service_block, env.id)
+    assert len(compiler_service._recompiles) == 0
 
 
 @pytest.fixture(scope="function")

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -19,7 +19,7 @@ from os import path
 
 from setuptools import find_namespace_packages, setup
 
-version = "8.3.1"
+version = "8.4.0"
 
 requires = [
     "asyncpg",


### PR DESCRIPTION
# Description

**Same PR as #5948 but applied on the iso6 branch, because the version numbers differ.**

This PR extends the API of the compiler service with functionality to request a compile inside a database transaction.

Part of inmanta/inmanta-lsm#1249

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
