### PR TITLE
Issue/5884 improve logging regarding resource sets

### DIFF
--- a/changelogs/unreleased/5884-improve-logging-regarding-resource-sets.yml
+++ b/changelogs/unreleased/5884-improve-logging-regarding-resource-sets.yml
@@ -1,0 +1,6 @@
+description: Improve error reporting when atempting to move a resource to another resource set in a partial compile.
+issue-nr: 5884
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/5884-improve-logging-regarding-resource-sets.yml
+++ b/changelogs/unreleased/5884-improve-logging-regarding-resource-sets.yml
@@ -1,4 +1,4 @@
-description: Improve error reporting when atempting to move a resource to another resource set in a partial compile.
+description: Improve error reporting when attempting to move a resource to another resource set in a partial compile.
 issue-nr: 5884
 change-type: patch
 destination-branches: [master, iso6]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4863,7 +4863,7 @@ class Resource(BaseDocument):
                 destination_version,
                 updated_resource_sets | deleted_resource_sets,
             )
-            return {record["resource_id"]: record["resource_set"] for record in result}
+            return {str(record["resource_id"]): str(record["resource_set"]) for record in result}
 
     @classmethod
     async def get_resources_in_resource_sets(

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4814,7 +4814,7 @@ class Resource(BaseDocument):
         deleted_resource_sets: abc.Set[str],
         *,
         connection: Optional[asyncpg.connection.Connection] = None,
-    ) -> abc.Set[m.ResourceIdStr]:
+    ) -> dict[m.ResourceIdStr, str]:
         """
         Copy the resources that belong to an unchanged resource set of a partial compile,
         from source_version to destination_version. This method doesn't copy shared resources.
@@ -4853,7 +4853,7 @@ class Resource(BaseDocument):
                 FROM {cls.table_name()} AS r
                 WHERE r.environment=$1 AND r.model=$2 AND r.resource_set IS NOT NULL AND NOT r.resource_set=ANY($4)
             )
-            RETURNING resource_id
+            RETURNING resource_id, resource_set
         """
         async with cls.get_connection(connection) as con:
             result = await con.fetch(
@@ -4863,7 +4863,7 @@ class Resource(BaseDocument):
                 destination_version,
                 updated_resource_sets | deleted_resource_sets,
             )
-            return {record["resource_id"] for record in result}
+            return {record["resource_id"]: record["resource_set"] for record in result}
 
     @classmethod
     async def get_resources_in_resource_sets(

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -736,6 +736,7 @@ class OrchestrationService(protocol.ServerSlice):
             if is_partial_update:
                 # Make mypy happy
                 assert partial_base_version is not None
+                # This dict maps a resource id to its resource set for unchanged resource sets.
                 rids_unchanged_resource_sets: dict[
                     ResourceIdStr, str
                 ] = await data.Resource.copy_resources_from_unchanged_resource_set(
@@ -758,7 +759,7 @@ class OrchestrationService(protocol.ServerSlice):
                     )
 
                     raise BadRequest(msg)
-                all_ids |= {Id.parse_id(rid, version) for rid in rids_unchanged_resource_sets}
+                all_ids |= {Id.parse_id(rid, version) for rid in rids_unchanged_resource_sets.keys()}
 
             await data.Resource.insert_many(list(rid_to_resource.values()), connection=connection)
             await cm.recalculate_total(connection=connection)

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -752,11 +752,12 @@ class OrchestrationService(protocol.ServerSlice):
                         "The following Resource(s) cannot be migrated to a different resource set using a partial compile, "
                         "a full compile is necessary for this process:\n"
                     )
