### PR TITLE
Issue/6629 f strings do not trim whitespace

### DIFF
--- a/changelogs/unreleased/6629-f-strings-do-not-trim-whitespaces.yml
+++ b/changelogs/unreleased/6629-f-strings-do-not-trim-whitespaces.yml
@@ -1,0 +1,4 @@
+description: Fix bug in f-strings not working when whitespaces surround the variable.
+issue-nr: 6629
+change-type: patch
+destination-branches: [master, iso6]

--- a/changelogs/unreleased/6629-f-strings-do-not-trim-whitespaces.yml
+++ b/changelogs/unreleased/6629-f-strings-do-not-trim-whitespaces.yml
@@ -2,3 +2,5 @@ description: Fix bug in f-strings not working when whitespaces surround the vari
 issue-nr: 6629
 change-type: patch
 destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -622,9 +622,9 @@ class StringFormatV2(FormattedString):
     def __init__(self, format_string: str, variables: abc.Sequence[typing.Tuple["Reference", str]]) -> None:
         """
         :param format_string: The string on which to perform substitution
-        :param variables: Sequence of tuples each holding a reference to a variable to substitute in the format_string
-            and the name of this variable. This name is not used in practice since it's already present in the reference's
-            full_name attribute.
+        :param variables: Sequence of tuples each holding a clean reference (i.e. stripped of eventual whitespaces ) to a
+         variable to substitute in the format_string and the raw full name of this variable (i.e. including eventual
+         whitespaces).
         """
         only_refs: abc.Sequence["Reference"] = [k for (k, _) in variables]
         super().__init__(format_string, only_refs)

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -560,7 +560,7 @@ class FormattedString(ReferenceStatement):
     This class is an abstraction around a string containing references to variables.
     """
 
-    __slots__ = ("_format_string", "_variables")
+    __slots__ = "_format_string"
 
     def __init__(self, format_string: str, variables: abc.Sequence["Reference"]) -> None:
         super().__init__(variables)
@@ -578,7 +578,7 @@ class StringFormat(FormattedString):
     Create a new string by doing a string interpolation
     """
 
-    __slots__ = ()
+    __slots__ = "_variables"
 
     def __init__(self, format_string: str, variables: abc.Sequence[Tuple["Reference", str]]) -> None:
         super().__init__(format_string, [k for (k, _) in variables])
@@ -617,18 +617,18 @@ class StringFormatV2(FormattedString):
 
     """
 
-    __slots__ = ()
+    __slots__ = "_variables"
 
     def __init__(self, format_string: str, variables: abc.Sequence[typing.Tuple["Reference", str]]) -> None:
         """
         :param format_string: The string on which to perform substitution
