### PR TITLE
Fix too eager overwrite of state by stale deploys

### DIFF
--- a/changelogs/unreleased/6475-prevent-too-eager-overwrite.yml
+++ b/changelogs/unreleased/6475-prevent-too-eager-overwrite.yml
@@ -1,0 +1,4 @@
+description: Fix for state overwriting introduced by #6486
+issue-nr: 6563
+change-type: patch
+destination-branches: [master, iso6]

--- a/changelogs/unreleased/6475-prevent-too-eager-overwrite.yml
+++ b/changelogs/unreleased/6475-prevent-too-eager-overwrite.yml
@@ -1,4 +1,4 @@
-description: Fix for state overwriting introduced by #6486
+description: "Fix for state overwriting introduced by #6486"
 issue-nr: 6563
 change-type: patch
 destination-branches: [master, iso6]

--- a/tests/agent_server/test_increment_interactions.py
+++ b/tests/agent_server/test_increment_interactions.py
@@ -28,8 +28,9 @@ LOGGER = logging.getLogger("test")
 
 
 @pytest.mark.slowtest
+@pytest.mark.parametrize("change_state", [False, True])
 async def test_6475_deploy_with_failure_masking(
-    server, agent: Agent, environment, resource_container, clienthelper, client, monkeypatch
+    server, agent: Agent, environment, resource_container, clienthelper, client, monkeypatch, change_state: bool
 ):
     """
     Consider:
@@ -58,7 +59,7 @@ async def test_6475_deploy_with_failure_masking(
             },
             {
                 "key": "key2",
-                "value": "value1",
+                "value": "value1" if not change_state else "value" + str(version),
                 "id": rvid2,
                 "send_event": False,
                 "purged": False,
@@ -128,6 +129,11 @@ async def test_6475_deploy_with_failure_masking(
     assert result.code == 200, result.result
     assert len(result.result["resources"]) == 1
     assert result.result["resources"][0]["resource_id"] == "test::Resource[agent1,key=key2]"
+    if not change_state:
+        assert result.result["resources"][0]["status"] == "failed"
+    else:
+        # issue 6563: don't overwrite available
+        assert result.result["resources"][0]["status"] == "available"
 
     result = await client.deploy(environment, agent_trigger_method=AgentTriggerMethod.push_incremental_deploy)
     assert result.code == 200

--- a/tests/agent_server/test_increment_interactions.py
+++ b/tests/agent_server/test_increment_interactions.py
@@ -41,6 +41,10 @@ async def test_6475_deploy_with_failure_masking(
     resource a[k=x],v=1 fails
 
     Now, the good state of v2 has masked the bad state of v1.
+
+    However, if the attribute hash changes between v1 and v2, failure masking can not happen,
+    so we don't need to prevent it
+    The change_state parameter ensure we support both cases
     """
 
     async def make_version() -> int:
@@ -59,6 +63,7 @@ async def test_6475_deploy_with_failure_masking(
             },
             {
                 "key": "key2",
+                # change the attribute hash in case we are testing that scenario
                 "value": "value1" if not change_state else "value" + str(version),
                 "id": rvid2,
                 "send_event": False,


### PR DESCRIPTION
# Description

Fix too eager overwrite of state by stale deploys

closes  #6563 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
