### PR TITLE
Drop support for the legacy relationship syntax

### DIFF
--- a/changelogs/unreleased/remove-old-relationship-syntax.yml
+++ b/changelogs/unreleased/remove-old-relationship-syntax.yml
@@ -1,0 +1,8 @@
+---
+description: Removed support for the old relationship syntax from the compiler.
+issue-nr: 5265
+issue-repo: inmanta-core
+change-type: major
+destination-branches: [master]
+sections:
+  deprecation-note: "{{description}}"

--- a/changelogs/unreleased/remove-old-relationship-syntax.yml
+++ b/changelogs/unreleased/remove-old-relationship-syntax.yml
@@ -1,5 +1,5 @@
 ---
-description: Removed support for the old relationship syntax from the compiler.
+description: Removed support for the legacy relationship syntax from the compiler.
 issue-nr: 5265
 issue-repo: inmanta-core
 change-type: major

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -343,12 +343,6 @@ For example
 Relation multiplicities are enforced by the compiler. If they are violated a compilation error
 is issued.
 
-.. note::
-
-    In previous version another relation syntax was used that was less natural to read and allowed only bidirectional relations. The relation above was defined as ``File file [1:] -- [1] Service service``
-    This synax is deprecated but still widely used in many modules.
-
-
 .. _lang-instance:
 
 Instantiation

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -19,7 +19,6 @@ import functools
 import logging
 import re
 import string
-import warnings
 from collections import abc
 from dataclasses import dataclass
 from itertools import accumulate
@@ -56,7 +55,7 @@ from inmanta.ast.statements.define import (
 from inmanta.ast.statements.generator import ConditionalExpression, Constructor, For, If, ListComprehension, WrappedKwargs
 from inmanta.ast.variables import AttributeReference, Reference
 from inmanta.execute.util import NoneValue
-from inmanta.parser import InvalidNamespaceAccess, ParserException, SyntaxDeprecationWarning, plyInmantaLex
+from inmanta.parser import InvalidNamespaceAccess, ParserException, plyInmantaLex
 from inmanta.parser.cache import CacheManager
 from inmanta.parser.plyInmantaLex import reserved, tokens  # NOQA
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -511,56 +511,6 @@ def p_block(p: YaccProduction) -> None:
 
 
 # RELATION
-def p_relation_deprecated(p: YaccProduction) -> None:
-    "relation : class_ref ID multi REL multi class_ref ID"
-    if not (p[4] == "--"):
-        LOGGER.warning(
-            "DEPRECATION: use of %s in relation definition is deprecated, use -- (in %s)" % (p[4], Location(file, p.lineno(4)))
-        )
-    p[0] = DefineRelation((p[1], p[2], p[3]), (p[6], p[7], p[5]))
-    attach_lnr(p, 2)
-    deprecated_relation_warning(p)
-
-
-def p_relation_deprecated_comment(p: YaccProduction) -> None:
-    "relation : class_ref ID multi REL multi class_ref ID MLS"
-    if not (p[4] == "--"):
-        LOGGER.warning(
-            "DEPRECATION: use of %s in relation definition is deprecated, use -- (in %s)" % (p[4], Location(file, p.lineno(4)))
-        )
-    rel = DefineRelation((p[1], p[2], p[3]), (p[6], p[7], p[5]))
-    rel.comment = str(p[8])
-    p[0] = rel
-    attach_lnr(p, 2)
-    deprecated_relation_warning(p)
-
-
-def deprecated_relation_warning(p: YaccProduction) -> None:
-    def format_multi(multi: Tuple[int, Optional[int]]) -> str:
-        values: Tuple[str, str] = tuple(v if v is not None else "" for v in multi)
-        return "[%s:%s]" % values if values[0] != values[1] else "[%s]" % values[0]
-
-    warnings.warn(
-        SyntaxDeprecationWarning(
-            p[0].location,
-            None,
-            "The relation definition syntax"
-            " `{entity_left} {attr_left_on_right} {multi_left} {rel} {multi_right} {entity_right} {attr_right_on_left}`"
-            " is deprecated. Please use"
-            " `{entity_left}.{attr_right_on_left} {multi_right} -- {entity_right}.{attr_left_on_right} {multi_left}`"
-            " instead.".format(
-                entity_left=p[1],
-                attr_left_on_right=p[2],
-                multi_left=format_multi(p[3]),
-                rel=p[4],
-                multi_right=format_multi(p[5]),
-                entity_right=p[6],
-                attr_right_on_left=p[7],
-            ),
-        ),
-    )
-
-
 def p_relation_outer_comment(p: YaccProduction) -> None:
     "relation : relation_def MLS"
     rel = p[1]

--- a/tests/compiler/test_defaults.py
+++ b/tests/compiler/test_defaults.py
@@ -46,8 +46,8 @@ entity Test2:
 end
 implement Test2 using std::none
 
-Test1 test1 [1] -- [0:] Test2 test2
-Test1 test1 [0:1] -- [0:] Test2 test2
+Test1.test2 [0:] -- Test2.test1 [1]
+Test1.test2 [0:] -- Test2.test1 [0:1]
 """
     )
     with pytest.raises(DuplicateException):

--- a/tests/compiler/test_docs.py
+++ b/tests/compiler/test_docs.py
@@ -37,26 +37,6 @@ Each file needs to be associated with a host
     assert types["__config__::File"].get_attribute("host").comment.strip() == "Each file needs to be associated with a host"
 
 
-def test_doc_string_on_relation(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
-        """
-entity File:
-end
-
-entity Host:
-end
-
-File file [1] -- [0:] Host host
-\"""
-Each file needs to be associated with a host
-\"""
-"""
-    )
-    (types, _) = compiler.do_compile()
-    assert types["__config__::File"].get_attribute("host").comment.strip() == "Each file needs to be associated with a host"
-    assert types["__config__::Host"].get_attribute("file").comment.strip() == "Each file needs to be associated with a host"
-
-
 def test_function_in_typedef(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """

--- a/tests/compiler/test_docs.py
+++ b/tests/compiler/test_docs.py
@@ -18,7 +18,7 @@
 import inmanta.compiler as compiler
 
 
-def test_doc_string_on_new_relation(snippetcompiler):
+def test_doc_string_on_relation_unidir(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity File:
@@ -35,6 +35,24 @@ Each file needs to be associated with a host
     )
     (types, _) = compiler.do_compile()
     assert types["__config__::File"].get_attribute("host").comment.strip() == "Each file needs to be associated with a host"
+
+
+def test_doc_string_on_relation(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+entity File:
+end
+entity Host:
+end
+File.host [0:] -- Host.file [1]
+\"""
+Each file needs to be associated with a host
+\"""
+"""
+    )
+    (types, _) = compiler.do_compile()
+    assert types["__config__::File"].get_attribute("host").comment.strip() == "Each file needs to be associated with a host"
+    assert types["__config__::Host"].get_attribute("file").comment.strip() == "Each file needs to be associated with a host"
 
 
 def test_function_in_typedef(snippetcompiler):

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -56,7 +56,7 @@ entity Test2:
 end
 implement Test2 using std::none
 
