### PR TITLE
Print deadlock issues

### DIFF
--- a/changelogs/unreleased/6090-deadlock-2.yml
+++ b/changelogs/unreleased/6090-deadlock-2.yml
@@ -1,0 +1,4 @@
+description: print info when detecting a deadlock
+issue-nr: 6090
+change-type: patch
+destination-branches: [master, iso6]

--- a/changelogs/unreleased/6090-deadlock-2.yml
+++ b/changelogs/unreleased/6090-deadlock-2.yml
@@ -1,4 +1,4 @@
-description: print info when detecting a deadlock
+description: add assertion in deadlock check
 issue-nr: 6090
 change-type: patch
 destination-branches: [master, iso6]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,9 +244,15 @@ def postgres_db(request: pytest.FixtureRequest):
     logfile = os.path.join(initial_cwd, "pg.log")
     if os.path.exists(logfile):
         with open(logfile, "r") as fh:
+            has_deadlock = False
             for line in fh:
                 if "deadlock" in line:
-                    assert False
+                    has_deadlock = True
+                    break
+            sublogger = logging.getLogger("pytest.postgresql.deadlock")
+            for line in fh:
+                sublogger.warning("%s", line)
+            assert not has_deadlock
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,7 +247,9 @@ def postgres_db(request: pytest.FixtureRequest):
             for line in fh:
                 if "deadlock" in line:
                     break
+            sublogger = logging.getLogger("pytest.postgresql.deadlock")
             for line in fh:
+                sublogger.warning("%s", line)
                 print(line)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,11 +246,7 @@ def postgres_db(request: pytest.FixtureRequest):
         with open(logfile, "r") as fh:
             for line in fh:
                 if "deadlock" in line:
-                    break
-            sublogger = logging.getLogger("pytest.postgresql.deadlock")
-            for line in fh:
-                sublogger.warning("%s", line)
-                print(line)
+                    assert False
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,7 +247,6 @@ def postgres_db(request: pytest.FixtureRequest):
             for line in fh:
                 if "deadlock" in line:
                     break
-            sublogger = logging.getLogger("pytest.postgresql.deadlock")
             for line in fh:
                 print(line)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,7 +249,7 @@ def postgres_db(request: pytest.FixtureRequest):
                     break
             sublogger = logging.getLogger("pytest.postgresql.deadlock")
             for line in fh:
-                sublogger.warning("%s", line)
+                print(line)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

add an assertion to the postgres_db to make if fail is there is a deadlock. This in the hope we will be able to get the logs.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
