### PR TITLE
Added regex_string method

### DIFF
--- a/changelogs/unreleased/regex-string.yml
+++ b/changelogs/unreleased/regex-string.yml
@@ -1,0 +1,4 @@
+description: Added regex_string method
+change-type: patch
+destination-branches:
+  - master

--- a/tests/test_import_entry_points.py
+++ b/tests/test_import_entry_points.py
@@ -124,3 +124,7 @@ def test_import_compiler(import_entry_point: Callable[[str], Optional[int]]) -> 
 def test_import_server(import_entry_point: Callable[[str], Optional[int]]) -> None:
     assert import_entry_point("inmanta.server.extensions") == 0
     assert import_entry_point("inmanta.server.bootloader") == 0
+
+
+def test_import_validation_type(import_entry_point: Callable[[str], Optional[int]]) -> None:
+    assert import_entry_point("inmanta.validation_type") == 0

--- a/tests/test_validation_type.py
+++ b/tests/test_validation_type.py
@@ -65,7 +65,6 @@ def test_type_validation(attr_type: str, value: str, validation_parameters: dict
         ("^abc.*", "xabc", False),
         ("^xabc.*", "xabc", True),
         ("^abc.*", "ab", False),
-        ("^abc.*", "abc", True),
         (".*", True, False),
     ],
 )

--- a/tests/test_validation_type.py
+++ b/tests/test_validation_type.py
@@ -15,13 +15,14 @@
 
     Contact: code@inmanta.com
 """
+import contextlib
 import uuid
 from typing import Optional
 
 import pydantic
 import pytest
 
-from inmanta.validation_type import validate_type
+from inmanta.validation_type import regex_string, validate_type
 
 
 @pytest.mark.parametrize(
@@ -54,3 +55,20 @@ def test_type_validation(attr_type: str, value: str, validation_parameters: dict
     except (pydantic.ValidationError, ValueError) as e:
         validation_error = e
     assert (validation_error is None) is is_valid, validation_error
+
+
+@pytest.mark.parametrize(
+    "regex, value, is_valid",
+    [
+        ("^abc.*", "abc", True),
+        ("^abc.*", "abcd", True),
+        ("^abc.*", "xabc", False),
+        ("^xabc.*", "xabc", True),
+        ("^abc.*", "ab", False),
+        ("^abc.*", "abc", True),
+        (".*", True, False),
+    ],
+)
+def test_regex_string(regex: str, value: object, is_valid: bool) -> None:
+    with contextlib.nullcontext() if is_valid else pytest.raises(pydantic.ValidationError):
+        pydantic.TypeAdapter(regex_string(regex)).validate_python(value)


### PR DESCRIPTION
# Description

Added `regex_string` method

replaces inmanta/std#481, see [Slack](https://inmanta.slack.com/archives/CKRF0C8R3/p1700554456479609)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
