### PR TITLE
Issue deadlock

### DIFF
--- a/changelogs/unreleased/6090-deadlock-4.yml
+++ b/changelogs/unreleased/6090-deadlock-4.yml
@@ -1,0 +1,4 @@
+description: add a fixture to prevent tests from adding there psql logs to the psql logfile.
+issue-nr: 6090
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,7 +269,9 @@ async def run_without_keeping_psql_logs(postgres_db):
         # Store the original content of the logfile
         with open(pg_logfile, "r") as file:
             original_content = file.read()
-        yield
+    yield
+
+    if os.path.exists(pg_logfile):
         # Restore the original content of the logfile
         with open(pg_logfile, "w") as file:
             file.write(original_content)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,17 +250,14 @@ def postgres_db(request: pytest.FixtureRequest):
     yield pg
 
     if os.path.exists(pg_logfile):
-        has_deadlock = False
         with open(pg_logfile, "r") as fh:
             for line in fh:
                 if "deadlock" in line:
-                    has_deadlock = True
                     break
             sublogger = logging.getLogger("pytest.postgresql.deadlock")
             for line in fh:
                 sublogger.warning("%s", line)
         os.remove(pg_logfile)
-        assert not has_deadlock
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,7 +267,6 @@ def postgres_db(request: pytest.FixtureRequest):
 async def run_without_keeping_psql_logs(postgres_db):
     if os.path.exists(pg_logfile):
         # Store the original content of the logfile
-        original_content = ""
         with open(pg_logfile, "r") as file:
             original_content = file.read()
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,6 +264,19 @@ def postgres_db(request: pytest.FixtureRequest):
 
 
 @pytest.fixture
+async def run_without_keeping_psql_logs(postgres_db):
+    if os.path.exists(pg_logfile):
+        # Store the original content of the logfile
+        original_content = ""
+        with open(pg_logfile, "r") as file:
+            original_content = file.read()
+        yield
+        # Restore the original content of the logfile
+        with open(pg_logfile, "w") as file:
+            file.write(original_content)
+
+
+@pytest.fixture
 async def postgres_db_debug(postgres_db, database_name) -> abc.AsyncIterator[None]:
     """
     Fixture meant for debugging through manual interaction with the database. Run pytest with `-s/--capture=no`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,14 +250,17 @@ def postgres_db(request: pytest.FixtureRequest):
     yield pg
 
     if os.path.exists(pg_logfile):
+        has_deadlock = False
         with open(pg_logfile, "r") as fh:
             for line in fh:
                 if "deadlock" in line:
+                    has_deadlock = True
                     break
             sublogger = logging.getLogger("pytest.postgresql.deadlock")
             for line in fh:
                 sublogger.warning("%s", line)
         os.remove(pg_logfile)
+        assert not has_deadlock
 
 
 @pytest.fixture

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -95,7 +95,9 @@ async def test_postgres_cascade_locking_order(postgresql_pool, run_without_keepi
 
 @pytest.mark.slowtest
 @pytest.mark.parametrize("definition_order_one_two", [True, False])
-async def test_postgres_cascade_locking_order_siblings(postgresql_pool, definition_order_one_two: bool) -> None:
+async def test_postgres_cascade_locking_order_siblings(
+    postgresql_pool, definition_order_one_two: bool, run_without_keeping_psql_logs
+) -> None:
     """
     Verifies locking order for siblings in the cascade tree. Locking order seems to be based on definition order of the
     referencing columns. Locking order may shift in case of updates to the definition of these columns.

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -27,70 +27,69 @@ from collections import abc
 import asyncpg
 import pytest
 
