### PR TITLE
Add validation_type method from std module (iso6)

### DIFF
--- a/changelogs/unreleased/move-validate-type-method-to-core.yml
+++ b/changelogs/unreleased/move-validate-type-method-to-core.yml
@@ -1,0 +1,8 @@
+---
+description: Moved the `validate_type` logic from the std module to inmanta-core.
+issue-nr: 6540
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/move-validate-type-method-to-core.yml
+++ b/changelogs/unreleased/move-validate-type-method-to-core.yml
@@ -3,6 +3,6 @@ description: Moved the `validate_type` logic from the std module to inmanta-core
 issue-nr: 6540
 issue-repo: inmanta-core
 change-type: minor
-destination-branches: [master]
+destination-branches: [iso6]
 sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-COMPILER_VERSION = "2023.4"
+COMPILER_VERSION = "2023.3"
 RUNNING_TESTS = False
 """
     This is enabled/disabled by the test suite when tests are run.

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-COMPILER_VERSION = "2023.3"
+COMPILER_VERSION = "2023.4"
 RUNNING_TESTS = False
 """
     This is enabled/disabled by the test suite when tests are run.

--- a/src/inmanta/validation_type.py
+++ b/src/inmanta/validation_type.py
@@ -1,0 +1,82 @@
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import importlib
+from collections import abc
+from typing import Optional
+
+import pydantic
+
+from inmanta.stable_api import stable_api
+from inmanta.types import PrimitiveTypes
+
+
+@stable_api
+def validate_type(
+    fq_type_name: str, value: PrimitiveTypes, validation_parameters: Optional[abc.Mapping[str, object]] = None
+) -> None:
+    """
+    Check whether `value` satisfies the constraints of type `fq_type_name`. When the given type (fq_type_name)
+    requires validation_parameters, they can be provided using the optional `validation_parameters` argument.
+
+    The following types require validation_parameters:
+
+        * pydantic.condecimal:
+            gt: Decimal = None
+            ge: Decimal = None
+            lt: Decimal = None
+            le: Decimal = None
+            max_digits: int = None
+            decimal_places: int = None
+            multiple_of: Decimal = None
+        * pydantic.confloat and pydantic.conint:
+            gt: float = None
+            ge: float = None
+            lt: float = None
+            le: float = None
+            multiple_of: float = None,
+        * pydantic.constr:
+            min_length: int = None
+            max_length: int = None
+            curtail_length: int = None (Only verify the regex on the first curtail_length characters)
+            regex: str = None          (The regex is verified via Pattern.match())
+        * pydantic.stricturl:
+            min_length: int = 1
+            max_length: int = 2 ** 16
+            tld_required: bool = True
+            allowed_schemes: Optional[Set[str]] = None
+
+    :raises ValueError: When the given fq_type_name is an unsupported type name.
+    :raises pydantic.ValidationError: The provided value didn't pass type validation.
+    """
+    if not (
+        fq_type_name.startswith("pydantic.")
+        or fq_type_name.startswith("datetime.")
+        or fq_type_name.startswith("ipaddress.")
+        or fq_type_name.startswith("uuid.")
+    ):
+        raise ValueError(f"Unknown fq_type_name: {fq_type_name}")
+    module_name, type_name = fq_type_name.split(".", 1)
+    module = importlib.import_module(module_name)
+    t = getattr(module, type_name)
+    # Construct pydantic model
+    if validation_parameters is not None:
+        model = pydantic.create_model(fq_type_name, value=(t(**validation_parameters), ...))
+    else:
+        model = pydantic.create_model(fq_type_name, value=(t, ...))
+    # Do validation
+    model(value=value)

--- a/tests/test_validation_type.py
+++ b/tests/test_validation_type.py
@@ -1,0 +1,60 @@
+"""
+    Copyright 2023 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+from typing import Optional
+
+import pydantic
+import pytest
+
+from inmanta.validation_type import validate_type
+
+
+@pytest.mark.parametrize(
+    "attr_type,value,validation_parameters,is_valid",
+    [
+        ("pydantic.condecimal", 8, {"gt": 0, "lt": 10}, True),
+        ("pydantic.condecimal", 8, {"gt": 0, "lt": 5}, False),
+        ("pydantic.confloat", 1.5, {"multiple_of": 0.5}, True),
+        ("pydantic.confloat", 1.5, {"multiple_of": 0.2}, False),
+        ("pydantic.conint", 4, {"ge": 4}, True),
+        ("pydantic.conint", 4, {"ge": 5}, False),
+        ("pydantic.constr", "test123", {"regex": "^test.*$"}, True),
+        ("pydantic.constr", "test123", {"regex": "^tst.*$"}, False),
+        (
+            "pydantic.stricturl",
+            "http://test:8080",
+            {"tld_required": False},
+            True,
+        ),
+        (
+            "pydantic.stricturl",
+            "http://test:8080",
+            {"tld_required": True},
+            False,
+        ),
+    ],
+)
+def test_type_validation(attr_type: str, value: str, validation_parameters: dict[str, object], is_valid: bool) -> None:
+    """
+    Test the behavior of the inmanta.validation_type.validate_type method.
+    """
+    validation_error: Optional[pydantic.ValidationError] = None
+    try:
+        validate_type(attr_type, value, validation_parameters)
+    except pydantic.ValidationError as e:
+        validation_error = e
+    assert (validation_error is None) is is_valid, validation_error


### PR DESCRIPTION
# Description

**Same PR as #6572 but on iso6**

This ticket moves the `validation_type()` method from the std module to inmanta-core.

closes #6540 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
