### PR TITLE
Add support for rounded timestamps on environment metrics

### DIFF
--- a/changelogs/unreleased/support-rounded-timestamps.yml
+++ b/changelogs/unreleased/support-rounded-timestamps.yml
@@ -1,5 +1,5 @@
 ---
-description: "Added support to the `GET /metrics` endpoint to round the returned timestamps to the previous hour."
+description: "Added support to the `GET /metrics` endpoint to round the returned timestamps to a full hour."
 issue-nr: 6051
 issue-repo: inmanta-core
 change-type: minor

--- a/changelogs/unreleased/support-rounded-timestamps.yml
+++ b/changelogs/unreleased/support-rounded-timestamps.yml
@@ -1,0 +1,8 @@
+---
+description: "Added support to the `GET /metrics` endpoint to round the returned timestamps to the previous hour."
+issue-nr: 6051
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -677,8 +677,8 @@ class EnvironmentMetricsResult(BaseModel):
     """
     A container for metrics as returned by the /metrics endpoint.
 
-    :param start: The starting of the requested aggregation interval.
-    :param end: The end of the requested aggregation interval.
+    :param start: The starting of the aggregation interval.
+    :param end: The end of the aggregation interval.
     :param timestamps: The timestamps that belongs to the aggregated metrics present in the `metrics` dictionary.
     :param metrics: A dictionary that maps the name of a metric to a list of aggregated datapoints. For metrics that are not
                     grouped on a specific property, this list only contains the values of the metrics. For metrics that

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1308,7 +1308,18 @@ def get_environment_metrics(
     :param start_interval: The start of the time window for which the metrics should be returned.
     :param end_interval: The end of the time window for which the metrics should be returned.
     :param nb_datapoints: The amount of datapoint that will be returned within the given time interval for each metric.
-    :param round_timestamps_to_previous_hour: True iff the returned timestamps are rounded to the previous hour.
+    :param round_timestamps_to_previous_hour: True iff the given start_interval and end_interval are rounded to a full hour.
+                                              The start_interval is rounded to the previous full hour and the end_interval
+                                              is rounded to the next full hour, unless they were already rounded.
+                                              When this parameter is set to True, the returned number of datapoints might
+                                              be less than the requested number of datapoints if this is required to
+                                              make the rounded interval dividable into equally sized full hour time windows.
+    :raises BadRequest: start_interval >= end_interval
+    :raises BadRequest: nb_datapoints < 0
+    :raises BadRequest: The provided metrics list is an empty list.
+    :raises BadRequest: The start_interval and end_interval are not separated from each other by at least nb_datapoints minutes separated from each other.
+    :raises BadRequest: The round_timestamps_to_previous_hour parameter is set to True and the amount of hours between
+                        start_interval and end_interval is less than the requested number of datapoints.
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1317,7 +1317,8 @@ def get_environment_metrics(
     :raises BadRequest: start_interval >= end_interval
     :raises BadRequest: nb_datapoints < 0
     :raises BadRequest: The provided metrics list is an empty list.
-    :raises BadRequest: The start_interval and end_interval are not separated from each other by at least nb_datapoints minutes separated from each other.
+    :raises BadRequest: The start_interval and end_interval are not separated from each other by at least nb_datapoints minutes
+                        separated from each other.
     :raises BadRequest: The round_timestamps_to_previous_hour parameter is set to True and the amount of hours between
                         start_interval and end_interval is less than the requested number of datapoints.
     """

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1298,7 +1298,7 @@ def get_environment_metrics(
     start_interval: datetime.datetime,
     end_interval: datetime.datetime,
     nb_datapoints: int,
-    round_timestamps_to_previous_hour: bool = False,
+    round_timestamps: bool = False,
 ) -> model.EnvironmentMetricsResult:
     """
     Obtain metrics about the given environment for the given time interval.
@@ -1308,18 +1308,18 @@ def get_environment_metrics(
     :param start_interval: The start of the time window for which the metrics should be returned.
     :param end_interval: The end of the time window for which the metrics should be returned.
     :param nb_datapoints: The amount of datapoint that will be returned within the given time interval for each metric.
-    :param round_timestamps_to_previous_hour: True iff the given start_interval and end_interval are rounded to a full hour.
-                                              The start_interval is rounded to the previous full hour and the end_interval
-                                              is rounded to the next full hour, unless they were already rounded.
-                                              When this parameter is set to True, the returned number of datapoints might
-                                              be less than the requested number of datapoints if this is required to
-                                              make the rounded interval dividable into equally sized full hour time windows.
+    :param round_timestamps: If this parameter is set to True, the timestamps in the reply will be rounded to a full hour.
+                             All time windows in the reply will have an equal size. To achieve this the start_interval,
+                             end_interval and nb_datapoint in the reply may differ from the ones requested.
+                               * The start_interval may be smaller than requested
+                               * The end_interval may be larger than requested
+                               * The nb_datapoints may be larger than requested
     :raises BadRequest: start_interval >= end_interval
     :raises BadRequest: nb_datapoints < 0
     :raises BadRequest: The provided metrics list is an empty list.
     :raises BadRequest: The start_interval and end_interval are not separated from each other by at least nb_datapoints minutes
                         separated from each other.
-    :raises BadRequest: The round_timestamps_to_previous_hour parameter is set to True and the amount of hours between
+    :raises BadRequest: The round_timestamps parameter is set to True and the amount of hours between
                         start_interval and end_interval is less than the requested number of datapoints.
     """
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1298,6 +1298,7 @@ def get_environment_metrics(
     start_interval: datetime.datetime,
     end_interval: datetime.datetime,
     nb_datapoints: int,
+    round_timestamps_to_previous_hour: bool = False,
 ) -> model.EnvironmentMetricsResult:
     """
     Obtain metrics about the given environment for the given time interval.
@@ -1307,6 +1308,7 @@ def get_environment_metrics(
     :param start_interval: The start of the time window for which the metrics should be returned.
     :param end_interval: The end of the time window for which the metrics should be returned.
     :param nb_datapoints: The amount of datapoint that will be returned within the given time interval for each metric.
+    :param round_timestamps_to_previous_hour: True iff the returned timestamps are rounded to the previous hour.
     """
 
 

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -336,12 +336,8 @@ class EnvironmentMetricsService(protocol.ServerSlice):
             hour_in_time_window_rounded: int = math.floor(
                 (end_interval - start_interval).total_seconds() / nb_time_windows / 3600
             )
