### PR TITLE
Fix test case that breaks when executing in different timezone

### DIFF
--- a/changelogs/unreleased/fix-timestamp-issue-in-tests.yml
+++ b/changelogs/unreleased/fix-timestamp-issue-in-tests.yml
@@ -1,0 +1,6 @@
+---
+description: Fix test case that breaks when run on a machine with a different default timestamp.
+issue-nr: 6051
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -1498,15 +1498,15 @@ async def test_cleanup_environment_metrics(init_dataclasses_and_load_schema, env
     [
         # Verify that the rounding works correctly
         (
-            datetime(year=2023, month=1, day=1, hour=2, minute=16, second=52, microsecond=33).astimezone(),
-            datetime(year=2023, month=1, day=2, hour=15, minute=12, second=22, microsecond=44).astimezone(),
+            datetime(year=2023, month=1, day=1, hour=2, minute=16, second=52, microsecond=33, tzinfo=timezone.utc),
+            datetime(year=2023, month=1, day=2, hour=15, minute=12, second=22, microsecond=44, tzinfo=timezone.utc),
             10,
         ),
         # Verify that no rounding is done when the given parameters are already rounded
         (
-            datetime(year=2023, month=1, day=1, hour=1).astimezone(),
-            datetime(year=2023, month=1, day=2, hour=16).astimezone(),
-            13,
+            datetime(year=2023, month=1, day=1, hour=0, tzinfo=timezone.utc),
+            datetime(year=2023, month=1, day=2, hour=18, tzinfo=timezone.utc),
+            14,
         ),
     ],
 )
@@ -1526,12 +1526,12 @@ async def test_get_environment_metrics_api_endpoint_round_timestamp(
     env_id = await environment_creator(client, project_default, env_name="env1")
 
     # The expected parameters after rounding
-    start_interval_reply = datetime(year=2023, month=1, day=1, hour=1).astimezone()
-    end_interval_reply = datetime(year=2023, month=1, day=2, hour=16).astimezone()
-    nb_datapoints_reply = 13
+    start_interval_reply = datetime(year=2023, month=1, day=1, hour=0, tzinfo=timezone.utc)
+    end_interval_reply = datetime(year=2023, month=1, day=2, hour=18, tzinfo=timezone.utc)
+    nb_datapoints_reply = 14
 
     # Insert one metric every hour
-    timestamp = datetime(year=2023, month=1, day=1, hour=0, minute=33, second=42).astimezone()
+    timestamp = datetime(year=2023, month=1, day=1, hour=0, minute=33, second=42, tzinfo=timezone.utc)
     while timestamp < end_interval_reply:
         await data.EnvironmentMetricsGauge(
             environment=uuid.UUID(env_id),


### PR DESCRIPTION
# Description

The timestamp inputs provided to the `test_get_environment_metrics_api_endpoint_round_timestamp` test case were using the default timezone of the machine the test case was executed on. As such, the test case used different inputs depending on the timezone it was executed on. This caused the test case when executing in the UTC timezone. This PR fixes that issue by using fixed inputs.

Belongs to #6051 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
