### PR TITLE
fixed link to pydantic docs

### DIFF
--- a/changelogs/unreleased/docs-pydantic-v1.yml
+++ b/changelogs/unreleased/docs-pydantic-v1.yml
@@ -1,0 +1,9 @@
+description: Fixed broken link to Pydantic docs in documentation
+change-type: patch
+sections:
+  bugfix: "{{description}}"
+destination-branches:
+  - iso4
+  - iso5
+  - iso6
+  - master

--- a/docs/reference/json.rst
+++ b/docs/reference/json.rst
@@ -4,7 +4,7 @@ Inmanta Compile Data Reference
 This page documents the compile data output when compiling with the `--export-compile-data` flag. The structure
 of this JSON is defined by :py:class:`inmanta.data.model.CompileData` which inherits
 from :py:class:`pydantic.BaseModel`. To produce the JSON representation of the object, `model.json()` is called. See the
-`pydantic documentation <https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson>`_
+`pydantic documentation <https://docs.pydantic.dev/1.10/usage/exporting_models/#modeljson>`_
 for more information on how exactly a JSON is generated from a model.
 
 .. autoclass:: inmanta.data.model.CompileData


### PR DESCRIPTION
docs link check was broken this morning because this page no longer exists on "latest" (v2) pydantic docs.