### PR TITLE
resource_deploy_done called without calling resource_deploy_start

### DIFF
--- a/changelogs/unreleased/6589-undeployable-resource-handling.yml
+++ b/changelogs/unreleased/6589-undeployable-resource-handling.yml
@@ -1,0 +1,6 @@
+---
+description: Fix issue where `resource_deploy_done()` raises an exception because `resource_deploy_start()` was never called.
+issue-nr: 6589
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -211,6 +211,25 @@ class ResourceAction(ResourceActionBase):
             # Explicit cast is required because mypy has issues with * and generics
             results: List[ResourceActionResult] = cast(List[ResourceActionResult], await asyncio.gather(*waiters))
 
+            if self.undeployable:
+                self.running = True
+                try:
+                    if self.is_done():
+                        # Action is cancelled
+                        self.logger.log(const.LogLevel.TRACE.to_int, "%s %s is no longer active" % (self.gid, self.resource))
+                        return
+                    result = sum(results, ResourceActionResult(cancel=False))
+                    if result.cancel:
+                        # self.running will be set to false when self.cancel is called
+                        # Only happens when global cancel has not cancelled us but our predecessors have already been cancelled
+                        return
+                    self.status = self.undeployable
+                    self.change = const.Change.nochange
+                    self.changes = {}
+                    self.future.set_result(ResourceActionResult(cancel=False))
+                finally:
+                    self.running = False
+
             async with self.scheduler.ratelimiter:
                 ctx = handler.HandlerContext(self.resource, logger=self.logger)
 
@@ -236,16 +255,13 @@ class ResourceAction(ResourceActionBase):
                         # Only happens when global cancel has not cancelled us but our predecessors have already been cancelled
                         return
 
-                    if self.undeployable is not None:
-                        ctx.set_status(self.undeployable)
+                    try:
+                        requires: Dict[ResourceIdStr, const.ResourceState] = await self.send_in_progress(ctx.action_id)
+                    except Exception:
+                        ctx.set_status(const.ResourceState.failed)
+                        ctx.exception("Failed to report the start of the deployment to the server")
                     else:
-                        try:
-                            requires: Dict[ResourceIdStr, const.ResourceState] = await self.send_in_progress(ctx.action_id)
-                        except Exception:
-                            ctx.set_status(const.ResourceState.failed)
-                            ctx.exception("Failed to report the start of the deployment to the server")
-                        else:
-                            await self._execute(ctx=ctx, requires=requires)
+                        await self._execute(ctx=ctx, requires=requires)
 
                     ctx.debug(
                         "End run for resource %(resource)s in deploy %(deploy_id)s",

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -227,6 +227,7 @@ class ResourceAction(ResourceActionBase):
                     self.change = const.Change.nochange
                     self.changes = {}
                     self.future.set_result(ResourceActionResult(cancel=False))
+                    return
                 finally:
                     self.running = False
 


### PR DESCRIPTION
# Description

It seems it was not required to call `resource_deploy_done()` for undeployable resources. The `resource_action_update()` method called by the `release_version()` API endpoint for undeployable resource invokes the `mark_done_if_done()` method. If the model consists of undeployable resources, the `release_version()` method make sure the status of the model is set to deployed.

closes #6589 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
