### PR TITLE
fix #5680

### DIFF
--- a/changelogs/unreleased/5680-opanapiurl.yml
+++ b/changelogs/unreleased/5680-opanapiurl.yml
@@ -1,0 +1,6 @@
+description: Make sure openapi UI works when ssl is enabled
+issue-nr: 5680
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -20,7 +20,6 @@ import json
 import re
 from typing import Callable, Dict, List, Optional, Type, Union
 
-from pydantic.networks import AnyUrl
 from pydantic.schema import model_schema
 from pydantic.typing import NoneType
 from typing_inspect import get_args, get_origin, is_generic_type
@@ -70,8 +69,11 @@ class OpenApiConverter:
     def _collect_server_information(self) -> List[Server]:
         bind_port = config.get_bind_port()
         server_address = config.server_address.get()
+        protocol = "https" if config.ssl_enabled() else "http"
         return [
-            Server(url=AnyUrl(url=f"http://{server_address}:{bind_port}/", scheme="http", host=server_address, port=bind_port))
+            Server(
+                url=f"{protocol}://{server_address}:{bind_port}/",
+            )
         ]
 
     def _get_inmanta_version(self) -> Optional[str]:

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -18,6 +18,7 @@
 
 import logging
 import warnings
+from typing import Optional
 
 from inmanta.config import (
     Config,
@@ -129,6 +130,14 @@ server_ssl_key = Option(
 server_ssl_cert = Option(
     "server", "ssl_cert_file", None, "SSL certificate file for the server key. Leave blank to disable SSL", is_str_opt
 )
+
+
+def ssl_enabled():
+    """Is ssl enabled on the server, given the current server config"""
+    ssl_key: Optional[str] = server_ssl_key.get()
+    ssl_cert: Optional[str] = server_ssl_cert.get()
+    return ssl_key is not None and ssl_cert is not None
+
 
 server_ssl_ca_cert = Option(
     "server",

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -39,7 +39,7 @@ from inmanta.protocol.openapi.converter import (
     OperationHandler,
 )
 from inmanta.protocol.openapi.model import MediaType, OpenApiDataTypes, ParameterType, Schema
-from inmanta.server import SLICE_SERVER
+from inmanta.server import SLICE_SERVER, config
 from inmanta.server.extensions import FeatureManager
 from inmanta.server.protocol import Server
 
@@ -179,13 +179,22 @@ def api_methods_fixture(clean_reset):
         return ""
 
 
-async def test_generate_openapi_definition(server: Server, feature_manager: FeatureManager):
+async def test_generate_openapi_definition(server: Server):
+    feature_manager = server.get_slice(SLICE_SERVER).feature_manager
     global_url_map = server._transport.get_global_url_map(server.get_slices().values())
     openapi = OpenApiConverter(global_url_map, feature_manager)
     openapi_json = openapi.generate_openapi_json()
     assert openapi_json
     openapi_parsed = json.loads(openapi_json)
     openapi_v30_spec_validator.validate(openapi_parsed)
+    assert "https" not in openapi_parsed["servers"][0]["url"]
+    # enable https
+    config.server_ssl_key.set("ssl_key")
+    config.server_ssl_cert.set("ssl_cert")
+    openapi_json = openapi.generate_openapi_json()
+    assert openapi_json
+    openapi_parsed = json.loads(openapi_json)
+    assert "https" in openapi_parsed["servers"][0]["url"]
 
 
 def test_filter_api_methods(server, api_methods_fixture, feature_manager):


### PR DESCRIPTION
# Description

Make sure proper url is produced 

closes #5680 

# Mypy

I introduced a type error, but I think this is the pydantic mypy extension being imprecise, because it works just fine and the way I use it now is the way it is documented.... 

(e.g. the example [here](https://docs.pydantic.dev/1.10/usage/types/#url-properties) )

 
```diff
+ src/inmanta/protocol/openapi/converter.py:75: error: Argument "url" to "Server" has incompatible type "str"; expected "AnyUrl"  [arg-type]
``` 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
