### PR TITLE
Bump inmanta-dev-dependencies[async,core,pytest] from 2.98.0 to 2.101.0 (#6912)

### DIFF
--- a/changelogs/unreleased/6912-dependabot.yml
+++ b/changelogs/unreleased/6912-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump inmanta-dev-dependencies[async,core,pytest] from 2.98.0 to 2.101.0
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[pytest,async,core]==2.98.0
+inmanta-dev-dependencies[pytest,async,core]==2.101.0
 bumpversion==0.6.0
 openapi_spec_validator==0.7.1
 pip2pi==0.8.2


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #6912