### PR TITLE
Issue/6092 repair runs out of specific timerange

### DIFF
--- a/changelogs/unreleased/6374-repair-runs-specific-timerange.yml
+++ b/changelogs/unreleased/6374-repair-runs-specific-timerange.yml
@@ -1,0 +1,5 @@
+description: Allow cron expressions in the agent_repair_interval so that we can specify a time-intervals where the repair runs happen.
+destination-branches: [master, iso6]
+change-type: minor
+sections:
+  feature: "{{description}}"

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -29,7 +29,7 @@ from asyncio import Lock
 from collections import defaultdict
 from concurrent.futures.thread import ThreadPoolExecutor
 from logging import Logger
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union, cast
 
 from inmanta import const, data, env, protocol
 from inmanta.agent import config as cfg
@@ -634,7 +634,7 @@ class AgentInstance(object):
         self._deploy_splay_value = random.randint(0, deploy_splay_time)
 
         # do regular repair runs
-        self._repair_interval = cfg.agent_repair_interval.get()
+        self._repair_interval: Union[int, str] = cfg.agent_repair_interval.get()
         repair_splay_time = cfg.agent_repair_splay_time.get()
         self._repair_splay_value = random.randint(0, repair_splay_time)
 
@@ -738,7 +738,7 @@ class AgentInstance(object):
             )
             self._enable_time_trigger(deploy_action, interval_schedule_deploy)
         if isinstance(self._repair_interval, int):
-            if not self._repair_interval:
+            if self._repair_interval <= 0:
                 return
             self.logger.info(
                 "Scheduling repair with interval %d and splay %d (first run at %s)",

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -738,7 +738,7 @@ class AgentInstance(object):
             )
             self._enable_time_trigger(deploy_action, interval_schedule_deploy)
         if isinstance(self._repair_interval, int):
-            if self._repair_interval == 0:
+            if not self._repair_interval:
                 return
             self.logger.info(
                 "Scheduling repair with interval %d and splay %d (first run at %s)",

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -44,7 +44,16 @@ from inmanta.loader import CodeLoader, ModuleSource
 from inmanta.protocol import SessionEndpoint, SyncClient, methods, methods_v2
 from inmanta.resources import Id, Resource
 from inmanta.types import Apireturn, JsonType
-from inmanta.util import IntervalSchedule, NamedLock, ScheduledTask, TaskMethod, add_future, join_threadpools
+from inmanta.util import (
+    CronSchedule,
+    IntervalSchedule,
+    NamedLock,
+    ScheduledTask,
+    TaskMethod,
+    TaskSchedule,
+    add_future,
+    join_threadpools,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -724,18 +733,30 @@ class AgentInstance(object):
                 self._deploy_splay_value,
                 (now + datetime.timedelta(seconds=self._deploy_splay_value)).strftime(const.TIME_LOGFMT),
             )
-            self._enable_time_trigger(deploy_action, self._deploy_interval, self._deploy_splay_value)
-        if self._repair_interval > 0:
+            interval_schedule: IntervalSchedule = IntervalSchedule(
+                interval=float(self._deploy_interval), initial_delay=float(self._deploy_splay_value)
+            )
+            self._enable_time_trigger(deploy_action, interval_schedule)
+        if isinstance(self._repair_interval, int):
+            if self._repair_interval == 0:
+                return
             self.logger.info(
                 "Scheduling repair with interval %d and splay %d (first run at %s)",
                 self._repair_interval,
                 self._repair_splay_value,
                 (now + datetime.timedelta(seconds=self._repair_splay_value)).strftime(const.TIME_LOGFMT),
             )
-            self._enable_time_trigger(repair_action, self._repair_interval, self._repair_splay_value)
+            interval_schedule: IntervalSchedule = IntervalSchedule(
+                interval=float(self._repair_interval), initial_delay=float(self._repair_splay_value)
+            )
+            self._enable_time_trigger(repair_action, interval_schedule)
 
-    def _enable_time_trigger(self, action: TaskMethod, interval: int, splay: int) -> None:
-        schedule: IntervalSchedule = IntervalSchedule(interval=float(interval), initial_delay=float(splay))
+        if isinstance(self._repair_interval, str):
+            self.logger.info("Scheduling repair with cron expression %s", self._repair_interval)
+            cron_schedule = CronSchedule(cron=self._repair_interval)
+            self._enable_time_trigger(repair_action, cron_schedule)
+
+    def _enable_time_trigger(self, action: TaskMethod, schedule: TaskSchedule) -> None:
         self.process._sched.add_action(action, schedule)
         self._time_triggered_actions.add(ScheduledTask(action=action, schedule=schedule))
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -733,10 +733,10 @@ class AgentInstance(object):
                 self._deploy_splay_value,
                 (now + datetime.timedelta(seconds=self._deploy_splay_value)).strftime(const.TIME_LOGFMT),
             )