-
-@pytest.mark.slowtest
-async def test_postgres_cascade_locking_order(postgresql_pool) -> None:
-    """
-    Verifies that Postgres' cascade deletion acquires locks top-down. This is important because in order to avoid deadlocks
-    we define a corresponding locking order for all transactions. See `TableLockMode`, `RowLockMode` and `ConfigurationModel`
-    docstrings in `inmanta.data`.
-    """
-    async with postgresql_pool.acquire() as connection:
-        await connection.execute(
-            """
-            CREATE TABLE IF NOT EXISTS root (name varchar PRIMARY KEY);
-            CREATE TABLE IF NOT EXISTS leaf (
-                name varchar PRIMARY KEY,
-                myroot varchar REFERENCES root(name) ON DELETE CASCADE
-            );
-            """
-        )
-
-    async def insert():
-        async with postgresql_pool.acquire() as connection:
-            await connection.execute(
-                """
-                INSERT INTO root VALUES
-                    ('root1');
-
-                INSERT INTO leaf VALUES
-                    ('leaf1', 'root1'),
-                    ('leaf2', 'root1');
-                """
-            )
-
-    async def lock_top_down():
-        async with postgresql_pool.acquire() as connection:
-            async with connection.transaction():
-                await connection.execute("LOCK TABLE root IN SHARE MODE")
-                await asyncio.sleep(0.1)
-                await connection.execute("LOCK TABLE leaf IN SHARE MODE")
-
-    async def lock_bottom_up():
-        async with postgresql_pool.acquire() as connection:
-            async with connection.transaction():
-                await connection.execute("LOCK TABLE leaf IN SHARE MODE")
-                await asyncio.sleep(0.1)
-                await connection.execute("LOCK TABLE root IN SHARE MODE")
-
-    async def delete():
-        async with postgresql_pool.acquire() as connection:
-            async with connection.transaction():
-                await asyncio.sleep(0.05)
-                await connection.execute("DELETE FROM root")
-
-    await insert()
-    await asyncio.gather(
-        lock_top_down(),
-        delete(),
-    )
-
-    await insert()
-    with pytest.raises(asyncpg.DeadlockDetectedError):
-        await asyncio.gather(
-            lock_bottom_up(),
-            delete(),
-        )
+# @pytest.mark.slowtest
+# async def test_postgres_cascade_locking_order(postgresql_pool) -> None:
+#     """
+#     Verifies that Postgres' cascade deletion acquires locks top-down. This is important because in order to avoid deadlocks
+#     we define a corresponding locking order for all transactions. See `TableLockMode`, `RowLockMode` and `ConfigurationModel`
+#     docstrings in `inmanta.data`.
+#     """
+#     async with postgresql_pool.acquire() as connection:
+#         await connection.execute(
+#             """
+#             CREATE TABLE IF NOT EXISTS root (name varchar PRIMARY KEY);
+#             CREATE TABLE IF NOT EXISTS leaf (
+#                 name varchar PRIMARY KEY,
+#                 myroot varchar REFERENCES root(name) ON DELETE CASCADE
+#             );
+#             """
+#         )
+#
+#     async def insert():
+#         async with postgresql_pool.acquire() as connection:
+#             await connection.execute(
+#                 """
+#                 INSERT INTO root VALUES
+#                     ('root1');
+#
+#                 INSERT INTO leaf VALUES
+#                     ('leaf1', 'root1'),
+#                     ('leaf2', 'root1');
+#                 """
+#             )
+#
+#     async def lock_top_down():
+#         async with postgresql_pool.acquire() as connection:
+#             async with connection.transaction():
+#                 await connection.execute("LOCK TABLE root IN SHARE MODE")
+#                 await asyncio.sleep(0.1)
+#                 await connection.execute("LOCK TABLE leaf IN SHARE MODE")
+#
+#     async def lock_bottom_up():
+#         async with postgresql_pool.acquire() as connection:
+#             async with connection.transaction():
+#                 await connection.execute("LOCK TABLE leaf IN SHARE MODE")
+#                 await asyncio.sleep(0.1)
+#                 await connection.execute("LOCK TABLE root IN SHARE MODE")
+#
+#     async def delete():
+#         async with postgresql_pool.acquire() as connection:
+#             async with connection.transaction():
+#                 await asyncio.sleep(0.05)
+#                 await connection.execute("DELETE FROM root")
+#
+#     await insert()
+#     await asyncio.gather(
+#         lock_top_down(),
+#         delete(),
+#     )
+#
+#     await insert()
+#     with pytest.raises(asyncpg.DeadlockDetectedError):
+#         await asyncio.gather(
+#             lock_bottom_up(),
+#             delete(),
+#         )
 
 
 @pytest.mark.slowtest

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -27,69 +27,70 @@ from collections import abc
 import asyncpg
 import pytest
 
