### PR TITLE
Typing extensions constraints

### DIFF
--- a/changelogs/unreleased/typing-extensions-constraints.yml
+++ b/changelogs/unreleased/typing-extensions-constraints.yml
@@ -1,0 +1,8 @@
+description: bumped pydantic and typing-inspect constraints for typing-extensions fixes
+issue-nr: 6021
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5
+  - iso4

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ texttable==1.6.7
 tornado==6.3.2
 toml==0.10.2
 typing_inspect==0.9.0
-typing-extensions==4.5.0
 build==0.10.0
 ruamel.yaml==0.17.26
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ netifaces==0.11.0
 packaging==23.1
 pip==23.1.2
 ply==3.11
-pydantic==1.10.7
+pydantic==1.10.8
 pyformance==0.4
 PyJWT==2.7.0
 pynacl==1.5.0
@@ -25,7 +25,7 @@ setuptools==67.8.0
 texttable==1.6.7
 tornado==6.3.2
 toml==0.10.2
-typing_inspect==0.8.0
+typing_inspect==0.9.0
 typing-extensions==4.5.0
 build==0.10.0
 ruamel.yaml==0.17.26

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ requires = [
     "tornado~=6.0",
     # lower bound because of ilevkivskyi/typing_inspect#100
     "typing_inspect~=0.9",
-    # typing-extensions-4.6 broken due to bugs in other packages: , pydantic/pydantic#5821
-    "typing-extensions<4.6",
     "build~=0.7",
     "ruamel.yaml~=0.17",
     "toml~=0.10 ",

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ requires = [
     # pip>=21.3 required for editable pyproject.toml + setup.cfg based install support
     "pip>=21.3",
     "ply~=3.0",
-    # Exclude pre-release due to https://github.com/samuelcolvin/pydantic/issues/3546
-    "pydantic~=1.0,!=1.9.0a1",
+    # lower bound because of pydantic/pydantic#5821
+    "pydantic>=1.10.8,<2",
     "pyformance~=0.4",
     "PyJWT~=2.0",
     "pynacl~=1.5",
@@ -32,8 +32,9 @@ requires = [
     "pyyaml~=6.0",
     "texttable~=1.0",
     "tornado~=6.0",
-    "typing_inspect~=0.7",
-    # typing-extensions-4.6 broken due to bugs in other packages: ilevkivskyi/typing_inspect#100, pydantic/pydantic#5821
+    # lower bound because of ilevkivskyi/typing_inspect#100
+    "typing_inspect~=0.9",
+    # typing-extensions-4.6 broken due to bugs in other packages: , pydantic/pydantic#5821
     "typing-extensions<4.6",
     "build~=0.7",
     "ruamel.yaml~=0.17",


### PR DESCRIPTION
Both typing-inspect and pydantic have fixed the "bugs" that made them incompatible with the latest typing-extensions release. This PR bumps the lower bound for these packages and drops the constraint on typing-extensions.

closes #6021