### PR TITLE
number type should no longer differentiate between integer and decima…

### DIFF
--- a/changelogs/unreleased/6526-index-float-int.yml
+++ b/changelogs/unreleased/6526-index-float-int.yml
@@ -1,0 +1,9 @@
+description: number type should no longer differentiate between integer and decimal notation when used in indexes.
+issue-nr: 6526
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master]
+sections:
+  feature: "Introduce the 'float' type for floating point numbers"
+  deprecation-note: "Deprecate the 'number' type. Use the 'int' or 'float' type instead"
+

--- a/changelogs/unreleased/6526-index-float-int.yml
+++ b/changelogs/unreleased/6526-index-float-int.yml
@@ -2,7 +2,7 @@ description: number type should no longer differentiate between integer and deci
 issue-nr: 6526
 issue-repo: inmanta-core
 change-type: minor
-destination-branches: [master]
+destination-branches: [iso6]
 sections:
   feature: "Introduce the 'float' type for floating point numbers"
   deprecation-note: "Deprecate the 'number' type. Use the 'int' or 'float' type instead"

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -125,14 +125,18 @@ Literal values can be assigned to variables
 Primitive types
 ==============================
 
-The basic primitive types are ``string``, ``number``, ``int`` or ``bool``. These basic types also support type casts:
+The basic primitive types are ``string``, ``float``, ``int`` or ``bool``. These basic types also support type casts:
+
+.. note::
+    To initialize or assign a float, the value should either include a decimal point or be explicitly converted to a float type.
+
 
 .. code-block:: inmanta
 
     assert = true
     assert = int("1") == 1
-    assert = number("1.2") == 1.2
-    assert = number(true) == 1
+    assert = float("1.2") == 1.2
+    assert = int(true) == 1
     assert = bool(1.2) == true
     assert = bool(0) == false
     assert = bool(null) == false
@@ -164,7 +168,7 @@ For example
     typedef mac_addr as string matching /([0-9a-fA-F]{2})(:[0-9a-fA-F]{2}){5}$/
 
 
-Lists of primitive types are also primitive types: ``string[]``, ``number[]``, ``bool[]`` or ``mac_addr[]``
+Lists of primitive types are also primitive types: ``string[]``, ``float[]``, ``bool[]`` or ``mac_addr[]``
 
 ``dict`` is the primitive type that represents a dictionary, with string keys. Dict values can be accessed using the ``[]`` operator. All members of a dict have to be set when the dict is constructed. e.g.
 
@@ -690,11 +694,13 @@ For indices on relations (instead of attributes) an alternative syntax can be us
     # a == b
 
 .. note::
-    The use of ``number`` as part of index properties is
+    The use of ``float`` (or ``number``) as part of index properties is
     generally discouraged. This is due to the reliance of index matching on precise equality,
     while floating-point numbers are represented with an inherent imprecision.
     If floating-point attributes are used in an index, it is crucial to handle arithmetic
     operations with caution to ensure the accuracy of the attribute values for index operations.
+
+
 
 
 For loop

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -21,6 +21,7 @@ from abc import abstractmethod
 from functools import lru_cache
 from typing import Dict, List, Optional, Union
 
+from inmanta import warnings
 from inmanta.ast import export
 from inmanta.stable_api import stable_api
 from inmanta.warnings import InmantaWarning
@@ -39,6 +40,10 @@ if TYPE_CHECKING:
     from inmanta.compiler import Compiler
     from inmanta.execute.runtime import DelayedResultVariable, ExecutionContext, Instance, ResultVariable  # noqa: F401
     from inmanta.plugins import PluginException
+
+
+class TypeDeprecationWarning(InmantaWarning):
+    pass
 
 
 class Location(export.Exportable):
@@ -382,6 +387,8 @@ class Namespace(Namespaced):
             else:
                 raise TypeNotFoundException(typ, self)
         elif name in self.primitives:
+            if name == "number":
+                warnings.warn(TypeDeprecationWarning("Type 'number' is deprecated, use 'float' or 'int' instead"))
             return self.primitives[name]
         else:
             cns = self  # type: Optional[Namespace]

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -33,7 +33,7 @@ from inmanta.ast import (
 )
 from inmanta.ast.blocks import BasicBlock
 from inmanta.ast.statements.generator import SubConstructor
