### PR TITLE
Issue/549 license extension fails to load when lsm extension is disabled

### DIFF
--- a/changelogs/unreleased/549-improve-docstrings.yml
+++ b/changelogs/unreleased/549-improve-docstrings.yml
@@ -1,4 +1,3 @@
 description: Fix typos in docstrings.
-issue-nr: 549
 change-type: patch
 destination-branches: [master, iso6]

--- a/changelogs/unreleased/549-improve-docstrings.yml
+++ b/changelogs/unreleased/549-improve-docstrings.yml
@@ -1,0 +1,4 @@
+description: Fix typos in docstrings.
+issue-nr: 549
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -105,7 +105,7 @@ class InmantaBootloader(object):
     @classmethod
     def get_available_extensions(cls) -> Dict[str, str]:
         """
-        Returns a dictionary of with all available inmanta extensions.
+        Returns a dictionary of all available inmanta extensions.
         The key contains the name of the extension and the value the fully qualified path to the python package.
         """
         if cls.AVAILABLE_EXTENSIONS is None:

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -47,7 +47,7 @@ from utils import log_contains
 
 @contextmanager
 def splice_extension_in(name: str) -> Generator[Any, Any, None]:
-    """Context manager to all extensions in tests/data/{name}/inmanta_ext/ to the interpreter and unload them again"""
+    """Context manager to load all extensions in tests/data/{name}/inmanta_ext/ to the interpreter and unload them again"""
     oldpath = sys.path
     try:
         sys.path = sys.path + [os.path.join(os.path.dirname(__file__), "data", name)]


### PR DESCRIPTION
# Description

Part of https://github.com/inmanta/inmanta-license/issues/549

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
