### PR TITLE
Fix race condition that resets environment setting to default

### DIFF
--- a/changelogs/unreleased/fix-race-condition-on-get-env-setting.yml
+++ b/changelogs/unreleased/fix-race-condition-on-get-env-setting.yml
@@ -1,0 +1,4 @@
+---
+description: Dummy merge record. Won't fix this issue on iso4 due to big merge conflict.
+change-type: patch
+destination-branches: [iso4]


### PR DESCRIPTION
# Description

Merging #6083 on the iso4 branch resulted in a merge conflict and it requires a lot of work to fix the conflict. Since the tests are not failing on this issue for iso4 and iso4 is nearly EOL, I decided not to fix this on iso4.