### PR TITLE
Issue/enable web console

### DIFF
--- a/changelogs/unreleased/fix-default-inmanta-config.yml
+++ b/changelogs/unreleased/fix-default-inmanta-config.yml
@@ -1,0 +1,6 @@
+description: Enable the web console in the default inmanta config shipped with the product.
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5

--- a/misc/inmanta.cfg
+++ b/misc/inmanta.cfg
@@ -95,3 +95,9 @@ host = localhost
 port = 8888
 #ssl=false
 #ssl_ca_cert_file=
+
+[web-console]
+# Enable the web console, for a user friendly web interface to interact with the orchestrator.
+# By default the web console is not reachable, and the orchestrator is only usable through its
+# api.
+enabled=true


### PR DESCRIPTION
# Description

A client reported that the latest install of the rpm (iso6) was giving `404` when trying to reach the web console or the dashboard.  It looks like by default the web console is not reachable, because the default config doesn't enable it.  This MR fixes it.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [x] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
