### PR TITLE
[FIX] pin execnect to 1.9.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
   ignore:
     - dependency-name: "pydantic"
       update-types: ["version-update:semver-major"]
+    - dependency-name: "execnet"
+      update-types: ["version-update:semver-major"]
 - target-branch: iso6
   package-ecosystem: pip
   directory: "/"
@@ -23,4 +25,6 @@ updates:
     - dependency-type: "all"
   ignore:
     - dependency-name: "pydantic"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "execnet"
       update-types: ["version-update:semver-major"]

--- a/changelogs/unreleased/issue-build-master-pin-execnet-to1-9-0.yml
+++ b/changelogs/unreleased/issue-build-master-pin-execnet-to1-9-0.yml
@@ -1,0 +1,3 @@
+description: Pin execnect to 1.9.0
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/changelogs/unreleased/issue-build-master-pin-execnet-to1-9-0.yml
+++ b/changelogs/unreleased/issue-build-master-pin-execnet-to1-9-0.yml
@@ -1,3 +1,3 @@
 description: Pin execnect to 1.9.0
 change-type: patch
-destination-branches: [master, iso6, iso5, iso4]
+destination-branches: [master, iso6]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ crontab==1.0.1
 cryptography==41.0.1
 docstring-parser==0.15
 email-validator==2.0.0.post2
-execnet==2.0.2
+execnet==1.9.0
 importlib_metadata==6.8.0
 jinja2==3.1.2
 more-itertools==9.1.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requires = [
     # docstring-parser has been known to publish non-backwards compatible minors in the past
     "docstring-parser>=0.10,<0.16",
     "email-validator>=1,<3",
-    "execnet>=1,<3",
+    "execnet>=1,<2",
     "importlib_metadata>=4,<7",
     "jinja2~=3.0",
     "more-itertools>=8,<10",


### PR DESCRIPTION
# Description

See [here](https://inmanta.slack.com/archives/CKRF0C8R3/p1689085078066149?thread_ts=1689083895.513759&cid=CKRF0C8R3) for full story

follow up ticket : https://github.com/inmanta/inmanta-core/issues/6257
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
