### PR TITLE
Fix race condition in compiler service

### DIFF
--- a/changelogs/unreleased/fix-race-condition-compilerservice.yml
+++ b/changelogs/unreleased/fix-race-condition-compilerservice.yml
@@ -1,0 +1,6 @@
+---
+description: Fix race condition in the compiler service where a KeyError is raised after the invocation of the `notify_compile_request_committed()` method.
+issue-nr: 6114
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -716,7 +716,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         if nextrun and not env.halted:
             task = self.add_background_task(self._run(nextrun))
             self._recompiles[environment] = task
-        else:
+        elif environment in self._recompiles:
             del self._recompiles[environment]
 
     async def _notify_listeners(self, compile: data.Compile) -> None:


### PR DESCRIPTION
# Description

This PR fixes a race condition that can cause a KeyError to be raised after the `notify_compile_request_committed()` method is called. The race happens in the following situation:

* The compiler service is running a compile A for environment.
* A compile request is created using the `request_recompile()` method with `in_db_transaction=True`.
* The `notify_compile_request_committed()` in invoked because the transaction that created the compile request has committed.
* [Before method of previous bullet acquires the _global_lock] Compile A has finished and the `_dequeue()` method is invoked to check whether there are any more compiles in the queue. This picks up the committed compile request. Let's call it compile B. 
* Compile B finishes and the `_dequeue()` method is invoked. There are no more compile requests in the queue, so the environment is removed from the `self._recompiles` dictionary.
* The execution of the `notify_compile_request_committed()` continues (bullet 3) and invokes the `process_next_compile_in_queue()`. The assumption made here is that there will be a compile request waiting in the queue, but in fact it was already processed. The KeyError is raised.

This sequence of event is very unlikely to happen in production, because it requires very short compile times. In practice only the test suite in vulnerable for this issue.

The above-mentioned KeyError can also occur when `process_next_compile_in_queue()` method is called when the environment is halted.

closes #6114

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
