### PR TITLE
Don't set undeployable resources in deploying state

### DIFF
--- a/changelogs/unreleased/dont-run-handler-when-no-code.yml
+++ b/changelogs/unreleased/dont-run-handler-when-no-code.yml
@@ -1,0 +1,6 @@
+---
+description: Don't set a resource to the deploying state if that resource is undeployable.
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -211,6 +211,13 @@ class ResourceAction(ResourceActionBase):
             # Explicit cast is required because mypy has issues with * and generics
             results: List[ResourceActionResult] = cast(List[ResourceActionResult], await asyncio.gather(*waiters))
 
+            if self.undeployable:
+                self.status = self.undeployable
+                self.change = const.Change.nochange
+                self.changes = {}
+                self.future.set_result(ResourceActionResult(cancel=False))
+                return
+
             async with self.scheduler.ratelimiter:
                 ctx = handler.HandlerContext(self.resource, logger=self.logger)
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -211,26 +211,6 @@ class ResourceAction(ResourceActionBase):
             # Explicit cast is required because mypy has issues with * and generics
             results: List[ResourceActionResult] = cast(List[ResourceActionResult], await asyncio.gather(*waiters))
 
-            if self.undeployable:
-                self.running = True
-                try:
-                    if self.is_done():
-                        # Action is cancelled
-                        self.logger.log(const.LogLevel.TRACE.to_int, "%s %s is no longer active" % (self.gid, self.resource))
-                        return
-                    result = sum(results, ResourceActionResult(cancel=False))
-                    if result.cancel:
-                        # self.running will be set to false when self.cancel is called
-                        # Only happens when global cancel has not cancelled us but our predecessors have already been cancelled
-                        return
-                    self.status = self.undeployable
-                    self.change = const.Change.nochange
-                    self.changes = {}
-                    self.future.set_result(ResourceActionResult(cancel=False))
-                finally:
-                    self.running = False
-                return
-
             async with self.scheduler.ratelimiter:
                 ctx = handler.HandlerContext(self.resource, logger=self.logger)
 
@@ -256,14 +236,14 @@ class ResourceAction(ResourceActionBase):
                         # Only happens when global cancel has not cancelled us but our predecessors have already been cancelled
                         return
 
-                    try:
-                        requires: Dict[ResourceIdStr, const.ResourceState] = await self.send_in_progress(ctx.action_id)
-                    except Exception:
-                        ctx.set_status(const.ResourceState.failed)
-                        ctx.exception("Failed to report the start of the deployment to the server")
+                    if self.undeployable is not None:
+                        ctx.set_status(self.undeployable)
                     else:
-                        if self.undeployable is not None:
-                            ctx.set_status(self.undeployable)
+                        try:
+                            requires: Dict[ResourceIdStr, const.ResourceState] = await self.send_in_progress(ctx.action_id)
+                        except Exception:
+                            ctx.set_status(const.ResourceState.failed)
+                            ctx.exception("Failed to report the start of the deployment to the server")
                         else:
                             await self._execute(ctx=ctx, requires=requires)
 

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -3256,12 +3256,6 @@ async def test_deploy_no_code(resource_container, client, clienthelper, environm
     """
     Test retrieving facts from the agent when there is no handler code available. We use an autostarted agent, these
     do not have access to the handler code for the resource_container.
-
-    Expected logs:
-        * Deploy action: Start run/End run
-        * Deploy action: Failed to load handler code or install handler code
-        * Pull action
-        * Store action
     """
     resource_container.Provider.reset()
     resource_container.Provider.set("agent1", "key", "value")
@@ -3277,21 +3271,20 @@ async def test_deploy_no_code(resource_container, client, clienthelper, environm
 
     await _wait_until_deployment_finishes(client, environment, version)
     # The resource state and its logs are not set atomically. This call prevents a race condition.
-    await wait_until_logs_are_available(client, environment, resource_id, expect_nr_of_logs=4)
+    await wait_until_logs_are_available(client, environment, resource_id, expect_nr_of_logs=3)
 
     response = await client.get_resource(environment, resource_id, logs=True)
     assert response.code == 200
     result = response.result
-
     assert result["resource"]["status"] == "unavailable"
 
+    # Expected logs:
+    #   [0] Deploy action: Failed to load handler code or install handler code
+    #   [1] Pull action
+    #   [2] Store action
     assert result["logs"][0]["action"] == "deploy"
     assert result["logs"][0]["status"] == "unavailable"
-    assert "Start run for " in result["logs"][0]["messages"][0]["msg"]
-
-    assert result["logs"][1]["action"] == "deploy"
-    assert result["logs"][1]["status"] == "unavailable"
-    assert "Failed to load handler code " in result["logs"][1]["messages"][0]["msg"]
+    assert "Failed to load handler code " in result["logs"][0]["messages"][0]["msg"]
 
 
 async def test_issue_1662(resource_container, server, client, clienthelper, environment, monkeypatch, async_finalizer):


### PR DESCRIPTION
# Description

Fix bug where undeployable resources are briefly moved into the "deploying" state when their resource action executes. This fix also resolves a race condition in the `test_deploy_no_code` test case.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
