### PR TITLE
added fixture to capture deadlock logs

### DIFF
--- a/changelogs/unreleased/6090-deadlock.yml
+++ b/changelogs/unreleased/6090-deadlock.yml
@@ -1,0 +1,4 @@
+description: Added more log info when detecting a deadlock
+issue-nr: 6090
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -411,10 +411,10 @@ class AgentManager(ServerSlice, SessionListener):
         now = datetime.now().astimezone()
         async with data.AgentProcess.get_connection() as connection:
             async with connection.transaction():
+                await data.AgentProcess.update_last_seen(session.id, now, connection)
                 await data.AgentInstance.log_instance_creation(session.tid, session.id, endpoints_to_add, connection)
                 await data.AgentInstance.log_instance_expiry(session.id, endpoints_to_remove, now, connection)
                 await data.Agent.update_primary(session.tid, endpoints_with_new_primary, now, connection)
-                await data.AgentProcess.update_last_seen(session.id, now, connection)
 
     # Session registration
     async def _register_session(self, session: protocol.Session, endpoint_names_snapshot: Set[str], now: datetime) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,13 +241,15 @@ def postgres_db(request: pytest.FixtureRequest):
     pg = request.getfixturevalue(fixture)
     yield pg
 
-    with open(os.path.join(initial_cwd, "pg.log"), "r") as fh:
-        for line in fh:
-            if "deadlock" in line:
-                break
-        sublogger = logging.getLogger("pytest.postgresql.deadlock")
-        for line in fh:
-            sublogger.warning("%s", line)
+    logfile = os.path.join(initial_cwd, "pg.log")
+    if os.path.exists(logfile):
+        with open(logfile, "r") as fh:
+            for line in fh:
+                if "deadlock" in line:
+                    break
+            sublogger = logging.getLogger("pytest.postgresql.deadlock")
+            for line in fh:
+                sublogger.warning("%s", line)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,7 +238,16 @@ def postgres_db(request: pytest.FixtureRequest):
         fixture = "postgresql_proc"
 
     logger.info("Using database fixture %s", fixture)
-    yield request.getfixturevalue(fixture)
+    pg = request.getfixturevalue(fixture)
+    yield pg
+
+    with open(os.path.join(initial_cwd, "pg.log"), "r") as fh:
+        for line in fh:
+            if "deadlock" in line:
+                break
+        sublogger = logging.getLogger("pytest.postgresql.deadlock")
+        for line in fh:
+            sublogger.warning("%s", line)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

In relation to #6117 and #6090 

1. I was unable to reproduce 
1. it is unclear to me how postgresql takes locks when doing a delete cascade 
 - In general, locks should be acquired consistently with delete cascade lock order, which is top down.  This means
   -  agentprocess -> agentinstance
   - environment -> agentprocess
   - environment -> agent
  2. the agent manager assumes agentprocess -> agentinstance -> agent
  3. I found one ordering bug in the agent manager, but I don't know if that was it
  4. I made it so the postgresql log part after the deadlock is logged, that is like
  
  ```15:37:49.068 WARNING 2023-06-15 15:29:43.830 CEST [75118] DETAIL:  Process 75118 waits for AccessExclusiveLock on relation 16571 of database 16385; blocked by process 75121.
15:37:49.068 WARNING 	Process 75121 waits for RowExclusiveLock on relation 16599 of database 16385; blocked by process 75118.
15:37:49.068 WARNING 	Process 75118: LOCK TABLE public.agentprocess
15:37:49.068 WARNING 	Process 75121: LOCK TABLE agent IN ROW EXCLUSIVE MODE
15:37:49.068 WARNING 2023-06-15 15:29:43.830 CEST [75118] HINT:  See server log for query details.
15:37:49.068 WARNING 2023-06-15 15:29:43.830 CEST [75118] STATEMENT:  LOCK TABLE public.agentproces

```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
