### PR TITLE
[FIX] bump asyncpg's constraint higher bound to 0.28

### DIFF
--- a/changelogs/unreleased/6232-bump-asyncpg-to-0-28.yml
+++ b/changelogs/unreleased/6232-bump-asyncpg-to-0-28.yml
@@ -1,4 +1,4 @@
-description: Increase higher bound on asyncpg constraint from 0.27 to 0.28
+description: Increase higher bound on asyncpg constraint from 0.27 to 0.28.
 issue-nr: 6232
 change-type: patch
 destination-branches: [master, iso6]

--- a/changelogs/unreleased/6232-bump-asyncpg-to-0-28.yml
+++ b/changelogs/unreleased/6232-bump-asyncpg-to-0-28.yml
@@ -1,0 +1,4 @@
+description: Increase higher bound on asyncpg constraint from 0.27 to 0.28
+issue-nr: 6232
+change-type: patch
+destination-branches: [master, iso6]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 from os import path
 
 requires = [
-    "asyncpg~=0.25,<0.28",
+    "asyncpg~=0.25,<0.29",
     "click-plugins~=1.0",
     # click has been known to publish non-backwards compatible minors in the past (removed deprecated code in 8.1.0)
     "click>=8.0,<8.2",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 from os import path
 
 requires = [
-    "asyncpg~=0.25,<0.29",
+    "asyncpg>=0.25,<0.29",
     "click-plugins~=1.0",
     # click has been known to publish non-backwards compatible minors in the past (removed deprecated code in 8.1.0)
     "click>=8.0,<8.2",


### PR DESCRIPTION
# Description


closes https://github.com/inmanta/inmanta-core/issues/6232

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
