### PR TITLE
update

### DIFF
--- a/changelogs/unreleased/fix-requirement-after-cython-bump.yml
+++ b/changelogs/unreleased/fix-requirement-after-cython-bump.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: bump the version of pyyml to constraint cython
+destination-branches:
+- iso4
+- iso5
+sections: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pydantic==1.10.8
 pyformance==0.4
 PyJWT==2.6.0
 python-dateutil==2.8.2
-pyyaml==6.0
+pyyaml==6.0.1
 setuptools==65.6.3
 texttable==1.6.7
 tornado==6.2


### PR DESCRIPTION
# Description

Due to the recent bump of cython to version 3.0.0 the pyyml dependency is broken.

debug: ERROR: Cannot install PyYAML because these package versions have conflicting dependencies.
debug: 
debug: The conflict is caused by:
debug:     The user requested PyYAML
debug:     The user requested (constraint) pyyaml==6.0

according to [this comment](https://github.com/yaml/pyyaml/issues/724#issuecomment-1639579725), bumping the version should fix it.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
