### PR TITLE
Issue/6428 add config option for timezone aware datetimes on the api iso6

### DIFF
--- a/changelogs/unreleased/6428-add-config-options-for-timezone-aware-datetimes-on-the-api.yml
+++ b/changelogs/unreleased/6428-add-config-options-for-timezone-aware-datetimes-on-the-api.yml
@@ -1,0 +1,8 @@
+description: Add server config options server.tz_aware_timestamps and server.timezone to make the server return time-zone
+  aware timestamps and set the server's timezone, respectively.
+issue-nr: 6428
+change-type: minor
+destination-branches: [iso6]
+sections:
+  feature: "{{description}}"
+

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -87,7 +87,11 @@ from inmanta.server.validate_filter import (
     LogLevelFilter,
 )
 from inmanta.types import JsonType, SimpleTypes
+<<<<<<< HEAD
 from inmanta.util import datetime_utc_isoformat
+=======
+from inmanta.util import datetime_iso_format
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 
 T_ORDER = TypeVar("T_ORDER", bound=DatabaseOrderV2)
 T_DTO = TypeVar("T_DTO", bound=BaseModel)
@@ -390,8 +394,14 @@ class DataView(FilterValidator, Generic[T_ORDER, T_DTO], ABC):
             def value_to_string(value: Union[str, int, UUID, datetime]) -> str:
                 if isinstance(value, datetime):
                     # Accross API boundaries, all naive datetime instances are assumed UTC.
+<<<<<<< HEAD
                     # Returns ISO timestamp implicitly in UTC.
                     return datetime_utc_isoformat(value, naive_utc=True)
+=======
+                    # Returns ISO timestamp either implicitly in UTC (if server.tz_aware_timestamps is False)
+                    # or in the server's timezone (set by server.timezone).
+                    return datetime_iso_format(value, naive_utc=True)
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
                 return str(value)
 
             def make_link(**args: Optional[Union[str, int, UUID, datetime]]) -> str:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -792,7 +792,11 @@ class AgentManager(ServerSlice, SessionListener):
             **query,
         )
 
+<<<<<<< HEAD
         return 200, {"agents": [a.to_dict() for a in ags], "servertime": util.datetime_utc_isoformat(datetime.now())}
+=======
+        return 200, {"agents": [a.to_dict() for a in ags], "servertime": util.datetime_iso_format(datetime.now())}
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 
     @handle(methods.get_state, env="tid")
     async def get_state(self, env: data.Environment, sid: uuid.UUID, agent: str) -> Apireturn:

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -118,6 +118,25 @@ def get_bind_port() -> int:
         )
         return Config.get("server_rest_transport", "port", 8888)
 
