### PR TITLE
Issue/6586 document in not in operators

### DIFF
--- a/changelogs/unreleased/6586-document-in-and-not-in.yml
+++ b/changelogs/unreleased/6586-document-in-and-not-in.yml
@@ -1,0 +1,5 @@
+description: Document the proper way to configure a project to access a private python package repository
+issue-nr: 6586
+change-type: patch
+destination-branches: [master]
+

--- a/changelogs/unreleased/6586-document-in-and-not-in.yml
+++ b/changelogs/unreleased/6586-document-in-and-not-in.yml
@@ -1,4 +1,4 @@
-description: Document the proper way to configure a project to access a private python package repository
+description: Add documentation for 'in' and 'not in' operators
 issue-nr: 6586
 change-type: patch
 destination-branches: [master]

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -208,13 +208,13 @@ The ``in`` and ``not in`` operators can be used to check if a value is present i
     myfiles = ["/a/b/c", "/c/d/e", "x/y/z/u/v/w"]
 
     condition1 = "/a/b/c" in myfiles # evaluates to True
-    condition2 = "/a/b/d" in myfiles # evaluates to False
+    condition2 = "/f/g/h" in myfiles # evaluates to False
 
     condition3 = "/a/b/c" not in myfiles # evaluates to False
-    condition4 = "/a/b/d" not in myfiles # evaluates to True
+    condition4 = "/f/g/h" not in myfiles # evaluates to True
 
     condition5 = not "/a/b/c" in myfiles # evaluates to False
-    condition6 = not "/a/b/d" in myfiles # evaluates to True
+    condition6 = not "/f/g/h" in myfiles # evaluates to True
 
 
 The ``is defined`` keyword checks if a value was assigned to an attribute or a relation of a certain entity. The following

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -195,9 +195,30 @@ value. It can have the following forms
         | value
         | value ('>' | '>=' | '<' | '<=' | '==' | '!=') value
         | value 'in' value
+        | value 'not in' value
         | functioncall
         | value 'is' 'defined'
         ;
+
+
+The ``in`` and ``not in`` operators can be used to check if a value is present in a list:
+
+.. code-block:: inmanta
+
+    myfiles = ["/a/b/c", "/c/d/e", "x/y/z/u/v/w"]
+
+    condition1 = "/a/b/c" in myfiles # evaluates to True
+    condition2 = "/a/b/d" in myfiles # evaluates to False
+
+    condition3 = "/a/b/c" not in myfiles # evaluates to False
+    condition4 = "/a/b/d" not in myfiles # evaluates to True
+
+    condition5 = not "/a/b/c" in myfiles # evaluates to False
+    condition6 = not "/a/b/d" in myfiles # evaluates to True
+
+
+
+
 
 The ``is defined`` keyword checks if a value was assigned to an attribute or a relation of a certain entity. The following
 example sets the monitoring configuration on a certain host when it has a monitoring server associated:

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -217,9 +217,6 @@ The ``in`` and ``not in`` operators can be used to check if a value is present i
     condition6 = not "/a/b/d" in myfiles # evaluates to True
 
 
-
-
-
 The ``is defined`` keyword checks if a value was assigned to an attribute or a relation of a certain entity. The following
 example sets the monitoring configuration on a certain host when it has a monitoring server associated:
 


### PR DESCRIPTION
# Description

document 'in' and 'not in' operators

closes #6586 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
