### PR TITLE
Issue/6612 fix mypy error on delete cascade method

### DIFF
--- a/changelogs/unreleased/6612-fix-mypy-error-on-delete-cascade-method.yml
+++ b/changelogs/unreleased/6612-fix-mypy-error-on-delete-cascade-method.yml
@@ -2,4 +2,3 @@ description: Fix mypy error on delete_cascade method.
 issue-nr: 6612
 change-type: patch
 destination-branches: [master, iso6]
-sections:

--- a/changelogs/unreleased/6612-fix-mypy-error-on-delete-cascade-method.yml
+++ b/changelogs/unreleased/6612-fix-mypy-error-on-delete-cascade-method.yml
@@ -1,0 +1,5 @@
+description: Fix mypy error on delete_cascade method.
+issue-nr: 6612
+change-type: patch
+destination-branches: [master, iso6]
+sections:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2210,7 +2210,9 @@ class BaseDocument(object, metaclass=DocumentMeta):
         query = "DELETE FROM " + self.table_name() + " WHERE " + filter_as_string
         await self._execute_query(query, *values, connection=connection)
 
-    async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+    async def delete_cascade(
+        self, only_content: Optional[bool] = None, connection: Optional[asyncpg.connection.Connection] = None
+    ) -> None:
         await self.delete(connection=connection)
 
     @classmethod
@@ -2312,7 +2314,9 @@ class Project(BaseDocument):
     def to_dto(self) -> m.Project:
         return m.Project(id=self.id, name=self.name, environments=[])
 
-    async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+    async def delete_cascade(
+        self, only_content: Optional[bool] = None, connection: Optional[asyncpg.connection.Connection] = None
+    ) -> None:
         """
         This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
         As such, we perform the deletes on each table in a separate transaction.
@@ -2841,7 +2845,7 @@ class Environment(BaseDocument):
             await self.set(key, self._settings[key].default)
 
     async def delete_cascade(
-        self, only_content: bool = False, connection: Optional[asyncpg.connection.Connection] = None
+        self, only_content: Optional[bool] = False, connection: Optional[asyncpg.connection.Connection] = None
     ) -> None:
         """
         This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
@@ -5531,7 +5535,9 @@ class ConfigurationModel(BaseDocument):
         )
         return versions
 
-    async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+    async def delete_cascade(
+        self, only_content: Optional[bool] = None, connection: Optional[asyncpg.connection.Connection] = None
+    ) -> None:
         """
         This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
         As such, we perform the deletes on each table in a separate transaction.

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2842,7 +2842,7 @@ class Environment(BaseDocument):
 
     async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
-            Completely remove this environment from the db
+        Completely remove this environment from the db
         """
         async with self.get_connection(connection=connection) as con:
             await self.clear(connection=con)
