### PR TITLE
[WIP] remove old pip config change entries

### DIFF
--- a/changelogs/9.3.0/5976-use-pip-config-file.yml
+++ b/changelogs/9.3.0/5976-use-pip-config-file.yml
@@ -2,6 +2,3 @@ description: improved support for pip config files by adding the use_config_file
 issue-nr: 5976
 change-type: minor
 destination-branches: [master, iso6]
-sections:
-  minor-improvement: "{{description}}"
-

--- a/changelogs/9.3.0/5993-add-dedicated-pip-index-url-config-for-full-project.yml
+++ b/changelogs/9.3.0/5993-add-dedicated-pip-index-url-config-for-full-project.yml
@@ -2,9 +2,3 @@ description: Add dedicated project-wide pip index url configuration option to th
 issue-nr: 5993
 change-type: minor
 destination-branches: [master, iso6]
-sections:
-  minor-improvement: "{{description}}"
-  deprecation-note: >
-    Setting a package source in the project.yml file through the `repo -> url <index_url>` option with type `package`
-    is now deprecated in favour of the `pip -> index_urls <index_url>` option.
-

--- a/changelogs/unreleased/445-drop-old-pip-config-change-entries-from-iso7-changelog.yml
+++ b/changelogs/unreleased/445-drop-old-pip-config-change-entries-from-iso7-changelog.yml
@@ -1,0 +1,3 @@
+description: Remove the change entries related to the initial attempt at a centralized pip config framework.
+change-type: patch
+destination-branches: [master]


### PR DESCRIPTION
# Description

Remove the changelog entries from our initial attempt at a centralized pip config.
For reference, this is the [changelog entry](https://github.com/inmanta/inmanta-core/blob/master/changelogs/unreleased/6518-pip-config-docs.yml) centralizing the changes for the latest attempt.

closes https://github.com/inmanta/inmanta-service-orchestrator/issues/445

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
