### PR TITLE
Issue/race on iso6 tests

### DIFF
--- a/changelogs/unreleased/race_in_server_tests.yml
+++ b/changelogs/unreleased/race_in_server_tests.yml
@@ -1,0 +1,4 @@
+description: Fix race condition in server tests
+change-type: patch
+destination-branches: [master]
+

--- a/changelogs/unreleased/race_in_server_tests.yml
+++ b/changelogs/unreleased/race_in_server_tests.yml
@@ -1,4 +1,4 @@
 description: Fix race condition in server tests
 change-type: patch
-destination-branches: [master]
+destination-branches: [iso6]
 

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -26,6 +26,8 @@ from inmanta import config, const, data
 from inmanta.agent.agent import Agent
 from inmanta.export import unknown_parameters
 from inmanta.main import Client
+from inmanta.server import SLICE_AGENT_MANAGER
+from inmanta.server.agentmanager import AgentManager
 from inmanta.server.protocol import Server
 from inmanta.util import get_compiler_version
 from utils import ClientHelper, retry_limited
@@ -58,6 +60,9 @@ async def test_purge_on_delete_requires(
     async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
+
+    agentmanager: AgentManager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     version = await clienthelper.get_version()
 
@@ -194,6 +199,9 @@ async def test_purge_on_delete_compile_failed(
     await agent.start()
     aclient = agent._client
 
+    agentmanager: AgentManager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
+
     version = await clienthelper.get_version()
 
     resources = [
@@ -303,6 +311,9 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
     async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
+
+    agentmanager: AgentManager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     version = await clienthelper.get_version()
 
@@ -441,6 +452,9 @@ async def test_purge_on_delete_ignore(
     await agent.start()
     aclient = agent._client
 
+    agentmanager: AgentManager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
+
     # Version 1 with purge_on_delete true
     version = await clienthelper.get_version()
 
@@ -577,6 +591,10 @@ async def test_disable_purge_on_delete(
     async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
+
+    agentmanager: AgentManager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
+
     env = await data.Environment.get_by_id(environment)
     await env.set(data.PURGE_ON_DELETE, False)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -312,6 +312,9 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     await agent.start()
     aclient = agent._client
 
+    agentmanager = server_multi.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
+
     version = (await client_multi.reserve_version(environment_multi)).result["data"]
 
     resources = [
@@ -480,6 +483,9 @@ async def test_resource_update(postgresql_client, client, clienthelper, server, 
     async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
+
+    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     version = await clienthelper.get_version()
 
@@ -791,6 +797,9 @@ async def test_get_resource_actions(postgresql_client, client, clienthelper, ser
     Test querying resource actions via the API
     """
     aclient = agent._client
+
+    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     version = await clienthelper.get_version()
 


### PR DESCRIPTION
# Description

Fix for race where agent would not be fully up, applied on all place I could find at first sight 

The file this originates from no longer exists on master, so I made two PR's 
@sanderr will this work with mergetool?

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
