### PR TITLE
Configure postgresql to stop queries when the connection drops (#6614)

### DIFF
--- a/changelogs/unreleased/make_postgresql_drop_dead_queries.yml
+++ b/changelogs/unreleased/make_postgresql_drop_dead_queries.yml
@@ -1,0 +1,5 @@
+description: Configure postgresql connections to stop queries one second after connection loss
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -6327,6 +6327,9 @@ async def connect(
         min_size=connection_pool_min_size,
         max_size=connection_pool_max_size,
         timeout=connection_timeout,
+        server_settings={
+            "client_connection_check_interval": "1000",  # make server check the tpc connection every 1 second
+        },
     )
     try:
         set_connection_pool(pool)


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #6614