### PR TITLE
Change default value of agent-get-resource-backoff config option

### DIFF
--- a/changelogs/unreleased/change-default-agent-backoff.yml
+++ b/changelogs/unreleased/change-default-agent-backoff.yml
@@ -1,0 +1,6 @@
+---
+description: The default agent backoff time has been changed from five to three seconds. This backoff is configurable using the `config.agent-get-resource-backoff` config option.
+change-type: major
+destination-branches: [master]
+sections:
+  deprecation-note: "{{description}}"

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -135,7 +135,7 @@ Each subsequent repair deployment will start agent-repair-interval seconds after
 agent_get_resource_backoff = Option(
     "config",
     "agent-get-resource-backoff",
-    5,
+    3,
     "This is a load management feature. It ensures that the agent will not pull resources from the inmanta server"
     " `<agent-get-resource-backoff>*<duration-last-pull-in-seconds>` seconds after the last time the agent pulled resources"
     " from the server. Setting this option too low may result in a high load on the Inmanta server. Setting it too high"


### PR DESCRIPTION
# Description

This PR changes the default agent backoff time from five to three seconds.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