+server_tz_aware_timestamps = Option(
+    "server",
+    "tz_aware_timestamps",
+    False,
+    "Whether the server should return timezone aware timestamps. "
+    "If False the timestamps are in UTC (Time zone naive). "
+    "If True the timestamps are in the time zone set by the server.timezone config option.",
+    is_bool,
+)
+
+
+server_timezone = Option(
+    "server",
+    "timezone",
+    0,
+    "Used in combination with the server.tz_aware_timestamps when it is set to true, ignored otherwise. "
+    "Integer offset with relation to UTC.",
+    is_int,
+)
 
 server_enable_auth = Option("server", "auth", False, "Enable authentication on the server API", is_bool)
 server_auth_method = Option("server", "auth_method", None, "The authentication method to use: oidc or database", is_str_opt)

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -118,6 +118,10 @@ def get_bind_port() -> int:
         )
         return Config.get("server_rest_transport", "port", 8888)
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 server_tz_aware_timestamps = Option(
     "server",
     "tz_aware_timestamps",
@@ -125,11 +129,16 @@ server_tz_aware_timestamps = Option(
     "Whether the server should return timezone aware timestamps. "
     "If False the timestamps are in UTC (Time zone naive). "
     "If True the timestamps are in the time zone set by the server.timezone config option.",
+<<<<<<< HEAD
     is_bool,
+=======
+    is_bool
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 )
 
 
 server_timezone = Option(
+<<<<<<< HEAD
     "server",
     "timezone",
     0,
@@ -138,6 +147,13 @@ server_timezone = Option(
     is_int,
 )
 
+=======
+    "server", "timezone", 0,
+    "Used in combination with the server.tz_aware_timestamps when it is set to true, ignored otherwise. "
+    "Integer offset with relation to UTC.",
+    is_int
+)
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 server_enable_auth = Option("server", "auth", False, "Enable authentication on the server API", is_bool)
 server_auth_method = Option("server", "auth_method", None, "The authentication method to use: oidc or database", is_str_opt)
 

--- a/src/inmanta/server/services/paramservice.py
+++ b/src/inmanta/server/services/paramservice.py
@@ -282,7 +282,11 @@ class ParameterService(protocol.ServerSlice):
                 "parameters": params,
                 "expire": self._fact_expire,
                 # Return datetime in UTC without explicit timezone offset
+<<<<<<< HEAD
                 "now": util.datetime_utc_isoformat(datetime.datetime.now()),
+=======
+                "now": util.datetime_iso_format(datetime.datetime.now()),
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
             },
         )
 

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -394,7 +394,11 @@ class ResourceService(protocol.ServerSlice):
         logline = {
             "level": "INFO",
             "msg": "Setting deployed due to known good status",
+<<<<<<< HEAD
             "timestamp": util.datetime_utc_isoformat(timestamp),
+=======
+            "timestamp": util.datetime_iso_format(timestamp),
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
             "args": [],
         }
         await self.resource_action_update(

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -45,6 +45,7 @@ from tornado import gen
 
 from crontab import CronTab
 from inmanta import COMPILER_VERSION
+from inmanta.server.config import server_timezone, server_tz_aware_timestamps
 from inmanta.stable_api import stable_api
 from inmanta.types import JsonType, PrimitiveTypes, ReturnTypes
 
@@ -406,6 +407,12 @@ def datetime_utc_isoformat(timestamp: datetime.datetime, *, naive_utc: bool = Fa
         if timestamp.tzinfo is None and naive_utc
         else timestamp.astimezone(datetime.timezone.utc).replace(tzinfo=None)
     )
+
+    if server_tz_aware_timestamps:
+        return naive_utc_timestamp.astimezone(datetime.timezone(timedelta(hours=server_timezone))).isoformat(
+            timespec="microseconds"
+        )
+
     return naive_utc_timestamp.isoformat(timespec="microseconds")
 
 

--- a/src/inmanta/util.py
+++ b/src/inmanta/util.py
@@ -36,6 +36,7 @@ from asyncio import CancelledError, Future, Lock, Task, ensure_future, gather
 from collections import abc, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from datetime import timedelta
 from logging import Logger
 from types import TracebackType
 from typing import Awaitable, BinaryIO, Callable, Coroutine, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar, Union
@@ -48,6 +49,10 @@ from inmanta import COMPILER_VERSION
 from inmanta.server.config import server_timezone, server_tz_aware_timestamps
 from inmanta.stable_api import stable_api
 from inmanta.types import JsonType, PrimitiveTypes, ReturnTypes
+<<<<<<< HEAD
+=======
+from inmanta.server.config import server_tz_aware_timestamps, server_timezone
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 
 LOGGER = logging.getLogger(__name__)
 SALT_SIZE = 16
@@ -395,9 +400,18 @@ def get_free_tcp_port() -> str:
         return str(port)
 
 
+<<<<<<< HEAD
 def datetime_utc_isoformat(timestamp: datetime.datetime, *, naive_utc: bool = False) -> str:
     """
     Returns a timestamp ISO string in implicit UTC.
+=======
+def datetime_iso_format(timestamp: datetime.datetime, *, naive_utc: bool = False) -> str:
+    """
+    Returns a timestamp ISO string. The :inmanta.config:option:`server.tz_aware_timestamps` config
+    option determines whether this timestamp is time-zone aware (in the time-zone configured in
+    :inmanta.config:option:`server.timezone`) or in UTC.
+
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 
     :param timestamp: The timestamp to get the ISO string for.
     :param naive_utc: Whether to interpret naive timestamps as UTC. By default naive timestamps are assumed to be in local time.
@@ -407,11 +421,16 @@ def datetime_utc_isoformat(timestamp: datetime.datetime, *, naive_utc: bool = Fa
         if timestamp.tzinfo is None and naive_utc
         else timestamp.astimezone(datetime.timezone.utc).replace(tzinfo=None)
     )
+<<<<<<< HEAD
 
     if server_tz_aware_timestamps:
         return naive_utc_timestamp.astimezone(datetime.timezone(timedelta(hours=server_timezone))).isoformat(
             timespec="microseconds"
         )
+=======
+    if server_tz_aware_timestamps:
+        return naive_utc_timestamp.astimezone(datetime.timezone(timedelta(hours=server_timezone))).isoformat(timespec="microseconds")
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 
     return naive_utc_timestamp.isoformat(timespec="microseconds")
 
@@ -452,7 +471,11 @@ def api_boundary_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable
     """
     if isinstance(o, datetime.datetime):
         # Accross API boundaries, all naive datetime instances are assumed UTC. Returns ISO timestamp implicitly in UTC.
+<<<<<<< HEAD
         return datetime_utc_isoformat(o, naive_utc=True)
+=======
+        return datetime_iso_format(o, naive_utc=True)
+>>>>>>> 851ca785 ([WIP] add options to make the server return timezone aware timestamps)
 
     return _custom_json_encoder(o)
 


### PR DESCRIPTION
# Description
Part of https://github.com/inmanta/inmanta-core/issues/6428


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