@@ -2850,11 +2850,11 @@ class Environment(BaseDocument):
 
     async def clear(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
-            Delete everything related to this environment from the db, except the entry in the Environment table.
+        Delete everything related to this environment from the db, except the entry in the Environment table.
 
-            This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
-            This is especially true for the tables resourceaction_resource, resource and resourceaction, because they
-            have a high read/write load. As such, we perform the deletes on each table in a separate transaction.
+        This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
+        This is especially true for the tables resourceaction_resource, resource and resourceaction, because they
+        have a high read/write load. As such, we perform the deletes on each table in a separate transaction.
         """
         async with self.get_connection(connection=connection) as con:
             await Agent.delete_all(environment=self.id, connection=con)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2210,9 +2210,7 @@ class BaseDocument(object, metaclass=DocumentMeta):
         query = "DELETE FROM " + self.table_name() + " WHERE " + filter_as_string
         await self._execute_query(query, *values, connection=connection)
 
-    async def delete_cascade(
-        self, only_content: Optional[bool] = None, connection: Optional[asyncpg.connection.Connection] = None
-    ) -> None:
+    async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         await self.delete(connection=connection)
 
     @classmethod
@@ -2314,9 +2312,7 @@ class Project(BaseDocument):
     def to_dto(self) -> m.Project:
         return m.Project(id=self.id, name=self.name, environments=[])
 
-    async def delete_cascade(
-        self, only_content: Optional[bool] = None, connection: Optional[asyncpg.connection.Connection] = None
-    ) -> None:
+    async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
         This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
         As such, we perform the deletes on each table in a separate transaction.
@@ -2844,14 +2840,17 @@ class Environment(BaseDocument):
         else:
             await self.set(key, self._settings[key].default)
 
-    async def delete_cascade(
-        self, only_content: Optional[bool] = False, connection: Optional[asyncpg.connection.Connection] = None
-    ) -> None:
+    async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
         This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
         This is especially true for the tables resourceaction_resource, resource and resourceaction, because they
         have a high read/write load. As such, we perform the deletes on each table in a separate transaction.
         """
+        async with self.get_connection(connection=connection) as con:
+            await self.delete_content(connection=con)
+            await self.delete(connection=con)
+
+    async def delete_content(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         async with self.get_connection(connection=connection) as con:
             await Agent.delete_all(environment=self.id, connection=con)
             await AgentProcess.delete_all(environment=self.id, connection=con)  # Triggers cascading delete on agentinstance
@@ -2870,8 +2869,6 @@ class Environment(BaseDocument):
             await ResourceAction.delete_all(environment=self.id, connection=con)
             await Resource.delete_all(environment=self.id, connection=con)
             await ConfigurationModel.delete_all(environment=self.id, connection=con)
-            if not only_content:
-                await self.delete(connection=con)
 
     async def get_next_version(self, connection: Optional[asyncpg.connection.Connection] = None) -> int:
         """
@@ -5535,9 +5532,7 @@ class ConfigurationModel(BaseDocument):
         )
         return versions
 
-    async def delete_cascade(
-        self, only_content: Optional[bool] = None, connection: Optional[asyncpg.connection.Connection] = None
-    ) -> None:
+    async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
         This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
         As such, we perform the deletes on each table in a separate transaction.

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2842,15 +2842,20 @@ class Environment(BaseDocument):
 
     async def delete_cascade(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
-        This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
-        This is especially true for the tables resourceaction_resource, resource and resourceaction, because they
-        have a high read/write load. As such, we perform the deletes on each table in a separate transaction.
+            Completely remove this environment from the db
         """
         async with self.get_connection(connection=connection) as con:
-            await self.delete_content(connection=con)
+            await self.clear(connection=con)
             await self.delete(connection=con)
 
-    async def delete_content(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+    async def clear(self, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+        """
+            Delete everything related to this environment from the db, except the entry in the Environment table.
+
+            This method doesn't rely on the DELETE CASCADE functionality of PostgreSQL because it causes deadlocks.
+            This is especially true for the tables resourceaction_resource, resource and resourceaction, because they
+            have a high read/write load. As such, we perform the deletes on each table in a separate transaction.
+        """
         async with self.get_connection(connection=connection) as con:
             await Agent.delete_all(environment=self.id, connection=con)
             await AgentProcess.delete_all(environment=self.id, connection=con)  # Triggers cascading delete on agentinstance

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -499,7 +499,7 @@ class EnvironmentService(protocol.ServerSlice):
             raise Forbidden(f"Environment {env.id} is protected. See environment setting: {data.PROTECTED_ENVIRONMENT}")
 
         await self.autostarted_agent_manager.stop_agents(env)
-        await env.delete_cascade(only_content=True)
+        await env.delete_content()
 
         await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
         self._delete_environment_dir(env.id)

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -499,7 +499,7 @@ class EnvironmentService(protocol.ServerSlice):
             raise Forbidden(f"Environment {env.id} is protected. See environment setting: {data.PROTECTED_ENVIRONMENT}")
 
         await self.autostarted_agent_manager.stop_agents(env)
-        await env.delete_content()
+        await env.clear()
 
         await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
         self._delete_environment_dir(env.id)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -348,7 +348,7 @@ async def test_environment_cascade_content_only(init_dataclasses_and_load_schema
     assert (await data.UnknownParameter.get_by_id(unknown_parameter.id)) is not None
     assert (await env.get(data.AUTO_DEPLOY)) is True
 
-    await env.delete_cascade(only_content=True)
+    await env.delete_content()
 
     assert (await data.Project.get_by_id(project.id)) is not None
     assert (await data.Environment.get_by_id(env.id)) is not None

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -348,7 +348,7 @@ async def test_environment_cascade_content_only(init_dataclasses_and_load_schema
     assert (await data.UnknownParameter.get_by_id(unknown_parameter.id)) is not None
     assert (await env.get(data.AUTO_DEPLOY)) is True
 
-    await env.delete_content()
+    await env.clear()
 
     assert (await data.Project.get_by_id(project.id)) is not None
     assert (await data.Environment.get_by_id(env.id)) is not None


### PR DESCRIPTION
# Description

Fixes the following mypy error:

```
$ make mypy-diff 
- src/inmanta/data/__init__.py:2843: error: Signature of "delete_cascade" incompatible with supertype "BaseDocument"  [override]
- src/inmanta/data/__init__.py:2843: note:      Superclass:
- src/inmanta/data/__init__.py:2843: note:          def delete_cascade(self, connection: Optional[Connection] = ...) -> Coroutine[Any, Any, None]
- src/inmanta/data/__init__.py:2843: note:      Subclass:
- src/inmanta/data/__init__.py:2843: note:          def delete_cascade(self, only_content: bool = ..., connection: Optional[Connection] = ...) -> Coroutine[Any, Any, None]

```

closes #6612

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
