### PR TITLE
Improve logging regarding enabled extensions

### DIFF
--- a/changelogs/unreleased/log-enabled-extensions.yml
+++ b/changelogs/unreleased/log-enabled-extensions.yml
@@ -1,0 +1,6 @@
+---
+description: The server now logs the enabled extensions when it starts.
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/log-enabled-extensions.yml
+++ b/changelogs/unreleased/log-enabled-extensions.yml
@@ -1,6 +1,6 @@
 ---
 description: The server now logs the enabled extensions when it starts.
 change-type: patch
-destination-branches: [master, iso6]
+destination-branches: [master, iso6, iso5]
 sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -187,7 +187,9 @@ class InmantaBootloader(object):
     def _load_extensions(self, load_all_extensions: bool = False) -> Dict[str, ModuleType]:
         """Discover all extensions, validate correct naming and load its setup function"""
         plugins: Dict[str, ModuleType] = {}
-        for name in self._discover_plugin_packages(load_all_extensions):
+        enabled_extensions: List[str] = self._discover_plugin_packages(load_all_extensions)
+        LOGGER.info("Loading extensions: %s", ", ".join(enabled_extensions))
+        for name in enabled_extensions:
             try:
                 module = self._load_extension(name)
                 assert name.startswith(f"{EXTENSION_NAMESPACE}.")

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -188,7 +188,7 @@ class InmantaBootloader(object):
         """Discover all extensions, validate correct naming and load its setup function"""
         plugins: Dict[str, ModuleType] = {}
         enabled_extensions: List[str] = self._discover_plugin_packages(load_all_extensions)
-        LOGGER.info("Loading extensions: %s", ", ".join(enabled_extensions))
+        LOGGER.info("Enabled extensions: %s", ", ".join(enabled_extensions))
         for name in enabled_extensions:
             try:
                 module = self._load_extension(name)

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -89,7 +89,12 @@ def test_phase_1(caplog):
         assert "testplugin" in all
         assert all["testplugin"] == inmanta_ext.testplugin.extension
 
-        log_contains(caplog, "inmanta.server.bootloader", logging.INFO, "Loading extensions: inmanta_ext.testplugin")
+        log_contains(
+            caplog,
+            "inmanta.server.bootloader",
+            logging.INFO,
+            "Enabled extensions: inmanta_ext.testplugin, inmanta_ext.noext, inmanta_ext.core"
+        )
         log_contains(caplog, "inmanta.server.bootloader", logging.WARNING, "Could not load extension inmanta_ext.noext")
 
 

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -89,6 +89,7 @@ def test_phase_1(caplog):
         assert "testplugin" in all
         assert all["testplugin"] == inmanta_ext.testplugin.extension
 
+        log_contains(caplog, "inmanta.server.bootloader", logging.INFO, "Loading extensions: inmanta_ext.testplugin")
         log_contains(caplog, "inmanta.server.bootloader", logging.WARNING, "Could not load extension inmanta_ext.noext")
 
 

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -93,7 +93,7 @@ def test_phase_1(caplog):
             caplog,
             "inmanta.server.bootloader",
             logging.INFO,
-            "Enabled extensions: inmanta_ext.testplugin, inmanta_ext.noext, inmanta_ext.core"
+            "Enabled extensions: inmanta_ext.testplugin, inmanta_ext.noext, inmanta_ext.core",
         )
         log_contains(caplog, "inmanta.server.bootloader", logging.WARNING, "Could not load extension inmanta_ext.noext")
 


### PR DESCRIPTION
# Description

This PR ensure that the server logs the enabled extensions when the server starts.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
