### PR TITLE
try to resolve issue with coverage

### DIFF
--- a/changelogs/unreleased/fix-coverage-reporting-issue.yml
+++ b/changelogs/unreleased/fix-coverage-reporting-issue.yml
@@ -1,0 +1,3 @@
+description: Attempt to fix problem reporting code coverage
+change-type: patch
+destination-branches: [master, iso6, iso5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,7 @@ markers = [
     "db_restore_dump(dump): mark the db dump to restore. To be used in conjunction with the `migrate_db_from` fixture."
 ]
 log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"
+
+[tool.coverage.run]
+parallel = true
+branch = false

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps=
 extras=
     dataflow_graphic
 # Set the environment variable INMANTA_EXTRA_PYTEST_ARGS='--fast' to run in fast mode
-commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests
+commands=py.test --log-level DEBUG --cov=inmanta --cov-report term --cov-report xml --cov-config=pyproject.toml --junitxml=junit-{envname}.xml -vvv {env:INMANTA_EXTRA_PYTEST_ARGS:} --durations=50 tests
 # The HOME environment variable is required for Git to discover the user.email and
 # user.name config options (required by test case: tests/test_app.py::test_init_project)
 # The INMANTA_RETRY_LIMITED_MULTIPLIER is used to set a multiplier in the retry_limited function


### PR DESCRIPTION
# Description

Attempt to fix coverage problem where the build crashes with 

```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/_pytest/main.py", line 270, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/_pytest/main.py", line 324, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/pluggy/_hooks.py", line 433, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/pluggy/_manager.py", line 112, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/pluggy/_callers.py", line 133, in _multicall
INTERNALERROR>     teardown[0].send(outcome)
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/pytest_cov/plugin.py", line 298, in pytest_runtestloop
INTERNALERROR>     self.cov_controller.finish()
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/pytest_cov/engine.py", line 44, in ensure_topdir_wrapper
INTERNALERROR>     return meth(self, *args, **kwargs)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib/python3.11/site-packages/pytest_cov/engine.py", line 254, in finish
INTERNALERROR>     self.cov.combine()
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib64/python3.11/site-packages/coverage/control.py", line 832, in combine
INTERNALERROR>     combine_parallel_data(
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib64/python3.11/site-packages/coverage/data.py", line 171, in combine_parallel_data
INTERNALERROR>     data.update(new_data, aliases=aliases)
INTERNALERROR>   File "/home/jenkins/workspace/_core-postgresql-versions_master/project/inmanta-core/.tox/py/lib64/python3.11/site-packages/coverage/sqldata.py", line 658, in update
INTERNALERROR>     raise DataError("Can't combine arc data with line data")
INTERNALERROR> coverage.exceptions.DataError: Can't combine arc data with line data
```

Some threads on the bug tracker seem to suggest we need to explicitly set a config file 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
