### PR TITLE
issue/6224-drop-instance-dump

### DIFF
--- a/changelogs/unreleased/6224-drop-instance-dump-method.yml
+++ b/changelogs/unreleased/6224-drop-instance-dump-method.yml
@@ -1,0 +1,4 @@
+description: Remove the inmanta.execute.runtime.Instance.dump method as it doesn't seem to be used and is currently broken.
+issue-nr: 6224
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/changelogs/unreleased/6224-drop-instance-dump-method.yml
+++ b/changelogs/unreleased/6224-drop-instance-dump-method.yml
@@ -1,4 +1,4 @@
 description: Remove the inmanta.execute.runtime.Instance.dump method as it doesn't seem to be used and is currently broken.
 issue-nr: 6224
 change-type: patch
-destination-branches: [master, iso6, iso5]
+destination-branches: [master]

--- a/src/inmanta/execute/runtime.py
+++ b/src/inmanta/execute/runtime.py
@@ -1335,17 +1335,6 @@ class Instance(ExecutionContext):
                             )
                         )
 
-    def dump(self) -> None:
-        print("------------ ")
-        print(str(self))
-        print("------------ ")
-        for n, v in self.slots.items():
-            if v.can_get():
-                value = v.value
-                print("%s\t\t%s" % (n, value))
-            else:
-                print("BAD: %s\t\t%s" % (n, ", ".join(repr(prom) for prom in v.promises)))
-
     def verify_done(self) -> bool:
         for v in self.slots.values():
             if not v.can_get():


### PR DESCRIPTION
# Description

The inmanta.execute.runtime.Instance.dump method doesn't seem to be used and is currently broken because it accesses ResultVariable.promises which only exists on some of its child classes. This PR removes the method

closes #6224 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
