### PR TITLE
Issue/5974 web console environment delete does not delete env directories on server

### DIFF
--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -31,7 +31,7 @@ class handle(object):  # noqa: N801
     Decorator for subclasses of an endpoint to handle protocol methods
 
     :param method: A subclass of method that defines the method
-    :param api_version: When specific this handler is only associated with a method of the specific api verision. If the
+    :param api_version: When specific this handler is only associated with a method of the specific api version. If the
                         version is not defined, the handler is not associated with a rest endpoint.
     :param kwargs: Map arguments in the message from one name to an other
     """

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -46,9 +46,8 @@ from inmanta.server import (
     SLICE_RESOURCE,
     SLICE_SERVER,
     SLICE_TRANSPORT,
+    protocol,
 )
-from inmanta.server import config as opt
-from inmanta.server import protocol
 from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager
 from inmanta.server.server import Server
 from inmanta.server.services import compilerservice
@@ -483,7 +482,7 @@ class EnvironmentService(protocol.ServerSlice):
         self.resource_service.close_resource_action_logger(environment_id)
         await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
 
-        state_dir = opt.state_dir.get()
+        state_dir = config.state_dir.get()
         environment_dir = os.path.join(state_dir, "server", "environments", str(environment_id))
 
         if os.path.exists(environment_dir):

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -46,9 +46,9 @@ from inmanta.server import (
     SLICE_RESOURCE,
     SLICE_SERVER,
     SLICE_TRANSPORT,
-    protocol,
-    config as opt,
 )
+from inmanta.server import config as opt
+from inmanta.server import protocol
 from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager
 from inmanta.server.server import Server
 from inmanta.server.services import compilerservice
@@ -483,7 +483,6 @@ class EnvironmentService(protocol.ServerSlice):
         self.resource_service.close_resource_action_logger(environment_id)
         await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
 
-
         state_dir = opt.state_dir.get()
         environment_dir = os.path.join(state_dir, "server", "environments", str(environment_id))
 
@@ -498,7 +497,6 @@ class EnvironmentService(protocol.ServerSlice):
                     f"Environment {environment_id} cannot be deleted because it contains files owned"
                     " by a different user from the one running the Inmanta server."
                 )
-
 
     @handle(methods_v2.environment_clear, env="id")
     async def environment_clear(self, env: data.Environment) -> None:

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -47,6 +47,7 @@ from inmanta.server import (
     SLICE_SERVER,
     SLICE_TRANSPORT,
     protocol,
+    config as opt,
 )
 from inmanta.server.agentmanager import AgentManager, AutostartedAgentManager
 from inmanta.server.server import Server
@@ -482,6 +483,23 @@ class EnvironmentService(protocol.ServerSlice):
         self.resource_service.close_resource_action_logger(environment_id)
         await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
 
+
+        state_dir = opt.state_dir.get()
+        environment_dir = os.path.join(state_dir, "server", "environments", str(environment_id))
+
+        if os.path.exists(environment_dir):
+            # This call might fail when someone manually creates a directory or file that is owned
+            # by another user than the user running the inmanta server. Execute rmtree() after
+            # notify_listeners() to ensure that the listeners are notified.
+            try:
+                shutil.rmtree(environment_dir)
+            except PermissionError:
+                raise Forbidden(
+                    f"Environment {environment_id} cannot be deleted because it contains files owned"
+                    " by a different user from the one running the Inmanta server."
+                )
+
+
     @handle(methods_v2.environment_clear, env="id")
     async def environment_clear(self, env: data.Environment) -> None:
         """
@@ -495,7 +513,6 @@ class EnvironmentService(protocol.ServerSlice):
         await env.delete_cascade(only_content=True)
 
         await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
-
         project_dir = os.path.join(self.server_slice._server_storage["environments"], str(env.id))
         if os.path.exists(project_dir):
             # This call might fail when someone manually creates a directory or file that is owned


### PR DESCRIPTION
# Description

- [x] Make sure the delete_environment endpoint deletes the env dir on the server.
- [x] Return an error code in case something goes wrong during deletion.

closes #5974 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
