### PR TITLE
Make sure that stop method of FeatureManager is called

### DIFF
--- a/changelogs/unreleased/make-stop-method-of-featuremanager-async.yml
+++ b/changelogs/unreleased/make-stop-method-of-featuremanager-async.yml
@@ -1,0 +1,6 @@
+---
+description: "Make the stop() method of the FeatureManager asynchronous + Make sure that calling BootLoader.stop() after BootLoader.load_slices() calls stop on the loaded FeatureManager."
+issue-nr: 520
+issue-repo: inmanta-license
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -80,7 +80,6 @@ class InmantaBootloader(object):
 
     async def start(self) -> None:
         ctx = self.load_slices()
-        self.feature_manager = ctx.get_feature_manager()
         for mypart in ctx.get_slices():
             self.restserver.add_slice(mypart)
             ctx.get_feature_manager().add_slice(mypart)
@@ -101,7 +100,7 @@ class InmantaBootloader(object):
     async def _stop(self) -> None:
         await self.restserver.stop()
         if self.feature_manager is not None:
-            self.feature_manager.stop()
+            await self.feature_manager.stop()
 
     @classmethod
     def get_available_extensions(cls) -> Dict[str, str]:
@@ -230,4 +229,6 @@ class InmantaBootloader(object):
         Load all slices in the server
         """
         exts: Dict[str, ModuleType] = self._load_extensions(load_all_extensions)
-        return self._collect_slices(exts, only_register_environment_settings)
+        ctx: ApplicationContext = self._collect_slices(exts, only_register_environment_settings)
+        self.feature_manager = ctx.get_feature_manager()
+        return ctx

--- a/src/inmanta/server/extensions.py
+++ b/src/inmanta/server/extensions.py
@@ -178,7 +178,7 @@ class FeatureManager:
             return True
         return item in value
 
-    def stop(self) -> None:
+    async def stop(self) -> None:
         """Called when the server is stopped"""
 
 


### PR DESCRIPTION
# Description

This PR makes the following changes:

* Make sure that calling `BootLoader.stop()` calls the stop() method on the FeatureManager created by the `BootLoader.load_slices()` invocation.
* Make the `stop()` method of the `FeatureManager` class asynchronous. This change is required for https://github.com/inmanta/inmanta-license/pull/528

Part of inmanta/inmanta-license#520

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
