### PR TITLE
Auto comment undesired lines in generated database dumps

### DIFF
--- a/changelogs/unreleased/auto-comment-lines-in-db-dump.yml
+++ b/changelogs/unreleased/auto-comment-lines-in-db-dump.yml
@@ -1,0 +1,4 @@
+---
+description: Make the dump_tool automatically comment out all undesired lines in the generated database dump to prevents issues with trailing whitespaces being removed from the file.
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/auto-comment-lines-in-db-dump.yml
+++ b/changelogs/unreleased/auto-comment-lines-in-db-dump.yml
@@ -1,4 +1,4 @@
 ---
 description: Make the dump_tool automatically comment out all undesired lines in the generated database dump to prevents issues with trailing whitespaces being removed from the file.
 change-type: patch
-destination-branches: [master, iso6, iso5]
+destination-branches: [iso5]

--- a/tests/db/migration_tests/dump_tool.py
+++ b/tests/db/migration_tests/dump_tool.py
@@ -39,12 +39,6 @@ def check_result(result):
 
 
 async def test_dump_db(server, client, postgres_db, database_name):
-    """
-    Note: remove following line from the dump: SELECT pg_catalog.set_config('search_path', '', false);
-    The line 'SET default_table_access_method = heap;' should also be removed.
-    Also be careful that the IDE doesn't remove trailing whitespace from the dump file.
-    """
-
     if False:
         # trick autocomplete to have autocomplete on client
         client = methods
@@ -99,3 +93,16 @@ async def test_dump_db(server, client, postgres_db, database_name):
         "pg_dump", "-h", "127.0.0.1", "-p", str(postgres_db.port), "-f", outfile, "-O", "-U", postgres_db.user, database_name
     )
     await proc.wait()
+
+    # Remove undesired lines in the database dump
+    lines_to_remove = [
+        "SELECT pg_catalog.set_config('search_path', '', false);\n",
+        "SET default_table_access_method = heap;\n",
+    ]
+    with open(outfile, "r+") as fh:
+        all_lines = fh.readlines()
+        assert all(to_remove in all_lines for to_remove in lines_to_remove)
+        fh.seek(0)
+        for line in all_lines:
+            fh.write(f"--{line}" if line in lines_to_remove else line)
+        fh.truncate()


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/6029 but scoped to the iso5 branch due to a merge conflict.**

Make the dump_tool automatically comment out all undesired lines in the generated database dump to prevents issues with trailing white-spaces being removed from the file.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