-                    msg += "\n".join(f"    {rid} moved from {rids_unchanged_resource_sets[rid]} to {resource_sets[rid]}" for rid in resources_that_moved_resource_sets)
-
-                    raise BadRequest(
-                        msg
+                    msg += "\n".join(
+                        f"    {rid} moved from {rids_unchanged_resource_sets[rid]} to {resource_sets[rid]}"
+                        for rid in resources_that_moved_resource_sets
                     )
+
+                    raise BadRequest(msg)
                 all_ids |= {Id.parse_id(rid, version) for rid in rids_unchanged_resource_sets}
 
             await data.Resource.insert_many(list(rid_to_resource.values()), connection=connection)

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -747,7 +747,7 @@ class OrchestrationService(protocol.ServerSlice):
                     deleted_resource_sets=set(removed_resource_sets),
                     connection=connection,
                 )
-                resources_that_moved_resource_sets = rids_unchanged_resource_sets.keys() & set(rid_to_resource.keys())
+                resources_that_moved_resource_sets = rids_unchanged_resource_sets.keys() & rid_to_resource.keys()
                 if resources_that_moved_resource_sets:
                     msg = (
                         "The following Resource(s) cannot be migrated to a different resource set using a partial compile, "

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -389,6 +389,13 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
             "send_event": False,
             "purged": False,
             "requires": [],
+        }, {
+            "key": "key2",
+            "value": "value2",
+            "id": "test::Resource[agent1,key=key2],v=%d" % version,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
         },
     ]
     result = await client.put_version(
@@ -399,7 +406,10 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
         unknowns=[],
         version_info={},
         compiler_version=get_compiler_version(),
-        resource_sets={"test::Resource[agent1,key=key1]": "set-a"},
+        resource_sets={
+            "test::Resource[agent1,key=key1]": "set-a",
+            "test::Resource[agent1,key=key2]": "set-b"
+        },
     )
     assert result.code == 200
     resources_partial = [
@@ -407,6 +417,13 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
             "key": "key1",
             "value": "value1",
             "id": "test::Resource[agent1,key=key1],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },{
+            "key": "key2",
+            "value": "value2",
+            "id": "test::Resource[agent1,key=key2],v=0",
             "send_event": False,
             "purged": False,
             "requires": [],
@@ -419,13 +436,17 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
         resource_state={},
         unknowns=[],
         version_info=None,
-        resource_sets={"test::Resource[agent1,key=key1]": "set-b"},
+        resource_sets={
+            "test::Resource[agent1,key=key1]": "set-b",
+            "test::Resource[agent1,key=key2]": "set-b"
+        },
     )
 
     assert result.code == 400
     assert result.result["message"] == (
-        "Invalid request: A partial compile cannot migrate resources "
-        "['test::Resource[agent1,key=key1]'] to another resource set"
+        "Invalid request: The following Resource(s) cannot be migrated to a different resource set using a partial compile, "
+        "a full compile is necessary for this process:\n"
+        '    test::Resource[agent1,key=key1] moved from set-a to set-b'
     )
 
 

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -376,7 +376,7 @@ async def test_put_partial_merge_not_in_resource_set(server, client, environment
         assert r.model == 2
 
 
-async def test_put_partial_migrate_resource_to_other_resource_set_sandbox(server, client, environment, clienthelper):
+async def test_put_partial_migrate_resource_to_other_resource_set(server, client, environment, clienthelper):
     """
     Resources cannot migrate to a different resource set using a partial compile.
     """
@@ -447,76 +447,6 @@ async def test_put_partial_migrate_resource_to_other_resource_set_sandbox(server
     ]
 
     assert all(line in result.result["message"] for line in expected_lines)
-
-
-async def test_put_partial_migrate_resource_to_other_resource_set(server, client, environment, clienthelper):
-    """
-    Resources cannot migrate to a different resource set using a partial compile.
-    """
-    version = await clienthelper.get_version()
-    resources = [
-        {
-            "key": "key1",
-            "value": "value1",
-            "id": "test::Resource[agent1,key=key1],v=%d" % version,
-            "send_event": False,
-            "purged": False,
-            "requires": [],
-        },
-        {
-            "key": "key2",
-            "value": "value2",
-            "id": "test::Resource[agent1,key=key2],v=%d" % version,
-            "send_event": False,
-            "purged": False,
-            "requires": [],
-        },
-    ]
-    result = await client.put_version(
-        tid=environment,
-        version=version,
-        resources=resources,
-        resource_state={},
-        unknowns=[],
-        version_info={},
-        compiler_version=get_compiler_version(),
-        resource_sets={"test::Resource[agent1,key=key1]": "set-a", "test::Resource[agent1,key=key2]": "set-b"},
-    )
-    assert result.code == 200
-    resources_partial = [
-        {
-            "key": "key1",
-            "value": "value1",
-            "id": "test::Resource[agent1,key=key1],v=0",
-            "send_event": False,
-            "purged": False,
-            "requires": [],
-        },
-        {
-            "key": "key2",
-            "value": "value2",
-            "id": "test::Resource[agent1,key=key2],v=0",
-            "send_event": False,
-            "purged": False,
-            "requires": [],
-        },
-    ]
-
-    result = await client.put_partial(
-        tid=environment,
-        resources=resources_partial,
-        resource_state={},
-        unknowns=[],
-        version_info=None,
-        resource_sets={"test::Resource[agent1,key=key1]": "set-b", "test::Resource[agent1,key=key2]": "set-b"},
-    )
-
-    assert result.code == 400
-    assert result.result["message"] == (
-        "Invalid request: The following Resource(s) cannot be migrated to a different resource set using a partial compile, "
-        "a full compile is necessary for this process:\n"
-        "    test::Resource[agent1,key=key1] moved from set-a to set-b"
-    )
 
 
 async def test_put_partial_update_not_in_resource_set(server, client, environment, clienthelper):

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -376,6 +376,81 @@ async def test_put_partial_merge_not_in_resource_set(server, client, environment
         assert r.model == 2
 
 
+async def test_put_partial_migrate_resource_to_other_resource_set_sandbox(server, client, environment, clienthelper):
+    """
+    Resources cannot migrate to a different resource set using a partial compile.
+    """
+    version = await clienthelper.get_version()
+    resources = [
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": "test::Resource[agent1,key=key1],v=%d" % version,
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        }
+        # , {
+        #     "key": "key2",
+        #     "value": "value2",
+        #     "id": "test::Resource[agent1,key=key2],v=%d" % version,
+        #     "send_event": False,
+        #     "purged": False,
+        #     "requires": [],
+        # },
+    ]
+    result = await client.put_version(
+        tid=environment,
+        version=version,
+        resources=resources,
+        resource_state={},
+        unknowns=[],
+        version_info={},
+        compiler_version=get_compiler_version(),
+        resource_sets={
+            "test::Resource[agent1,key=key1]": "set-a",
+            # "test::Resource[agent1,key=key2]": "set-b"
+        },
+    )
+    assert result.code == 200
+    resources_partial = [
+        {
+            "key": "key1",
+            "value": "value1",
+            "id": "test::Resource[agent1,key=key1],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        # {
+        #     "key": "key2",
+        #     "value": "value2",
+        #     "id": "test::Resource[agent1,key=key2],v=0",
+        #     "send_event": False,
+        #     "purged": False,
+        #     "requires": [],
+        # },
+    ]
+
+    result = await client.put_partial(
+        tid=environment,
+        resources=resources_partial,
+        resource_state={},
+        unknowns=[],
+        version_info=None,
+        resource_sets={
+            "test::Resource[agent1,key=key1]": "set-b",
+            # "test::Resource[agent1,key=key2]": "set-c"
+        },
+    )
+
+    assert result.code == 400
+    assert result.result["message"] == (
+        "Invalid request: The following Resource(s) cannot be migrated to a different resource set using a partial compile, "
+        "a full compile is necessary for this process:\n"
+        '    test::Resource[agent1,key=key1] moved from set-a to set-b'
+    )
+
 async def test_put_partial_migrate_resource_to_other_resource_set(server, client, environment, clienthelper):
     """
     Resources cannot migrate to a different resource set using a partial compile.


### PR DESCRIPTION
# Description

 Improve error reporting when attempting to move a resource to another resource set in a partial compile. 

closes #5884 


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
