### PR TITLE
Fix documentation of the inmanta module release command

### DIFF
--- a/changelogs/unreleased/fix-formatting-docs-v1tov2-cmd.yml
+++ b/changelogs/unreleased/fix-formatting-docs-v1tov2-cmd.yml
@@ -1,0 +1,6 @@
+---
+description: Fix issue where the documentation of the `inmanta module release` command is incorrectly formatted on the documentation pages.
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -738,11 +738,14 @@ mode.
             help="Release a new stable or dev release for this module.",
             description="""
 When a stable release is done, this command:
+
 * Does a commit that changes the current version to a stable version.
 * Adds Git release tag.
 * Does a commit that changes the current version to a development version that is one patch increment ahead of the released
   version.
+
 When a development release is done using the --dev option, this command:
+
 * Does a commit that updates the current version of the module to a development version that is a patch, minor or major version
   ahead of the previous stable release. The size of the increment is determined by the --revision, --patch, --minor or
   --major argument (--patch is the default). When a CHANGELOG.md file is present in the root of the module

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -744,11 +744,11 @@ When a stable release is done, this command:
 * Does a commit that changes the current version to a development version that is one patch increment ahead of the released
   version.
 
-When a development release is done using the --dev option, this command:
+When a development release is done using the \-\-dev option, this command:
 
 * Does a commit that updates the current version of the module to a development version that is a patch, minor or major version
-  ahead of the previous stable release. The size of the increment is determined by the --revision, --patch, --minor or
-  --major argument (--patch is the default). When a CHANGELOG.md file is present in the root of the module
+  ahead of the previous stable release. The size of the increment is determined by the \-\-revision, \-\-patch, \-\-minor or
+  \-\-major argument (\-\-patch is the default). When a CHANGELOG.md file is present in the root of the module
   directory then the version number in the changelog is also updated accordingly. The changelog file is always populated with
   the associated stable version and not a development version.
             """.strip(),

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -108,7 +108,7 @@ def add_deps_check_arguments(parser: argparse.ArgumentParser) -> None:
         help=(
             "When this option is enabled, only version conflicts in the direct dependencies will result in an error. "
             "All other version conflicts will result in a warning. This option is mutually exclusive with the "
-            "--strict-deps-check option."
+            "\--strict-deps-check option."
         ),
     )
     parser.add_argument(
@@ -118,7 +118,7 @@ def add_deps_check_arguments(parser: argparse.ArgumentParser) -> None:
         default=False,
         help=(
             "When this option is enabled, a version conflict in any (transitive) dependency will results in an error. "
-            "This option is mutually exclusive with the --no-strict-deps-check option."
+            "This option is mutually exclusive with the \--no-strict-deps-check option."
         ),
     )
 
@@ -569,7 +569,7 @@ class ModuleTool(ModuleLikeTool):
             "add",
             help=add_help_msg,
             description=f"{add_help_msg} When executed on a project, the module is installed as well. "
-            f"Either --v1 or --v2 has to be set.",
+            f"Either \--v1 or \--v2 has to be set.",
             parents=parent_parsers,
         )
         add.add_argument(
@@ -744,11 +744,11 @@ When a stable release is done, this command:
 * Does a commit that changes the current version to a development version that is one patch increment ahead of the released
   version.
 
-When a development release is done using the \-\-dev option, this command:
+When a development release is done using the \--dev option, this command:
 
 * Does a commit that updates the current version of the module to a development version that is a patch, minor or major version
-  ahead of the previous stable release. The size of the increment is determined by the \-\-revision, \-\-patch, \-\-minor or
-  \-\-major argument (\-\-patch is the default). When a CHANGELOG.md file is present in the root of the module
+  ahead of the previous stable release. The size of the increment is determined by the \--revision, \--patch, \--minor or
+  \--major argument (\--patch is the default). When a CHANGELOG.md file is present in the root of the module
   directory then the version number in the changelog is also updated accordingly. The changelog file is always populated with
   the associated stable version and not a development version.
             """.strip(),

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -108,7 +108,7 @@ def add_deps_check_arguments(parser: argparse.ArgumentParser) -> None:
         help=(
             "When this option is enabled, only version conflicts in the direct dependencies will result in an error. "
             "All other version conflicts will result in a warning. This option is mutually exclusive with the "
-            "\--strict-deps-check option."
+            "\--strict-deps-check option."  # noqa: W605
         ),
     )
     parser.add_argument(
@@ -118,7 +118,7 @@ def add_deps_check_arguments(parser: argparse.ArgumentParser) -> None:
         default=False,
         help=(
             "When this option is enabled, a version conflict in any (transitive) dependency will results in an error. "
-            "This option is mutually exclusive with the \--no-strict-deps-check option."
+            "This option is mutually exclusive with the \--no-strict-deps-check option."  # noqa: W605
         ),
     )
 
@@ -569,7 +569,7 @@ class ModuleTool(ModuleLikeTool):
             "add",
             help=add_help_msg,
             description=f"{add_help_msg} When executed on a project, the module is installed as well. "
-            f"Either \--v1 or \--v2 has to be set.",
+            f"Either \--v1 or \--v2 has to be set.",  # noqa: W605
             parents=parent_parsers,
         )
         add.add_argument(
@@ -751,7 +751,7 @@ When a development release is done using the \--dev option, this command:
   \--major argument (\--patch is the default). When a CHANGELOG.md file is present in the root of the module
   directory then the version number in the changelog is also updated accordingly. The changelog file is always populated with
   the associated stable version and not a development version.
-            """.strip(),
+            """.strip(),  # noqa: W605
             formatter_class=RawTextHelpFormatter,
         )
         release.add_argument(


### PR DESCRIPTION
# Description

* Add newlines before and after an itemization.
* Use `\--` instead of `--` otherwise it will get rendered as a single `-`.

Before:

![before](https://github.com/inmanta/inmanta-core/assets/2684622/e9d1c1b7-c81a-4e86-84d1-1b9a5d9b5282)

After:

![after](https://github.com/inmanta/inmanta-core/assets/2684622/a6decaf9-e5f6-449c-a128-8ecc19869adf)


# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
