### PR TITLE
Add connection parameter to methods in database layer

### DIFF
--- a/changelogs/unreleased/connection-wiring.yml
+++ b/changelogs/unreleased/connection-wiring.yml
@@ -1,0 +1,6 @@
+---
+description: Add connection parameter to some methods in the database layer.
+issue-nr: 1279
+issue-repo: inmanta-lsm
+change-type: minor
+destination-branches: [master, iso6]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3685,7 +3685,7 @@ class Compile(BaseDocument):
     failed_compile_message: Optional[str] = None
 
     @classmethod
-    async def get_substitute_by_id(cls, compile_id: uuid.UUID) -> Optional["Compile"]:
+    async def get_substitute_by_id(cls, compile_id: uuid.UUID, connection: Optional[Connection] = None) -> Optional["Compile"]:
         """
         Get a compile's substitute compile if it exists, otherwise get the compile by id.
 
@@ -3693,12 +3693,13 @@ class Compile(BaseDocument):
         :return: The compile object for compile c2 that is the substitute of compile c1 with the given id. If c1 does not have
             a substitute, returns c1 itself.
         """
-        result: Optional[Compile] = await cls.get_by_id(compile_id)
-        if result is None:
-            return None
-        if result.substitute_compile_id is None:
-            return result
-        return await cls.get_substitute_by_id(result.substitute_compile_id)
+        async with Compile.get_connection(connection=connection) as con:
+            result: Optional[Compile] = await cls.get_by_id(compile_id, connection=con)
+            if result is None:
+                return None
+            if result.substitute_compile_id is None:
+                return result
+            return await cls.get_substitute_by_id(result.substitute_compile_id, connection=con)
 
     @classmethod
     # TODO: Use join
@@ -4085,7 +4086,12 @@ class ResourceAction(BaseDocument):
 
     @classmethod
     async def get_logs_for_version(
-        cls, environment: uuid.UUID, version: int, action: Optional[str] = None, limit: int = 0
+        cls,
+        environment: uuid.UUID,
+        version: int,
+        action: Optional[str] = None,
+        limit: int = 0,
+        connection: Optional[Connection] = None,
     ) -> List["ResourceAction"]:
         query = f"""SELECT *
                         FROM {cls.table_name()}
@@ -4099,7 +4105,7 @@ class ResourceAction(BaseDocument):
         if limit is not None and limit > 0:
             query += " LIMIT $%d" % (len(values) + 1)
             values.append(cls._get_value(limit))
-        async with cls.get_connection() as con:
+        async with cls.get_connection(connection=connection) as con:
             async with con.transaction():
                 return [cls(**dict(record), from_postgres=True) async for record in con.cursor(query, *values)]
 
@@ -5513,12 +5519,14 @@ class ConfigurationModel(BaseDocument):
         return result
 
     @classmethod
-    async def get_versions(cls, environment: uuid.UUID, start: int = 0, limit: int = DBLIMIT) -> List["ConfigurationModel"]:
+    async def get_versions(
+        cls, environment: uuid.UUID, start: int = 0, limit: int = DBLIMIT, connection: Optional[Connection] = None
+    ) -> List["ConfigurationModel"]:
         """
         Get all versions for an environment ordered descending
         """
         versions = await cls.get_list(
-            order_by_column="version", order="DESC", limit=limit, offset=start, environment=environment
+            order_by_column="version", order="DESC", limit=limit, offset=start, environment=environment, connection=connection
         )
         return versions
 


### PR DESCRIPTION
# Description

Add the connection attribute to some methods in the database layer to prevent subsequent allocation/de-allocation requests to the connection pool.

Part of inmanta/inmanta-lsm#1279

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
