### PR TITLE
Fix race condition where dist directory is not cleaned up

### DIFF
--- a/changelogs/unreleased/fix-race-dist-dir-not-cleaned-up.yml
+++ b/changelogs/unreleased/fix-race-dist-dir-not-cleaned-up.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition where the `test_module_install` test case creates a dist directory in the `./data/modules_v2/minimalv2module` module, which makes the `test_build_v2_module_set_output_directory` test case fail.
+change-type: patch
+destination-branches: [master]

--- a/tests/moduletool/test_install.py
+++ b/tests/moduletool/test_install.py
@@ -215,14 +215,17 @@ def test_dev_checkout(git_modules_dir, modules_repo):
 
 
 @pytest.mark.parametrize_any("editable", [True, False])
-def test_module_install(snippetcompiler_clean, modules_v2_dir: str, editable: bool) -> None:
+def test_module_install(tmpdir, snippetcompiler_clean, modules_v2_dir: str, editable: bool) -> None:
     """
     Make sure it is possible to install a module in both non-editable and editable mode
     """
     # activate snippetcompiler's venv
     snippetcompiler_clean.setup_for_snippet("")
 
-    module_path: str = os.path.join(modules_v2_dir, "minimalv2module")
+    source_module_path: str = os.path.join(modules_v2_dir, "minimalv2module")
+    module_path: str = os.path.join(tmpdir, "minimalv2module")
+    shutil.copytree(source_module_path, module_path)
+
     python_module_name: str = "inmanta-module-minimalv2module"
 
     def is_installed(name: str, only_editable: bool = False) -> bool:


### PR DESCRIPTION
# Description

#6737 introduced a race condition where the `test_module_install` test case creates a dist directory in the `./data/modules_v2/minimalv2module` directory, which makes the `test_build_v2_module_set_output_directory` test case fail. The latter test case has an assertion to make sure no dist directory exists.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