-from inmanta.ast.type import NamedType, Type
+from inmanta.ast.type import Float, NamedType, Type
 from inmanta.execute.runtime import Instance, QueueScheduler, Resolver, dataflow
 from inmanta.execute.util import AnyType
 
@@ -382,6 +382,7 @@ class Entity(NamedType, WithComment):
         been set
         """
         attributes = {k: repr(v.get_value()) for (k, v) in instance.slots.items() if v.is_ready()}
+
         # check if an index entry can be added
         for index_attributes in self.get_indices():
             index_ok = True
@@ -427,9 +428,16 @@ class Entity(NamedType, WithComment):
             raise NotFoundException(
                 stmt, self.get_full_name(), "No index defined on %s for this lookup: " % self.get_full_name() + str(params)
             )
-
-        key = ", ".join(["%s=%s" % (k, repr(v)) for (k, v) in sorted(params, key=lambda x: x[0])])
-
+        key = ", ".join(
+            [
+                "%s=%s"
+                % (
+                    k,
+                    repr(self.get_attribute(k).type.cast(v) if isinstance(self.get_attribute(k).type, Float) else v),
+                )
+                for k, v in sorted(params, key=lambda x: x[0])
+            ]
+        )
         if target is None:
             if key in self._index:
                 return self._index[key]

--- a/tests/compiler/dataflow/test_model_assignment.py
+++ b/tests/compiler/dataflow/test_model_assignment.py
@@ -104,7 +104,7 @@ def test_dataflow_model_attribute_assignment_responsible(dataflow_test_helper: D
     dataflow_test_helper.compile(
         """
 entity Test:
-    number n
+    int n
 end
 implement Test using std::none
 
