### PR TITLE
[FEAT] add get_resource_type_count_for_latest_version query

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 9.1.0
+current_version = 9.2.0
 
 [bumpversion:file:setup.py]
 search = version = "{current_version}"

--- a/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
+++ b/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
@@ -1,4 +1,4 @@
-description: Add get_latest_resources_resource_type_count to get the count for each resource_type over all resources in their latest version.
+description: Add get_latest_resources_resource_type_count to get the count for each resource_type over all resources in the model's latest version.
 issue-nr: 5933
 change-type: patch
 destination-branches: [master, iso6]

--- a/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
+++ b/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
@@ -1,4 +1,4 @@
 description: Add get_latest_resources_resource_type_count to get the count for each resource_type over all resources in the model's latest version.
 issue-nr: 5933
-change-type: patch
+change-type: minor
 destination-branches: [master, iso6]

--- a/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
+++ b/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
@@ -1,4 +1,4 @@
-description: Add get_latest_resources_resource_type_count to get the count for each resource_type over all resources in the model's latest version.
+description: Add get_resource_type_count_for_latest_version to get the count for each resource_type over all resources in the model's latest version.
 issue-nr: 5933
 change-type: minor
 destination-branches: [master, iso6]

--- a/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
+++ b/changelogs/unreleased/5933-investigate-timeout-on-license-component.yml
@@ -1,0 +1,4 @@
+description: Add get_latest_resources_resource_type_count to get the count for each resource_type over all resources in their latest version.
+issue-nr: 5933
+change-type: patch
+destination-branches: [master, iso6]

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-version = "9.1.0"
+version = "9.2.0"
 
 setup(
     version=version,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4536,10 +4536,11 @@ class Resource(BaseDocument):
             GROUP BY resource_type;
         """
         values = [cls._get_value(environment)]
-        result: JsonType = {}
+        result: dict[str, int] = {}
         async with cls.get_connection() as con:
             async with con.transaction():
                 async for record in con.cursor(query, *values):
+                    assert isinstance(record["count"], int)
                     result[str(record["resource_type"])] = record["count"]
         return result
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4542,11 +4542,11 @@ class Resource(BaseDocument):
             GROUP BY resource_type;
         """
         values = [cls._get_value(environment)]
-        result = {}
+        result: JsonType = {}
         async with cls.get_connection() as con:
             async with con.transaction():
                 async for record in con.cursor(query, *values):
-                    result[record["resource_type"]] = record["count"]
+                    result[str(record["resource_type"])] = record["count"]
         return result
 
     @classmethod

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4520,7 +4520,7 @@ class Resource(BaseDocument):
         return result
 
     @classmethod
-    async def get_resource_type_count_for_latest_version(cls, environment: uuid.UUID) -> JsonType:
+    async def get_resource_type_count_for_latest_version(cls, environment: uuid.UUID) -> dict[str, int]:
         """
         Returns the count for each resource_type over all resources in the model's latest version
         """

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4531,12 +4531,8 @@ class Resource(BaseDocument):
         """
         query = f"""
             SELECT resource_type, count(*) as count
-            FROM (
-                SELECT DISTINCT resource_id, resource_type
-                FROM {Resource.table_name()}
-                WHERE environment=$1
-                AND model=({query_latest_model})
-            ) AS r1
+            FROM {Resource.table_name()}
+            WHERE environment=$1 AND model=({query_latest_model})
             GROUP BY resource_type;
         """
         values = [cls._get_value(environment)]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4520,7 +4520,7 @@ class Resource(BaseDocument):
         return result
 
     @classmethod
-    async def get_latest_resources_resource_type_count(cls, environment: uuid.UUID) -> JsonType:
+    async def get_resource_type_count_for_latest_version(cls, environment: uuid.UUID) -> JsonType:
         """
         Returns the count for each resource_type over all resources in the model's latest version
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1699,7 +1699,7 @@ async def test_get_latest_resources_resource_type_count(init_dataclasses_and_loa
     )
     await res1_1.insert()
 
-    await assert_expected_count({"std::File": 1})
+    await assert_expected_count({"std::File": 1})  # 1 File resource in model v1
 
     res2_1 = data.Resource.new(
         environment=env.id,
@@ -1710,7 +1710,7 @@ async def test_get_latest_resources_resource_type_count(init_dataclasses_and_loa
     )
     await res2_1.insert()
 
-    await assert_expected_count({"std::File": 2})
+    await assert_expected_count({"std::File": 2})  # 2 File resources in model v1
 
     version += 1
     cm2 = data.ConfigurationModel(
@@ -1734,7 +1734,7 @@ async def test_get_latest_resources_resource_type_count(init_dataclasses_and_loa
     )
     await res2_2.insert()
 
-    await assert_expected_count({"std::File": 2})
+    await assert_expected_count({"std::File": 1})  # 1 File resource in model v2
 
     res3_2 = data.Resource.new(
         environment=env.id,
@@ -1744,7 +1744,7 @@ async def test_get_latest_resources_resource_type_count(init_dataclasses_and_loa
     )
     await res3_2.insert()
 
-    await assert_expected_count({"std::File": 2, "std::Dummy": 1})
+    await assert_expected_count({"std::File": 1, "std::Dummy": 1})  # 1 File resource and 1 Dummy resource in model v2
 
 
 async def test_resources_report(init_dataclasses_and_load_schema):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1661,9 +1661,9 @@ async def test_resource_hash(init_dataclasses_and_load_schema):
     assert res1.attribute_hash != res3.attribute_hash
 
 
-async def test_get_latest_resources_resource_type_count(init_dataclasses_and_load_schema):
+async def test_get_resource_type_count_for_latest_version(init_dataclasses_and_load_schema):
     """
-    Test for the get_latest_resources_resource_type_count query
+    Test for the get_resource_type_count_for_latest_version query
     """
     project = data.Project(name="test")
     await project.insert()
@@ -1673,7 +1673,7 @@ async def test_get_latest_resources_resource_type_count(init_dataclasses_and_loa
 
     async def assert_expected_count(expected_report: Dict[str, int]):
         # Checks the expected_report against the actual one
-        report = await data.Resource.get_latest_resources_resource_type_count(env.id)
+        report = await data.Resource.get_resource_type_count_for_latest_version(env.id)
         assert report == expected_report
 
     # model 1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1661,6 +1661,92 @@ async def test_resource_hash(init_dataclasses_and_load_schema):
     assert res1.attribute_hash != res3.attribute_hash
 
 
+async def test_get_latest_resources_resource_type_count(init_dataclasses_and_load_schema):
+    """
+    Test for the get_latest_resources_resource_type_count query
+    """
+    project = data.Project(name="test")
+    await project.insert()
+
+    env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
+    await env.insert()
+
+    async def assert_expected_count(expected_report: Dict[str, int]):
+        # Checks the expected_report against the actual one
+        report = await data.Resource.get_latest_resources_resource_type_count(env.id)
+        assert report == expected_report
+
+    # model 1
+    version = 1
+    cm1 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+        is_suitable_for_partial_compiles=False,
+    )
+    await cm1.insert()
+
+    res1_1 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file1],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
+        attributes={"path": "/etc/file1"},
+    )
+    await res1_1.insert()
+
+    await assert_expected_count({"std::File": 1})
+
+    res2_1 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
+        attributes={"path": "/etc/file2"},
+    )
+    await res2_1.insert()
+
+    await assert_expected_count({"std::File": 2})
+
+    version += 1
+    cm2 = data.ConfigurationModel(
+        environment=env.id,
+        version=version,
+        date=datetime.datetime.now(),
+        total=1,
+        version_info={},
+        released=True,
+        deployed=True,
+        is_suitable_for_partial_compiles=False,
+    )
+    await cm2.insert()
+
+    res2_2 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::File[agent1,path=/etc/file2],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
+        attributes={"path": "/etc/file2"},
+    )
+    await res2_2.insert()
+
+    await assert_expected_count({"std::File": 2})
+
+    res3_2 = data.Resource.new(
+        environment=env.id,
+        resource_version_id="std::Dummy[agent1,path=/etc/file3],v=%s" % version,
+        status=const.ResourceState.deployed,
+        last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
+    )
+    await res3_2.insert()
+
+    await assert_expected_count({"std::File": 2, "std::Dummy": 1})
+
+
 async def test_resources_report(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -19,7 +19,7 @@ from os import path
 
 from setuptools import find_namespace_packages, setup
 
-version = "9.1.0"
+version = "9.2.0"
 
 requires = [
     "asyncpg",


### PR DESCRIPTION
# Description
The `get_license_metrics` was calling `get_resources_report` but only using it to get the resource_type count. This PR adds a query to retrieve only this.

TODO: 

- [x] use this newly added get_resource_type_count_for_latest_version query instead of get_resources_report in inmanta-license
-> PR [here](https://github.com/inmanta/inmanta-license/pull/516)
- [x] [bump inmanta core 1 minor up](https://github.com/inmanta/inmanta-core/pull/6094#issuecomment-1580000173)

closes https://github.com/inmanta/inmanta-core/issues/5933

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
