### PR TITLE
Add custom log location for logs of psql in tests

### DIFF
--- a/changelogs/unreleased/6090-deadlock-3.yml
+++ b/changelogs/unreleased/6090-deadlock-3.yml
@@ -1,0 +1,4 @@
+description: add a custom log location for the logs produced by postgres in the postgres_db fixture.
+issue-nr: 6090
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,6 +260,7 @@ def postgres_db(request: pytest.FixtureRequest):
             for line in fh:
                 sublogger.warning("%s", line)
             assert not has_deadlock
+        os.remove(pg_logfile)
 
 
 @pytest.fixture
@@ -538,10 +539,6 @@ def reset_all_objects():
     compiler.Finalizers.reset_finalizers()
     AuthJWTConfig.reset()
     InmantaLoggerConfig.clean_instance()
-    # truncate the logs produced by postgres
-    if os.path.exists(pg_logfile):
-        with open(pg_logfile, "w") as file:
-            file.truncate()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def pytest_runtest_setup(item: "pytest.Item"):
 
 
 # adds a custom log location for postgres
-postgresql_proc_with_log = factories.postgresql_proc(startparams=f"--log={pg_logfile}")
+postgresql_proc_with_log = factories.postgresql_proc(startparams=f"--log='{pg_logfile}'")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,7 +228,8 @@ def pytest_runtest_setup(item: "pytest.Item"):
             pytest.skip("Skipping old migration test")
 
 
-postgresql_proc = factories.postgresql_proc(startparams=f"--log={pg_logfile}")
+# adds a custom log location for postgres
+postgresql_proc_with_log = factories.postgresql_proc(startparams=f"--log={pg_logfile}")
 
 
 @pytest.fixture(scope="session")
@@ -242,7 +243,7 @@ def postgres_db(request: pytest.FixtureRequest):
     if conf:
         fixture = "postgresql_noproc"
     else:
-        fixture = "postgresql_proc"
+        fixture = "postgresql_proc_with_log"
 
     logger.info("Using database fixture %s", fixture)
     pg = request.getfixturevalue(fixture)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -538,6 +538,10 @@ def reset_all_objects():
     compiler.Finalizers.reset_finalizers()
     AuthJWTConfig.reset()
     InmantaLoggerConfig.clean_instance()
+    # truncate the logs produced by postgres
+    if os.path.exists(pg_logfile):
+        with open(pg_logfile, "w") as file:
+            file.truncate()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,8 +250,8 @@ def postgres_db(request: pytest.FixtureRequest):
     yield pg
 
     if os.path.exists(pg_logfile):
+        has_deadlock = False
         with open(pg_logfile, "r") as fh:
-            has_deadlock = False
             for line in fh:
                 if "deadlock" in line:
                     has_deadlock = True
@@ -259,8 +259,8 @@ def postgres_db(request: pytest.FixtureRequest):
             sublogger = logging.getLogger("pytest.postgresql.deadlock")
             for line in fh:
                 sublogger.warning("%s", line)
-            assert not has_deadlock
         os.remove(pg_logfile)
+        assert not has_deadlock
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

adds a custom log location for the logs produced by postgres in the postgres_db fixture.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
