### PR TITLE
Add support to expose API methods using multiple URLs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 9.2.0
+current_version = 9.3.0
 
 [bumpversion:file:setup.py]
 search = version = "{current_version}"

--- a/changelogs/unreleased/add-support-for-multi-url-endpoints.yml
+++ b/changelogs/unreleased/add-support-for-multi-url-endpoints.yml
@@ -1,0 +1,8 @@
+---
+description: Add support to expose the same method via the API using different URLs.
+issue-nr: 1274
+issue-repo: inmanta-lsm
+change-type: minor
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-version = "9.2.0"
+version = "9.3.0"
 
 setup(
     version=version,

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -366,7 +366,7 @@ class MethodProperties(object):
         if (properties.path, properties.api_version) in current_list:
             raise Exception(
                 f"Method {properties.function.__name__} already has a "
-                f"method definition for api version path {properties.path} and API version {properties.api_version}"
+                f"method definition for api path {properties.path} and API version {properties.api_version}"
             )
 
         cls.methods[properties.function.__name__].append(properties)

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -358,12 +358,15 @@ class MethodProperties(object):
 
     @classmethod
     def register_method(cls, properties: "MethodProperties") -> None:
-        """Register new method properties. Multiple properties on a method is supported but versions have to be unique."""
-        current_list = [x.api_version for x in cls.methods[properties.function.__name__]]
-        if properties.api_version in current_list:
+        """
+        Register new method properties. Multiple properties on a method is supported but the (URL, API version) combination has
+        to be unique.
+        """
+        current_list = [(x.path, x.api_version) for x in cls.methods[properties.function.__name__]]
+        if (properties.path, properties.api_version) in current_list:
             raise Exception(
                 f"Method {properties.function.__name__} already has a "
-                f"method definition for api version {properties.api_version}"
+                f"method definition for api version path {properties.path} and API version {properties.api_version}"
             )
 
         cls.methods[properties.function.__name__].append(properties)
@@ -422,6 +425,7 @@ class MethodProperties(object):
             validate_sid = agent_server and not api
 
         self._path = UrlPath(path)
+        self.path = path
         self._operation = operation
         self._reply = reply
         self._arg_options = arg_options

--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 import inspect
-from typing import Callable, Dict, List, Optional, TypeVar
+from typing import Callable, Dict, List, Optional, TypeVar, Union
 
 from inmanta import const
 from inmanta.types import Apireturn, HandlerType, MethodType
@@ -128,7 +128,7 @@ def method(
 
 
 def typedmethod(
-    path: str,
+    path: Union[str, list[str]],
     operation: str = "POST",
     reply: bool = True,
     arg_options: Dict[str, common.ArgOption] = {},
@@ -149,7 +149,7 @@ def typedmethod(
     Decorator to identify a method as a RPC call. The arguments of the decorator are used by each transport to build
     and model the protocol.
 
-    :param path: The url path to use for this call. This path can contain parameter names of the function. These names
+    :param path: The url path(s) to use for this call. This path can contain parameter names of the function. These names
                  should be enclosed in < > brackets.
     :param operation: The type of HTTP operation (verb)
     :param timeout: nr of seconds before request it terminated
@@ -178,28 +178,30 @@ def typedmethod(
     """
 
     def wrapper(func: MethodT) -> MethodT:
-        properties = common.MethodProperties(
-            func,
-            path,
-            operation,
-            reply,
-            arg_options,
-            timeout,
-            server_agent,
-            api,
-            agent_server,
-            validate_sid,
-            client_types,
-            api_version,
-            api_prefix,
-            True,
-            True,
-            envelope_key,
-            strict_typing=strict_typing,
-            enforce_auth=enforce_auth,
-            varkw=varkw,
-        )
-        common.MethodProperties.register_method(properties)
+        paths = path if isinstance(path, list) else [path]
+        for current_path in paths:
+            properties = common.MethodProperties(
+                func,
+                current_path,
+                operation,
+                reply,
+                arg_options,
+                timeout,
+                server_agent,
+                api,
+                agent_server,
+                validate_sid,
+                client_types,
+                api_version,
+                api_prefix,
+                True,
+                True,
+                envelope_key,
+                strict_typing=strict_typing,
+                enforce_auth=enforce_auth,
+                varkw=varkw,
+            )
+            common.MethodProperties.register_method(properties)
         return func
 
     return wrapper

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -363,9 +363,7 @@ class Client(Endpoint):
         elif self._version_match is VersionMatch.highest:
             return max(methods, key=lambda x: x.api_version)
         elif self._version_match is VersionMatch.exact:
-            for method in methods:
-                if method.api_version == self._exact_version:
-                    return method
+            return next((m for m in methods if m.api_version == self._exact_version), None)
 
         return None
 

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -123,15 +123,34 @@ class CallArguments(object):
         return self._metadata
 
     def _is_header_param(self, arg: str) -> bool:
+        """
+        Return True of the given call argument can be provided using a header parameter.
+        """
         if arg not in self._properties.arg_options:
             return False
 
         opts = self._properties.arg_options[arg]
+        return opts.header is not None
 
-        if opts.header is None:
-            return False
+    def _is_header_param_provided(self, arg: str) -> bool:
+        """
+        Return True iff a value for the given call argument was provided using a header parameter.
 
-        return True
+        :raise Exception: The given call argument is not a header parameter.
+        """
+        value = self._get_header_value_for(arg)
+        return value is not None
+
+    def _get_header_value_for(self, arg: str) -> Optional[str]:
+        """
+        Return the header value that belongs to the given call argument or None when the header was not set.
+
+        :raise Exception: The given call argument is not a header parameter.
+        """
+        if not self._is_header_param(arg):
+            raise Exception(f"Parameter {arg} is not a header parameter")
+        opts = self._properties.arg_options[arg]
+        return self._request_headers.get(opts.header)
 
     def _map_headers(self, arg: str) -> Optional[object]:
         if not self._is_header_param(arg):
@@ -183,52 +202,61 @@ class CallArguments(object):
         if self._argspec.defaults is not None:
             defaults_start = len(args) - len(self._argspec.defaults)
 
+        # Make sure that an arguments is not passed both using the header and a non-header value with a different value
+        for arg in args:
+            if arg in self._message and self._is_header_param(arg) and self._is_header_param_provided(arg):
+                message_value = self._message[arg]
+                header_value = self._get_header_value_for(arg)
+                if message_value != header_value:
+                    raise exceptions.BadRequest(
+                        f"Value for argument {arg} was provided via a header and a non-header argument, but both values"
+                        f" don't match (header={header_value}; non-header={message_value})"
+                    )
+
         call_args = {}
 
         for i, arg in enumerate(args):
-            # get value from headers, defaults or message
-            value = self._map_headers(arg)
-            if value is None:
-                if not self._is_header_param(arg):
-                    arg_type: Optional[Type[object]] = self._argspec.annotations.get(arg)
-                    if arg in self._message:
-                        if (
-                            arg_type
-                            and self._properties.operation == "GET"
-                            and typing_inspect.is_generic_type(arg_type)
-                            and issubclass(typing_inspect.get_origin(arg_type), list)
-                            and not isinstance(self._message[arg], list)
-                            and len(typing_inspect.get_args(arg_type, evaluate=True)) == 1
-                            and isinstance(self._message[arg], typing_inspect.get_args(arg_type)[0])
-                        ):
-                            # If a GET endpoint has a parameter of type list that is encoded as a URL query parameter and the
-                            # specific request provides a list with one element, urllib doesn't parse it as a list.
-                            # Map it here explicitly to a list.
-                            value = [self._message[arg]]
-                        else:
-                            value = self._message[arg]
-                        all_fields.remove(arg)
-                    # Pre-process dict params for GET
-                    elif arg_type and self._properties.operation == "GET" and self._is_dict_or_optional_dict(arg_type):
-                        dict_prefix = f"{arg}."
-                        dict_with_prefixed_names = {
-                            param_name: param_value
-                            for param_name, param_value in self._message.items()
-                            if param_name.startswith(dict_prefix) and len(param_name) > len(dict_prefix)
-                        }
-                        value = (
-                            await self._get_dict_value_from_message(arg, dict_prefix, dict_with_prefixed_names)
-                            if dict_with_prefixed_names
-                            else None
-                        )
+            arg_type: Optional[Type[object]] = self._argspec.annotations.get(arg)
+            if arg in self._message:
+                # Argument is parameter in body of path of HTTP request
+                if (
+                    arg_type
+                    and self._properties.operation == "GET"
+                    and typing_inspect.is_generic_type(arg_type)
+                    and issubclass(typing_inspect.get_origin(arg_type), list)
+                    and not isinstance(self._message[arg], list)
+                    and len(typing_inspect.get_args(arg_type, evaluate=True)) == 1
+                    and isinstance(self._message[arg], typing_inspect.get_args(arg_type)[0])
+                ):
+                    # If a GET endpoint has a parameter of type list that is encoded as a URL query parameter and the
+                    # specific request provides a list with one element, urllib doesn't parse it as a list.
+                    # Map it here explicitly to a list.
+                    value = [self._message[arg]]
+                else:
+                    value = self._message[arg]
+                all_fields.remove(arg)
+            elif arg_type and self._properties.operation == "GET" and self._is_dict_or_optional_dict(arg_type):
+                # Argument is dictionary-based expression in query parameters of GET operation
+                dict_prefix = f"{arg}."
+                dict_with_prefixed_names = {
+                    param_name: param_value
+                    for param_name, param_value in self._message.items()
+                    if param_name.startswith(dict_prefix) and len(param_name) > len(dict_prefix)
+                }
+                value = (
+                    await self._get_dict_value_from_message(arg, dict_prefix, dict_with_prefixed_names)
+                    if dict_with_prefixed_names
+                    else None
+                )
 
-                        for key in dict_with_prefixed_names.keys():
-                            all_fields.remove(key)
-
-                    else:  # get default value
-                        value = self.get_default_value(arg, i, defaults_start)
-                else:  # get default value
+                for key in dict_with_prefixed_names.keys():
+                    all_fields.remove(key)
+            elif self._is_header_param(arg):
+                value = self._map_headers(arg)
+                if value is None:
                     value = self.get_default_value(arg, i, defaults_start)
+            else:
+                value = self.get_default_value(arg, i, defaults_start)
 
             call_args[arg] = value
 

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -124,7 +124,7 @@ class CallArguments(object):
 
     def _is_header_param(self, arg: str) -> bool:
         """
-        Return True of the given call argument can be provided using a header parameter.
+        Return True if the given call argument can be provided using a header parameter.
         """
         if arg not in self._properties.arg_options:
             return False
@@ -202,7 +202,7 @@ class CallArguments(object):
         if self._argspec.defaults is not None:
             defaults_start = len(args) - len(self._argspec.defaults)
 
-        # Make sure that an arguments is not passed both using the header and a non-header value with a different value
+        # Make sure that an argument is not passed both using the header and a non-header value with a different value
         for arg in args:
             if arg in self._message and self._is_header_param(arg) and self._is_header_param_provided(arg):
                 message_value = self._message[arg]

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1557,25 +1557,50 @@ async def test_2151_method_header_parameter_in_body(async_finalizer, unused_tcp_
     async_finalizer.add(server.stop)
 
     client = tornado.httpclient.AsyncHTTPClient()
+    param_value = "header_param_value"
 
-    # valid request should succeed
+    # Only parameter as header: should succeed
     request = tornado.httpclient.HTTPRequest(
         url=f"http://localhost:{opt.get_bind_port()}/api/v1/testmethod",
         method="POST",
         body=json_encode({"body_param": "body_param_value"}),
-        headers={"X-Inmanta-Header-Param": "header_param_value"},
+        headers={"X-Inmanta-Header-Param": param_value},
     )
     response: tornado.httpclient.HTTPResponse = await client.fetch(request)
     assert response.code == 200
 
-    # invalid request should fail
+    # Only provide parameter in body: should succeed
     request = tornado.httpclient.HTTPRequest(
         url=f"http://localhost:{opt.get_bind_port()}/api/v1/testmethod",
         method="POST",
-        body=json_encode({"header_param": "header_param_value", "body_param": "body_param_value"}),
+        body=json_encode({"header_param": param_value, "body_param": "body_param_value"}),
     )
-    with pytest.raises(tornado.httpclient.HTTPClientError):
-        await client.fetch(request)
+    response: tornado.httpclient.HTTPResponse = await client.fetch(request)
+    assert response.code == 200
+
+    # Body and header contain the same value for parameter: should succeed
+    request = tornado.httpclient.HTTPRequest(
+        url=f"http://localhost:{opt.get_bind_port()}/api/v1/testmethod",
+        method="POST",
+        body=json_encode({"header_param": param_value, "body_param": "body_param_value"}),
+        headers={"X-Inmanta-Header-Param": param_value},
+    )
+    response: tornado.httpclient.HTTPResponse = await client.fetch(request)
+    assert response.code == 200
+
+    # Body and header contain different value for parameter: should fail
+    param_different_value = "different_value"
+    request = tornado.httpclient.HTTPRequest(
+        url=f"http://localhost:{opt.get_bind_port()}/api/v1/testmethod",
+        method="POST",
+        body=json_encode({"header_param": param_value, "body_param": "body_param_value"}),
+        headers={"X-Inmanta-Header-Param": param_different_value},
+    )
+    response = await client.fetch(request, raise_error=False)
+    assert response.code == 400
+    body = json.loads(response.body)
+    assert "Value for argument header_param was provided via a header and a non-header argument, but both" \
+           f" values don\'t match (header={param_different_value}; non-header={param_value})" in body["message"]
 
 
 @pytest.mark.parametrize("return_value,valid", [(1, True), (None, True), ("Hello World!", False)])

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1599,8 +1599,10 @@ async def test_2151_method_header_parameter_in_body(async_finalizer, unused_tcp_
     response = await client.fetch(request, raise_error=False)
     assert response.code == 400
     body = json.loads(response.body)
-    assert "Value for argument header_param was provided via a header and a non-header argument, but both" \
-           f" values don\'t match (header={param_different_value}; non-header={param_value})" in body["message"]
+    assert (
+        "Value for argument header_param was provided via a header and a non-header argument, but both"
+        f" values don't match (header={param_different_value}; non-header={param_value})" in body["message"]
+    )
 
 
 @pytest.mark.parametrize("return_value,valid", [(1, True), (None, True), ("Hello World!", False)])

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -19,7 +19,7 @@ from os import path
 
 from setuptools import find_namespace_packages, setup
 
-version = "9.2.0"
+version = "9.3.0"
 
 requires = [
     "asyncpg",


### PR DESCRIPTION
# Description

Add support to expose API methods using multiple URLs. If the path property of the typedmethod annotation has type list, the inmanta client will always use the first path to perform its API calls.

closes  inmanta/inmanta-lsm#1274

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
