### PR TITLE
Improve the performance of the resource_logs endpoint

### DIFF
--- a/changelogs/unreleased/improve-performance-get-resource-logs-endpoint.yml
+++ b/changelogs/unreleased/improve-performance-get-resource-logs-endpoint.yml
@@ -1,0 +1,8 @@
+---
+description: Improve the performance of the `GET /api/v2/resource/<resource_id>/logs` endpoint.
+issue-nr: 6147
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -887,7 +887,7 @@ class ResourceLogsView(DataView[ResourceLogOrder, ResourceLog]):
             prelude=f"""
                 -- Get all resource action in the given environment for the given resource_id
                 WITH actions AS (
-                    SELECT DISTINCT ON (ra.action_id) ra.*
+                    SELECT  ra.*
                     FROM {Resource.table_name()} AS r INNER JOIN resourceaction_resource AS rr ON (
                                                           r.environment=rr.environment
                                                           AND r.resource_id=rr.resource_id

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -904,7 +904,8 @@ class ResourceLogsView(DataView[ResourceLogOrder, ResourceLog]):
             FROM
                 (
                     SELECT action_id,
-                           action, (unnested_message ->> 'timestamp')::timestamptz AS timestamp,
+                           action,
+                           (unnested_message ->> 'timestamp')::timestamptz AS timestamp,
                            unnested_message ->> 'level' AS level,
                            unnested_message ->> 'msg' AS msg,
                            unnested_message

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -885,6 +885,7 @@ class ResourceLogsView(DataView[ResourceLogOrder, ResourceLog]):
     def get_base_query(self) -> SimpleQueryBuilder:
         query_builder = SimpleQueryBuilder(
             prelude=f"""
+                -- Get all resource action in the given environment for the given resource_id
                 WITH actions AS (
                     SELECT DISTINCT ON (ra.action_id) ra.*
                     FROM {Resource.table_name()} AS r INNER JOIN resourceaction_resource AS rr ON (

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -47,6 +47,7 @@ from inmanta.data import (
     Parameter,
     ParameterOrder,
     QueryFilter,
+    Resource,
     ResourceAction,
     ResourceHistoryOrder,
     ResourceLogOrder,
@@ -54,7 +55,6 @@ from inmanta.data import (
     SimpleQueryBuilder,
     VersionedResourceOrder,
     model,
-    Resource,
 )
 from inmanta.data.model import (
     BaseModel,
@@ -900,7 +900,7 @@ class ResourceLogsView(DataView[ResourceLogOrder, ResourceLog]):
                 )
             """,
             select_clause="SELECT action_id, action, timestamp, unnested_message",
-            from_clause=f"""
+            from_clause="""
             FROM
                 (
                     SELECT action_id,


### PR DESCRIPTION
# Description

Improve the performance of the `GET /api/v2/resource/<resource_id>/logs` endpoint.

closes #6147

Query plan old query:

```
 Finalize Aggregate  (cost=49158.37..49158.38 rows=1 width=24) (actual time=263.131..266.089 rows=1 loops=1)
   ->  Gather  (cost=49158.15..49158.36 rows=2 width=24) (actual time=262.854..266.084 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=48158.15..48158.16 rows=1 width=24) (actual time=260.818..260.819 rows=1 loops=3)
               ->  Nested Loop  (cost=0.01..34622.87 rows=492192 width=32) (actual time=1.602..260.131 rows=170 loops=3)
                     ->  Nested Loop  (cost=0.00..24779.07 rows=49219 width=466) (actual time=1.599..259.820 rows=166 loops=3)
                           ->  Parallel Seq Scan on resourceaction  (cost=0.00..18134.50 rows=49219 width=672) (actual time=0.020..24.118 rows=38620 loops=3)
                                 Filter: (environment = 'f81be80b-8582-499f-b002-7cdd2f2df98a'::uuid)
                                 Rows Removed by Filter: 27198
                           ->  Function Scan on unnest rvid  (cost=0.00..0.13 rows=1 width=0) (actual time=0.006..0.006 rows=0 loops=115860)
                                 Filter: ((rvid)::text ~~ 'exec::Run[ci-pytest-inmanta-lsm-iso5-dev.inmanta.com,command=sh -c "sudo su -c ''/usr/pgsql-10/bin/initdb /v
ar/lib/pgsql/10/data'' - postgres"]%'::text)
                                 Rows Removed by Filter: 20
                     ->  Function Scan on unnest unnested_message  (cost=0.00..0.10 rows=10 width=32) (actual time=0.001..0.001 rows=1 loops=499)
 Planning Time: 0.809 ms
 Execution Time: 266.240 ms
(16 rows)
```
Query plan new query:

```
 Aggregate  (cost=3149.31..3149.32 rows=1 width=24) (actual time=11.670..11.672 rows=1 loops=1)
   ->  Nested Loop  (cost=2.37..3052.51 rows=3520 width=32) (actual time=0.493..10.000 rows=509 loops=1)
         ->  Nested Loop  (cost=2.37..2982.11 rows=352 width=466) (actual time=0.485..8.929 rows=499 loops=1)
               ->  Merge Join  (cost=1.95..211.25 rows=352 width=16) (actual time=0.458..1.567 rows=499 loops=1)
                     Merge Cond: (r.model = rr.resource_version)
                     ->  Index Only Scan Backward using resource_env_resourceid_index on resource r  (cost=0.55..82.17 rows=97 width=92) (actual time=0.179..0.659 rows
=100 loops=1)
                           Index Cond: ((environment = 'f81be80b-8582-499f-b002-7cdd2f2df98a'::uuid) AND (resource_id = 'exec::Run[ci-pytest-inmanta-lsm-iso5-dev.inman
ta.com,command=sh -c "sudo su -c ''/usr/pgsql-10/bin/initdb /var/lib/pgsql/10/data'' - postgres"]'::text))
                           Heap Fetches: 53
                     ->  Index Only Scan using resourceaction_resource_pkey on resourceaction_resource rr  (cost=0.56..126.59 rows=502 width=111) (actual time=0.274..0
.730 rows=499 loops=1)
                           Index Cond: ((environment = 'f81be80b-8582-499f-b002-7cdd2f2df98a'::uuid) AND (resource_id = 'exec::Run[ci-pytest-inmanta-lsm-iso5-dev.inman
ta.com,command=sh -c "sudo su -c ''/usr/pgsql-10/bin/initdb /var/lib/pgsql/10/data'' - postgres"]'::text))
                           Heap Fetches: 34
               ->  Index Scan using resourceaction_pkey on resourceaction ra  (cost=0.42..7.87 rows=1 width=482) (actual time=0.014..0.014 rows=1 loops=499)
                     Index Cond: (action_id = rr.resource_action_id)
         ->  Function Scan on unnest unnested_message  (cost=0.00..0.10 rows=10 width=32) (actual time=0.001..0.001 rows=1 loops=499)
 Planning Time: 2.525 ms
 Execution Time: 11.806 ms
(16 rows)
```

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
