### PR TITLE
Fix exception message

### DIFF
--- a/changelogs/unreleased/fix-exception-typo.yml
+++ b/changelogs/unreleased/fix-exception-typo.yml
@@ -2,4 +2,4 @@ description: Fix jwt config error message to use the correct attribute and provi
 change-type: patch
 destination-branches: [master, iso6]
 sections:
-  feature: "{{description}}"
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-exception-typo.yml
+++ b/changelogs/unreleased/fix-exception-typo.yml
@@ -1,0 +1,5 @@
+description: Fix jwt config error message to use the correct attribute and provide more context
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  feature: "{{description}}"

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -631,7 +631,8 @@ class AuthJWTConfig(object):
             # HTTPError is raised for non-200 responses; the response
             # can be found in e.response.
             raise ValueError(
-                "Unable to load key data for %s using the provided jwks_uri. Got error: %s" % (self.section, e.response)
+                "Unable to load key data for %s using the provided jwks_uri %s. Got error: %s"
+                % (self.section, self.jwks_uri, e.reason)
             )
         except Exception as e:
             # Other errors are possible, such as IOError.


### PR DESCRIPTION
# Description

The exception message used the wrong attribute on the exception. This has never worked before.

I also added the url it tries to make the logs more clear.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