-        :param variables: Sequence of tuples each holding a clean reference (i.e. stripped of eventual whitespaces ) to a
-         variable to substitute in the format_string and the raw full name of this variable (i.e. including eventual
+        :param variables: Sequence of tuples each holding a normalized reference (i.e. stripped of eventual whitespaces ) to a
+         variable to substitute in the format_string and the raw full name of this variable (i.e. including potential
          whitespaces).
         """
         only_refs: abc.Sequence["Reference"] = [k for (k, _) in variables]
         super().__init__(format_string, only_refs)
-        self._variables = {ref: full_name for (ref, full_name) in variables}
+        self._variables: abc.Mapping[Reference, str] = {ref: full_name for (ref, full_name) in variables}
 
     def execute(self, requires: typing.Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         super().execute(requires, resolver, queue)

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -628,7 +628,7 @@ class StringFormatV2(FormattedString):
         """
         only_refs: abc.Sequence["Reference"] = [k for (k, _) in variables]
         super().__init__(format_string, only_refs)
-        self._variables = {ref:full_name for (ref, full_name) in variables}
+        self._variables = {ref: full_name for (ref, full_name) in variables}
 
     def execute(self, requires: typing.Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         super().execute(requires, resolver, queue)

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -621,10 +621,10 @@ class StringFormatV2(FormattedString):
 
     def __init__(self, format_string: str, variables: abc.Sequence[typing.Tuple["Reference", str]]) -> None:
         """
-            :param format_string: The string on which to perform substitution
-            :param variables: Sequence of tuples each holding a reference to a variable to substitute in the format_string
-                and the name of this variable. This name is not used in practice since it's already present in the reference's
-                full_name attribute.
+        :param format_string: The string on which to perform substitution
+        :param variables: Sequence of tuples each holding a reference to a variable to substitute in the format_string
+            and the name of this variable. This name is not used in practice since it's already present in the reference's
+            full_name attribute.
         """
         only_refs: abc.Sequence["Reference"] = [k for (k, _) in variables]
         super().__init__(format_string, only_refs)

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -622,7 +622,6 @@ class StringFormatV2(FormattedString):
         only_refs: abc.Sequence["Reference"] = [k for (k, _) in variables]
         super().__init__(format_string, only_refs)
         self._variables = variables
-        # self._padded_names = padded_names
 
     def execute(self, requires: typing.Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         super().execute(requires, resolver, queue)

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -621,7 +621,8 @@ class StringFormatV2(FormattedString):
     def __init__(self, format_string: str, variables: abc.Sequence[typing.Tuple["Reference", str]]) -> None:
         only_refs: abc.Sequence["Reference"] = [k for (k, _) in variables]
         super().__init__(format_string, only_refs)
-        self._variables = only_refs
+        self._variables = variables
+        # self._padded_names = padded_names
 
     def execute(self, requires: typing.Dict[object, object], resolver: Resolver, queue: QueueScheduler) -> object:
         super().execute(requires, resolver, queue)
@@ -630,14 +631,14 @@ class StringFormatV2(FormattedString):
         # We can't cache the formatter because it has no ability to cache the parsed string
 
         kwargs = {}
-        for _var in self._variables:
+        for _var, _name in self._variables:
             value = _var.execute(requires, resolver, queue)
             if isinstance(value, Unknown):
                 return Unknown(self)
             if isinstance(value, float) and (value - int(value)) == 0:
                 value = int(value)
 
-            kwargs[_var.full_name] = value
+            kwargs[_name] = value
 
         result_string = formatter.vformat(self._format_string, args=[], kwargs=kwargs)
 

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -560,7 +560,7 @@ class FormattedString(ReferenceStatement):
     This class is an abstraction around a string containing references to variables.
     """
 
-    __slots__ = "_format_string"
+    __slots__ = ("_format_string",)
 
     def __init__(self, format_string: str, variables: abc.Sequence["Reference"]) -> None:
         super().__init__(variables)
@@ -578,7 +578,7 @@ class StringFormat(FormattedString):
     Create a new string by doing a string interpolation
     """
 
-    __slots__ = "_variables"
+    __slots__ = ("_variables",)
 
     def __init__(self, format_string: str, variables: abc.Sequence[Tuple["Reference", str]]) -> None:
         super().__init__(format_string, [k for (k, _) in variables])
@@ -617,7 +617,7 @@ class StringFormatV2(FormattedString):
 
     """
 
-    __slots__ = "_variables"
+    __slots__ = ("_variables",)
 
     def __init__(self, format_string: str, variables: abc.Sequence[typing.Tuple["Reference", str]]) -> None:
         """

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -67,7 +67,7 @@ tokens = ["INT", "FLOAT", "ID", "CID", "SEP", "STRING", "MLS", "CMP_OP", "REGEX"
 
 def t_FSTRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
     r"f(\"([^\\\"\n]|\\.)*\")|f(\'([^\\\'\n]|\\.)*\')"
-    t.value = t.value[2:-1]
+    t.value = safe_decode(token=t, warning_message="Invalid escape sequence in f-string.", start=2, end=-1)
     lexer = t.lexer
 
     end = lexer.lexpos - lexer.linestart + 1

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -900,13 +900,6 @@ def p_constant_fstring(p: YaccProduction) -> None:
         Associates a parsed field name with a locatable string
         """
         assert match[1]  # make mypy happy
-        # field_name_left_trim = match[1].lstrip()
-        # left_spaces: int = len(match[1]) - len(field_name_left_trim)
-        # field_name_full_trim = field_name_left_trim.rstrip()
-        # right_spaces: int = len(field_name_left_trim) - len(field_name_full_trim)
-
-        # range: Range = Range(p[1].location.file, start_lnr, start_char_pos + left_spaces, start_lnr, end_char - right_spaces)
-        # locatable_string = LocatableString(field_name_full_trim, range, p[1].lexpos, p[1].namespace)
         range: Range = Range(p[1].location.file, start_lnr, start_char_pos, start_lnr, end_char)
         locatable_string = LocatableString(match[1], range, p[1].lexpos, p[1].namespace)
         locatable_matches.append((match[1], locatable_string))

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -893,7 +893,9 @@ def p_constant_fstring(p: YaccProduction) -> None:
 
     locatable_matches: List[Tuple[str, LocatableString, Tuple[int, int]]] = []
 
-    def locate_match(match: Tuple[str, Optional[str], Optional[str], Optional[str]], start_char_pos: int, end_char: int) -> None:
+    def locate_match(
+        match: Tuple[str, Optional[str], Optional[str], Optional[str]], start_char_pos: int, end_char: int
+    ) -> None:
         """
         Associates a parsed field name with a locatable string
         """
@@ -939,7 +941,7 @@ def p_constant_fstring(p: YaccProduction) -> None:
                 start_char_pos += literal_text_len + inner_brackets_len
                 end_char = start_char_pos + inner_field_name_len
 
-                locate_match(submatch)
+                locate_match(submatch, start_char_pos, end_char)
                 start_char_pos += inner_field_name_len + inner_brackets_len
 
         start_char_pos += brackets_length
@@ -1039,7 +1041,7 @@ def convert_to_references(variables: List[Tuple[str, LocatableString, Tuple[int,
             # For a composite variable e.g. 'a.b.c', we only add the reference to the innermost attribute (e.g. 'c')
             _vars.append((ref, match))
         else:
-            _vars.append((ref, " "*padding[0]+match+" "*padding[1]))
+            _vars.append((ref, " " * padding[0] + match + " " * padding[1]))
     return _vars
 
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -1005,7 +1005,7 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
         potential whitespace characters.
     """
 
-    def normalize(variable: str, locatable: LocatableString, offset: Optional[int] = 0) -> LocatableString:
+    def normalize(variable: str, locatable: LocatableString, offset: int = 0) -> LocatableString:
         """
         Strip a variable of potential whitespaces and compute the locatable string.
         :param variable: String representation for a plain variable or composite part of a variable

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -1037,9 +1037,9 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
             )
             for attr, char_offset in zip(var_parts[1:], attribute_offsets):
                 field_name_left_trim = attr.lstrip()
-                left_spaces: int = len(attr) - len(field_name_left_trim)
+                left_spaces = len(attr) - len(field_name_left_trim)
                 field_name_full_trim = field_name_left_trim.rstrip()
-                right_spaces: int = len(field_name_left_trim) - len(field_name_full_trim)
+                right_spaces = len(field_name_left_trim) - len(field_name_full_trim)
 
                 range_attr: Range = Range(
                     var.location.file,

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -1001,8 +1001,9 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
         For f-strings:
             - The string is the plain variable name without brackets (ex: 'a.b') and including any potential whitespaces.
             - The LocatableString is the same as for regular string interpolation
-    :returns: A tuple where all LocatableString have been converted to Reference. The matching str holding the variable
-        name is left untouched
+    :returns: A tuple where all LocatableString have been converted to Reference. These references are cleaned up of any
+        eventual whitespace character. The matching str holding the variable name is left untouched i.e. will still contain
+        eventual whitespace characters.
     """
     assert namespace
     _vars: List[Tuple[Reference, str]] = []
@@ -1041,7 +1042,9 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
                     var.location.lnr,
                     char_offset + len(attr) - right_spaces,
                 )
-                attr_locatable_string: LocatableString = LocatableString(attr.strip(), range_attr, var.lexpos, var.namespace)
+                attr_locatable_string: LocatableString = LocatableString(
+                    field_name_full_trim, range_attr, var.lexpos, var.namespace
+                )
                 ref = AttributeReference(ref, attr_locatable_string)
                 ref.location = range_attr
                 ref.namespace = namespace

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -891,16 +891,26 @@ def p_constant_fstring(p: YaccProduction) -> None:
     start_lnr = p[1].location.lnr
     start_char_pos = p[1].location.start_char + 2  # FSTRING tokens begin with `f"` or `f'` of length 2
 
-    locatable_matches: List[Tuple[str, LocatableString]] = []
+    locatable_matches: List[Tuple[str, LocatableString, Tuple[int, int]]] = []
 
-    def locate_match(match: Tuple[str, Optional[str], Optional[str], Optional[str]]) -> None:
+    def locate_match(match: Tuple[str, Optional[str], Optional[str], Optional[str]], start_char_pos: int, end_char: int) -> None:
         """
         Associates a parsed field name with a locatable string
         """
-        range: Range = Range(p[1].location.file, start_lnr, start_char_pos, start_lnr, end_char)
+        # range: Range = Range(p[1].location.file, start_lnr, start_char_pos, start_lnr, end_char)
+        # assert match[1]  # make mypy happy
+        # locatable_string = LocatableString(match[1], range, p[1].lexpos, p[1].namespace)
+        # locatable_matches.append((match[1], locatable_string))
+
+        field_name_left_trim = match[1].lstrip()
+        left_spaces: int = len(match[1]) - len(field_name_left_trim)
+        field_name_full_trim = field_name_left_trim.rstrip()
+        right_spaces: int = len(field_name_left_trim) - len(field_name_full_trim)
+
+        range: Range = Range(p[1].location.file, start_lnr, start_char_pos + left_spaces, start_lnr, end_char - right_spaces)
         assert match[1]  # make mypy happy
-        locatable_string = LocatableString(match[1], range, p[1].lexpos, p[1].namespace)
-        locatable_matches.append((match[1], locatable_string))
+        locatable_string = LocatableString(field_name_full_trim, range, p[1].lexpos, p[1].namespace)
+        locatable_matches.append((field_name_full_trim, locatable_string, (left_spaces, right_spaces)))
 
     for match in parsed:
         if not match[1]:
@@ -912,7 +922,7 @@ def p_constant_fstring(p: YaccProduction) -> None:
         start_char_pos += literal_text_len + brackets_length
         end_char = start_char_pos + field_name_len
 
-        locate_match(match)
+        locate_match(match, start_char_pos, end_char)
         start_char_pos += field_name_len
 
         if match[2]:
@@ -979,12 +989,12 @@ def get_string_ast_node(string_ast: LocatableString, mls: bool) -> Union[Literal
         end_line, end_char = char_count_to_lnr_char(match.end(2))
         range: Range = Range(string_ast.location.file, start_line, start_char, end_line, end_char)
         locatable_string = LocatableString(match[2], range, string_ast.lexpos, string_ast.namespace)
-        locatable_matches.append((match[1], locatable_string))
+        locatable_matches.append((match[1], locatable_string, (0, 0)))
 
     return StringFormat(str(string_ast), convert_to_references(locatable_matches))
 
 
-def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[Tuple["Reference", str]]:
+def convert_to_references(variables: List[Tuple[str, LocatableString, Tuple[int, int]]]) -> List[Tuple["Reference", str]]:
     """
     This function is used in a context of string formatting. It expects variables that are part of a single line
     format string and converts them to a format that can be processed by StringFormat (for regular
@@ -1004,7 +1014,7 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
     """
     assert namespace
     _vars: List[Tuple[Reference, str]] = []
-    for match, var in variables:
+    for match, var, padding in variables:
         var_name: str = str(var)
         var_parts: List[str] = var_name.split(".")
         start_char = var.location.start_char
@@ -1029,7 +1039,7 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
             # For a composite variable e.g. 'a.b.c', we only add the reference to the innermost attribute (e.g. 'c')
             _vars.append((ref, match))
         else:
-            _vars.append((ref, match))
+            _vars.append((ref, " "*padding[0]+match+" "*padding[1]))
     return _vars
 
 

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -900,10 +900,10 @@ def p_constant_fstring(p: YaccProduction) -> None:
         Associates a parsed field name with a locatable string
         """
         # range: Range = Range(p[1].location.file, start_lnr, start_char_pos, start_lnr, end_char)
-        # assert match[1]  # make mypy happy
         # locatable_string = LocatableString(match[1], range, p[1].lexpos, p[1].namespace)
         # locatable_matches.append((match[1], locatable_string))
 
+        assert match[1]  # make mypy happy
         field_name_left_trim = match[1].lstrip()
         left_spaces: int = len(match[1]) - len(field_name_left_trim)
         field_name_full_trim = field_name_left_trim.rstrip()
@@ -985,7 +985,7 @@ def get_string_ast_node(string_ast: LocatableString, mls: bool) -> Union[Literal
         else:
             return start_lnr + lines, position - before.rindex("\n")
 
-    locatable_matches: List[Tuple[str, LocatableString]] = []
+    locatable_matches: List[Tuple[str, LocatableString, Tuple[int, int]]] = []
     for match in matches:
         start_line, start_char = char_count_to_lnr_char(match.start(2))
         end_line, end_char = char_count_to_lnr_char(match.end(2))

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -907,7 +907,7 @@ def p_constant_fstring(p: YaccProduction) -> None:
 
         range: Range = Range(p[1].location.file, start_lnr, start_char_pos + left_spaces, start_lnr, end_char - right_spaces)
         locatable_string = LocatableString(field_name_full_trim, range, p[1].lexpos, p[1].namespace)
-        locatable_matches.append((field_name_full_trim, locatable_string))
+        locatable_matches.append((match[1], locatable_string))
 
     for match in parsed:
         if not match[1]:
@@ -1004,7 +1004,7 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
             (ex. LocatableString("a.b", range(a.b), lexpos, namespace))
 
         For f-strings:
-            - The string is the plain variable name without brackets (ex: 'a.b')
+            - The string is the plain variable name without brackets (ex: 'a.b') and including any potential whitespaces.
             - The LocatableString is the same as for regular string interpolation
     :returns: A tuple where all LocatableString have been converted to Reference. The matching str holding the variable
         name is left untouched
@@ -1029,7 +1029,7 @@ def convert_to_references(variables: List[Tuple[str, LocatableString]]) -> List[
                 range_attr: Range = Range(
                     var.location.file, var.location.lnr, char_offset, var.location.lnr, char_offset + len(attr)
                 )
-                attr_locatable_string: LocatableString = LocatableString(attr, range_attr, var.lexpos, var.namespace)
+                attr_locatable_string: LocatableString = LocatableString(attr.strip(), range_attr, var.lexpos, var.namespace)
                 ref = AttributeReference(ref, attr_locatable_string)
                 ref.location = range_attr
                 ref.namespace = namespace

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -899,10 +899,6 @@ def p_constant_fstring(p: YaccProduction) -> None:
         """
         Associates a parsed field name with a locatable string
         """
-        # range: Range = Range(p[1].location.file, start_lnr, start_char_pos, start_lnr, end_char)
-        # locatable_string = LocatableString(match[1], range, p[1].lexpos, p[1].namespace)
-        # locatable_matches.append((match[1], locatable_string))
-
         assert match[1]  # make mypy happy
         field_name_left_trim = match[1].lstrip()
         left_spaces: int = len(match[1]) - len(field_name_left_trim)
@@ -1039,7 +1035,7 @@ def convert_to_references(variables: List[Tuple[str, LocatableString, Tuple[int,
                 ref.location = range_attr
                 ref.namespace = namespace
             # For a composite variable e.g. 'a.b.c', we only add the reference to the innermost attribute (e.g. 'c')
-            _vars.append((ref, match))
+            _vars.append((ref, " " * padding[0] + match + " " * padding[1]))
         else:
             _vars.append((ref, " " * padding[0] + match + " " * padding[1]))
     return _vars

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -906,7 +906,6 @@ def p_constant_fstring(p: YaccProduction) -> None:
         right_spaces: int = len(field_name_left_trim) - len(field_name_full_trim)
 
         range: Range = Range(p[1].location.file, start_lnr, start_char_pos + left_spaces, start_lnr, end_char - right_spaces)
-        assert match[1]  # make mypy happy
         locatable_string = LocatableString(field_name_full_trim, range, p[1].lexpos, p[1].namespace)
         locatable_matches.append((field_name_full_trim, locatable_string))
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -237,7 +237,7 @@ a = A(b=b)
 b = B(c=c)
 c = C()
 
-std::print(f"{  a.b.c. n_c }")
+std::print(f"{  a .b . c . n_c }")
         """
     )
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -248,12 +248,13 @@ std::print(f"{a.b.c.n_c}")
 
 def test_fstring_numbering_logic():
     """
-    Check that variable ranges in f-string are
+    Check that variable ranges in f-strings are correctly computed
     """
     statements = parse_code(
         """
 std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr   }")
-#                <> <->        <--->      <----->                   <--->
+#                |   |           |           |                        |
+#                [[ [-[        [---[      [-----[                   [---[     <--- expected ranges
         """
     )
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -182,10 +182,10 @@ std::print(z)
 @pytest.mark.parametrize(
     "f_string,expected_output",
     [
+        (r"f'{arg}'", "123\n"),
         (r"f'{arg}{arg}{arg}'", "123123123\n"),
         (r"f'{arg:@>5}'", "@@123\n"),
         (r"f'{arg:^5}'", " 123 \n"),
-        (r"f'{arg}'", "123\n"),
         (r"f' {  arg    } '", " 123 \n"),
     ],
 )
@@ -259,8 +259,8 @@ std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr   }")
     )
 
     def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
-        assert variable.location.start_char == start, (variable, start, end)
-        assert variable.location.end_char == end, (variable, start, end)
+        assert variable.location.start_char == start
+        assert variable.location.end_char == end
 
     # Ranges are 1-indexed [start:end[
     ranges = [

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -29,7 +29,7 @@ def test_multiline_string_interpolation(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 var = 42
-str = \"\"\"var == {{var}}\"\"\"
+str = \"\"\"var == {{   var }}\"\"\"
         """,
     )
     (_, scopes) = compiler.do_compile()
@@ -182,10 +182,11 @@ std::print(z)
 @pytest.mark.parametrize(
     "f_string,expected_output",
     [
-        (r"f'{arg}'", "123\n"),
-        (r"f'{arg}{arg}{arg}'", "123123123\n"),
-        (r"f'{arg:@>5}'", "@@123\n"),
-        (r"f'{arg:^5}'", " 123 \n"),
+        # (r"f'{arg}{arg}{arg}'", "123123123\n"),
+        # (r"f'{arg:@>5}'", "@@123\n"),
+        # (r"f'{arg:^5}'", " 123 \n"),
+        # (r"f'{arg}'", "123\n"),
+        (r"f' {  arg    } '", " 123 \n"),
     ],
 )
 def test_fstring_formatting(snippetcompiler, capsys, f_string, expected_output):

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -182,7 +182,7 @@ std::print(z)
 @pytest.mark.parametrize(
     "f_string,expected_output",
     [
-        (r"f'{   arg}'", "123\n"),
+        (r"f'{   arg }'", "123\n"),
         (r"f'{arg}'", "123\n"),
         (r"f'{arg}{arg}{arg}'", "123123123\n"),
         (r"f'{arg:@>5}'", "@@123\n"),
@@ -253,6 +253,8 @@ def test_fstring_numbering_logic():
     """
     statements = parse_code(
         """
+#        10        20        30        40        50        60        70        80
+#        |         |         |         |         |         |         |         |
 std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  \tpadded.sub.attr   }")
 #                |   |           |           |                          |
 #               [-][--]       [----]     [------]                    [----]    <--- expected ranges
@@ -260,8 +262,10 @@ std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  \tpadded.sub.attr   }")
     )
 
     def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
-        assert variable.location.start_char == start
-        assert variable.location.end_char == end
+        assert variable.location.start_char == start, print(
+            f"{variable=} expected {start=} got {variable.location.start_char=}"
+        )
+        assert variable.location.end_char == end, print(f"{variable=} expected {end=} got {variable.location.end_char=}")
 
     # Ranges are 1-indexed [start:end[
     ranges = [

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -182,11 +182,12 @@ std::print(z)
 @pytest.mark.parametrize(
     "f_string,expected_output",
     [
-        (r"f'{arg}'", "123\n"),
-        (r"f'{arg}{arg}{arg}'", "123123123\n"),
-        (r"f'{arg:@>5}'", "@@123\n"),
-        (r"f'{arg:^5}'", " 123 \n"),
-        (r"f' {  \t\narg  \n  } '", " 123 \n"),
+        (r"f'{   arg}'", "123\n"),
+        # (r"f'{arg}'", "123\n"),
+        # (r"f'{arg}{arg}{arg}'", "123123123\n"),
+        # (r"f'{arg:@>5}'", "@@123\n"),
+        # (r"f'{arg:^5}'", " 123 \n"),
+        # (r"f' {  \t\narg  \n  } '", " 123 \n"),
     ],
 )
 def test_fstring_formatting(snippetcompiler, capsys, f_string, expected_output):
@@ -236,7 +237,7 @@ a = A(b=b)
 b = B(c=c)
 c = C()
 
-std::print(f"{  a.b.c.n_c }")
+std::print(f"{  a.b.c. n_c }")
         """
     )
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -254,7 +254,7 @@ def test_fstring_numbering_logic():
         """
 std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  \tpadded.sub.attr   }")
 #                |   |           |           |                          |
-#                [[ [-[        [---[      [-----[                     [---[     <--- expected ranges
+#               [-][--]       [----]     [------]                    [----]    <--- expected ranges
         """
     )
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -187,6 +187,7 @@ std::print(z)
         (r"f'{arg:^5}'", " 123 \n"),
         (r"f'{arg}'", "123\n"),
         (r"f' {  arg    } '", " 123 \n"),
+        (r"f' {\t arg \t} '", " 123 \n"),
     ],
 )
 def test_fstring_formatting(snippetcompiler, capsys, f_string, expected_output):
