### PR TITLE
Improve visual appearance of the compiler on failure

### DIFF
--- a/changelogs/unreleased/improve-visual-appearence-compiler.yml
+++ b/changelogs/unreleased/improve-visual-appearence-compiler.yml
@@ -1,0 +1,8 @@
+---
+description: Improve the output of the `inmanta compile` and `inmanta export` commands to make it more clear to the end-user when the command failed.
+issue-nr: 5258
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -678,7 +678,7 @@ class CompileSummaryReporter:
 
     def is_failure(self) -> bool:
         """
-        Return iff an exception has occurred during the compile or export stage.
+        Return true iff an exception has occurred during the compile or export stage.
         """
         return self.compiler_exception.has_exception() or self.exporter_exception.has_exception()
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -668,7 +668,7 @@ class ExceptionCollector:
 
 class CompileSummaryReporter:
     """
-    Contains the logic to print a summary at the end of the `inmanta compile` of `inmanta export`
+    Contains the logic to print a summary at the end of the `inmanta compile` or `inmanta export`
     command that provides an overview on whether the command was successful or not.
     """
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -714,6 +714,7 @@ class CompileSummaryReporter:
         """
         assert self.is_failure()
         if self.compiler_exception.has_exception():
+            assert self.compiler_exception.exception is not None
             return self.compiler_exception.exception
         else:
             assert self.exporter_exception.exception is not None

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -770,7 +770,7 @@ class CompileSummaryReporter:
 
     def print_summary_and_exit(self, show_stack_traces: bool) -> None:
         """
-        Print the compile summary and exit with a 0 status code in case success or 1 in case of failure.
+        Print the compile summary and exit with a 0 status code in case of success or 1 in case of failure.
         """
         self.print_summary(show_stack_traces)
         exit(1 if self.is_failure() else 0)

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -656,7 +656,7 @@ class ExceptionCollector:
         return self.exception is not None
 
     @contextlib.contextmanager
-    def capture(self) -> abc.Iterator[None]:
+    def capture(self) -> abc.Iterator["ExceptionCollector"]:
         """
         Record any exceptions raised within the context manager. The exception will not be re-raised.
         """
@@ -716,13 +716,13 @@ class CompileSummaryReporter:
         if self.compiler_exception.has_exception():
             return self.compiler_exception.exception
         else:
+            assert self.exporter_exception.exception is not None
             return self.exporter_exception.exception
 
     def _get_error_message(self) -> str:
         """
         Return the error message associated with `self._get_exception_to_report()`.
         """
-        assert self.is_failure()
         exc = self._get_exception_to_report()
         if isinstance(exc, CompilerException):
             error_message = exc.format_trace(indent="  ").strip("\n")
@@ -741,7 +741,6 @@ class CompileSummaryReporter:
         """
         Return the stack trace associated with `self._get_exception_to_report()`.
         """
-        assert self.is_failure()
         exc = self._get_exception_to_report()
         return "".join(traceback.format_exception(exc)).strip("\n")
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -30,9 +30,9 @@
     @command annotation to register new command
 """
 import argparse
-import dataclasses
-import contextlib
 import asyncio
+import contextlib
+import dataclasses
 import enum
 import json
 import logging
@@ -373,6 +373,7 @@ def compile_project(options: argparse.Namespace) -> None:
     if options.profile:
         import cProfile
         import pstats
+
         with summary_reporter.compiler_exception.capture():
             cProfile.runctx("do_compile()", globals(), {}, "run.profile")
         p = pstats.Stats("run.profile")
@@ -648,6 +649,7 @@ class ExceptionCollector:
     """
     This class defines a context manager that captures any unhandled exception raised within the context.
     """
+
     exception: Optional[Exception] = None
 
     def has_exception(self) -> bool:


### PR DESCRIPTION
# Description

Improve visual appearance of the compiler on failure

closes #5258 

# Self Check:

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
