### PR TITLE
Improve the error reporting of the inmanta module release command

### DIFF
--- a/changelogs/unreleased/improve-error-reporting-release-command.yml
+++ b/changelogs/unreleased/improve-error-reporting-release-command.yml
@@ -1,0 +1,6 @@
+---
+description: "Prefix the error messages produced by the `inmanta module release` command with `Error:` to make clear it's an error message."
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1238,8 +1238,9 @@ version: 0.0.1dev0"""
         ]
         if versions_between_current_and_new_version:
             raise click.ClickException(
-                f"Stable release {versions_between_current_and_new_version[0]} exists between "
-                f"current version {current_version} and new version {new_version}"
+                f"Error: Stable release {versions_between_current_and_new_version[0]} exists between "
+                f"current version {current_version} and new version {new_version}. Make sure your branch is up-to-update "
+                f"with the remote repository."
             )
 
         return new_version
@@ -1262,18 +1263,18 @@ version: 0.0.1dev0"""
         # Validate patch, minor, major
         nb_version_bump_arguments_set = sum([revision, patch, minor, major])
         if nb_version_bump_arguments_set > 1:
-            raise click.UsageError("Only one of --revision, --patch, --minor and --major can be set at the same time.")
+            raise click.UsageError("Error: Only one of --revision, --patch, --minor and --major can be set at the same time.")
 
         # Make module
         module_dir = os.path.abspath(os.getcwd())
         module: Module[ModuleMetadata] = self.construct_module(project=DummyProject(), path=module_dir)
         if not gitprovider.is_git_repository(repo=module_dir):
-            raise click.ClickException(f"Directory {module_dir} is not a git repository.")
+            raise click.ClickException(f"Error: Directory {module_dir} is not a git repository.")
 
         # Validate current state of the module
         current_version: Version = module.version
         if current_version.epoch != 0:
-            raise click.ClickException("Version with an epoch value larger than zero are not supported by this tool.")
+            raise click.ClickException("Error: Version with an epoch value larger than zero are not supported by this tool.")
         gitprovider.fetch(module_dir)
 
         # Get history
@@ -1324,7 +1325,7 @@ version: 0.0.1dev0"""
         else:
             release_tag: Version = VersionOperation.set_version_tag(new_version, version_tag="")
             if release_tag in stable_releases:
-                raise click.ClickException(f"A Git version tag already exists for version {release_tag}")
+                raise click.ClickException(f"Error: A Git version tag already exists for version {release_tag}")
             module.rewrite_version(new_version=str(release_tag), version_tag="")
             if changelog:
                 changelog.set_release_date_for_version(release_tag)


### PR DESCRIPTION
# Description

This PR applies the following changes:

* Prefix the error messages of the `inmanta module release` command with `Error:`. A ClickException just output the error messages and exits with a non-zero exit code. Without the `Error:` prefix, it might not be very clear that something is an error message. This change should improve that.
* Enhance the error message regarding an outdated feature branch to make it more actionable.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