@@ -236,7 +237,7 @@ a = A(b=b)
 b = B(c=c)
 c = C()
 
-std::print(f"{a.b.c.n_c}")
+std::print(f"{  a.b.c.n_c }")
         """
     )
 
@@ -275,7 +276,7 @@ std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr   }")
     ]
     variables = statements[0].children[0]._variables
 
-    for var, range in zip([var[0] for var in variables], ranges):
+    for var, range in zip(variables, ranges):
         check_range(var, *range)
 
 
@@ -345,5 +346,5 @@ std::print(f"-{arg:{width}.{precision}}{other}-text-{a:{w}.{p}}-----{w}")
     ]
     variables = statements[0].children[0]._variables
 
-    for var, range in zip([var[0] for var in variables], ranges):
+    for var, range in zip(variables, ranges):
         check_range(var, *range)

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -249,23 +249,25 @@ std::print(f"{a.b.c.n_c}")
 def test_fstring_numbering_logic():
     statements = parse_code(
         """
-std::print(f"---{s}{mm} - {sub.attr}")
+std::print(f"---{s}{mm} - {sub.attr} - {  padded  }")
         """
     )
 
     def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
-        assert variable.location.start_char == start
-        assert variable.location.end_char == end
+        assert variable.location.start_char == start, (variable, start, end)
+        assert variable.location.end_char == end, (variable, start, end)
 
     # Ranges are 1-indexed [start:end[
     ranges = [
         (len('std::print(f"---{s'), len('std::print(f"---{s}')),
         (len('std::print(f"---{s}{m'), len('std::print(f"---{s}{mm}')),
         (len('std::print(f"---{s}{mm} - {sub.a'), len('std::print(f"---{s}{mm} - {sub.attr}')),
+        (len('std::print(f"---{s}{mm} - {sub.attr} - {  p'), len('std::print(f"---{s}{mm} - {sub.attr} - {  padded ')),
+        #                                                                                               43  ^     ^ 49 |
     ]
     variables = statements[0].children[0]._variables
 
-    for var, range in zip(variables, ranges):
+    for var, range in zip([var[0] for var in variables], ranges):
         check_range(var, *range)
 
 
@@ -335,5 +337,5 @@ std::print(f"-{arg:{width}.{precision}}{other}-text-{a:{w}.{p}}-----{w}")
     ]
     variables = statements[0].children[0]._variables
 
-    for var, range in zip(variables, ranges):
+    for var, range in zip([var[0] for var in variables], ranges):
         check_range(var, *range)

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -187,7 +187,6 @@ std::print(z)
         (r"f'{arg:^5}'", " 123 \n"),
         (r"f'{arg}'", "123\n"),
         (r"f' {  arg    } '", " 123 \n"),
-        (r"f' {\t arg \t} '", " 123 \n"),
     ],
 )
 def test_fstring_formatting(snippetcompiler, capsys, f_string, expected_output):

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -247,6 +247,11 @@ std::print(f"{  a .b . c . n_c }")
     assert out == expected_output
 
 
+def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
+    assert variable.location.start_char == start, f"{variable=} expected {start=} got {variable.location.start_char=}"
+    assert variable.location.end_char == end, f"{variable=} expected {end=} got {variable.location.end_char=}"
+
+
 def test_fstring_numbering_logic():
     """
     Check that variable ranges in f-strings are correctly computed
