### PR TITLE
Fix race condition in the test_get_facts_extended test case

### DIFF
--- a/changelogs/unreleased/fix-race-condition-test-get-facts-extended.yml
+++ b/changelogs/unreleased/fix-race-condition-test-get-facts-extended.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in `test_get_facts_extended` test case.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/tests/agent_server/test_facts.py
+++ b/tests/agent_server/test_facts.py
@@ -273,15 +273,20 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
 
     await agent.stop()
 
-    LogSequence(caplog, allow_errors=False, ignore=["tornado.access"]).contains(
-        "inmanta.agent.agent.agent1", logging.ERROR, "Unable to retrieve fact"
-    ).contains("inmanta.agent.agent.agent1", logging.ERROR, "Unable to retrieve fact").contains(
-        "inmanta.agent.agent.agent1", logging.ERROR, "Unable to retrieve fact"
-    ).contains(
-        "inmanta.agent.agent.agent1", logging.ERROR, "Unable to retrieve fact"
-    ).contains(
-        "inmanta.agent.agent.agent1", logging.ERROR, "Unable to retrieve fact"
-    ).no_more_errors()
+    def wait_until_log_records_are_available() -> bool:
+        try:
+            log_sequence = LogSequence(caplog, allow_errors=False, ignore=["tornado.access"])
+            for i in range(5):
+                log_sequence = log_sequence.contains("inmanta.agent.agent.agent1", logging.ERROR, "Unable to retrieve fact")
+            log_sequence.no_more_errors()
+        except AssertionError:
+            return False
+        else:
+            return True
+
+    # The get_parameter() API calls from the server to the agent are executed asynchronously with respect the
+    # get_param() API calls done from the test case to the server. Here we wait until all log records are available.
+    await retry_limited(wait_until_log_records_are_available, timeout=10)
 
 
 async def test_purged_resources(resource_container, client, clienthelper, server, environment, agent, no_agent_backoff):


### PR DESCRIPTION
# Description

Fix race condition in the `test_get_facts_extended test` case.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
