### PR TITLE
Add `in` operation for DictPath

### DIFF
--- a/changelogs/unreleased/add_contains_operation_dict_path.yml
+++ b/changelogs/unreleased/add_contains_operation_dict_path.yml
@@ -1,0 +1,6 @@
+---
+description: Add `in` operation for DictPath.
+change-type: minor
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -667,6 +667,15 @@ class DictPath(WildDictPath):
             return NotImplemented
         return ComposedPath(path=list(self.get_path_sections()) + list(other.get_path_sections()))
 
+    def __contains__(self, other: "DictPath") -> bool:
+        other_key_path_sections = [e.get_key() for e in other.get_path_sections()]
+        self_key_path_sections = [e.get_key() for e in self.get_path_sections()]
+        min_len = min(len(other_key_path_sections), len(self_key_path_sections))
+        for i in range(min_len):
+            if self_key_path_sections[i] != other_key_path_sections[i]:
+                return False
+        return True
+
     def get_path_sections(self) -> Sequence["DictPath"]:
         """Get the individual parts of this path"""
         return []

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -88,6 +88,18 @@ def test_add() -> None:
         assert (ComposedPath(path_str=first) + ComposedPath(path_str=second)).to_str() == first + "." + second
 
 
+def test_in() -> None:
+    items = [
+        ("a.b.c", "a.b", True),
+        ("a.c[z=www].d.e", "c.a", False),
+        ("a.c[z=www].d.g", "a.c.d", True),
+        ("e.f", "g", False),
+    ]
+    for composed_path, sub_composed_path, assert_value in items:
+        is_contained_in_path = ComposedPath(path_str=sub_composed_path) in ComposedPath(path_str=composed_path)
+        assert assert_value == is_contained_in_path
+
+
 def test_null_path() -> None:
     items = [
         ("a.b.c", "d"),


### PR DESCRIPTION
# Description

When we compare `DictPaths`, the `in` operator may be useful. This pr adds the `in` operation.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
