### PR TITLE
Drop equals injection in constraints of typedefs

### DIFF
--- a/changelogs/unreleased/5787-drop-equals-injection.yml
+++ b/changelogs/unreleased/5787-drop-equals-injection.yml
@@ -5,4 +5,4 @@ issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master]
 sections:
-  deprecation-note: "{{description}}"
+  deprecation-note: "The compiler no longer explicitly injects the implied `== true` for plugin calls in typedef constraints"

--- a/changelogs/unreleased/5787-drop-equals-injection.yml
+++ b/changelogs/unreleased/5787-drop-equals-injection.yml
@@ -1,0 +1,8 @@
+---
+description: Drop `== True` injection on constraints of a typedef.
+issue-nr: 5787
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master]
+sections:
+  deprecation-note: "{{description}}"

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -41,7 +41,6 @@ from inmanta.ast import (
 )
 from inmanta.ast.attribute import Attribute, RelationAttribute
 from inmanta.ast.blocks import BasicBlock
-from inmanta.ast.constraint.expression import Equals
 from inmanta.ast.entity import Entity, Implement, Implementation
 from inmanta.ast.statements import BiStatement, ExpressionStatement, Literal, Statement, TypeDefinitionStatement
 from inmanta.ast.type import TYPES, ConstraintType, NullableType, Type, TypedList

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -437,10 +437,6 @@ class DefineTypeConstraint(TypeDefinitionStatement):
         """
         contains_var = False
 
-        if hasattr(expression, "arguments"):
-            # some sort of function call
-            expression = Equals(expression, Literal(True))
-
         for var in expression.requires():
             if var == self.name or var == "self":
                 contains_var = True

--- a/tests/compiler/test_defaults.py
+++ b/tests/compiler/test_defaults.py
@@ -274,6 +274,6 @@ entity Test:
     std::date d = "nodatevalue"
 end
         """,
-        "Invalid value 'nodatevalue', does not match constraint `(std::validate_type('datetime.date',self) == true)`"
+        "Invalid value 'nodatevalue', does not match constraint `std::validate_type('datetime.date',self)`"
         " (reported in std::date d = 'nodatevalue' ({dir}/main.cf:3:15))",
     )

--- a/tests/compiler/test_typedef.py
+++ b/tests/compiler/test_typedef.py
@@ -105,7 +105,7 @@ entity A:
         mytype v = [42, 42]
 end
         """,
-        "Invalid value [42, 42], does not match constraint `(std::unique(self) == true)`"
+        "Invalid value [42, 42], does not match constraint `std::unique(self)`"
         " (reported in mytype v = List() ({dir}/main.cf:5:16))",
     )
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -568,30 +568,6 @@ typedef abc as string matching self in ["a","b","c"]
     assert [x.value for x in stmt.get_expression().children[1].items] == ["a", "b", "c"]
 
 
-def test_typedef_plugin_call():
-    """
-    If this test fails, the collection of validation types and
-    validation_parameters will fail in the LSM module.
-    plugin_call() must expand to (plugin_call() == true)
-    """
-    statements = parse_code(
-        """
-typedef abc as string matching std::is_base64_encoded(self)
-"""
-    )
-    assert len(statements) == 1
-    stmt = statements[0]
-    assert isinstance(stmt, DefineTypeConstraint)
-    assert str(stmt.name) == "abc"
-    assert str(stmt.basetype) == "string"
-    assert isinstance(stmt.get_expression(), Equals)
-    left_side_equals = stmt.get_expression()._arguments[0]
-    right_side_equals = stmt.get_expression()._arguments[1]
-    assert isinstance(left_side_equals, FunctionCall)
-    assert isinstance(right_side_equals, Literal)
-    assert isinstance(right_side_equals.value, bool) and right_side_equals.value
-
-
 def test_index():
     statements = parse_code(
         """


### PR DESCRIPTION
# Description

Drop `== True` injection on constraints of a typedef.

closes #5787

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
