### PR TITLE
fix race between release, deploy and agent pull

### DIFF
--- a/changelogs/unreleased/race-in-increment-back-propagation.yml
+++ b/changelogs/unreleased/race-in-increment-back-propagation.yml
@@ -1,0 +1,5 @@
+description: "No longer update the increment when the agent pulls (this is now done when a new version is released), to prevent race with #6486."
+change-type: minor
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -327,13 +327,6 @@ class ResourceService(protocol.ServerSlice):
 
         now = datetime.datetime.now().astimezone()
 
-        def on_agent(res: ResourceIdStr) -> bool:
-            idr = Id.parse_id(res)
-            return idr.get_agent_name() == agent
-
-        # set already done to deployed
-        await self.mark_deployed(env, neg_increment, now, version, filter=on_agent)
-
         resources = await data.Resource.get_resources_for_version(env.id, version, agent)
 
         deploy_model: List[Dict[str, Any]] = []


### PR DESCRIPTION
# Description

fix race between release, deploy and agent pull

It could occur that an agent pull would calculate an increment, overwriting the current state set by release version (#6486). 

![image](https://github.com/inmanta/inmanta-core/assets/1788254/9d7f3a36-d9d2-4079-891f-370a58f5cfd5)

This calculation is no longer required, as increments are now calculate on release. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature) 
   -  I think this is not worth testing, as it is very delicate, covered by other testcases and in relation to a race that I have now removed.
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [x] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
