### PR TITLE
Fix broken test_batch_code_upload test case

### DIFF
--- a/changelogs/unreleased/fix-broken-test-batch-code-upload-test.yml
+++ b/changelogs/unreleased/fix-broken-test-batch-code-upload-test.yml
@@ -1,0 +1,4 @@
+---
+description: Fix broken `test_batch_code_upload` test, caused by the addition of the `plugins/types.py` file to the std module.
+change-type: patch
+destination-branches: [master, iso6]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -698,7 +698,7 @@ async def test_batched_code_upload(
     for name, source_info in code_manager.get_types():
         res = await agent_multi._client.get_code(tid=environment_multi, id=version, resource=name)
         assert res.code == 200
-        assert len(source_info) == 2
+        assert len(source_info) >= 2
         for info in source_info:
             assert info.hash in res.result["sources"]
             code = res.result["sources"][info.hash]


### PR DESCRIPTION
# Description

Fix broken `test_batch_code_upload` test, caused by the addition of the `plugins/types.py` file to the std module.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
