### PR TITLE
Fix sum python312

### DIFF
--- a/changelogs/unreleased/fix-sum-python312.yml
+++ b/changelogs/unreleased/fix-sum-python312.yml
@@ -1,0 +1,5 @@
+description: "Fixed some tests for Python 3.12 by not relying on Python's built-in sum function"
+change-type: patch
+destination-branches:
+  - master
+  - iso6

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -15,6 +15,8 @@
 
     Contact: code@inmanta.com
 """
+import functools
+import operator
 import uuid
 from collections import abc, defaultdict
 from collections.abc import AsyncIterator, Sequence
@@ -801,7 +803,7 @@ async def test_compile_time_metric(client, server):
     result_timer = await data.EnvironmentMetricsTimer.get_list()
 
     expected_count = len(compile_times)
-    expected_total_compile_time = sum(compile_times)
+    expected_total_compile_time = functools.reduce(operator.add, compile_times)
 
     assert len(result_timer) == 1
     assert any(
@@ -828,7 +830,7 @@ async def test_compile_time_metric(client, server):
     result_timer = await data.EnvironmentMetricsTimer.get_list()
 
     expected_count = len(compile_times)
-    expected_total_compile_time = sum(compile_times)
+    expected_total_compile_time = functools.reduce(operator.add, compile_times)
 
     # 1 new entry
     assert len(result_timer) == 2
@@ -943,7 +945,7 @@ async def test_compile_wait_time_metric(client, server):
     result_timer = await data.EnvironmentMetricsTimer.get_list()
 
     expected_count = len(wait_times)
-    expected_total_wait_time = sum(wait_times)
+    expected_total_wait_time = functools.reduce(operator.add, wait_times)
 
     assert len(result_timer) == 1
     assert any(
@@ -969,7 +971,7 @@ async def test_compile_wait_time_metric(client, server):
     result_timer = await data.EnvironmentMetricsTimer.get_list()
 
     expected_count = len(wait_times)
-    expected_total_wait_time = sum(wait_times)
+    expected_total_wait_time = functools.reduce(operator.add, wait_times)
 
     # 1 new entry
     assert len(result_timer) == 2
@@ -990,7 +992,7 @@ async def test_compile_wait_time_metric(client, server):
     result_timer = await data.EnvironmentMetricsTimer.get_list()
 
     expected_count = len(wait_times)
-    expected_total_wait_time = sum(wait_times)
+    expected_total_wait_time = functools.reduce(operator.add, wait_times)
 
     # 1 new entry
     assert len(result_timer) == 3


### PR DESCRIPTION
The ordering in which `sum` does float sums has changed in Python 3.12. I changed some calls in the test cases to use `reduce` instead for a stable ordering between Python versions.

I will cherry-pick this to the stable branches.