@@ -260,12 +265,6 @@ std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  \tpadded.sub.attr   }")
 #               [-][--]       [----]     [------]                    [----]    <--- expected ranges
         """
     )
-
-    def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
-        assert variable.location.start_char == start, print(
-            f"{variable=} expected {start=} got {variable.location.start_char=}"
-        )
-        assert variable.location.end_char == end, print(f"{variable=} expected {end=} got {variable.location.end_char=}")
 
     # Ranges are 1-indexed [start:end[
     ranges = [
@@ -295,10 +294,6 @@ std::print(f"---{s}----{s}")
 #               [-]    [-] <--- expected ranges
         """
     )
-
-    def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
-        assert variable.location.start_char == start
-        assert variable.location.end_char == end
 
     # Ranges are 1-indexed [start:end[
     ranges = [
@@ -347,12 +342,6 @@ def test_fstring_numbering_logic_complex():
 std::print(f"-{arg:{width}.{precision}}{other}-text-{a:{w}.{p}}-----{w}")
         """
     )
-
-    def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
-        assert variable.location.start_char == start, print(
-            f"error for {variable} got {variable.location.start_char} expected {start}"
-        )
-        assert variable.location.end_char == end, print(f"error for {variable} got {variable.location.end_char} expected {end}")
 
     # Ranges are 1-indexed [start:end[
     ranges = [

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -182,10 +182,10 @@ std::print(z)
 @pytest.mark.parametrize(
     "f_string,expected_output",
     [
-        # (r"f'{arg}{arg}{arg}'", "123123123\n"),
-        # (r"f'{arg:@>5}'", "@@123\n"),
-        # (r"f'{arg:^5}'", " 123 \n"),
-        # (r"f'{arg}'", "123\n"),
+        (r"f'{arg}{arg}{arg}'", "123123123\n"),
+        (r"f'{arg:@>5}'", "@@123\n"),
+        (r"f'{arg:^5}'", " 123 \n"),
+        (r"f'{arg}'", "123\n"),
         (r"f' {  arg    } '", " 123 \n"),
     ],
 )
@@ -247,9 +247,13 @@ std::print(f"{a.b.c.n_c}")
 
 
 def test_fstring_numbering_logic():
+    """
+    Check that variable ranges in f-string are
+    """
     statements = parse_code(
         """
-std::print(f"---{s}{mm} - {sub.attr} - {  padded  }")
+std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr   }")
+#                <> <->        <--->      <----->                   <--->
         """
     )
 
@@ -263,7 +267,7 @@ std::print(f"---{s}{mm} - {sub.attr} - {  padded  }")
         (len('std::print(f"---{s}{m'), len('std::print(f"---{s}{mm}')),
         (len('std::print(f"---{s}{mm} - {sub.a'), len('std::print(f"---{s}{mm} - {sub.attr}')),
         (len('std::print(f"---{s}{mm} - {sub.attr} - {  p'), len('std::print(f"---{s}{mm} - {sub.attr} - {  padded ')),
-        #                                                                                               43  ^     ^ 49 |
+        (len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.a'), len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr ')),
     ]
     variables = statements[0].children[0]._variables
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -291,6 +291,7 @@ std::print(f"---{s}----{s}")
 #               [-]    [-] <--- expected ranges
         """
     )
