### PR TITLE
Remove not used imports

### DIFF
--- a/changelogs/unreleased/6372-run-pyupgrade-py39-remove-unused-export.yml
+++ b/changelogs/unreleased/6372-run-pyupgrade-py39-remove-unused-export.yml
@@ -1,0 +1,4 @@
+description: Remove unused export after pyupgrade with python3.9
+issue-nr: 6372
+change-type: patch
+destination-branches: [master, iso6]

--- a/docs/lsm/allocation/allocation_sources/deallocation.py
+++ b/docs/lsm/allocation/allocation_sources/deallocation.py
@@ -6,7 +6,7 @@
     :license: Inmanta EULA
 """
 import os
-from typing import Optional, Tuple
+from typing import Optional
 from uuid import UUID
 
 import psycopg2

--- a/docs/lsm/allocation/allocation_sources/pg_attr_example.py
+++ b/docs/lsm/allocation/allocation_sources/pg_attr_example.py
@@ -6,7 +6,7 @@
     :license: Inmanta EULA
 """
 import os
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 import inmanta_plugins.lsm.allocation as lsm
 import psycopg2

--- a/docs/lsm/allocation/allocation_sources/pg_id_example.py
+++ b/docs/lsm/allocation/allocation_sources/pg_id_example.py
@@ -6,7 +6,7 @@
     :license: Inmanta EULA
 """
 import os
-from typing import Optional, Tuple
+from typing import Optional
 from uuid import UUID
 
 import inmanta_plugins.lsm.allocation as lsm

--- a/docs/lsm/allocation/allocation_sources/pg_lookup_example.py
+++ b/docs/lsm/allocation/allocation_sources/pg_lookup_example.py
@@ -6,7 +6,7 @@
     :license: Inmanta EULA
 """
 import os
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 import inmanta_plugins.lsm.allocation as lsm
 import psycopg2


### PR DESCRIPTION
# Description

after the pyupgrade command there were still some unused imports.
I noticed this because this build failed: https://jenkins.inmanta.com/job/docs/job/lsm-documentation-examples-verification/job/master/315/console
and had to make the same changes on lsm than does that where made to the core doc. On lsm it complained about those
imports

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
