### PR TITLE
[FIX] bump asyncpg's constraint higher bound to 0.28 (#6233)

### DIFF
--- a/changelogs/unreleased/6232-bump-asyncpg-to-0-28.yml
+++ b/changelogs/unreleased/6232-bump-asyncpg-to-0-28.yml
@@ -1,0 +1,4 @@
+description: Increase higher bound on asyncpg constraint from 0.27 to 0.28.
+issue-nr: 6232
+change-type: patch
+destination-branches: [master, iso6]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 from os import path
 
 requires = [
-    "asyncpg~=0.25,<0.28",
+    "asyncpg>=0.25,<0.29",
     "click-plugins~=1.0",
     # click has been known to publish non-backwards compatible minors in the past (removed deprecated code in 8.1.0)
     "click>=8.0,<8.2",


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #6233