### PR TITLE
Issue/5974 web console environment delete does not delete env directories on server iso6

### DIFF
--- a/changelogs/unreleased/5974-web-console-environment-delete-does-not-delete-env-dir-on-server.yml
+++ b/changelogs/unreleased/5974-web-console-environment-delete-does-not-delete-env-dir-on-server.yml
@@ -1,0 +1,6 @@
+description: The environment_delete endpoint now correctly removes the environment directory on the server.
+issue-nr: 5974
+change-type: minor
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/5974-web-console-environment-delete-does-not-delete-env-dir-on-server.yml
+++ b/changelogs/unreleased/5974-web-console-environment-delete-does-not-delete-env-dir-on-server.yml
@@ -1,6 +1,6 @@
 description: The environment_delete endpoint now correctly removes the environment directory on the server.
 issue-nr: 5974
 change-type: minor
-destination-branches: [master, iso6]
+destination-branches: [iso6]
 sections:
   bugfix: "{{description}}"

--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -31,7 +31,7 @@ class handle(object):  # noqa: N801
     Decorator for subclasses of an endpoint to handle protocol methods
 
     :param method: A subclass of method that defines the method
-    :param api_version: When specific this handler is only associated with a method of the specific api verision. If the
+    :param api_version: When specific this handler is only associated with a method of the specific api version. If the
                         version is not defined, the handler is not associated with a rest endpoint.
     :param kwargs: Map arguments in the message from one name to an other
     """

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -493,7 +493,6 @@ class EnvironmentService(protocol.ServerSlice):
         await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
         self._delete_environment_dir(environment_id)
 
-
     @handle(methods_v2.environment_decommission, env="id")
     async def environment_decommission(self, env: data.Environment, metadata: Optional[model.ModelMetadata]) -> int:
         is_protected_environment = await env.get(data.PROTECTED_ENVIRONMENT)
@@ -505,7 +504,6 @@ class EnvironmentService(protocol.ServerSlice):
         version_info = model.ModelVersionInfo(export_metadata=metadata)
         await self.orchestration_service.put_version(env, version, [], {}, [], version_info.dict(), get_compiler_version())
         return version
-
 
     @handle(methods_v2.environment_clear, env="id")
     async def environment_clear(self, env: data.Environment) -> None:

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -491,6 +491,8 @@ class EnvironmentService(protocol.ServerSlice):
 
         self.resource_service.close_resource_action_logger(environment_id)
         await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
+        self._delete_environment_dir(environment_id)
+
 
     @handle(methods_v2.environment_decommission, env="id")
     async def environment_decommission(self, env: data.Environment, metadata: Optional[model.ModelMetadata]) -> int:
@@ -503,6 +505,7 @@ class EnvironmentService(protocol.ServerSlice):
         version_info = model.ModelVersionInfo(export_metadata=metadata)
         await self.orchestration_service.put_version(env, version, [], {}, [], version_info.dict(), get_compiler_version())
         return version
+
 
     @handle(methods_v2.environment_clear, env="id")
     async def environment_clear(self, env: data.Environment) -> None:
@@ -517,13 +520,7 @@ class EnvironmentService(protocol.ServerSlice):
         await env.delete_cascade(only_content=True)
 
         await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
-
-        project_dir = os.path.join(self.server_slice._server_storage["environments"], str(env.id))
-        if os.path.exists(project_dir):
-            # This call might fail when someone manually creates a directory or file that is owned
-            # by another user than the user running the inmanta server. Execute rmtree() after
-            # notify_listeners() to ensure that the listeners are notified.
-            shutil.rmtree(project_dir)
+        self._delete_environment_dir(env.id)
 
     @handle(methods_v2.environment_create_token, env="tid")
     async def environment_create_token(self, env: data.Environment, client_types: List[str], idempotent: bool) -> str:
@@ -600,6 +597,30 @@ class EnvironmentService(protocol.ServerSlice):
 
     def remove_listener(self, action: EnvironmentAction, listener: EnvironmentListener) -> None:
         self.listeners[action].remove(listener)
+
+    def _delete_environment_dir(self, environment_id: uuid.UUID) -> None:
+        """
+        Deletes an environment from the server's state_dir directory. This method should be called after
+        notify_listeners() to ensure that the listeners are notified.
+
+        :param environment_id: The uuid of the environment to remove from the state directory.
+
+        :raises ServerError: When a file or directory has been created by a user different than the
+        one running the Inmanta server inside the environment directory marked for removal.
+        """
+        state_dir = config.state_dir.get()
+        environment_dir = os.path.join(state_dir, "server", "environments", str(environment_id))
+
+        if os.path.exists(environment_dir):
+            # This call might fail when someone manually creates a directory or file that is owned
+            # by another user than the user running the inmanta server.
+            try:
+                shutil.rmtree(environment_dir)
+            except PermissionError:
+                raise ServerError(
+                    f"Environment {environment_id} cannot be deleted because it contains files owned"
+                    " by a different user than the one running the Inmanta server."
+                )
 
     async def notify_listeners(
         self, action: EnvironmentAction, updated_env: model.Environment, original_env: Optional[model.Environment] = None


### PR DESCRIPTION
# Description

Part of https://github.com/inmanta/inmanta-core/issues/5974

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
