### PR TITLE
Make agent backoff configurable

### DIFF
--- a/changelogs/unreleased/add_agent_resource_backoff_config_option.yml
+++ b/changelogs/unreleased/add_agent_resource_backoff_config_option.yml
@@ -1,0 +1,6 @@
+---
+description: The hardcoded agent backoff time is now configurable using the `config.agent_get_resource_backoff` config option. The default value was changed from five to three seconds.
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/add_agent_resource_backoff_config_option.yml
+++ b/changelogs/unreleased/add_agent_resource_backoff_config_option.yml
@@ -1,6 +1,6 @@
 ---
-description: The hardcoded agent backoff time is now configurable using the `config.agent_get_resource_backoff` config option. The default value was changed from five to three seconds.
-change-type: patch
+description: The hardcoded agent backoff time is now configurable using the `config.agent_get_resource_backoff` config option.
+change-type: minor
 destination-branches: [master, iso6]
 sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -45,7 +45,6 @@ from inmanta.types import Apireturn, JsonType
 from inmanta.util import IntervalSchedule, NamedLock, ScheduledTask, TaskMethod, add_future, join_threadpools
 
 LOGGER = logging.getLogger(__name__)
-GET_RESOURCE_BACKOFF = 5
 
 
 class ResourceActionResult(object):
@@ -714,7 +713,7 @@ class AgentInstance(object):
                 self._getting_resources = False
             end = time.time()
             self._get_resource_duration = end - start
-            self._get_resource_timeout = GET_RESOURCE_BACKOFF * self._get_resource_duration + end
+            self._get_resource_timeout = cfg.agent_get_resource_backoff.get() * self._get_resource_duration + end
             if result.code == 404:
                 self.logger.info("No released configuration model version available for %s", reason)
             elif result.code == 409:

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -132,6 +132,17 @@ Each subsequent repair deployment will start agent-repair-interval seconds after
     is_time,
 )
 
+agent_get_resource_backoff = Option(
+    "config",
+    "agent-get-resource-backoff",
+    3,
+    "This is a load management feature. It ensures that the agent will not pull resources from the inmanta server"
+    " `<agent-get-resource-backoff>*<duration-last-pull-in-seconds>` seconds after the last time the agent pulled resources"
+    " from the server. Setting this option too low may result in a high load on the Inmanta server. Setting it too high"
+    " may result in long deployment times.",
+    is_float,
+)
+
 
 ##############################
 # agent_rest_transport

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -135,7 +135,7 @@ Each subsequent repair deployment will start agent-repair-interval seconds after
 agent_get_resource_backoff = Option(
     "config",
     "agent-get-resource-backoff",
-    3,
+    5,
     "This is a load management feature. It ensures that the agent will not pull resources from the inmanta server"
     " `<agent-get-resource-backoff>*<duration-last-pull-in-seconds>` seconds after the last time the agent pulled resources"
     " from the server. Setting this option too low may result in a high load on the Inmanta server. Setting it too high"

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -30,6 +30,7 @@ from uuid import UUID
 import asyncpg.connection
 
 from inmanta import const, data, util
+from inmanta.agent import config as agent_cfg
 from inmanta.config import Config
 from inmanta.const import AgentAction, AgentStatus
 from inmanta.data import APILIMIT, InvalidSort, model
@@ -1195,6 +1196,8 @@ agent-deploy-interval=%(agent_deploy_interval)d
 agent-repair-splay-time=%(agent_repair_splay)d
 agent-repair-interval=%(agent_repair_interval)d
 
+agent-get-resource-backoff=%(agent_get_resource_backoff)f
+
 [agent_rest_transport]
 port=%(port)s
 host=%(serveradress)s
@@ -1208,6 +1211,7 @@ host=%(serveradress)s
             "agent_repair_splay": agent_repair_splay,
             "agent_repair_interval": agent_repair_interval,
             "serveradress": server_config.server_address.get(),
+            "agent_get_resource_backoff": agent_cfg.agent_get_resource_backoff.get(),
         }
 
         if server_config.server_enable_auth.get():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -538,7 +538,7 @@ def no_agent_backoff(inmanta_config: ConfigParser) -> None:
     old_backoff = agent_cfg.agent_get_resource_backoff.get()
     inmanta_config.set(section="config", option="agent-get-resource-backoff", value="0")
     yield
-    inmanta_config.set(section="config", option="agent-get-resource-backoff", value=old_backoff)
+    inmanta_config.set(section="config", option="agent-get-resource-backoff", value=str(old_backoff))
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,7 @@ import inmanta.compiler.config
 import inmanta.main
 import inmanta.user_setup
 from inmanta import config, const, data, env, loader, protocol, resources
+from inmanta.agent import config as agent_cfg
 from inmanta.agent import handler
 from inmanta.agent.agent import Agent
 from inmanta.ast import CompilerException
@@ -533,11 +534,11 @@ def restore_cwd():
 
 
 @pytest.fixture(scope="function")
-def no_agent_backoff():
-    backoff = inmanta.agent.agent.GET_RESOURCE_BACKOFF
-    inmanta.agent.agent.GET_RESOURCE_BACKOFF = 0
+def no_agent_backoff(inmanta_config: ConfigParser) -> None:
+    old_backoff = agent_cfg.agent_get_resource_backoff.get()
+    inmanta_config.set(section="config", option="agent-get-resource-backoff", value="0")
     yield
-    inmanta.agent.agent.GET_RESOURCE_BACKOFF = backoff
+    inmanta_config.set(section="config", option="agent-get-resource-backoff", value=old_backoff)
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

This PR adds a configuration option for the agent backoff time. I will create a follow up PR to change the default value on  master only.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
