### PR TITLE
issue/6084-remove-env-settings

### DIFF
--- a/changelogs/unreleased/6084-remove-deprecated-settings.yml
+++ b/changelogs/unreleased/6084-remove-deprecated-settings.yml
@@ -1,0 +1,6 @@
+description: Remove the autostart_agent_interval and autostart_splay environment settings
+issue-nr: 6084
+change-type: major
+destination-branches: [master, iso6]
+sections:
+  deprecation-note: "{{description}}"

--- a/changelogs/unreleased/6084-remove-deprecated-settings.yml
+++ b/changelogs/unreleased/6084-remove-deprecated-settings.yml
@@ -1,6 +1,6 @@
 description: Remove the autostart_agent_interval and autostart_splay environment settings
 issue-nr: 6084
 change-type: major
-destination-branches: [master, iso6]
+destination-branches: [master]
 sections:
   deprecation-note: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2424,14 +2424,12 @@ AUTO_DEPLOY = "auto_deploy"
 PUSH_ON_AUTO_DEPLOY = "push_on_auto_deploy"
 AGENT_TRIGGER_METHOD_ON_AUTO_DEPLOY = "agent_trigger_method_on_auto_deploy"
 ENVIRONMENT_AGENT_TRIGGER_METHOD = "environment_agent_trigger_method"
-AUTOSTART_SPLAY = "autostart_splay"
 AUTOSTART_AGENT_DEPLOY_INTERVAL = "autostart_agent_deploy_interval"
 AUTOSTART_AGENT_DEPLOY_SPLAY_TIME = "autostart_agent_deploy_splay_time"
 AUTOSTART_AGENT_REPAIR_INTERVAL = "autostart_agent_repair_interval"
 AUTOSTART_AGENT_REPAIR_SPLAY_TIME = "autostart_agent_repair_splay_time"
 AUTOSTART_ON_START = "autostart_on_start"
 AUTOSTART_AGENT_MAP = "autostart_agent_map"
-AUTOSTART_AGENT_INTERVAL = "autostart_agent_interval"
 AGENT_AUTH = "agent_auth"
 SERVER_COMPILE = "server_compile"
 AUTO_FULL_COMPILE = "auto_full_compile"
@@ -2602,13 +2600,6 @@ class Environment(BaseDocument):
             f"For auto deploy, {AGENT_TRIGGER_METHOD_ON_AUTO_DEPLOY} is used.",
             allowed_values=[opt.name for opt in const.AgentTriggerMethod],
         ),
-        AUTOSTART_SPLAY: Setting(
-            name=AUTOSTART_SPLAY,
-            typ="int",
-            default=10,
-            doc="[DEPRECATED] Splay time for autostarted agents.",
-            validator=convert_int,
-        ),
         AUTOSTART_AGENT_DEPLOY_INTERVAL: Setting(
             name=AUTOSTART_AGENT_DEPLOY_INTERVAL,
             typ="str",
@@ -2663,14 +2654,6 @@ class Environment(BaseDocument):
             validator=convert_agent_map,
             doc="A dict with key the name of agents that should be automatically started. The value "
             "is either an empty string or an agent map string. See also: :inmanta.config:option:`config.agent-map`",
-            agent_restart=True,
-        ),
-        AUTOSTART_AGENT_INTERVAL: Setting(
-            name=AUTOSTART_AGENT_INTERVAL,
-            default=600,
-            typ="int",
-            validator=convert_int,
-            doc="[DEPRECATED] Agent interval for autostarted agents in seconds",
             agent_restart=True,
         ),
         SERVER_COMPILE: Setting(
@@ -2739,11 +2722,6 @@ class Environment(BaseDocument):
         ),
     }
 
-    _renamed_settings_map = {
-        AUTOSTART_AGENT_DEPLOY_INTERVAL: AUTOSTART_AGENT_INTERVAL,
-        AUTOSTART_AGENT_DEPLOY_SPLAY_TIME: AUTOSTART_SPLAY,
-    }  # name new_option -> name deprecated_option
-
     @classmethod
     def get_setting_definition(cls, setting_name: str) -> Setting:
         """
@@ -2761,15 +2739,6 @@ class Environment(BaseDocument):
         """
         if key not in self._settings:
             raise KeyError()
-
-        if key in self._renamed_settings_map:
-            name_deprecated_setting = self._renamed_settings_map[key]
-            if name_deprecated_setting in self.settings and key not in self.settings:
-                warnings.warn(
-                    "Config option %s is deprecated. Use %s instead." % (name_deprecated_setting, key),
-                    category=DeprecationWarning,
-                )
-                return self.settings[name_deprecated_setting]
 
         if key in self.settings:
             return self.settings[key]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -422,33 +422,6 @@ async def test_population_settings_dict_on_get_of_setting(init_dataclasses_and_l
     assert assert_setting_in_db(autostart_agent_map)
 
 
-async def test_environment_deprecated_setting(init_dataclasses_and_load_schema, caplog):
-    project = data.Project(name="proj")
-    await project.insert()
-
-    env = data.Environment(name="dev", project=project.id, repo_url="", repo_branch="")
-    await env.insert()
-
-    for deprecated_option, new_option, old_value, new_value in [
-        (data.AUTOSTART_AGENT_INTERVAL, data.AUTOSTART_AGENT_DEPLOY_INTERVAL, 22, "23"),
-        (data.AUTOSTART_SPLAY, data.AUTOSTART_AGENT_DEPLOY_SPLAY_TIME, 22, 23),
-    ]:
-        await env.set(deprecated_option, old_value)
-        caplog.clear()
-        assert (await env.get(new_option)) == old_value
-        assert "Config option %s is deprecated. Use %s instead." % (deprecated_option, new_option) in caplog.text
-
-        await env.set(new_option, new_value)
-        caplog.clear()
-        assert (await env.get(new_option)) == new_value
-        assert "Config option %s is deprecated. Use %s instead." % (deprecated_option, new_option) not in caplog.text
-
-        await env.unset(deprecated_option)
-        caplog.clear()
-        assert (await env.get(new_option)) == new_value
-        assert "Config option %s is deprecated. Use %s instead." % (deprecated_option, new_option) not in caplog.text
-
-
 async def test_agent_process(init_dataclasses_and_load_schema):
     project = data.Project(name="test")
     await project.insert()


### PR DESCRIPTION
# Description

Remove the autostart_agent_interval and autostart_splay environment settings

closes #6084 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
