### PR TITLE
fix extension loading test case

### DIFF
--- a/changelogs/unreleased/fix-extension-loading-test.yml
+++ b/changelogs/unreleased/fix-extension-loading-test.yml
@@ -1,0 +1,3 @@
+description: Fixed extension loading test case
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -84,18 +84,19 @@ def test_phase_1(caplog):
 
         config.server_enabled_extensions.set("testplugin,noext")
 
-        all = ibl._load_extensions()
+        with caplog.at_level(logging.INFO):
+            all = ibl._load_extensions()
 
-        assert "testplugin" in all
-        assert all["testplugin"] == inmanta_ext.testplugin.extension
+            assert "testplugin" in all
+            assert all["testplugin"] == inmanta_ext.testplugin.extension
 
-        log_contains(
-            caplog,
-            "inmanta.server.bootloader",
-            logging.INFO,
-            "Enabled extensions: inmanta_ext.testplugin, inmanta_ext.noext, inmanta_ext.core",
-        )
-        log_contains(caplog, "inmanta.server.bootloader", logging.WARNING, "Could not load extension inmanta_ext.noext")
+            log_contains(
+                caplog,
+                "inmanta.server.bootloader",
+                logging.INFO,
+                "Enabled extensions: inmanta_ext.testplugin, inmanta_ext.noext, inmanta_ext.core",
+            )
+            log_contains(caplog, "inmanta.server.bootloader", logging.WARNING, "Could not load extension inmanta_ext.noext")
 
 
 def test_phase_2():


### PR DESCRIPTION
The core test suite runs with `--log-cli-level=DEBUG` so it didn't fail on this but pytest in docker does.