### PR TITLE
Fix issue with deploy_with_failure_masking test case

### DIFF
--- a/changelogs/unreleased/fix-deploy-with-failure-masking-test-case.yml
+++ b/changelogs/unreleased/fix-deploy-with-failure-masking-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix issue with the `test_6475_deploy_with_failure_masking` test case where it hits the max_client limit of Tornado."
+change-type: patch
+destination-branches: [iso6]

--- a/tests/agent_server/test_increment_interactions.py
+++ b/tests/agent_server/test_increment_interactions.py
@@ -29,7 +29,7 @@ LOGGER = logging.getLogger("test")
 
 @pytest.mark.slowtest
 async def test_6475_deploy_with_failure_masking(
-    server, agent: Agent, environment, resource_container, clienthelper, client, monkeypatch
+    server, agent: Agent, environment, resource_container, clienthelper, client, monkeypatch, no_agent_backoff
 ):
     """
     Consider:
@@ -72,9 +72,9 @@ async def test_6475_deploy_with_failure_masking(
 
     assert resource_container.Provider.readcount("agent1", "key2") == 0
     # deploy resource: success
-    result = await client.release_version(environment, v1, True)
+    result = await client.release_version(environment, v1, push=True)
     assert result.code == 200
-    await resource_container.wait_for_done_with_waiters(client, environment, v1, 2)
+    await resource_container.wait_for_done_with_waiters(client, environment, v1, wait_for_this_amount_of_resources_in_done=2)
 
     # start deploy but hang
     # Make it fail
@@ -85,20 +85,24 @@ async def test_6475_deploy_with_failure_masking(
 
     # add new version
     # hammer it with new versions!
-    new_versions_to_add = 20
+    # We use only 5 versions here (iso6), instead of the 20 version on iso7.
+    # This is done because iso6 doesn't use a different Tornado connection pool for the agent session.
+    # Using 20 versions here would result in hitting the max_client limit of Tornado, which would cause the
+    # session of the agent to expire, which would fail the test case.
+    new_versions_to_add = 5
     new_versions_pre = 1
 
-    versions = [await make_version() for i in range(new_versions_to_add)]
+    versions = [await make_version() for _ in range(new_versions_to_add)]
 
     for version in versions[0:new_versions_pre]:
-        result = await client.release_version(environment, version, False)
+        result = await client.release_version(environment, version, push=False)
         assert result.code == 200
 
     slowdown_queries(monkeypatch, delay=0.01)
 
     # let some run in parallel
     tasks = [
-        asyncio.create_task(client.release_version(environment, version, False)) for version in versions[new_versions_pre:]
+        asyncio.create_task(client.release_version(environment, version, push=False)) for version in versions[new_versions_pre:]
     ]
 
     # fail deploy


### PR DESCRIPTION
# Description

Fix issue with the `test_6475_deploy_with_failure_masking` test case where it hits the max_client limit of Tornado.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
