### PR TITLE
start event loop for inmanta --version

### DIFF
--- a/changelogs/unreleased/event-loop-fix.yml
+++ b/changelogs/unreleased/event-loop-fix.yml
@@ -1,0 +1,5 @@
+description: "Start event loop for `inmanta --version`"
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -693,21 +693,28 @@ def cmd_parser() -> argparse.ArgumentParser:
 
 
 def print_versions_installed_components_and_exit() -> None:
-    bootloader = InmantaBootloader()
-    app_context = bootloader.load_slices()
-    product_metadata = app_context.get_product_metadata()
-    extension_statuses = app_context.get_extension_statuses()
-    if product_metadata.version:
-        print(f"{product_metadata.product} ({product_metadata.edition}): {product_metadata.version}")
-    else:
-        print(f"{product_metadata.product} ({product_metadata.edition}): version unknown")
-    print(f"Compiler version: {get_compiler_version()}")
-    if extension_statuses:
-        print("Extensions:")
-        for ext_status in extension_statuses:
-            print(f"    * {ext_status.name}: {ext_status.version}")
-    else:
-        print("Extensions: No extensions found")
+    # coroutine to make sure event loop is running for server slices
+    async def print_status() -> None:
+        bootloader = InmantaBootloader()
+        app_context = bootloader.load_slices()
+        product_metadata = app_context.get_product_metadata()
+        extension_statuses = app_context.get_extension_statuses()
+
+        if product_metadata.version:
+            print(f"{product_metadata.product} ({product_metadata.edition}): {product_metadata.version}")
+        else:
+            print(f"{product_metadata.product} ({product_metadata.edition}): version unknown")
+        print(f"Compiler version: {get_compiler_version()}")
+        if extension_statuses:
+            print("Extensions:")
+            for ext_status in extension_statuses:
+                print(f"    * {ext_status.name}: {ext_status.version}")
+        else:
+            print("Extensions: No extensions found")
+
+        await bootloader.stop()
+
+    asyncio.run(print_status())
     sys.exit(0)
 
 

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -241,6 +241,7 @@ class Scheduler(object):
     An event scheduler class. Identifies tasks based on an action and a schedule. Considers tasks with the same action and the
     same schedule to be the same. Callers that wish to be able to delete the tasks they add should make sure to use unique
     `call` functions.
+    Assumes an event loop is already running on this thread.
     """
 
     def __init__(self, name: str) -> None:
@@ -738,7 +739,7 @@ async def join_threadpools(threadpools: List[ThreadPoolExecutor]) -> None:
 def ensure_event_loop() -> asyncio.AbstractEventLoop:
     """
     Returns the event loop for this thread. Creates a new one if none exists yet and registers it with asyncio's active event
-    loop policy.
+    loop policy. Does not ensure that the event loop is running.
     """
     try:
         # nothing needs to be done if this thread already has an event loop


### PR DESCRIPTION
`inmanta --version` with an expired license currently leads to the following output because `inmanta-license` tries to use the scheduler to log a warning.

```
Traceback (most recent call last):
  File "/home/sander/documents/projects/inmanta/inmanta-license/src/inmanta_license/license.py", line 671, in _load_entitlements_file
    jwt_data = jwt.decode(token_data, key=pk_pem, audience=self.licensee, algorithms=["RS512"])
  File "/home/sander/.virtualenvs/tmp-2dc293d8facc2d4/lib/python3.9/site-packages/jwt/api_jwt.py", line 210, in decode
    decoded = self.decode_complete(
  File "/home/sander/.virtualenvs/tmp-2dc293d8facc2d4/lib/python3.9/site-packages/jwt/api_jwt.py", line 162, in decode_complete
    self._validate_claims(
  File "/home/sander/.virtualenvs/tmp-2dc293d8facc2d4/lib/python3.9/site-packages/jwt/api_jwt.py", line 248, in _validate_claims
    self._validate_exp(payload, now, leeway)
  File "/home/sander/.virtualenvs/tmp-2dc293d8facc2d4/lib/python3.9/site-packages/jwt/api_jwt.py", line 304, in _validate_exp
    raise ExpiredSignatureError("Signature has expired")
jwt.exceptions.ExpiredSignatureError: Signature has expired

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sander/.virtualenvs/tmp-2dc293d8facc2d4/bin/inmanta", line 8, in <module>
    sys.exit(app())
  File "/home/sander/documents/projects/inmanta/inmanta-core/src/inmanta/app.py", line 737, in app
    print_versions_installed_components_and_exit()
  File "/home/sander/documents/projects/inmanta/inmanta-core/src/inmanta/app.py", line 697, in print_versions_installed_components_and_exit
    app_context = bootloader.load_slices()
  File "/home/sander/documents/projects/inmanta/inmanta-core/src/inmanta/server/bootloader.py", line 233, in load_slices
    return self._collect_slices(exts, only_register_environment_settings)
  File "/home/sander/documents/projects/inmanta/inmanta-core/src/inmanta/server/bootloader.py", line 223, in _collect_slices
    ext_module.setup(myctx)
  File "/home/sander/documents/projects/inmanta/inmanta-license/src/inmanta_ext/license/extension.py", line 13, in setup
    application.set_feature_manager(LicensedFeatureManager())
  File "/home/sander/documents/projects/inmanta/inmanta-license/src/inmanta_license/license.py", line 625, in __init__
    self._load_entitlements_file()
  File "/home/sander/documents/projects/inmanta/inmanta-license/src/inmanta_license/license.py", line 673, in _load_entitlements_file
    self._repeat_warning("The entitlements file expired, running unlicensed version! Contact support@inmanta.com")
  File "/home/sander/documents/projects/inmanta/inmanta-license/src/inmanta_license/license.py", line 629, in _repeat_warning
    self._scheduler.add_action(get_warning_func(message), IntervalSchedule(60, 0))
  File "/home/sander/documents/projects/inmanta/inmanta-core/src/inmanta/util.py", line 332, in add_action
    handle: asyncio.TimerHandle = asyncio.get_running_loop().call_later(schedule_typed.get_initial_delay(), action_function)
RuntimeError: no running event loop
```

This PR makes sure we start an event loop before loading the slices. Remaining, less urgent, issue: inmanta/inmanta-license#520.