-            start_interval: datetime = self._round_timestamp_for_interval(
-                start_interval, hour_in_time_window_rounded, round_up=False
-            )
-            end_interval: datetime = self._round_timestamp_for_interval(
-                end_interval, hour_in_time_window_rounded, round_up=True
-            )
+            start_interval = self._round_timestamp_for_interval(start_interval, hour_in_time_window_rounded, round_up=False)
+            end_interval = self._round_timestamp_for_interval(end_interval, hour_in_time_window_rounded, round_up=True)
             nb_time_windows = int((end_interval - start_interval).total_seconds() / (hour_in_time_window_rounded * 3600))
         total_seconds_in_interval: float = (end_interval - start_interval).total_seconds()
         seconds_per_time_window = math.floor(total_seconds_in_interval / nb_time_windows)

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -1493,11 +1493,13 @@ async def test_cleanup_environment_metrics(init_dataclasses_and_load_schema, env
             assert sorted([r.timestamp for r in result], reverse=True) == timestamps_metrics[0:3]
 
 
+@pytest.mark.parametrize("request_nr_datapoints", [2, 3])
 async def test_get_environment_metrics_api_endpoint_round_to_prev_hour(
     server_with_dummy_metric_collectors,
     client,
     project_default,
     environment_creator: Callable[[protocol.Client, str, str, bool], Awaitable[str]],
+    request_nr_datapoints: int,
 ):
     """
     Verify whether the get_environment_metrics() endpoint rounds the timestamps correctly when the
@@ -1505,36 +1507,92 @@ async def test_get_environment_metrics_api_endpoint_round_to_prev_hour(
     """
     env_id = await environment_creator(client, project_default, env_name="env1")
 
-    start_interval = datetime(year=2023, month=1, day=1, hour=9, minute=20, second=22, microsecond=33).astimezone()
-    await data.EnvironmentMetricsGauge.insert_many(
-        [
-            data.EnvironmentMetricsGauge(
-                environment=uuid.UUID(env_id),
-                metric_name="gauge_metric1",
-                category=DEFAULT_CATEGORY,
-                timestamp=start_interval + timedelta(minutes=i * 15),
-                count=1,
-            )
-            for i in range(20)
-        ]
-    )
+    await data.EnvironmentMetricsGauge(
+        environment=uuid.UUID(env_id),
+        metric_name="gauge_metric1",
+        category=DEFAULT_CATEGORY,
+        timestamp=datetime(year=2023, month=1, day=1, hour=2, minute=15, second=23, microsecond=43).astimezone(),
+        count=5,
+    ).insert()
+    await data.EnvironmentMetricsGauge(
+        environment=uuid.UUID(env_id),
+        metric_name="gauge_metric1",
+        category=DEFAULT_CATEGORY,
+        timestamp=datetime(year=2023, month=1, day=1, hour=2, minute=45, second=11, microsecond=12).astimezone(),
+        count=3,
+    ).insert()
+    await data.EnvironmentMetricsGauge(
+        environment=uuid.UUID(env_id),
+        metric_name="gauge_metric1",
+        category=DEFAULT_CATEGORY,
+        timestamp=datetime(year=2023, month=1, day=1, hour=3, minute=33, second=25, microsecond=0).astimezone(),
+        count=7,
+    ).insert()
+    await data.EnvironmentMetricsGauge(
+        environment=uuid.UUID(env_id),
+        metric_name="gauge_metric1",
+        category=DEFAULT_CATEGORY,
+        timestamp=datetime(year=2023, month=1, day=1, hour=4, minute=10, second=1, microsecond=1).astimezone(),
+        count=1,
+    ).insert()
+    await data.EnvironmentMetricsGauge(
+        environment=uuid.UUID(env_id),
+        metric_name="gauge_metric1",
+        category=DEFAULT_CATEGORY,
+        timestamp=datetime(year=2023, month=1, day=1, hour=4, minute=40, second=1, microsecond=1).astimezone(),
+        count=9,
+    ).insert()
+    await data.EnvironmentMetricsGauge(
+        environment=uuid.UUID(env_id),
+        metric_name="gauge_metric1",
+        category=DEFAULT_CATEGORY,
+        timestamp=datetime(year=2023, month=1, day=1, hour=5, minute=10, second=20, microsecond=10).astimezone(),
+        count=20,
+    ).insert()
 
-    nb_datapoints = 2
-    start_interval_plus_3h = start_interval + timedelta(hours=3)
+    start_interval = datetime(year=2023, month=1, day=1, hour=2, minute=30, second=52, microsecond=33).astimezone()
+    end_interval = datetime(year=2023, month=1, day=1, hour=5, minute=40, second=34, microsecond=45).astimezone()
+    # Interval after rounding is: 2h00 - 6h00
     result = await client.get_environment_metrics(
         tid=env_id,
         metrics=["gauge_metric1"],
         start_interval=start_interval,
-        end_interval=start_interval_plus_3h,
-        nb_datapoints=nb_datapoints,
+        end_interval=end_interval,
+        nb_datapoints=request_nr_datapoints,
         round_timestamps_to_previous_hour=True,
     )
+
+    # An interval of four hours cannot be split equally in three parts that start and end on a full hour.
+    # As such, the number of datapoints is adjusted to 2.
+    expected_timestamps = [
+        get_as_naive_datetime(datetime(year=2023, month=1, day=1, hour=4).astimezone()),
+        get_as_naive_datetime(datetime(year=2023, month=1, day=1, hour=6).astimezone()),
+    ]
+
     assert result.code == 200, result.result
-    assert datetime.fromisoformat(result.result["data"]["start"]) == get_as_naive_datetime(start_interval)
-    assert datetime.fromisoformat(result.result["data"]["end"]) == get_as_naive_datetime(start_interval_plus_3h)
+    assert get_as_naive_datetime(start_interval) == datetime.fromisoformat(result.result["data"]["start"])
+    assert get_as_naive_datetime(end_interval) == datetime.fromisoformat(result.result["data"]["end"])
     timestamps = [datetime.fromisoformat(t) for t in result.result["data"]["timestamps"]]
     assert len(timestamps) == 2
-    assert timestamps[-1] == get_as_naive_datetime(start_interval_plus_3h.replace(minute=0, second=0, microsecond=0))
-    assert timestamps[0] == get_as_naive_datetime(
-        (start_interval_plus_3h - timedelta(hours=2)).replace(minute=0, second=0, microsecond=0)
+    assert timestamps == expected_timestamps
+    assert result.result["data"]["metrics"]["gauge_metric1"] == [5.0, 10.0]
+
+
+async def test_get_environment_metrics_interval_too_short(server_with_dummy_metric_collectors, client, environment):
+    """
+    Verify that an exception is raised when the get_environment_metrics() endpoint is called with the
+    round_timestamps_to_previous_hour set to True and the provided interval is too short with respect to the
+    number of requested datapoints.
+    """
+    result = await client.get_environment_metrics(
+        tid=environment,
+        metrics=["gauge_metric1"],
+        start_interval=datetime(year=2023, month=1, day=1, hour=6, minute=33).astimezone(),
+        end_interval=datetime(year=2023, month=1, day=1, hour=7, minute=22).astimezone(),
+        nb_datapoints=2,
+        round_timestamps_to_previous_hour=True,
     )
+    assert result.code == 400
+    assert "Invalid request: When round_timestamps_to_previous_hour is set to True, the number of hours between" \
+           " start_interval and end_interval should be at least the amount of hours equal to" \
+           " nb_datapoints." in result.result["message"]

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -1593,6 +1593,8 @@ async def test_get_environment_metrics_interval_too_short(server_with_dummy_metr
         round_timestamps_to_previous_hour=True,
     )
     assert result.code == 400
-    assert "Invalid request: When round_timestamps_to_previous_hour is set to True, the number of hours between" \
-           " start_interval and end_interval should be at least the amount of hours equal to" \
-           " nb_datapoints." in result.result["message"]
+    assert (
+        "Invalid request: When round_timestamps_to_previous_hour is set to True, the number of hours between"
+        " start_interval and end_interval should be at least the amount of hours equal to"
+        " nb_datapoints." in result.result["message"]
+    )


### PR DESCRIPTION
# Description

This PR adds support to the `GET /metrics` endpoint to round the returned timestamps to the previous hour

closes #6051

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
