### PR TITLE
update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       update-types: ["version-update:semver-major"]
     - dependency-name: "execnet"
       update-types: ["version-update:semver-major"]
-- target-branch: iso6
+- target-branch: iso7
   package-ecosystem: pip
   directory: "/"
   schedule:

--- a/changelogs/unreleased/update-dependabot-release.yml
+++ b/changelogs/unreleased/update-dependabot-release.yml
@@ -1,3 +1,3 @@
 description: update dependabot
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso7]

--- a/changelogs/unreleased/update-dependabot-release.yml
+++ b/changelogs/unreleased/update-dependabot-release.yml
@@ -1,0 +1,3 @@
+description: update dependabot
+change-type: patch
+destination-branches: [master]


### PR DESCRIPTION
# Description

Set up dependabot for the new branches:

make sure dependabot is enabled for master and disabled for the iso branch that moved to patch because
it should only receive security updates (which we manage by hand for now, https://github.com/inmanta/irt/issues/512).
Merge the config change (if any) using the merge tool, which acts as a guard against accidental branch divergence.

on the product repo and repos that were diverged earlier in the major release process (inmanta-lsm), additionally
enable updates for the newly created iso branch but set it up to ignore all extensions.

- [ ] Changelog entry