@@ -204,7 +204,7 @@ def test_dataflow_model_assignment_from_attribute(dataflow_test_helper: Dataflow
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
+    int n
 end
 implement A using std::none
 
@@ -232,7 +232,7 @@ def test_dataflow_model_assignment_outside_constructor(dataflow_test_helper: Dat
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
+    int n
 end
 implement A using std::none
 
@@ -268,7 +268,7 @@ def test_dataflow_model_result_variable(dataflow_test_helper: DataflowTestHelper
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
+    int n
 end
 
 index A(n)

--- a/tests/compiler/dataflow/test_model_datatrace.py
+++ b/tests/compiler/dataflow/test_model_datatrace.py
@@ -142,7 +142,7 @@ EQUIVALENT TO {{x, y, z}} DUE TO STATEMENTS:
             "equivalence with attribute",
             """
 entity A:
-    number n
+    int n
 end
 implement A using std::none
 
@@ -192,11 +192,11 @@ x
             "implementation",
             """
 entity A:
-    number n
+    int n
 end
 
 entity B:
-    number n
+    int n
 end
 
 implementation ia for A:
@@ -260,8 +260,8 @@ x_n
             "index match double assignment",
             """
 entity A:
-    number n
-    number m
+    int n
+    int m
 end
 
 index A(n)

--- a/tests/compiler/dataflow/test_model_dynamic_scope.py
+++ b/tests/compiler/dataflow/test_model_dynamic_scope.py
@@ -31,11 +31,11 @@ def test_dataflow_model_implementation_assignment_from_self(dataflow_test_helper
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
+    int n
 end
 
 entity B:
-    number n
+    int n
 end
 
 A.b [1] -- B

--- a/tests/compiler/dataflow/test_model_graphic.py
+++ b/tests/compiler/dataflow/test_model_graphic.py
@@ -193,9 +193,9 @@ def test_dataflow_graphic_instance(graphic_asserter: GraphicAsserter) -> None:
     graphic_asserter(
         """
 entity A:
-    number l
-    number m
-    number n
+    int l
+    int m
+    int n
 end
 
 implement A using std::none
@@ -329,8 +329,8 @@ def test_dataflow_graphic_implementation(graphic_asserter: GraphicAsserter) -> N
     graphic_asserter(
         """
 entity A:
-    number m
-    number n
+    int m
+    int n
 end
 
 implement A using i
@@ -393,8 +393,8 @@ def test_dataflow_graphic_index(graphic_asserter: GraphicAsserter) -> None:
     graphic_asserter(
         """
 entity A:
-    number m
-    number n
+    int m
+    int n
 end
 
 index A(n)

--- a/tests/compiler/dataflow/test_model_index.py
+++ b/tests/compiler/dataflow/test_model_index.py
@@ -29,8 +29,8 @@ def test_dataflow_model_index_resultvariable_binding(dataflow_test_helper: Dataf
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
-    number m
+    int n
+    int m
 end
 
 index A(n)

--- a/tests/compiler/dataflow/test_model_relations.py
+++ b/tests/compiler/dataflow/test_model_relations.py
@@ -80,7 +80,7 @@ entity U:
 end
 
 entity V:
-    number n
+    int n
 end
 
 X.u [1] -- U
@@ -117,7 +117,7 @@ entity U:
 end
 
 entity V:
-    number n
+    int n
 end
 
 U.v [1] -- V
@@ -152,9 +152,9 @@ def test_dataflow_model_index(dataflow_test_helper: DataflowTestHelper) -> None:
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
-    number k
-    number l
+    int n
+    int k
+    int l
 end
 
 index A(n)
@@ -186,7 +186,7 @@ def test_dataflow_model_default_attribute(dataflow_test_helper: DataflowTestHelp
     dataflow_test_helper.compile(
         """
 entity A:
-    number n = 42
+    int n = 42
 end
 
 implement A using std::none
@@ -211,7 +211,7 @@ def test_dataflow_model_implementation(dataflow_test_helper: DataflowTestHelper,
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
+    int n
 end
 
 implementation i for A:

--- a/tests/compiler/dataflow/test_model_root_cause.py
+++ b/tests/compiler/dataflow/test_model_root_cause.py
@@ -41,13 +41,13 @@ def test_dataflow_model_root_cause(
     dataflow_test_helper.compile(
         """
 entity C:
-    number i
+    int i
 end
 
 
 entity V:
-    number n
-    number i
+    int n
+    int i
 end
 
 index V(i)
@@ -60,7 +60,7 @@ U.v [1] -- V
 
 
 entity X:
-    number n
+    int n
 end
 
 
@@ -118,7 +118,7 @@ def test_cyclic_model_a(dataflow_test_helper: DataflowTestHelper):
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
+    int n
 end
 
 implement A using std::none
@@ -159,7 +159,7 @@ def test_cyclic_model_b(dataflow_test_helper: DataflowTestHelper):
     dataflow_test_helper.compile(
         """
 entity A:
-    number n
+    int n
 end
 
 implement A using std::none

--- a/tests/compiler/dataflow/test_model_stubs.py
+++ b/tests/compiler/dataflow/test_model_stubs.py
@@ -49,7 +49,7 @@ from inmanta.execute.dataflow import (
             [
                 """
                 entity A:
-                    number n
+                    int n
                 end
 
                 index A(n)

--- a/tests/compiler/test_conditional.py
+++ b/tests/compiler/test_conditional.py
@@ -394,7 +394,7 @@ def test_1804_false_and_condition(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity A:
-    number n
+    int n
 end
 implement A using std::none
 

--- a/tests/compiler/test_defaults.py
+++ b/tests/compiler/test_defaults.py
@@ -188,12 +188,12 @@ def test_1292_default_type_check(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
 entity Test:
-    number t = "str"
+    int t = "str"
 end
 
 Test(t=5)
         """,
-        "Invalid value 'str', expected Number (reported in number t = 'str' ({dir}/main.cf:3:12))",
+        "Invalid value 'str', expected int (reported in int t = 'str' ({dir}/main.cf:3:9))",
     )
 
 
@@ -216,21 +216,21 @@ def test_1292_default_type_check3(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
 entity Test:
-    number? t = [1, 2]
+    int? t = [1, 2]
 end
 
 implement Test using std::none
 
 Test(t = 12)
         """,
-        "Invalid value '[1, 2]', expected Number (reported in number? t = List() ({dir}/main.cf:3:13))",
+        "Invalid value '[1, 2]', expected int (reported in int? t = List() ({dir}/main.cf:3:10))",
     )
 
 
 def test_1292_default_type_check4(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
-typedef digit as number matching self > 0 and self < 10
+typedef digit as int matching self > 0 and self < 10
 
 entity Test:
     digit t = 12
@@ -249,10 +249,10 @@ def test_1292_default_type_check5(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
 entity Test:
-    number t = "str"
+    int t = "str"
 end
         """,
-        "Invalid value 'str', expected Number (reported in number t = 'str' ({dir}/main.cf:3:12))",
+        "Invalid value 'str', expected int (reported in int t = 'str' ({dir}/main.cf:3:9))",
     )
 
 

--- a/tests/compiler/test_dict.py
+++ b/tests/compiler/test_dict.py
@@ -219,8 +219,8 @@ def test_constructor_kwargs(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Test:
-    number n
-    number m
+    int n
+    int m
     string str
 end
 
@@ -245,7 +245,7 @@ def test_2003_constructor_kwargs_default(snippetcompiler, override: bool):
     snippetcompiler.setup_for_snippet(
         """
 entity Test:
-    number v = 0
+    int v = 0
 end
 
 implement Test using std::none
@@ -282,8 +282,8 @@ def test_constructor_kwargs_index_match(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Test:
-    number n
-    number m
+    int n
+    int m
     string str
 end
 
@@ -309,8 +309,8 @@ def test_indexlookup_kwargs(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity Test:
-    number n
-    number m
+    int n
+    int m
     string str
 end
 
@@ -341,8 +341,8 @@ end
 implement Collection using std::none
 
 entity Test:
-    number n
-    number m
+    int n
+    int m
     string str
 end
 

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -143,7 +143,7 @@ def test_dataflow_multi_exception(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity A:
-    number n
+    int n
 end
 
 implement A using std::none
@@ -166,7 +166,7 @@ mm = nn
             """
 Reported 1 errors
 error 0:
-  The object __config__::A (instantiated at {dir}/main.cf:9) is not complete: attribute n ({dir}/main.cf:3:12) is not set
+  The object __config__::A (instantiated at {dir}/main.cf:9) is not complete: attribute n ({dir}/main.cf:3:9) is not set
 data trace:
 attribute n on __config__::A instance
 SUBTREE for __config__::A instance:
@@ -247,8 +247,8 @@ def test_exception_default_constructors(snippetcompiler):
 typedef MyType as A(n = 42)
 
 entity A:
-    number n
-    number m
+    int n
+    int m
 end
 
 implement A using std::none

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -272,7 +272,7 @@ def test_lazy_attibutes(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity  Thing:
-   number id
+   int id
    string value = ""
 end
 
@@ -295,7 +295,7 @@ def test_lazy_attibutes2(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity  Thing:
-   number id
+   int id
    string value
 end
 
@@ -319,7 +319,7 @@ def test_lazy_attibutes3(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity  Thing:
-   number id
+   int id
 end
 
 Thing.value [1] -- StringWrapper

--- a/tests/compiler/test_implement.py
+++ b/tests/compiler/test_implement.py
@@ -30,11 +30,11 @@ def test_implement_parents(snippetcompiler, parents: bool):
     snippetcompiler.setup_for_snippet(
         """
 entity Parent:
-    number n
+    int n
 end
 
 entity Child extends Parent:
-    number m
+    int m
 end
 
 implement Parent using p

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -55,7 +55,7 @@ entity Repository extends std::File:
     bool enabled=true
     string baseurl
     string gpgkey=""
-    number metadata_expire=7200
+    int metadata_expire=7200
     bool send_event=true
 end
 
@@ -543,7 +543,7 @@ def test_index_attribute_missing_in_constructor_call(snippetcompiler, use_wrappe
     """
     model = f"""
 entity Test_A:
-    number id
+    int id
     string name
 end
 

--- a/tests/compiler/test_is_defined.py
+++ b/tests/compiler/test_is_defined.py
@@ -113,7 +113,7 @@ def test_is_defined_attribute(snippetcompiler, capsys, condition_block):
         f"""
 
 entity A:
-    number? a
+    int? a
 end
 
 implement A using std::none
@@ -133,7 +133,7 @@ def test_is_defined_attribute_not(snippetcompiler, capsys, condition_block_with_
         f"""
 
 entity A:
-    number? a = null
+    int? a = null
 end
 
 implement A using std::none
@@ -151,8 +151,8 @@ x = A()
 @pytest.mark.parametrize(
     "relation, attr_type",
     [
-        (False, "number?"),
-        (False, "number[]?"),
+        (False, "int?"),
+        (False, "int[]?"),
         (True, "[0:1]"),
         (True, "[0:]"),
     ],
@@ -188,7 +188,7 @@ def test_is_defined_attribute_not_3(snippetcompiler, capsys, condition_block):
         f"""
 
     entity A:
-        number[]? a = null
+        int[]? a = null
     end
 
     implement A using std::none
@@ -208,7 +208,7 @@ def test_is_defined_attribute_2(snippetcompiler, capsys):
         """
 
     entity A:
-        number[]? a
+        int[]? a
     end
 
     implement A using std::none

--- a/tests/compiler/test_null.py
+++ b/tests/compiler/test_null.py
@@ -118,7 +118,7 @@ def test_exception_nullable(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
 entity A:
-    number? n
+    int? n
 end
 
 implement A using std::none
@@ -132,6 +132,6 @@ A(n = null)
     except UnsetException as e:
         message: str = (
             f"The object __config__::A (instantiated at {snippetcompiler.project_dir}/main.cf:8) is not "
-            f"complete: attribute n ({snippetcompiler.project_dir}/main.cf:3:13) is not set"
+            f"complete: attribute n ({snippetcompiler.project_dir}/main.cf:3:10) is not set"
         )
         assert e.msg == message

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -199,7 +199,7 @@ import test_674
 
 test_674::test_not_nullable_list(null)
         """,
-        "Invalid value 'null', expected number[] (reported in test_674::test_not_nullable_list(null) ({dir}/main.cf:4))",
+        "Invalid value 'null', expected int[] (reported in test_674::test_not_nullable_list(null) ({dir}/main.cf:4))",
     )
 
 

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -166,7 +166,7 @@ def test_m_to_n(snippetcompiler):
         """
 entity LogFile:
   string name
-  number members
+  int members
 end
 
 implement LogFile using std::none

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -15,17 +15,17 @@
 
     Contact: code@inmanta.com
 """
-
+import re
 import typing
 
 import pytest
 
 import inmanta.ast.type as inmanta_type
 import inmanta.compiler as compiler
-from inmanta.ast import AttributeException, Namespace, TypingException
+from inmanta.ast import AttributeException, Namespace, TypeDeprecationWarning, TypingException
 from inmanta.ast.attribute import Attribute
 from inmanta.ast.entity import Entity
-from inmanta.ast.type import Bool, Integer, Number, String
+from inmanta.ast.type import Bool, Float, Integer, Number, String
 from inmanta.execute.util import Unknown
 
 
@@ -269,9 +269,9 @@ number(null)
 def test_cast_exception_value_error(snippetcompiler):
     snippetcompiler.setup_for_error(
         """
-number("Hello World!")
+int("Hello World!")
         """,
-        "Failed to cast 'Hello World!' to number (reported in number('Hello World!') ({dir}/main.cf:2))",
+        "Failed to cast 'Hello World!' to int (reported in int('Hello World!') ({dir}/main.cf:2))",
     )
 
 
@@ -383,6 +383,186 @@ Child()
     )
 
 
+def test_deprecate_number(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+entity Test:
+    number val
+end
+        """,
+    )
+    with pytest.warns(
+        TypeDeprecationWarning,
+        match=re.escape("Type 'number' is deprecated, use 'float' or 'int' instead"),
+    ):
+        (_, scopes) = compiler.do_compile()
+
+
+def test_same_value_float_int(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+    i = 42.0
+    j = 42
+    i = j
+    j = i
+    a = (42 == 42.0)
+    a = true
+    """,
+    )
+    (_, scopes) = compiler.do_compile()
+
+
+def test_different_value_float_int(snippetcompiler, capsys):
+    snippetcompiler.setup_for_error(
+        """
+    i = 42.1
+    j = 42
+    i = j
+    """,
+        "value set twice:\n"
+        "\told value: 42.1\n"
+        "\t\tset at {dir}/main.cf:2\n"
+        "\tnew value: 42\n"
+        "\t\tset at {dir}/main.cf:4:9\n"
+        " (reported in i = j ({dir}/main.cf:4))",
+    )
+
+
+@pytest.mark.parametrize("float_val", ["42.0", "42.1"])
+def test_float_attribute(snippetcompiler, float_val):
+    snippet = f"""
+    entity Float:
+        float i
+    end
+    implement Float using std::none
+    f = Float(i={float_val})
+    """
+    snippetcompiler.setup_for_snippet(snippet)
+
+
+@pytest.mark.parametrize("float_val", ["42.0", "42.1"])
+def test_int_attribute_with_float(snippetcompiler, float_val):
+    snippet = f"""
+    entity Int:
+        int i
+    end
+    implement Int using std::none
+    i = Int(i={float_val}) # => not an int
+    """
+    snippetcompiler.setup_for_error(
+        snippet,
+        "Could not set attribute `i` on instance `__config__::Int (instantiated at "
+        "{dir}/main.cf:6)` (reported in Construct(Int) "
+        "({dir}/main.cf:6))\n"
+        "caused by:\n"
+        f"  Invalid value '{float_val}', expected int (reported in Construct(Int) "
+        "({dir}/main.cf:6))",
+    )
+
+
+def test_assign_float_to_int(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+    entity Test:
+        int i = 0
+    end
+    implement Test using std::none
+    Test(i = 42.1)
+        """,
+        "Could not set attribute `i` on instance `__config__::Test (instantiated at {dir}/main.cf:6)` "
+        "(reported in Construct(Test) ({dir}/main.cf:6))\n"
+        "caused by:\n"
+        "  Invalid value '42.1', expected int (reported in Construct(Test) ({dir}/main.cf:6))",
+    )
+
+
+def test_assign_int_to_float(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+    entity Test:
+        float i = 0.0
+    end
+    implement Test using std::none
+    x = Test(i = 42.0)
+    """,
+    )
+    (_, scopes) = compiler.do_compile()
+    root: Namespace = scopes.get_child("__config__")
+    x = root.lookup("x").get_value()
+    i = x.get_attribute("i").get_value()
+    assert not isinstance(i, int)
+    assert isinstance(i, float)
+
+
+def test_float_type(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+    entity Test:
+        float i = 0.0
+    end
+    implement Test using std::none
+    Test(i = 42.0)
+    Test(i = -42.0)
+    Test()
+    a = float(21)
+    a = 21.0
+    b = float(25.0)
+    b = 25.0
+    x = float("31")
+    x = 31.0
+    y = float("22.0")
+    y = 22.0
+    z = float(true)
+    z = 1.0
+    u = float(false)
+    u = 0.0
+    """,
+    )
+    (_, scopes) = compiler.do_compile()
+    root: Namespace = scopes.get_child("__config__")
+    a = root.lookup("a").get_value()
+    b = root.lookup("b").get_value()
+    x = root.lookup("x").get_value()
+    y = root.lookup("y").get_value()
+    z = root.lookup("z").get_value()
+    u = root.lookup("u").get_value()
+    assert Number().validate(a)
+    assert Number().validate(b)
+    assert Number().validate(x)
+    assert Number().validate(y)
+    assert Number().validate(z)
+    assert Number().validate(u)
+
+
+def test_lookup_on_float_with_int(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+entity A:
+    float x
+end
+implement A using std::none
+index A(x)
+a = A(x=1.0)
+y = A[x=1]
+a = y
+        """,
+    )
+    compiler.do_compile()
+
+
+def test_print_float(snippetcompiler, capsys):
+    snippetcompiler.setup_for_snippet(
+        """
+std::print(float(1.234))
+std::print(float(1.0))
+        """,
+    )
+    compiler.do_compile()
+    out, err = capsys.readouterr()
+    assert "1.234" in out
+    assert "1.0" in out
+
+
 def test_print_number(snippetcompiler, capsys):
     snippetcompiler.setup_for_snippet(
         """
@@ -392,3 +572,63 @@ std::print(number(1.234))
     compiler.do_compile()
     out, err = capsys.readouterr()
     assert "1.234" in out
+
+
+def test_float_type_argument_plugin(snippetcompiler, caplog):
+    snippetcompiler.setup_for_snippet(
+        """
+import test_674
+
+test = test_674::test_float_to_int(1.234)
+        """
+    )
+    (_, scopes) = compiler.do_compile()
+    root: Namespace = scopes.get_child("__config__")
+    x = root.lookup("test").get_value()
+    assert Integer().validate(x)
+
+
+@pytest.mark.parametrize("val", [42, "test"])
+def test_float_type_argument_plugin_error(snippetcompiler, val):
+    snippet = f"""
+    import test_674
+
+    test = test_674::test_float_to_int({repr(val)})
+            """
+    msg = f"Invalid value '{val}', expected float (reported in test_674::test_float_to_int({repr(val)}) ({{dir}}/main.cf:4))"
+
+    snippetcompiler.setup_for_error(
+        snippet,
+        msg,
+    )
+
+
+def test_float_type_return_type_plugin(snippetcompiler, caplog):
+    snippetcompiler.setup_for_snippet(
+        """
+import test_674
+
+test = test_674::test_int_to_float(1)
+        """
+    )
+    (_, scopes) = compiler.do_compile()
+    root: Namespace = scopes.get_child("__config__")
+    x = root.lookup("test").get_value()
+    assert Float().validate(x)
+
+
+def test_float_type_return_type_plugin_error(snippetcompiler, caplog):
+    snippetcompiler.setup_for_error(
+        """
+import test_674
+
+test = test_674::test_error_float()
+        """,
+        (
+            "Exception in plugin test_674::test_error_float (reported in "
+            "test_674::test_error_float() ({dir}/main.cf:4))\n"
+            "caused by:\n"
+            "  Invalid value '1', expected float (reported in "
+            "test_674::test_error_float() ({dir}/main.cf:4))"
+        ),
+    )

--- a/tests/compiler/test_warnings.py
+++ b/tests/compiler/test_warnings.py
@@ -186,7 +186,7 @@ def test_2030_type_overwrite_warning(snippetcompiler):
     with warnings.catch_warnings(record=True) as caught_warnings:
         snippetcompiler.setup_for_snippet(
             """
-typedef string as number matching self > 0
+typedef string as int matching self > 0
             """,
         )
         compiler.do_compile()

--- a/tests/data/modules/test_674/plugins/__init__.py
+++ b/tests/data/modules/test_674/plugins/__init__.py
@@ -12,15 +12,30 @@ def test_not_nullable(param: "string") -> "bool":
 
 
 @plugin
-def test_nullable_list(param: "number[]?") -> "bool":
+def test_nullable_list(param: "int[]?") -> "bool":
     return True
 
 
 @plugin
-def test_not_nullable_list(param: "number[]") -> "bool":
+def test_not_nullable_list(param: "int[]") -> "bool":
     return True
 
 
 @plugin
 def test_returns_none() -> "string?":
     return None
+
+
+@plugin
+def test_float_to_int(val1: "float") -> "int":
+    return int(val1)
+
+
+@plugin
+def test_int_to_float(val1: "int") -> "float":
+    return float(val1)
+
+
+@plugin
+def test_error_float() -> "float":
+    return 1

--- a/tests/data/modules/tests/plugins/__init__.py
+++ b/tests/data/modules/tests/plugins/__init__.py
@@ -10,7 +10,7 @@ def unknown() -> "any":
 
 
 @plugin
-def length(string: "string") -> "number":
+def length(string: "string") -> "int":
     """returns the length of the string"""
     return len(string)
 
@@ -45,7 +45,7 @@ def resolve_rule_purged_status(
 
 
 @plugin
-def once(string: "string") -> "number":
+def once(string: "string") -> "int":
     prev = counter[string]
     counter[string] = prev + 1
     return prev

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -441,7 +441,7 @@ def test_compiler_exception_output(snippetcompiler, cache_cf_files):
     snippetcompiler.setup_for_snippet(
         """
 entity Test:
-    number attr
+    int attr
 end
 
 implement Test using std::none
@@ -455,7 +455,7 @@ o = Test(attr="1234")
         f"""Could not set attribute `attr` on instance `__config__::Test (instantiated at {cwd}/main.cf:8)` """
         f"""(reported in Construct(Test) ({cwd}/main.cf:8))
 caused by:
-  Invalid value '1234', expected Number (reported in Construct(Test) ({cwd}/main.cf:8))
+  Invalid value '1234', expected int (reported in Construct(Test) ({cwd}/main.cf:8))
 """
     )
 
@@ -511,7 +511,7 @@ def test_warning_min_c_option_file_doesnt_exist(snippetcompiler, tmpdir):
     snippetcompiler.setup_for_snippet(
         """
 entity Test:
-    number attr
+    int attr
 end
 """
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -141,7 +141,7 @@ entity Test extends Foo, foo::sub::Bar:
     \"\"\"
     string hello
     bool bar = true
-    number? ten=5
+    int? ten=5
 end
 """
         % documentation


### PR DESCRIPTION
…l notation when used in indexes. (Issue inmanta/inmanta-core#6526, PR #6772)

# Description

1. create the float type which is like a float in python. Update documentation to mention number will be deprecated

2. add testcases for following scenario and fix it

```
entity A:
    float x
end

implement A using std::none

index A(x)

std::print(A(x=0) == A(x=0.0))
```
This will still not work with the number type

3. index lookup on float with int should work

closes https://github.com/inmanta/inmanta-core/issues/6526

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)


