### PR TITLE
pytest-inmanta-extensions: require exact same version for core

### DIFF
--- a/changelogs/unreleased/pytest-inmanta-extensions-fix.yml
+++ b/changelogs/unreleased/pytest-inmanta-extensions-fix.yml
@@ -1,0 +1,5 @@
+description: "pytest-inmanta-extensions: require exact same version for core"
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -24,7 +24,7 @@ version = "9.3.1"
 requires = [
     "asyncpg",
     "click",
-    f"inmanta-core~={version}.dev",
+    f"inmanta-core~={version}.0.dev",
     "pip2pi",
     "pyformance",
     "pytest-asyncio",


### PR DESCRIPTION
Motivation: renames of unstable names in core may require an update of pytest-inmanta-extensions as well. This is currently the cause for e.g. the extension template tests to break.