### PR TITLE
Add setuptools package in requires

### DIFF
--- a/changelogs/unreleased/require-setuptools.yml
+++ b/changelogs/unreleased/require-setuptools.yml
@@ -1,0 +1,3 @@
+description: Add setuptools package in requires
+change-type: patch
+destination-branches: [master, iso6]

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ requires = [
     "pynacl~=1.5",
     "python-dateutil~=2.0",
     "pyyaml~=6.0",
+    "setuptools",
     "texttable~=1.0",
     "tornado~=6.0",
     "typing-extensions~=4.8.0",


### PR DESCRIPTION
# Description

Inmanta core uses setuptools but doesn't require it in its setup.py.  This means that `pip install inmanta` is not enough to have a working product if you don't have setuptools installed already.

Related to https://inmanta.slack.com/archives/CKRF0C8R3/p1701448113908329

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
