### PR TITLE
Fix a bug where numbers where cast to int instead of float (PR #6730)

### DIFF
--- a/changelogs/unreleased/fix-cast-number.yml
+++ b/changelogs/unreleased/fix-cast-number.yml
@@ -1,7 +1,7 @@
 ---
 description: Fix a bug where numbers where cast to int instead of float
 change-type: patch
-destination-branches: [iso6]
+destination-branches: [master]
 sections:
   bugfix: "{{description}}"
 

--- a/changelogs/unreleased/fix-cast-number.yml
+++ b/changelogs/unreleased/fix-cast-number.yml
@@ -1,0 +1,7 @@
+---
+description: Fix a bug where numbers where cast to int instead of float
+change-type: patch
+destination-branches: [iso6]
+sections:
+  bugfix: "{{description}}"
+

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -701,6 +701,13 @@ For indices on relations (instead of attributes) an alternative syntax can be us
     b = vm1.files[path="/etc/passwd"]  # selector style index lookup
     # a == b
 
+.. note::
+    The use of ``number`` as part of index properties is
+    generally discouraged. This is due to the reliance of index matching on precise equality,
+    while floating-point numbers are represented with an inherent imprecision.
+    If floating-point attributes are used in an index, it is crucial to handle arithmetic
+    operations with caution to ensure the accuracy of the attribute values for index operations.
+
 
 For loop
 =========

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -229,15 +229,21 @@ class Primitive(Type):
 @stable_api
 class Number(Primitive):
     """
-    This class represents an integer or float in the configuration model. On
-    these numbers the following operations are supported:
-
-    +, -, /, *
+    This class represents an integer or float in the configuration model.
     """
 
     def __init__(self) -> None:
         Primitive.__init__(self)
-        self.try_cast_functions: Sequence[Callable[[Optional[object]], numbers.Number]] = [int, float]
+        self.try_cast_functions: Sequence[Callable[[Optional[object]], numbers.Number]] = [float]
+
+    def cast(self, value: Optional[object]) -> object:
+        """
+        Attempts to cast a given value to an int or a float.
+        """
+        # Keep precision: cast to an int only if it already is an int
+        if isinstance(value, int):
+            return int(value)
+        return super().cast(value)
 
     def validate(self, value: Optional[object]) -> bool:
         """

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -151,6 +151,7 @@ w = int(tests::unknown())
     assert Integer().validate(y)
     assert Integer().validate(z)
     assert isinstance(w, Unknown)
+    assert not any(isinstance(v, (bool, float)) for v in (x, y, z))
 
 
 def test_cast_to_string(snippetcompiler):
@@ -380,3 +381,14 @@ implement Child using std::none
 Child()
         """,
     )
+
+
+def test_print_number(snippetcompiler, capsys):
+    snippetcompiler.setup_for_snippet(
+        """
+std::print(number(1.234))
+        """,
+    )
+    compiler.do_compile()
+    out, err = capsys.readouterr()
+    assert "1.234" in out


### PR DESCRIPTION
# Description

while working on https://github.com/inmanta/inmanta-core/pull/6686 we noticed a bug [here](https://github.com/inmanta/inmanta-core/pull/6686#discussion_r1386642720) . This PR fixes this bug

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)