+
     def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
         assert variable.location.start_char == start
         assert variable.location.end_char == end
@@ -299,7 +300,6 @@ std::print(f"---{s}----{s}")
     ranges = [
         (len('std::print(f"---{s'), len('std::print(f"---{s}')),
         (len('std::print(f"---{s}----{s'), len('std::print(f"---{s}----{s}')),
-
     ]
     variables = statements[0].children[0]._variables
 
@@ -345,7 +345,9 @@ std::print(f"-{arg:{width}.{precision}}{other}-text-{a:{w}.{p}}-----{w}")
     )
 
     def check_range(variable: Union[Reference, AttributeReference], start: int, end: int):
-        assert variable.location.start_char == start, print(f"error for {variable} got {variable.location.start_char} expected {start}")
+        assert variable.location.start_char == start, print(
+            f"error for {variable} got {variable.location.start_char} expected {start}"
+        )
         assert variable.location.end_char == end, print(f"error for {variable} got {variable.location.end_char} expected {end}")
 
     # Ranges are 1-indexed [start:end[

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -186,7 +186,7 @@ std::print(z)
         (r"f'{arg}{arg}{arg}'", "123123123\n"),
         (r"f'{arg:@>5}'", "@@123\n"),
         (r"f'{arg:^5}'", " 123 \n"),
