### PR TITLE
Optimize the '_list_python_files' function for packaged V2 modules (I…

### DIFF
--- a/changelogs/unreleased/optimize-packaged-v2-modules.yml
+++ b/changelogs/unreleased/optimize-packaged-v2-modules.yml
@@ -1,0 +1,4 @@
+description: "Optimize the '_list_python_files' function for packaged V2 modules"
+change-type: patch
+issue-nr: 4799
+destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/optimize-packaged-v2-modules.yml
+++ b/changelogs/unreleased/optimize-packaged-v2-modules.yml
@@ -1,4 +1,4 @@
 description: "Optimize the '_list_python_files' function for packaged V2 modules"
 change-type: patch
 issue-nr: 4799
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -18,7 +18,6 @@
 
 import configparser
 import enum
-import glob
 import importlib
 import logging
 import operator
@@ -2705,6 +2704,7 @@ class Module(ModuleLike[TModuleMetadata], ABC):
 
         self._ast_cache: dict[str, tuple[list[Statement], BasicBlock]] = {}  # Cache for expensive method calls
         self._import_cache: dict[str, list[DefineImport]] = {}  # Cache for expensive method calls
+        self._dir_cache: Dict[str, list[str]] = {}  # Cache containing all the filepaths present in a dir
 
     @classmethod
     @abstractmethod
@@ -2885,20 +2885,55 @@ class Module(ModuleLike[TModuleMetadata], ABC):
         raise NotImplementedError()
 
     def _list_python_files(self, plugin_dir: str) -> list[str]:
-        """Generate a list of all python files"""
+        """
+        Generate a list of all Python files in the given plugin directory.
+        This method prioritizes .pyc files over .py files, uses caching to avoid duplicate directory walks,
+        and only considers directories that are Python packages.
+        """
+        # Return cached results if this directory has been processed before
+        if plugin_dir in self._dir_cache:
+            return self._dir_cache[plugin_dir]
+
         files: dict[str, str] = {}
 
-        for file_name in glob.iglob(os.path.join(plugin_dir, "**", "*.pyc"), recursive=True):
-            # Filter out pyc files in the default cache dir. Only support our compiled pyc files.
-            if "__pycache__" not in file_name:
-                files[file_name[:-3]] = file_name
+        for dirpath, dirnames, filenames in os.walk(plugin_dir):
+            # Skip non-package directories (those without an __init__.py or __init__.pyc file)
+            if not any(fname for fname in filenames if fname in ["__init__.py", "__init__.pyc"]):
+                continue
 
-        for file_name in glob.iglob(os.path.join(plugin_dir, "**", "*.py"), recursive=True):
-            # store the python source file if we do not have a python file
-            if file_name[:-2] not in files:
-                files[file_name[:-2]] = file_name
+            # Skip this directory if it's already in the cache
+            if dirpath in self._dir_cache:
+                cached_files = self._dir_cache[dirpath]
+                for file in cached_files:
+                    base_file_path = os.path.splitext(file)[0]
+                    files[base_file_path] = file
+                continue
 
-        return list(files.values())
+            current_path_files = []
+
+            for filename in filenames:
+                file_path = os.path.join(dirpath, filename)
+
+                # Skip files in the default cache directory
+                if "__pycache__" in file_path:
+                    continue
+
+                base_file_path = os.path.splitext(file_path)[0]
+
+                # Prioritize .pyc files over .py files
+                if file_path.endswith(".pyc"):
+                    files[base_file_path] = file_path
+                    current_path_files.append(file_path)
+                elif file_path.endswith(".py") and base_file_path not in files:
+                    files[base_file_path] = file_path
+                    current_path_files.append(file_path)
+
+            # Update the cache with files found in the current directory
+            self._dir_cache[dirpath] = current_path_files
+
+        # Cache the final list of files for the root directory and return it
+        self._dir_cache[plugin_dir] = list(files.values())
+        return self._dir_cache[plugin_dir]
 
     def get_plugin_files(self) -> Iterator[tuple[Path, ModuleName]]:
         """


### PR DESCRIPTION
…ssue #4799, PR #6882)

make some optimizations to the _list_python_files function:
1. replace glob by os.walk
2. cache directories to avoid duplicate directory walks
3. only considers directories that are Python packages

this was the profile before:
![Screenshot from 2023-12-21 10-28-58](https://github.com/inmanta/inmanta-core/assets/95339363/12c84d67-7113-40b2-9847-7731d905b55c)

this is the profile now. I'm a bit surprised by the number of calls to os.walk: ![Screenshot from 2023-12-21 10-29-26](https://github.com/inmanta/inmanta-core/assets/95339363/5c946d2d-d663-4e18-879b-4154c8290435)

closes #4799

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)


