### PR TITLE
added pytest-inmanta-extensions to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
   ignore:
+    - dependency-name: "pytest-inmanta-extensions"
+      # pytest-inmanta-extensions version is tied to inmanta-core's version with an f-string
+      # dependabot crashes on trying to bump it
+      versions: [">=0.0.1"]
     - dependency-name: "pydantic"
       update-types: ["version-update:semver-major"]
     - dependency-name: "execnet"
@@ -24,6 +28,8 @@ updates:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
   ignore:
+    - dependency-name: "pytest-inmanta-extensions"
+      versions: [">=0.0.1"]
     - dependency-name: "pydantic"
       update-types: ["version-update:semver-major"]
     - dependency-name: "execnet"

--- a/changelogs/unreleased/dependabot-fix.yml
+++ b/changelogs/unreleased/dependabot-fix.yml
@@ -1,0 +1,4 @@
+description: added pytest-inmanta-extensions to dependabot ignore list
+change-type: patch
+destination-branches:
+  - master


### PR DESCRIPTION
See https://github.com/inmanta/inmanta-core/network/updates/703336675. Relevant portion of log copied below because I'm not sure how long that link stays valid

```
updater | 2023/08/01 07:42:03 INFO <job_703336675> Checking if more-itertools 10.0.0 needs updating
  proxy | 2023/08/01 07:42:03 [150] GET https://pypi.org:443/simple/more-itertools/
  proxy | 2023/08/01 07:42:03 [150] 200 https://pypi.org:443/simple/more-itertools/
updater | 2023/08/01 07:42:03 INFO <job_703336675> Latest version is 10.0.0
updater | 2023/08/01 07:42:03 INFO <job_703336675> No update needed for more-itertools 10.0.0
updater | 2023/08/01 07:42:03 INFO <job_703336675> Checking if pytest-inmanta-extensions  needs updating
  proxy | 2023/08/01 07:42:03 [152] GET https://pypi.org:443/simple/pytest-inmanta-extensions/
  proxy | 2023/08/01 07:42:03 [152] 200 https://pypi.org:443/simple/pytest-inmanta-extensions/
updater | 2023/08/01 07:42:03 INFO <job_703336675> Latest version is 9.3.0
  proxy | 2023/08/01 07:42:04 [154] GET https://pypi.org:443/simple/pytest-inmanta-extensions/
  proxy | 2023/08/01 07:42:04 [154] 200 https://pypi.org:443/simple/pytest-inmanta-extensions/
updater | 2023/08/01 07:42:04 INFO <job_703336675> Requirements to unlock own
updater | 2023/08/01 07:42:04 INFO <job_703336675> Requirements update strategy bump_versions
updater | 2023/08/01 07:42:04 INFO <job_703336675> Updating pytest-inmanta-extensions from  to 9.3.0
updater | 2023/08/01 07:42:04 INFO <job_703336675> Sending event 03499fda92e94e94b2ed509a37c0d3b7 to Sentry
  proxy | 2023/08/01 07:42:04 [156] POST https://sentry.io:443/api/1451818/store/
  proxy | 2023/08/01 07:42:04 [156] 200 https://sentry.io:443/api/1451818/store/
updater | 2023/08/01 07:42:04 ERROR <job_703336675> Error processing pytest-inmanta-extensions (RuntimeError)
updater | 2023/08/01 07:42:04 ERROR <job_703336675> Declaration not found for pytest-inmanta-extensions!
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_replacer.rb:159:in `original_dependency_declaration_string'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_replacer.rb:100:in `original_declaration_replacement_regex'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_replacer.rb:25:in `updated_content'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_file_updater.rb:61:in `updated_requirement_or_setup_file_content'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_file_updater.rb:44:in `block in fetch_updated_dependency_files'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_file_updater.rb:39:in `each'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_file_updater.rb:39:in `filter_map'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_file_updater.rb:39:in `fetch_updated_dependency_files'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater/requirement_file_updater.rb:26:in `updated_dependency_files'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater.rb:115:in `updated_requirement_based_files'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/python/lib/dependabot/python/file_updater.rb:35:in `updated_dependency_files'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:86:in `generate_dependency_files'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:36:in `run'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:25:in `create_from'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:122:in `check_and_create_pull_request'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:59:in `check_and_create_pr_with_error_handling'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:34:in `block in perform'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:34:in `each'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:34:in `perform'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:63:in `run'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:38:in `perform_job'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:52:in `run'
updater | 2023/08/01 07:42:04 ERROR <job_703336675> bin/update_files.rb:23:in `<main>'
updater | 2023/08/01 07:42:04 INFO <job_703336675> Finished job processing
updater | 2023/08/01 07:42:04 INFO Results:
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +-------------------------------------------+
updater | |       Dependencies failed to update       |
updater | +---------------------------+---------------+
updater | | pytest-inmanta-extensions | unknown_error |
updater | +---------------------------+---------------+
updater | time="2023-08-01T07:42:04Z" level=info msg="task complete" container_id=job-703336675-updater exit_code=0 job_id=703336675 step=updater
```