-        (r"f' {  arg    } '", " 123 \n"),
+        (r"f' {  \t\narg  \n  } '", " 123 \n"),
     ],
 )
 def test_fstring_formatting(snippetcompiler, capsys, f_string, expected_output):
@@ -252,9 +252,9 @@ def test_fstring_numbering_logic():
     """
     statements = parse_code(
         """
-std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr   }")
-#                |   |           |           |                        |
-#                [[ [-[        [---[      [-----[                   [---[     <--- expected ranges
+std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  \tpadded.sub.attr   }")
+#                |   |           |           |                          |
+#                [[ [-[        [---[      [-----[                     [---[     <--- expected ranges
         """
     )
 
@@ -269,8 +269,8 @@ std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr   }")
         (len('std::print(f"---{s}{mm} - {sub.a'), len('std::print(f"---{s}{mm} - {sub.attr}')),
         (len('std::print(f"---{s}{mm} - {sub.attr} - {  p'), len('std::print(f"---{s}{mm} - {sub.attr} - {  padded ')),
         (
-            len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.a'),
-            len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr '),
+            len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  \tpadded.sub.a'),
+            len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  \tpadded.sub.attr '),
         ),
     ]
     variables = statements[0].children[0]._variables

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -267,7 +267,10 @@ std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr   }")
         (len('std::print(f"---{s}{m'), len('std::print(f"---{s}{mm}')),
         (len('std::print(f"---{s}{mm} - {sub.a'), len('std::print(f"---{s}{mm} - {sub.attr}')),
         (len('std::print(f"---{s}{mm} - {sub.attr} - {  p'), len('std::print(f"---{s}{mm} - {sub.attr} - {  padded ')),
-        (len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.a'), len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr ')),
+        (
+            len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.a'),
+            len('std::print(f"---{s}{mm} - {sub.attr} - {  padded  } - {  padded.sub.attr '),
+        ),
     ]
     variables = statements[0].children[0]._variables
 


### PR DESCRIPTION
# Description

Fix bug in f-strings where surrounding a variable with spaces would result in a variable not found error 

closes https://github.com/inmanta/inmanta-core/issues/6629

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
