### PR TITLE
Issue/392 document config private package iso6

### DIFF
--- a/changelogs/unreleased/392-document-config-private-package-repo.yml
+++ b/changelogs/unreleased/392-document-config-private-package-repo.yml
@@ -1,0 +1,5 @@
+description: Document the proper way to configure a project to access a private python package repository
+issue-nr: 392
+issue-repo: inmanta-service-orchestrator
+change-type: patch
+destination-branches: [iso6]

--- a/docs/administrators/credentials.rst
+++ b/docs/administrators/credentials.rst
@@ -1,3 +1,5 @@
+.. _env_vars:
+
 Environment variables
 =====================
 

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -339,9 +339,11 @@ Create a file named ``/var/lib/inmanta/.netrc`` in the orchestrator's file syste
 Add the following content to the file:
 
 .. code-block:: text
+
   machine <hostname of the private repository>
   login <username>
   password <password>
+  
 for more information see the  doc about`pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
 
 You will also need to specify the url of the repository in the ``project.yml`` file of your project (See: :ref:`specify_location_pip`).

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -329,3 +329,21 @@ for supplying the agents with the appropriate ``inmanta_plugins`` packages.
 The only exception to this rule is when using the ``inmanta export`` command. It exports a project and all its modules'
 ``inmanta_plugins`` packages to the orchestrator server. When this method is used, the orchestrator does not install any modules
 from the Python package repository but instead contains all Python code as present in the local Python environment.
+
+Configure the Inmanta server to install modules from a private python package repository
+----------------------------------------------------------------------------------------
+
+V2 modules can be installed from a Python package repository that requires authentication. This section explains how the Inmanta server should be configured to install v2 modules from such a Python package repository.
+
+Create a file named ``/var/lib/inmanta/.netrc`` in the orchestrator's file system.
+Add the following content to the file:
+
+.. code-block:: text
+  machine <hostname of the private repository>
+  login <username>
+  password <password>
+for more information see the  doc about`pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
+
+You will also need to specify the url of the repository in the ``project.yml`` file of your project (See: :ref:`specify_location_pip`).
+
+By following the previous steps, the Inmanta server will be able to install modules from a private Python package repository.

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -344,7 +344,7 @@ Add the following content to the file:
   login <username>
   password <password>
   
-for more information see the  doc about`pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
+For more information, please refer to the documentation about `pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
 
 You will also need to specify the url of the repository in the ``project.yml`` file of your project (See: :ref:`specify_location_pip`).
 

--- a/docs/reference/projectyml.rst
+++ b/docs/reference/projectyml.rst
@@ -67,6 +67,7 @@ By default, a project created using the :ref:`project-creation-guide` is configu
 by changing the  ``url`` option of type ``package`` in the ``repo`` section of the ``project.yml`` file, the python package will be downloaded from the specified index_url:
 
 .. code-block:: yaml
+
     repo:
       - url: https://github.com/inmanta/
         type: git

--- a/docs/reference/projectyml.rst
+++ b/docs/reference/projectyml.rst
@@ -64,7 +64,7 @@ Specify locations from where V2 modules will be installed
 This section explains how to configure your project in order to download v2 modules from any python package repository.
 By default, a project created using the :ref:`project-creation-guide` is configured to install packages from ``https://pypi.org/simple/``.
 
-by changing the  ``url`` option of type ``package`` in the ``repo`` section of the ``project.yml`` file, the python package will be downloaded from the specified index_url:
+By changing the ``url`` option of type ``package`` in the ``repo`` section of the ``project.yml`` file, python packages will be downloaded from the specified index_url:
 
 .. code-block:: yaml
 

--- a/docs/reference/projectyml.rst
+++ b/docs/reference/projectyml.rst
@@ -56,6 +56,22 @@ The code snippet below provides an example of a complete ``project.yml`` file:
     freeze_recursive: true
     freeze_operator: ~=
 
+.. _specify_location_pip:
+
+
+Specify locations from where V2 modules will be installed
+---------------------------------------------------------
+This section explains how to configure your project in order to download v2 modules from any python package repository.
+By default, a project created using the :ref:`project-creation-guide` is configured to install packages from ``https://pypi.org/simple/``.
+
+by changing the  ``url`` option of type ``package`` in the ``repo`` section of the ``project.yml`` file, the python package will be downloaded from the specified index_url:
+
+.. code-block:: yaml
+    repo:
+      - url: https://github.com/inmanta/
+        type: git
+      - url: <url of a python package repository>
+        type: package
 
 Module metadata files
 #####################


### PR DESCRIPTION
# Description

Document the proper way to configure a project to access a private python package repository

closes https://github.com/inmanta/inmanta-service-orchestrator/issues/392

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
