### PR TITLE
Issue/6182 dont log everytime db pool exhaustion is checked

### DIFF
--- a/changelogs/unreleased/6182-dont-log-everytime-database-pool-exhaustion-is-checked.yml
+++ b/changelogs/unreleased/6182-dont-log-everytime-database-pool-exhaustion-is-checked.yml
@@ -1,0 +1,4 @@
+description: Add quiet_mode to add_action to avoid pollution in the server logs for actions called with a high frequency.
+issue-nr: 6182
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -308,7 +308,7 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler):
         interval: float = 60,
         initial_delay: Optional[float] = None,
         cancel_on_stop: bool = True,
-        quiet_mode=False,
+        quiet_mode: bool = False,
     ) -> None:
         """
         Schedule a task repeatedly with a given interval. Tasks with the same call and the same schedule are considered the

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -303,7 +303,12 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler):
 
     # utility methods for extensions developers
     def schedule(
-        self, call: TaskMethod, interval: float = 60, initial_delay: Optional[float] = None, cancel_on_stop: bool = True
+        self,
+        call: TaskMethod,
+        interval: float = 60,
+        initial_delay: Optional[float] = None,
+        cancel_on_stop: bool = True,
+        quiet_mode=False,
     ) -> None:
         """
         Schedule a task repeatedly with a given interval. Tasks with the same call and the same schedule are considered the
@@ -311,8 +316,10 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler):
 
         :param interval: The interval between executions of the task.
         :param initial_delay: The delay to execute the task for the first time. If not set, interval is used.
+        :quiet_mode: Set to true to disable logging the recurring notification that the action is being called. Use this to
+        avoid polluting the server log for very frequent actions.
         """
-        self._sched.add_action(call, IntervalSchedule(interval, initial_delay), cancel_on_stop)
+        self._sched.add_action(call, IntervalSchedule(interval, initial_delay), cancel_on_stop, quiet_mode)
 
     def schedule_cron(self, call: TaskMethod, cron: str, cancel_on_stop: bool = True) -> None:
         """

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -55,7 +55,7 @@ class DatabaseService(protocol.ServerSlice):
         self._db_pool_watcher = util.ExhaustedPoolWatcher(self._pool)
         # Schedule database pool exhaustion watch:
         # Check for pool exhaustion every 200 ms
-        self.schedule(self._check_database_pool_exhaustion, interval=0.2, cancel_on_stop=True)
+        self.schedule(self._check_database_pool_exhaustion, interval=0.2, cancel_on_stop=True, quiet_mode=True)
         # Report pool exhaustion every 24h
         self.schedule(self._report_database_pool_exhaustion, interval=3_600 * 24, cancel_on_stop=True)
 

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -293,7 +293,8 @@ class Scheduler(object):
         :param action: A function to call periodically
         :param schedule: The schedule for this action
         :param cancel_on_stop: Cancel the task when the scheduler is stopped. If false, the coroutine will be awaited.
-        :param quiet_mode: Set to true to disable logging the notification that the action is being called. Use this to
+        :param quiet_mode: Set to true to disable logging the recurring  notification that the action is being called.
+        Use this to avoid polluting the server log for very frequent actions.
         """
         assert is_coroutine(action)
 

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -317,7 +317,7 @@ class Scheduler(object):
 
         def action_function() -> None:
             if not quiet_mode:
-                LOGGER.info("Calling %s" % action)
+                LOGGER.info("Calling %s", action)
             if task_spec in self._scheduled:
                 try:
                     task = ensure_future_and_handle_exception(

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -285,6 +285,7 @@ class Scheduler(object):
         action: TaskMethod,
         schedule: Union[TaskSchedule, int],  # int for backward compatibility,
         cancel_on_stop: bool = True,
+        quiet_mode: bool = False,
     ) -> ScheduledTask:
         """
         Add a new action
@@ -292,6 +293,7 @@ class Scheduler(object):
         :param action: A function to call periodically
         :param schedule: The schedule for this action
         :param cancel_on_stop: Cancel the task when the scheduler is stopped. If false, the coroutine will be awaited.
+        :param quiet_mode: Set to true to disable logging the notification that the action is being called. Use this to
         """
         assert is_coroutine(action)
 
@@ -313,7 +315,8 @@ class Scheduler(object):
             self.remove(task_spec)
 
         def action_function() -> None:
-            LOGGER.info("Calling %s" % action)
+            if not quiet_mode:
+                LOGGER.info("Calling %s" % action)
             if task_spec in self._scheduled:
                 try:
                     task = ensure_future_and_handle_exception(


### PR DESCRIPTION
# Description

Adds a mechanism to silence logging "Calling ..." for very frequently called actions 

closes #6182 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
