### PR TITLE
Allow product's conf.py to inject version information when building docs

### DIFF
--- a/changelogs/unreleased/docs-confpy-allow-version-injection.yml
+++ b/changelogs/unreleased/docs-confpy-allow-version-injection.yml
@@ -1,0 +1,6 @@
+description: "Allow product's conf.py to inject version information when building docs"
+change-type: patch
+destination-branches:
+  - master
+  - iso6
+  - iso5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,6 @@ import sys, os, pkg_resources, datetime
 from importlib.metadata import PackageNotFoundError
 from sphinx.errors import ConfigError
 
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,12 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+import importlib.metadata
 import shutil
 import sys, os, pkg_resources, datetime
+from importlib.metadata import PackageNotFoundError
 from sphinx.errors import ConfigError
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -94,26 +97,27 @@ copyright = f'{datetime.datetime.now().year} Inmanta NV'
 # built documents.
 #
 # The short X.Y version.
-if "INMANTA_DONT_DISCOVER_VERSION" in os.environ:
-    # Used to:
-    # 1) Decouple the inmanta-core package from the inmanta
-    #    package when running the tests.
-    # 2) Build the ISO documentation, which is built on top
-    #    of the inmanta-core documentation. During the ISO docs build,
-    #    this value will be overwritten with the ISO product version.
-    version = "1.0.0"
-else:
-    try:
-        version = pkg_resources.get_distribution("inmanta").version
-    except pkg_resources.DistributionNotFound:
-        raise ConfigError(
-            """
+version: str
+try:
+    # if product's conf.py injected version information, use that one
+    version
+except NameError:
+    if "INMANTA_DONT_DISCOVER_VERSION" in os.environ:
+        # Used to:
+        # Decouple the inmanta-core package from the inmanta package when running the tests.
+        version = "1.0.0"
+    else:
+        try:
+            version = importlib.metadata.version("inmanta")
+        except PackageNotFoundError:
+            raise ConfigError(
+                """
 The inmanta package is not installed. This way sphinx failed to discover the version number that should be
 displayed on the documentation pages. Either install the inmanta package or set the environment variable
 INMANTA_DONT_DISCOVER_VERSION when the version number is not important for this documentation build. The latter
 solution will set the version number to 1.0.0.
-            """
-        )
+                """
+            )
 
 # The full version, including alpha/beta/rc tags.
 release = version


### PR DESCRIPTION
This allows the product to inject the version information before this file is even loaded. This in turn allows us to use this version for other purposes. This was not possible before because e.g. for the iso product the version would be inaccurate (`INMANTA_DONT_DISCOVER_VERSION` -> `1.0.0`) until after this file had finished loading. By allowing version injection, the version becomes accurate at load-time.

See inmanta/inmanta-service-orchestrator#410