### PR TITLE
switch to mono time

### DIFF
--- a/changelogs/unreleased/session_timer_to_monotonic_time.yml
+++ b/changelogs/unreleased/session_timer_to_monotonic_time.yml
@@ -1,0 +1,3 @@
+description: Put session timer on monotonic time
+change-type: Patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -464,7 +464,7 @@ class Session(object):
         await self._sessionstore.expire(self, timeout)
 
     def seen(self, endpoint_names: Set[str]) -> None:
-        self._seen = time.time()
+        self._seen = time.monotonic()
         self.endpoint_names = endpoint_names
 
     async def _handle_timeout(self, future: asyncio.Future, timeout: int, log_message: str) -> None:


### PR DESCRIPTION
# Description

I observed a negative timeout here, switched to mono time 



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
