### PR TITLE
Increase timeout on get status_call method of a servers slice

### DIFF
--- a/changelogs/unreleased/6599-increase-timeout-get-status-method.yml
+++ b/changelogs/unreleased/6599-increase-timeout-get-status-method.yml
@@ -1,0 +1,8 @@
+---
+description: "Increase the timeout on the status method of a server slice 1s to prevent undesired timeouts on the status page of the web-console."
+issue-nr: 6599
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -130,7 +130,7 @@ class Server(protocol.ServerSlice):
 
         async def collect_for_slice(slice_name: str, slice: protocol.ServerSlice) -> SliceStatus:
             try:
-                return SliceStatus(name=slice_name, status=await asyncio.wait_for(slice.get_status(), 0.1))
+                return SliceStatus(name=slice_name, status=await asyncio.wait_for(slice.get_status(), 1))
             except asyncio.TimeoutError:
                 return SliceStatus(
                     name=slice_name,
@@ -141,7 +141,7 @@ class Server(protocol.ServerSlice):
                 )
             except Exception:
                 LOGGER.error(
-                    f"The following error occured while trying to determine the status of slice {slice_name}",
+                    f"The following error occurred while trying to determine the status of slice {slice_name}",
                     exc_info=True,
                 )
                 return SliceStatus(name=slice_name, status={"error": "An unexpected error occurred, reported to server log"})

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -54,6 +54,9 @@ class Server(protocol.ServerSlice):
     compiler: "CompilerService"
     _server: protocol.Server
 
+    # The number of seconds after which the call to the get_status() endpoint of a server slice should time out.
+    GET_SERVER_STATUS_TIMEOUT: int = 1
+
     def __init__(self) -> None:
         super().__init__(name=SLICE_SERVER)
         LOGGER.info("Starting server endpoint")
@@ -130,7 +133,10 @@ class Server(protocol.ServerSlice):
 
         async def collect_for_slice(slice_name: str, slice: protocol.ServerSlice) -> SliceStatus:
             try:
-                return SliceStatus(name=slice_name, status=await asyncio.wait_for(slice.get_status(), 1))
+                return SliceStatus(
+                    name=slice_name,
+                    status=await asyncio.wait_for(slice.get_status(), self.GET_SERVER_STATUS_TIMEOUT),
+                )
             except asyncio.TimeoutError:
                 return SliceStatus(
                     name=slice_name,

--- a/tests/server/test_server_status.py
+++ b/tests/server/test_server_status.py
@@ -18,6 +18,7 @@
 import asyncio
 
 from inmanta import data
+from inmanta.server.server import Server
 from inmanta.server.services.compilerservice import CompilerService
 
 
@@ -53,6 +54,8 @@ async def test_server_status_database_unreachable(server, client):
 
 
 async def test_server_status_timeout(server, client, monkeypatch):
+    monkeypatch.setattr(Server, "GET_SERVER_STATUS_TIMEOUT", 0.1)
+
     async def hang(self):
         await asyncio.sleep(0.2)
         return {}


### PR DESCRIPTION
# Description

Increase the timeout on the status method of a server slice 1s to prevent undesired timeouts on the status page of the web-console.

closes #6599 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
