### PR TITLE
issue6375/add_exclude_event_to_get_resource_events

### DIFF
--- a/changelogs/unreleased/6375-add_exclude_event_to_get_resource_events.yml
+++ b/changelogs/unreleased/6375-add_exclude_event_to_get_resource_events.yml
@@ -1,7 +1,7 @@
 description: Add 'exclude_change' argument to 'get_resource_events' to be able to exclude some types of changes from the results.
 issue-nr: 6375
 change-type: minor
-destination-branches: [master]
+destination-branches: [master, iso6]
 sections:
   feature: "{{description}}"
 

--- a/changelogs/unreleased/6375-add_exclude_event_to_get_resource_events.yml
+++ b/changelogs/unreleased/6375-add_exclude_event_to_get_resource_events.yml
@@ -1,0 +1,7 @@
+description: Add 'exclude_change' argument to 'get_resource_events' to be able to exclude some types of changes from the results.
+issue-nr: 6375
+change-type: minor
+destination-branches: [master]
+sections:
+  feature: "{{description}}"
+

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -623,7 +623,7 @@ def get_resource_events(
     Return relevant events for a resource, i.e. all deploy actions for each of its dependencies since this resources' last
     successful deploy or all deploy actions if this resources hasn't been deployed before. The resource actions are sorted in
     descending order according to their started timestamp. If exclude_change is set, exclude all resource actions with this
-    specific type of change
+    specific type of change.
 
     This method searches through all versions of this resource.
     This method should only be called when a deploy is in progress.

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -617,7 +617,7 @@ def resource_deploy_start(
 def get_resource_events(
     tid: uuid.UUID,
     rvid: model.ResourceVersionIdStr,
-    exclude_change: Optional[Change],
+    exclude_change: Optional[Change] = None,
 ) -> Dict[model.ResourceIdStr, List[model.ResourceAction]]:
     """
     Return relevant events for a resource, i.e. all deploy actions for each of its dependencies since this resources' last

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -617,17 +617,20 @@ def resource_deploy_start(
 def get_resource_events(
     tid: uuid.UUID,
     rvid: model.ResourceVersionIdStr,
+    exclude_change: Optional[Change],
 ) -> Dict[model.ResourceIdStr, List[model.ResourceAction]]:
     """
     Return relevant events for a resource, i.e. all deploy actions for each of its dependencies since this resources' last
     successful deploy or all deploy actions if this resources hasn't been deployed before. The resource actions are sorted in
-    descending order according to their started timestamp.
+    descending order according to their started timestamp. If exclude_change is set, exclude all resource actions with this
+    specific type of change
 
     This method searches through all versions of this resource.
     This method should only be called when a deploy is in progress.
 
     :param tid: The id of the environment this resource belongs to
     :param rvid: The id of the resource to get events for.
+    :param exclude_change: exclude all resource actions with this specific type of change
     :raises BadRequest: When this endpoint in called while the resource with the given resource version is not
                         in the deploying state.
     """

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -630,7 +630,7 @@ def get_resource_events(
 
     :param tid: The id of the environment this resource belongs to
     :param rvid: The id of the resource to get events for.
-    :param exclude_change: exclude all resource actions with this specific type of change
+    :param exclude_change: Exclude all resource actions with this specific type of change.
     :raises BadRequest: When this endpoint in called while the resource with the given resource version is not
                         in the deploying state.
     """

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -1117,7 +1117,7 @@ class ResourceService(protocol.ServerSlice):
 
     @handle(methods_v2.get_resource_events, env="tid", resource_id="rvid")
     async def get_resource_events(
-        self, env: data.Environment, resource_id: Id, exclude_change: Optional[const.Change]
+        self, env: data.Environment, resource_id: Id, exclude_change: Optional[const.Change] = None
     ) -> Dict[ResourceIdStr, List[ResourceAction]]:
         return {
             k: [ra.to_dto() for ra in v]

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -1117,12 +1117,11 @@ class ResourceService(protocol.ServerSlice):
 
     @handle(methods_v2.get_resource_events, env="tid", resource_id="rvid")
     async def get_resource_events(
-        self,
-        env: data.Environment,
-        resource_id: Id,
+        self, env: data.Environment, resource_id: Id, exclude_change: Optional[const.Change]
     ) -> Dict[ResourceIdStr, List[ResourceAction]]:
         return {
-            k: [ra.to_dto() for ra in v] for k, v in (await data.ResourceAction.get_resource_events(env, resource_id)).items()
+            k: [ra.to_dto() for ra in v]
+            for k, v in (await data.ResourceAction.get_resource_events(env, resource_id, exclude_change)).items()
         }
 
     @handle(methods_v2.resource_did_dependency_change, env="tid", resource_id="rvid")

--- a/tests/server/test_resourceservice.py
+++ b/tests/server/test_resourceservice.py
@@ -167,7 +167,7 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
 async def test_events_api_endpoints_increment(server, client, environment, clienthelper, agent, resource_deployer):
     """
     Test whether the `get_resource_events` and the `resource_did_dependency_change`
-    endpoints behave as expected
+    endpoints behave as expected. Also test the exclude_change parameter for get_resource_events
     """
     rid = r"""exec::Run[agent1,command=sh -c "git _%\/ clone \"https://codis.git\"  && chown -R centos:centos "]"""
     rid_r1 = ResourceIdStr(rid)

--- a/tests/server/test_resourceservice.py
+++ b/tests/server/test_resourceservice.py
@@ -155,6 +155,7 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
     assert len(result.result["data"][rid_r3_v1]) == 1
     assert result.result["data"][rid_r3_v1][0]["action"] == const.ResourceAction.deploy
     assert result.result["data"][rid_r3_v1][0]["status"] == const.ResourceState.deployed
+
     result = await agent._client.resource_did_dependency_change(tid=environment, rvid=rvid_r1_v1)
     assert result.code == 200
     assert not result.result["data"]
@@ -251,6 +252,22 @@ async def test_events_api_endpoints_increment(server, client, environment, clien
     assert result.result["data"][rid_r3][1]["action"] == const.ResourceAction.deploy
     assert result.result["data"][rid_r3][1]["status"] == const.ResourceState.deployed
     assert result.result["data"][rid_r3][1]["change"] == const.Change.updated
+
+    # Assert we find the events excluding the nochange changes
+    result = await agent._client.get_resource_events(tid=environment, rvid=rvid_r1_v2, exclude_change=const.Change.nochange)
+    assert result.code == 200
+    assert len(result.result["data"]) == 2
+    assert len(result.result["data"][rid_r2]) == 1
+
+    assert result.result["data"][rid_r2][0]["action"] == const.ResourceAction.deploy
+    assert result.result["data"][rid_r2][0]["status"] == const.ResourceState.deployed
+    assert result.result["data"][rid_r2][0]["change"] == const.Change.updated
+
+    assert len(result.result["data"][rid_r3]) == 1
+
+    assert result.result["data"][rid_r3][0]["action"] == const.ResourceAction.deploy
+    assert result.result["data"][rid_r3][0]["status"] == const.ResourceState.deployed
+    assert result.result["data"][rid_r3][0]["change"] == const.Change.updated
 
     # Finish deployment r1
     await resource_deployer.deployment_finished(rvid=rvid_r1_v2, action_id=action_id)

--- a/tests/server/test_resourceservice.py
+++ b/tests/server/test_resourceservice.py
@@ -155,7 +155,6 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
     assert len(result.result["data"][rid_r3_v1]) == 1
     assert result.result["data"][rid_r3_v1][0]["action"] == const.ResourceAction.deploy
     assert result.result["data"][rid_r3_v1][0]["status"] == const.ResourceState.deployed
-
     result = await agent._client.resource_did_dependency_change(tid=environment, rvid=rvid_r1_v1)
     assert result.code == 200
     assert not result.result["data"]


### PR DESCRIPTION
# Description

Add exclude_change argument to get_resource_events to be able to perform the equivalent of resource_did_dependency_change
but with details about what changed.

closes #6375 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
