### PR TITLE
Fix race in test for incremental deploys

### DIFF
--- a/changelogs/unreleased/fix-race-in-incremental-deploy-test.yml
+++ b/changelogs/unreleased/fix-race-in-incremental-deploy-test.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix race condition in the `test_s_incremental_deploy_interrupts_full_deploy` test case where it could happen that a test::Wait resource was not notified."
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -2557,8 +2557,8 @@ async def test_s_incremental_deploy_interrupts_full_deploy(
     myagent_instance = agent._instances[agent_name]
 
     resource_container.Provider.set("agent1", "key1", "value1")
-    resource_container.Provider.set("agent1", "key1", "value1")
-    resource_container.Provider.set("agent1", "key1", "value1")
+    resource_container.Provider.set("agent1", "key2", "value1")
+    resource_container.Provider.set("agent1", "key3", "value1")
 
     def get_resources(version, value_resource_three):
         return [


### PR DESCRIPTION
# Description

This PR fixes a race condition in the `test_s_incremental_deploy_interrupts_full_deploy` test case. The old wait condition `wait_for_done_with_waiters(client, environment, version2)` returned as soon as all resources in version2 were deployed successfully. But in fact we should wait for two deployments in version2, one incremental deploy and one repair run that v2 interrupted.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