-            interval_schedule: IntervalSchedule = IntervalSchedule(
+            interval_schedule_deploy: IntervalSchedule = IntervalSchedule(
                 interval=float(self._deploy_interval), initial_delay=float(self._deploy_splay_value)
             )
-            self._enable_time_trigger(deploy_action, interval_schedule)
+            self._enable_time_trigger(deploy_action, interval_schedule_deploy)
         if isinstance(self._repair_interval, int):
             if self._repair_interval == 0:
                 return
@@ -746,10 +746,10 @@ class AgentInstance(object):
                 self._repair_splay_value,
                 (now + datetime.timedelta(seconds=self._repair_splay_value)).strftime(const.TIME_LOGFMT),
             )
-            interval_schedule: IntervalSchedule = IntervalSchedule(
+            interval_schedule_repair: IntervalSchedule = IntervalSchedule(
                 interval=float(self._repair_interval), initial_delay=float(self._repair_splay_value)
             )
-            self._enable_time_trigger(repair_action, interval_schedule)
+            self._enable_time_trigger(repair_action, interval_schedule_repair)
 
         if isinstance(self._repair_interval, str):
             self.logger.info("Scheduling repair with cron expression %s", self._repair_interval)

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -116,9 +116,9 @@ agent_repair_interval = Option(
     "config",
     "agent-repair-interval",
     600,
-    "The number of seconds between two repair runs (full deploy) of the agent. "
+    "The number of seconds between two repair runs (full deploy) of the agent or a cron expression of when to run the repair run"
     + "Set this to 0 to disable the scheduled repair runs.",
-    is_time,
+    is_time_or_cron,
 )
 agent_repair_splay_time = Option(
     "config",

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -117,9 +117,9 @@ agent_repair_interval = Option(
     "agent-repair-interval",
     600,
     "Either the number of seconds between two repair runs (full deploy) of the agent or a cron-like expression."
-    " If a cron-like expression is specified, a repair will be run following a cron-like time-to-run specification, interpreted in UTC"
-    " (e.g. `min hour dom month dow`). A repair will be requested at the scheduled time. Note that if a cron expression is use"
-    " the 'agent_repair_splay_time' setting will be ignored."
+    " If a cron-like expression is specified, a repair will be run following a cron-like time-to-run specification,"
+    " interpreted in UTC (e.g. `min hour dom month dow`). A repair will be requested at the scheduled time. Note that if a cron"
+    " expression is used the 'agent_repair_splay_time' setting will be ignored."
     " Setting this to 0 to disable the scheduled repair runs.",
     is_time_or_cron,
 )

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -116,11 +116,11 @@ agent_repair_interval = Option(
     "config",
     "agent-repair-interval",
     600,
-    "Either the number of seconds between two repair runs (full deploy) of the agent or a cron-like expression"
-    "If a cron-like expression is specified, a repair will be run following a cron-like time-to-run specification, interpreted in UTC"
-    "(e.g. `min hour dom month dow`). A repair will be requested at the scheduled time. Note that if a cron expression is use"
-    "the 'agent_repair_splay_time' setting will be ignored"
-    "Setting this to 0 to disable the scheduled repair runs.",
+    "Either the number of seconds between two repair runs (full deploy) of the agent or a cron-like expression."
+    " If a cron-like expression is specified, a repair will be run following a cron-like time-to-run specification, interpreted in UTC"
+    " (e.g. `min hour dom month dow`). A repair will be requested at the scheduled time. Note that if a cron expression is use"
+    " the 'agent_repair_splay_time' setting will be ignored."
+    " Setting this to 0 to disable the scheduled repair runs.",
     is_time_or_cron,
 )
 agent_repair_splay_time = Option(

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -116,8 +116,11 @@ agent_repair_interval = Option(
     "config",
     "agent-repair-interval",
     600,
-    "The number of seconds between two repair runs (full deploy) of the agent or a cron expression of when to run the repair run"
-    + "Set this to 0 to disable the scheduled repair runs.",
+    "Either the number of seconds between two repair runs (full deploy) of the agent or a cron-like expression"
+    "If a cron-like expression is specified, a repair will be run following a cron-like time-to-run specification, interpreted in UTC"
+    "(e.g. `min hour dom month dow`). A repair will be requested at the scheduled time. Note that if a cron expression is use"
+    "the 'agent_repair_splay_time' setting will be ignored"
+    "Setting this to 0 to disable the scheduled repair runs.",
     is_time_or_cron,
 )
 agent_repair_splay_time = Option(
@@ -128,7 +131,8 @@ agent_repair_splay_time = Option(
 
 At startup the agent will choose a random number between 0 and agent-repair-splay-time.
 It will wait this number of second before performing the first repair run.
-Each subsequent repair deployment will start agent-repair-interval seconds after the previous one.""",
+Each subsequent repair deployment will start agent-repair-interval seconds after the previous one.
+This option is ignored and a splay of 0 is used if 'agent_repair_interval' is a cron expression""",
     is_time,
 )
 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -209,7 +209,7 @@ def is_time(value: str) -> int:
 
 
 def is_time_or_cron(value: Union[int, str]) -> Union[int, str]:
-    """Time, the number of seconds represented as an integer value"""
+    """Time, the number of seconds represented as an integer value or a cron-like expression"""
     if isinstance(value, int):
         return value
     try:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -208,7 +208,7 @@ def is_time(value: str) -> int:
     return int(value)
 
 
-def is_time_or_cron(value: str) -> Union[int, str]:
+def is_time_or_cron(value: Union[bool, str]) -> Union[int, str]:
     """Time, the number of seconds represented as an integer value"""
     if isinstance(value, int):
         return value

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -34,6 +34,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
 
+from crontab import CronTab
 from inmanta import const
 
 LOGGER = logging.getLogger(__name__)
@@ -205,6 +206,17 @@ def is_float(value: str) -> float:
 def is_time(value: str) -> int:
     """Time, the number of seconds represented as an integer value"""
     return int(value)
+
+
+def is_time_or_cron(value: str) -> Union[int, str]:
+    """Time, the number of seconds represented as an integer value"""
+    if isinstance(value, int):
+        return value
+    try:
+        CronTab(value)
+    except ValueError as e:
+        return int(value)
+    return value
 
 
 def is_bool(value: Union[bool, str]) -> bool:

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -17,7 +17,6 @@
 """
 import asyncio
 import dataclasses
-import datetime
 import logging
 import time
 import uuid

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -388,16 +388,19 @@ async def test_spontaneous_deploy(
 
 
 @pytest.mark.parametrize(
-    "agent_repair_interval",
-    ["2"],
+    "cron",
+    [False, True],
 )
 async def test_spontaneous_repair(
-    resource_container, environment, client, clienthelper, no_agent_backoff, async_finalizer, server, agent_repair_interval
+    resource_container, environment, client, clienthelper, no_agent_backoff, async_finalizer, server, cron
 ):
     """
-    dryrun and deploy a configuration model
+    Test that a repair run is executed every 2 seconds as specified in the agent_repair_interval (using a cron or not)
     """
     resource_container.Provider.reset()
+    agent_repair_interval = "2"
+    if cron:
+        agent_repair_interval = "*/2 * * * * * *"
 
     env_id = environment
 

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -388,11 +388,11 @@ async def test_spontaneous_deploy(
 
 
 @pytest.mark.parametrize(
-    "agent-repair-interval",
+    "agent_repair_interval",
     ["2"],
 )
 async def test_spontaneous_repair(
-    resource_container, environment, client, clienthelper, no_agent_backoff, async_finalizer, server
+    resource_container, environment, client, clienthelper, no_agent_backoff, async_finalizer, server, agent_repair_interval
 ):
     """
     dryrun and deploy a configuration model
@@ -401,7 +401,7 @@ async def test_spontaneous_repair(
 
     env_id = environment
 
-    Config.set("config", "agent-repair-interval", "2")
+    Config.set("config", "agent-repair-interval", agent_repair_interval)
     Config.set("config", "agent-repair-splay-time", "2")
     Config.set("config", "agent-deploy-interval", "0")
 

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -17,6 +17,7 @@
 """
 import asyncio
 import dataclasses
+import datetime
 import logging
 import time
 import uuid
@@ -386,6 +387,10 @@ async def test_spontaneous_deploy(
     ), f"Sent {len(beats)} heartbeats over a time period of {duration} seconds, sleep mechanism is broken"
 
 
+@pytest.mark.parametrize(
+    "agent-repair-interval",
+    ["2"],
+)
 async def test_spontaneous_repair(
     resource_container, environment, client, clienthelper, no_agent_backoff, async_finalizer, server
 ):


### PR DESCRIPTION
# Description

allow both a number and a cron expression in the agent_repair_interval so that we can specify a timerange where the repair runs happen. 

closes #6092 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
