### PR TITLE
issue/5511-doc-multiple-indexes

### DIFF
--- a/changelogs/unreleased/5514-doc-warning-multiple-indexes.yml
+++ b/changelogs/unreleased/5514-doc-warning-multiple-indexes.yml
@@ -1,3 +1,5 @@
 description: add a warning to the docs about the risk of using multiple python package indexes
 change-type: patch
 destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/5514-doc-warning-multiple-indexes.yml
+++ b/changelogs/unreleased/5514-doc-warning-multiple-indexes.yml
@@ -1,0 +1,3 @@
+description: add a warning to the docs about the risk of using multiple python package indexes
+change-type: patch
+destination-branches: [master, iso6]

--- a/docs/model_developers/project_creation.rst
+++ b/docs/model_developers/project_creation.rst
@@ -51,6 +51,10 @@ An example ``project.yml`` could be:
       index_urls:
           - https://pypi.org/simple
 
+.. warning::
+    Using more than one Python package index in the project config is generally discouraged.
+    It is a security risk and using more than one should be done with extreme care.
+    Only proceed if you are aware of dependency confusion attacks.
 
 The main file
 -------------

--- a/docs/model_developers/project_creation.rst
+++ b/docs/model_developers/project_creation.rst
@@ -55,6 +55,7 @@ An example ``project.yml`` could be:
     Using more than one Python package index in the project config is discouraged.
     It is a security risk and using more than one should be done with extreme care.
     Only proceed if you are aware of dependency confusion attacks.
+    For more information see the `pip documentation <https://pip.pypa.io/en/stable/cli/pip_install/>`_ and the draft `PEP 708  <https://peps.python.org/pep-0708/#motivation>`_
 
 The main file
 -------------

--- a/docs/model_developers/project_creation.rst
+++ b/docs/model_developers/project_creation.rst
@@ -52,7 +52,7 @@ An example ``project.yml`` could be:
           - https://pypi.org/simple
 
 .. warning::
-    Using more than one Python package index in the project config is generally discouraged.
+    Using more than one Python package index in the project config is discouraged.
     It is a security risk and using more than one should be done with extreme care.
     Only proceed if you are aware of dependency confusion attacks.
 


### PR DESCRIPTION
# Description

add a warning to the docs about the risk of using multiple python package indexes

closes #5514 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