-Test1 test1 [1] -- [0:] Test2 test2
+Test1.test2 [0:] -- Test2.test1 [1]
 
 a=Test1()
 b=Test2()

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -296,7 +296,7 @@ end
 implement Host using none
 implement File using none
 
-Host host [1] -- [0:] File files
+Host.files [0:] -- File.host [1]
 
 index Host(name)
 index File(host, name)

--- a/tests/compiler/test_list.py
+++ b/tests/compiler/test_list.py
@@ -23,7 +23,7 @@ import inmanta.compiler as compiler
 from inmanta.ast import AttributeException, OptionalValueException, RuntimeException
 
 
-def test_list_atributes(snippetcompiler):
+def test_list_attributes(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Jos:
@@ -61,7 +61,7 @@ d = Jos(bar = [], floom=["test","test2"])
     check_jos(scope.lookup("d"), [], floom=["test", "test2"])
 
 
-def test_list_atribute_type_violation_1(snippetcompiler):
+def test_list_attribute_type_violation_1(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Jos:
@@ -75,7 +75,7 @@ c = Jos()
         compiler.do_compile()
 
 
-def test_list_atribute_type_violation_2(snippetcompiler):
+def test_list_attribute_type_violation_2(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Jos:
@@ -89,7 +89,7 @@ c = Jos()
         compiler.do_compile()
 
 
-def test_list_atribute_type_violation_3(snippetcompiler):
+def test_list_attribute_type_violation_3(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Jos:
@@ -115,7 +115,7 @@ entity Test2:
 end
 implement Test2 using std::none
 
-Test1 tests [0:] -- [0:] Test2 tests
+Test1.tests [0:] -- Test2.tests [0:]
 
 t1 = Test1(tests=[])
 std::print(t1.tests)

--- a/tests/compiler/test_options.py
+++ b/tests/compiler/test_options.py
@@ -35,7 +35,7 @@ end
 
 implement Test2 using std::none
 
-Test1 test1 [1] -- [0:1] Test2 other
+Test1.other [0:1] -- Test2.test1 [1]
 
 implementation tt for Test1:
 
@@ -63,7 +63,7 @@ end
 
 implement Test2 using std::none
 
-Test1 test1 [1] -- [0:1] Test2 other
+Test1.other [0:1] -- Test2.test1 [1]
 
 implementation tt for Test1:
 

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -38,7 +38,7 @@ entity Test2:
 end
 implement Test2 using std::none
 
-Test1 test1 [1] -- [0:] Test2 test2
+Test1.test2 [0:] -- Test2.test1 [1]
 
 t = Test1()
 t2a = Test2(test1=t)
@@ -67,8 +67,8 @@ entity Test2:
 end
 implement Test2 using std::none
 
-Test1 test1 [1] -- [0:] Test2 test2
-Test1 test1 [1] -- [0:] Test2 floem
+Test1.test2 [0:] -- Test2.test1 [1]
+Test1.floem [0:] -- Test2.test1 [1]
 """
     )
     with pytest.raises(DuplicateException):
@@ -87,8 +87,8 @@ entity Test2:
 end
 implement Test2 using std::none
 
-Test1 test1 [1] -- [0:] Test2 test2
-Test1 test1 [1] -- [0:] Test1 test2
+Test1.test2 [0:] -- Test2.test1 [1]
+Test1.test2 [0:] -- Test1.test1 [1]
 """
     )
     with pytest.raises(DuplicateException):
@@ -112,8 +112,8 @@ end
 entity Agent:
 end
 
-Agent inmanta_agent   [1] -- [1] Oshost os_host
-Stdhost deploy_host [1] -- [0:1] Agent inmanta_agent
+Agent.os_host [1] -- Oshost.inmanta_agent [1]
+Stdhost.inmanta_agent [0:1] -- Agent.deploy_host [1]
 """
     )
     with pytest.raises(DuplicateException):
@@ -137,9 +137,9 @@ end
 entity Agent:
 end
 
-Oshost os_host [1] -- [1] Agent inmanta_agent
+Oshost.inmanta_agent [1] -- Agent.os_host [1]
 
-Stdhost deploy_host [1] -- [0:1] Agent inmanta_agent
+Stdhost.inmanta_agent [0:1] -- Agent.deploy_host [1]
 """
     )
     with pytest.raises(DuplicateException):
@@ -155,7 +155,7 @@ entity SpecialService extends std::Service:
 
 end
 
-std::Host host [1] -- [0:] SpecialService services_list"""
+std::Host.services_list [0:] -- SpecialService.host [1]"""
     )
     with pytest.raises(DuplicateException):
         compiler.do_compile()
@@ -177,7 +177,7 @@ end
 
 implement LogCollector using std::none
 
-LogCollector collectors [0:] -- [0:] LogFile logfiles
+LogCollector.logfiles [0:] -- LogFile.collectors [0:]
 
 lf1 = LogFile(name="lf1", collectors = [c1, c2], members=3)
 lf2 = LogFile(name="lf2", collectors = [c1, c2], members=2)
@@ -203,7 +203,7 @@ std::print([c1,c2,lf1,lf2,lf3,lf4,lf5,lf6,lf7,lf8])
         assert lf.get_attribute("members").get_value() == len(lf.get_attribute("collectors").get_value())
 
 
-def test_new_relation_syntax(snippetcompiler):
+def test_relation_syntax(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Test1:
@@ -230,7 +230,7 @@ Test2(test1 = b)
     assert len(scope.lookup("b").get_value().get_attribute("tests").get_value()) == 1
 
 
-def test_new_relation_with_annotation_syntax(snippetcompiler):
+def test_relation_with_annotation_syntax(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Test1:
@@ -259,7 +259,7 @@ Test2(test1 = b)
     assert len(scope.lookup("b").get_value().get_attribute("tests").get_value()) == 1
 
 
-def test_new_relation_uni_dir(snippetcompiler):
+def test_relation_uni_dir(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Test1:
@@ -284,7 +284,7 @@ a = Test1(tests=[Test2(),Test2()])
     assert len(scope.lookup("a").get_value().get_attribute("tests").get_value()) == 2
 
 
-def test_new_relation_uni_dir_double_define(snippetcompiler):
+def test_relation_uni_dir_double_define(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Test1:

--- a/tests/data/compile_138/main.cf
+++ b/tests/data/compile_138/main.cf
@@ -18,8 +18,8 @@ end
 entity Name:
 end
 
-Agent agent [1] -- [0:] Name names
-std::Host host [1] -- [0:1] Agent agent
+Name.agent [1] -- Agent.names [0:]
+Agent.host [1] -- std::Host.agent [0:1]
 
 implement Agent using std::none
 implement Name using std::none

--- a/tests/data/compile_test_1/main.cf
+++ b/tests/data/compile_test_1/main.cf
@@ -21,8 +21,8 @@ end
 
 implement OS using none
 
-OS os [1] -- [0:] Host host
-OS member [0:] -- [0:1] OS family
+Host.os [1] -- OS.host [0:]
+OS.member [0:] -- OS.family [0:1]
 
 entity ManagedDevice:
     """

--- a/tests/data/compile_test_index/main.cf
+++ b/tests/data/compile_test_index/main.cf
@@ -14,7 +14,7 @@ end
 implement Host using none
 implement File using none
 
-Host host [1] -- [0:] File files
+File.host [1] -- Host.files [0:]
 
 index Host(name)
 index File(host, name)

--- a/tests/data/compile_test_index_collission/main.cf
+++ b/tests/data/compile_test_index_collission/main.cf
@@ -14,7 +14,7 @@ end
 implement Host using none
 implement File using none
 
-Host host [1] -- [0:] File files
+File.host [1] -- Host.files [0:]
 
 index Host(name)
 index File(host, name)


### PR DESCRIPTION
# Description

Drop support for the legacy relationship syntax from the compiler.

closes #5265

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
