### PR TITLE
Update the dict_path docs for iso6

### DIFF
--- a/changelogs/unreleased/6631-update-doc-dictpah.yml
+++ b/changelogs/unreleased/6631-update-doc-dictpah.yml
@@ -1,0 +1,6 @@
+---
+description: Update the dict_path docs (imports + location)
+issue-nr: 6631
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso6]

--- a/changelogs/unreleased/6631-update-doc-dictpah.yml
+++ b/changelogs/unreleased/6631-update-doc-dictpah.yml
@@ -3,4 +3,4 @@ description: Update the dict_path docs (imports + location)
 issue-nr: 6631
 issue-repo: inmanta-core
 change-type: patch
-destination-branches: [master, iso6]
+destination-branches: [iso6]

--- a/docs/lsm/allocation/allocation_sources/allocation_v2_native.py
+++ b/docs/lsm/allocation/allocation_sources/allocation_v2_native.py
@@ -5,7 +5,7 @@
     :contact: code@inmanta.com
     :license: Inmanta EULA
 """
-from inmanta_lsm import dict_path
+from inmanta.util import dict_path
 from inmanta_plugins.lsm.allocation import AllocationSpecV2
 from inmanta_plugins.lsm.allocation_v2.framework import AllocatorV2, ContextV2, ForEach
 

--- a/docs/lsm/allocation/allocation_sources/allocation_v2_track_delete.py
+++ b/docs/lsm/allocation/allocation_sources/allocation_v2_track_delete.py
@@ -5,7 +5,7 @@
     :contact: code@inmanta.com
     :license: Inmanta EULA
 """
-from inmanta_lsm import dict_path
+from inmanta.util import dict_path
 from inmanta_plugins.lsm.allocation import AllocationSpecV2
 from inmanta_plugins.lsm.allocation_v2.framework import (
     AllocatorV2,

--- a/docs/lsm/allocation/allocation_sources/allocation_v2_with_context_v2_wrapper.py
+++ b/docs/lsm/allocation/allocation_sources/allocation_v2_with_context_v2_wrapper.py
@@ -5,7 +5,7 @@
     :contact: code@inmanta.com
     :license: Inmanta EULA
 """
-from inmanta_lsm import dict_path
+from inmanta.util import dict_path
 from inmanta_plugins.lsm.allocation import AllocationSpecV2
 from inmanta_plugins.lsm.allocation_v2.framework import (
     AllocatorV2,

--- a/docs/lsm/index.rst
+++ b/docs/lsm/index.rst
@@ -196,7 +196,7 @@
     Dict Path Library
     -----------------
 
-    This extension also provides the :ref:`Dict Path library<dict_path>`. This library can be used to extract or modify specific elements
+    This extension also uses the :ref:`Dict Path library<dict_path>`. This library can be used to extract or modify specific elements
     from an arbitrary location in a nested dictionary-based data structure.
 
 

--- a/docs/model_developers.rst
+++ b/docs/model_developers.rst
@@ -18,3 +18,4 @@ Model developer documentation
     model_developers/model_debugging.rst
     model_developers/model_design.rst
     model_developers/resource_sets.rst
+    model_developers/dictpath.rst

--- a/docs/model_developers/dictpath.rst
+++ b/docs/model_developers/dictpath.rst
@@ -34,18 +34,18 @@ Using DictPath in code
 - To get the element from a collection use ``DictPath.get_element(collection)``
 - To set an element in a collection use ``DictPath.set_element(collection, value)``
 
-.. autoclass:: inmanta_lsm.dict_path.DictPath
+.. autoclass:: inmanta.util.dict_path.DictPath
    :members:
 
-.. autofunction:: inmanta_lsm.dict_path.to_path
-.. autofunction:: inmanta_lsm.dict_path.to_wild_path
+.. autofunction:: inmanta.util.dict_path.to_path
+.. autofunction:: inmanta.util.dict_path.to_wild_path
 
 Example
 #######
 
 .. code-block:: python
 
-    from inmanta_lsm import dict_path
+    from inmanta.util import dict_path
 
     container = {
         "a": "b",


### PR DESCRIPTION
https://github.com/inmanta/inmanta-core/pull/6656 for iso6

-reworked the wrong imports in the docs
-moved the doc about dict-path away from lsm.

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)


