### PR TITLE
Drop PG10 as supported PG version

### DIFF
--- a/.ci-integration-tests-pg-versions.yml
+++ b/.ci-integration-tests-pg-versions.yml
@@ -1,6 +1,5 @@
 pipeline_template: ci/inmanta-extensions/Jenkinsfile-integration-tests-all-postgres-versions
 repo_name: inmanta-core
 postgresql_versions:
-    - 10 # The iso module still uses postgresql 10
     - 13
     - 14

--- a/changelogs/unreleased/drop-pg10-support.yml
+++ b/changelogs/unreleased/drop-pg10-support.yml
@@ -1,0 +1,4 @@
+---
+description: Drop PG10 from the list of supported PG versions.
+change-type: patch
+destination-branches: [master, iso6, iso5]


### PR DESCRIPTION
# Description

Drop PG10 from the list of supported PG versions. It's end of life.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~