### PR TITLE
Moved sphinx dependencies from inmanta-dev-dependencies to requirements.dev.txt

### DIFF
--- a/changelogs/unreleased/sphinx.yml
+++ b/changelogs/unreleased/sphinx.yml
@@ -1,0 +1,5 @@
+description: Moved sphinx dependencies from inmanta-dev-dependencies to requirements.dev.txt and dropped unused extensions
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,7 +11,7 @@ flake8-junit-report==2.1.0
 # documentation
 furo==2023.7.26
 inmanta-sphinx==1.7.0
-myst_parser==2.0.0
+myst-parser==2.0.0
 sphinx==6.2.1
 sphinxcontrib-contentui==0.2.5
 sphinxcontrib-redoc==1.6.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,14 +1,21 @@
-inmanta-dev-dependencies[pytest,async,core,sphinx]==2.77.0
+inmanta-dev-dependencies[pytest,async,core]==2.77.0
 bumpversion==0.6.0
 openapi_spec_validator==0.6.0
 pip2pi==0.8.2
-sphinxcontrib-contentui==0.2.5
 types-PyYAML==6.0.12.11
 types-python-dateutil==2.8.19.14
 types-setuptools==68.0.0.3
 types-toml==0.10.8.7
 flake8-junit-report==2.1.0
 
-# documentation theme
+# documentation
 furo==2023.7.26
+inmanta-sphinx==1.7.0
+myst_parser==2.0.0
+sphinx==6.2.1
+sphinxcontrib-contentui==0.2.5
+sphinxcontrib-redoc==1.6.0
+sphinx-argparse==0.4.0
+sphinx-autodoc-annotation==1.0-1
+sphinx-click==4.4.0
 sphinx-design==0.5.0


### PR DESCRIPTION
# Description

The `sphinx` extra for `inmanta-dev-dependencies` is currently only used by `inmanta-core` and the `developerdocs`. Given that the indirect dependencies occasionally gives conflicts when dependabot tries to bump versions, it's easier to depend on them directly and drop them from `inmanta-dev-dependencies`.

I additionally checked which of the sphinx dependencies I think we actually use and I dropped `recommonmark`, `sphinx-tab` and `sphinxcontrib-serializinghtml` because I don't think we use them anymore.

PRs for `developerdocs` and `inmanta-dev-dependencies` will follow.
