### PR TITLE
Fix sequencing issue stop procedure of database slice

### DIFF
--- a/changelogs/unreleased/fix-sequencing-issue-disconnect-from-db.yml
+++ b/changelogs/unreleased/fix-sequencing-issue-disconnect-from-db.yml
@@ -1,0 +1,4 @@
+---
+description: Make sure the background tasks of the database slice are stopped first, before the slice disconnects from the database. This is required because the background tasks need the database connection.
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -60,10 +60,9 @@ class DatabaseService(protocol.ServerSlice):
         self.schedule(self._report_database_pool_exhaustion, interval=3_600 * 24, cancel_on_stop=True)
 
     async def stop(self) -> None:
-        await self.disconnect_database()
-
-        self._pool = None
         await super().stop()
+        await self.disconnect_database()
+        self._pool = None
 
     def get_dependencies(self) -> List[str]:
         return []


### PR DESCRIPTION
# Description

Make sure the background tasks of the database slice are stopped first, before the slice disconnects from the database. This is required because the background tasks need the database connection.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
