### PR TITLE
fix for potential race

### DIFF
--- a/changelogs/unreleased/race_in_server_tests.yml
+++ b/changelogs/unreleased/race_in_server_tests.yml
@@ -1,0 +1,4 @@
+description: Fix race condition in server tests
+change-type: patch
+destination-branches: [master]
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -312,6 +312,9 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     await agent.start()
     aclient = agent._client
 
+    agentmanager = server_multi.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
+
     version = (await client_multi.reserve_version(environment_multi)).result["data"]
 
     resources = [
@@ -480,6 +483,9 @@ async def test_resource_update(postgresql_client, client, clienthelper, server, 
     async_finalizer(agent.stop)
     await agent.start()
     aclient = agent._client
+
+    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     version = await clienthelper.get_version()
 
@@ -791,6 +797,9 @@ async def test_get_resource_actions(postgresql_client, client, clienthelper, ser
     Test querying resource actions via the API
     """
     aclient = agent._client
+
+    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
+    await retry_limited(lambda: len(agentmanager.sessions) == 1, 10)
 
     version = await clienthelper.get_version()
 


### PR DESCRIPTION
# Description

Fix for race where agent would not be fully up, applied on all place I could find at first sight 

The file this originates from no longer exists on master, so I made two PR's 
@sanderr will this work with mergetool?

sibling: https://github.com/inmanta/inmanta-core/pull/6379

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
