### PR TITLE
issue/6731:dict path: allow matching float with corresponding int

### DIFF
--- a/changelogs/unreleased/6731-fix-dict-path-matching-float-int.yml
+++ b/changelogs/unreleased/6731-fix-dict-path-matching-float-int.yml
@@ -1,0 +1,4 @@
+description: Allow matching floats with corresponding ints in dict path
+issue-nr: 6734
+change-type: patch
+destination-branches: [master, iso6]

--- a/changelogs/unreleased/6731-fix-dict-path-matching-float-int.yml
+++ b/changelogs/unreleased/6731-fix-dict-path-matching-float-int.yml
@@ -2,3 +2,6 @@ description: Allow matching floats with corresponding ints in dict path
 issue-nr: 6734
 change-type: patch
 destination-branches: [master, iso6]
+sections:
+  bugfix: "Fix the handling of numeric keys in dict paths:
+  floating-point numbers and their integer equivalents are treated as the same key."

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -133,7 +133,7 @@ class NormalValue(DictPathValue):
         return str(self._value) == str(value)
 
     @staticmethod
-    def _try_parse_numeric(value: object) -> Optional[float]:
+    def _try_parse_numeric(value: str) -> Optional[float]:
         try:
             return float(value)
         except (ValueError, TypeError):

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -122,6 +122,15 @@ class NormalValue(DictPathValue):
     def matches(self, value: Optional[object]) -> bool:
         if value is None:
             return False
+
+        # Attempt numeric comparison if both values can be converted to floats
+        try:
+            if float(self._value) == float(value):
+                return True
+        except ValueError:
+            pass
+
+        # Fallback to string comparison
         return self._value == str(value)
 
     @property

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -127,10 +127,10 @@ class NormalValue(DictPathValue):
         # Perform a numeric comparison only if the value is an int/float and
         # The key in the dictpath can be interpreted as an int/float
         if self._numeric_value is not None and isinstance(value, (int, float)):
-            return float(self._value) == value
+            return self._numeric_value == value
 
         # Fallback to string comparison for other types
-        return str(self._value) == str(value)
+        return self._value == str(value)
 
     @staticmethod
     def _try_parse_numeric(value: str) -> Optional[float]:

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -378,6 +378,12 @@ WILD_PATH_TEST_CONTAINER = {
             "value": "number 0",
         },
     ],
+    "3.0": "float key 3.0",
+    "4": "int key 4",
+    "mixed_list": [
+        {"key": 5.0, "value": "float key 5.0"},
+        {"key": 6, "value": "int key 6"},
+    ],
 }
 
 
@@ -399,6 +405,14 @@ WILD_PATH_TEST_CONTAINER = {
         (None, "special_list[key=None].value", ["just-a-string"], False),
         (None, r"special_list[key=\\0].value", [r"literal \0"], False),
         (None, "special_list[key=0].value", ["number 0"], False),
+        (None, "3", ["float key 3.0"], False),
+        (None, "4", ["int key 4"], False),
+        (None, "3\.0", ["float key 3.0"], False),
+        (None, "4\.0", ["int key 4"], False),
+        (None, "mixed_list[key=5]", [{"key": 5.0, "value": "float key 5.0"}], False),
+        (None, "mixed_list[key=6]", [{"key": 6, "value": "int key 6"}], False),
+        (None, "mixed_list[key=5\.0]", [{"key": 5.0, "value": "float key 5.0"}], False),
+        (None, "mixed_list[key=6\.0]", [{"key": 6, "value": "int key 6"}], False),
     ],
 )
 def test_dict_path_get_elements(

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -378,11 +378,17 @@ WILD_PATH_TEST_CONTAINER = {
             "value": "number 0",
         },
     ],
-    "3.0": "float key 3.0",
-    "4": "int key 4",
+    3.0: "float key 3.0",
+    4: "int key 4",
     "mixed_list": [
         {"key": 5.0, "value": "float key 5.0"},
         {"key": 6, "value": "int key 6"},
+    ],
+    "7.0": "str key 7.0",
+    "8": "str key 8",
+    "mixed_list_str": [
+        {"key": "9.0", "value": "str key 9.0"},
+        {"key": "10", "value": "str key 10"},
     ],
 }
 
@@ -413,6 +419,14 @@ WILD_PATH_TEST_CONTAINER = {
         (None, "mixed_list[key=6]", [{"key": 6, "value": "int key 6"}], False),
         (None, r"mixed_list[key=5\.0]", [{"key": 5.0, "value": "float key 5.0"}], False),
         (None, r"mixed_list[key=6\.0]", [{"key": 6, "value": "int key 6"}], False),
+        (None, r"7\.0", ["str key 7.0"], False),
+        (None, "7", [], False),
+        (None, r"8\.0", [], False),
+        (None, "8", ["str key 8"], False),
+        (None, r"mixed_list_str[key=9\.0]", [{"key": "9.0", "value": "str key 9.0"}], False),
+        (None, r"mixed_list_str[key=9]", [], False),
+        (None, r"mixed_list_str[key=10\.0]", [], False),
+        (None, r"mixed_list_str[key=10]", [{"key": "10", "value": "str key 10"}], False),
     ],
 )
 def test_dict_path_get_elements(

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -407,12 +407,12 @@ WILD_PATH_TEST_CONTAINER = {
         (None, "special_list[key=0].value", ["number 0"], False),
         (None, "3", ["float key 3.0"], False),
         (None, "4", ["int key 4"], False),
-        (None, "3\.0", ["float key 3.0"], False),
-        (None, "4\.0", ["int key 4"], False),
+        (None, r"3\.0", ["float key 3.0"], False),
+        (None, r"4\.0", ["int key 4"], False),
         (None, "mixed_list[key=5]", [{"key": 5.0, "value": "float key 5.0"}], False),
         (None, "mixed_list[key=6]", [{"key": 6, "value": "int key 6"}], False),
-        (None, "mixed_list[key=5\.0]", [{"key": 5.0, "value": "float key 5.0"}], False),
-        (None, "mixed_list[key=6\.0]", [{"key": 6, "value": "int key 6"}], False),
+        (None, r"mixed_list[key=5\.0]", [{"key": 5.0, "value": "float key 5.0"}], False),
+        (None, r"mixed_list[key=6\.0]", [{"key": 6, "value": "int key 6"}], False),
     ],
 )
 def test_dict_path_get_elements(


### PR DESCRIPTION
# Description

1.0 is a float. When it appears in a dict, the dict path library does not support matching it as key=1, only key=1.0. Since 1 == 1.0 this should be supported. I expect changing NormalValue.matches should fix this.

closes #6731 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
