### PR TITLE
fixed openapi reference link

### DIFF
--- a/changelogs/unreleased/6338-docs-openapi-ref.yml
+++ b/changelogs/unreleased/6338-docs-openapi-ref.yml
@@ -1,0 +1,6 @@
+description: Fixed reference to OpenAPI docs to work from any page
+change-type: patch
+minor-improvement: "{{description}}"
+destination-branches:
+  - master
+  - iso6

--- a/changelogs/unreleased/6338-docs-openapi-ref.yml
+++ b/changelogs/unreleased/6338-docs-openapi-ref.yml
@@ -1,6 +1,7 @@
 description: Fixed reference to OpenAPI docs to work from any page
 change-type: patch
-minor-improvement: "{{description}}"
+sections:
+  minor-improvement: "{{description}}"
 destination-branches:
   - master
   - iso6

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -17,4 +17,4 @@ Inmanta, please check out the :doc:`../quickstart` guide.
     api
     json
     modules
-    REST API Reference <openapi.html#http://>
+    openapi

--- a/docs/reference/openapi.rst
+++ b/docs/reference/openapi.rst
@@ -1,0 +1,5 @@
+REST API reference
+==================
+
+..
+    This file will be overridden by the redoc-rendered API reference (see conf.py)


### PR DESCRIPTION
# Description

Fixes reference to OpenAPI docs so that it works when clicked on from nested pages. I added a sphinx file for the page so that we can refer to it using sphinx' native linking. The generated html will eventually be overrided by the redoc generated OpenAPI docs. I ran the docs build with this change and the resulting `openapi.html` was identical.

closes #6338 
