### PR TITLE
increased max_iterations

### DIFF
--- a/changelogs/unreleased/increase_max_iterations.yml
+++ b/changelogs/unreleased/increase_max_iterations.yml
@@ -1,0 +1,5 @@
+description: Increase the default value of INMANTA_MAX_ITERATIONS to 100000
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -55,7 +55,7 @@ DEBUG = True
 LOGGER = logging.getLogger(__name__)
 
 
-MAX_ITERATIONS = 100000
+MAX_ITERATIONS = 100_000
 
 
 class Scheduler(object):

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -55,7 +55,7 @@ DEBUG = True
 LOGGER = logging.getLogger(__name__)
 
 
-MAX_ITERATIONS = 10000
+MAX_ITERATIONS = 100000
 
 
 class Scheduler(object):


### PR DESCRIPTION
# Description

Increase the default value of INMANTA_MAX_ITERATIONS to 100000


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
