### PR TITLE
Fix timeout in test_server_recompile test case

### DIFF
--- a/changelogs/unreleased/fix-test-server-recompile-test-case.yml
+++ b/changelogs/unreleased/fix-test-server-recompile-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: Fix issue where the `test_server_recompile` test case times out because the compile takes longer than 30 seconds.
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -22,6 +22,7 @@ import os
 import queue
 import shutil
 import subprocess
+import time
 import uuid
 from asyncio import Semaphore
 from collections import abc
@@ -697,7 +698,7 @@ async def test_server_recompile(server, client, environment, monkeypatch):
     assert result.code == 200
 
     logger.info("wait for 1")
-    versions = await wait_for_version(client, environment, 1)
+    versions = await wait_for_version(client, environment, 1, compile_timeout=40)
     assert versions["versions"][0]["total"] == 1
     assert versions["versions"][0]["version_info"]["export_metadata"]["type"] == "api"
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -22,7 +22,6 @@ import os
 import queue
 import shutil
 import subprocess
-import time
 import uuid
 from asyncio import Semaphore
 from collections import abc

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -270,7 +270,10 @@ async def report_db_index_usage(min_precent=100):
         print(row)
 
 
-async def wait_for_version(client, environment, cnt):
+async def wait_for_version(client, environment, cnt, compile_timeout: int = 30):
+    """
+    :param compile_timeout: Raise an AssertionError if the compilation didn't finish after this amount of seconds.
+    """
     # Wait until the server is no longer compiling
     # wait for it to finish
     async def compile_done():
@@ -278,7 +281,7 @@ async def wait_for_version(client, environment, cnt):
         code = compiling.code
         return code == 204
 
-    await retry_limited(compile_done, 30)
+    await retry_limited(compile_done, compile_timeout)
 
     reports = await client.get_reports(environment)
     for report in reports.result["reports"]:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -274,6 +274,7 @@ async def wait_for_version(client, environment, cnt, compile_timeout: int = 30):
     """
     :param compile_timeout: Raise an AssertionError if the compilation didn't finish after this amount of seconds.
     """
+
     # Wait until the server is no longer compiling
     # wait for it to finish
     async def compile_done():


### PR DESCRIPTION
# Description

The `test_server_recompile`  test case has been very flaky for a while. In some situations compiles take 20 seconds and sometimes they take more than 30 seconds. This is caused by the way we compose the pip commands. We supply some constraint to pip to make sure we don't change inmanta packages. This is done based on the working set (See: https://github.com/inmanta/inmanta-core/blob/132f0a7739464409f833e18dc12ec61ac98ae6ea/src/inmanta/env.py#L246). Because this is a set, the order of these constraints is undeterministic. Depending on this order, pip needs more or less time to resolve the required version, which reflects on the compile time. For example:

* `python -m pip install --upgrade --upgrade-strategy eager Jinja2<4,>=3.1 pydantic<2,>=1.10 email_validator<3,>=1.3 inmanta-core==9.1.0.dev0` happens to be a lot slower than on a venv with inmanta installed than
* `python -m pip install --upgrade --upgrade-strategy eager email_validator<3,>=1.3 Jinja2<4,>=3.1 pydantic<2,>=1.10 inmanta-core==9.1.0.dev0`

This PR raises the timeout threshold from 30 to 40 second to make sure that the slow path doesn't result in a timeout anymore.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
