### PR TITLE
Fix bug in notify_compile_request_committed method

### DIFF
--- a/changelogs/unreleased/fix-bug-compile-request-committed.yml
+++ b/changelogs/unreleased/fix-bug-compile-request-committed.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug in `notify_compile_request_committed()` that occurs when the compile with the given id cannot be found.
+issue-nr: 1249
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -668,9 +668,11 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         but before this method was invoked, the server will automatically recover from this and run the requested compile
         without any need to call this method.
         """
+        compile_obj: Optional[data.Compile] = await data.Compile.get_by_id(compile_id)
+        if not compile_obj:
+            raise Exception(f"Compile with id {compile_id} not found.")
         async with self._queue_count_cache_lock:
             self._queue_count_cache += 1
-        compile_obj: data.Compile = await data.Compile.get_by_id(compile_id)
         async with self._global_lock:
             if compile_obj.environment not in self._recompiles:
                 await self.process_next_compile_in_queue(compile_obj.environment)


### PR DESCRIPTION
# Description

Fix bug in `notify_compile_request_committed()` that occurs when the compile with the given id cannot be found.

Part of inmanta/inmanta-lsm#1249

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