-# @pytest.mark.slowtest
-# async def test_postgres_cascade_locking_order(postgresql_pool) -> None:
-#     """
-#     Verifies that Postgres' cascade deletion acquires locks top-down. This is important because in order to avoid deadlocks
-#     we define a corresponding locking order for all transactions. See `TableLockMode`, `RowLockMode` and `ConfigurationModel`
-#     docstrings in `inmanta.data`.
-#     """
-#     async with postgresql_pool.acquire() as connection:
-#         await connection.execute(
-#             """
-#             CREATE TABLE IF NOT EXISTS root (name varchar PRIMARY KEY);
-#             CREATE TABLE IF NOT EXISTS leaf (
-#                 name varchar PRIMARY KEY,
-#                 myroot varchar REFERENCES root(name) ON DELETE CASCADE
-#             );
-#             """
-#         )
-#
-#     async def insert():
-#         async with postgresql_pool.acquire() as connection:
-#             await connection.execute(
-#                 """
-#                 INSERT INTO root VALUES
-#                     ('root1');
-#
-#                 INSERT INTO leaf VALUES
-#                     ('leaf1', 'root1'),
-#                     ('leaf2', 'root1');
-#                 """
-#             )
-#
-#     async def lock_top_down():
-#         async with postgresql_pool.acquire() as connection:
-#             async with connection.transaction():
-#                 await connection.execute("LOCK TABLE root IN SHARE MODE")
-#                 await asyncio.sleep(0.1)
-#                 await connection.execute("LOCK TABLE leaf IN SHARE MODE")
-#
-#     async def lock_bottom_up():
-#         async with postgresql_pool.acquire() as connection:
-#             async with connection.transaction():
-#                 await connection.execute("LOCK TABLE leaf IN SHARE MODE")
-#                 await asyncio.sleep(0.1)
-#                 await connection.execute("LOCK TABLE root IN SHARE MODE")
-#
-#     async def delete():
-#         async with postgresql_pool.acquire() as connection:
-#             async with connection.transaction():
-#                 await asyncio.sleep(0.05)
-#                 await connection.execute("DELETE FROM root")
-#
-#     await insert()
-#     await asyncio.gather(
-#         lock_top_down(),
-#         delete(),
-#     )
-#
-#     await insert()
-#     with pytest.raises(asyncpg.DeadlockDetectedError):
-#         await asyncio.gather(
-#             lock_bottom_up(),
-#             delete(),
-#         )
+
+@pytest.mark.slowtest
+async def test_postgres_cascade_locking_order(postgresql_pool, run_without_keeping_psql_logs) -> None:
+    """
+    Verifies that Postgres' cascade deletion acquires locks top-down. This is important because in order to avoid deadlocks
+    we define a corresponding locking order for all transactions. See `TableLockMode`, `RowLockMode` and `ConfigurationModel`
+    docstrings in `inmanta.data`.
+    """
+    async with postgresql_pool.acquire() as connection:
+        await connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS root (name varchar PRIMARY KEY);
+            CREATE TABLE IF NOT EXISTS leaf (
+                name varchar PRIMARY KEY,
+                myroot varchar REFERENCES root(name) ON DELETE CASCADE
+            );
+            """
+        )
+
+    async def insert():
+        async with postgresql_pool.acquire() as connection:
+            await connection.execute(
+                """
+                INSERT INTO root VALUES
+                    ('root1');
+
+                INSERT INTO leaf VALUES
+                    ('leaf1', 'root1'),
+                    ('leaf2', 'root1');
+                """
+            )
+
+    async def lock_top_down():
+        async with postgresql_pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute("LOCK TABLE root IN SHARE MODE")
+                await asyncio.sleep(0.1)
+                await connection.execute("LOCK TABLE leaf IN SHARE MODE")
+
+    async def lock_bottom_up():
+        async with postgresql_pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute("LOCK TABLE leaf IN SHARE MODE")
+                await asyncio.sleep(0.1)
+                await connection.execute("LOCK TABLE root IN SHARE MODE")
+
+    async def delete():
+        async with postgresql_pool.acquire() as connection:
+            async with connection.transaction():
+                await asyncio.sleep(0.05)
+                await connection.execute("DELETE FROM root")
+
+    await insert()
+    await asyncio.gather(
+        lock_top_down(),
+        delete(),
+    )
+
+    await insert()
+    with pytest.raises(asyncpg.DeadlockDetectedError):
+        await asyncio.gather(
+            lock_bottom_up(),
+            delete(),
+        )
 
 
 @pytest.mark.slowtest


### PR DESCRIPTION
# Description

test_postgres_cascade_locking_order create a deadlock on purpose which will conflict with the
"assert not has deadlock" check in the postgres_db fixture.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
