### PR TITLE
6861: Use 401 and 403 correctly

### DIFF
--- a/changelogs/unreleased/6861-use-corrrect-htttp-status-code.yml
+++ b/changelogs/unreleased/6861-use-corrrect-htttp-status-code.yml
@@ -1,0 +1,6 @@
+description: Use 401 and 403 correctly where they are used incorrectly
+change-type: patch
+destination-branches:
+  - master
+  - iso7
+  - iso6

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -59,10 +59,10 @@ def authorize_request(
     env_key: str = const.INMANTA_URN + "env"
     if env_key in auth_data:
         if env_key not in metadata:
-            raise exceptions.UnauthorizedException("The authorization token is scoped to a specific environment.")
+            raise exceptions.Forbidden("The authorization token is scoped to a specific environment.")
 
         if metadata[env_key] != "all" and auth_data[env_key] != metadata[env_key]:
-            raise exceptions.UnauthorizedException("The authorization token is not valid for the requested environment.")
+            raise exceptions.Forbidden("The authorization token is not valid for the requested environment.")
 
     # Enforce client_types restrictions
     ok: bool = False
@@ -72,7 +72,7 @@ def authorize_request(
             ok = True
 
     if not ok:
-        raise exceptions.UnauthorizedException(
+        raise exceptions.Forbidden(
             "The authorization token does not have a valid client type for this call."
             + f" ({auth_data[ct_key]} provided, {config.properties.client_types} expected"
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -652,7 +652,7 @@ async def test_tokens(server_multi, client_multi, environment_multi, request):
 
     # try to access a non environment call (global)
     result = await client_multi.list_environments()
-    assert result.code == 401
+    assert result.code == 403
 
     result = await client_multi.list_versions(environment_multi)
     assert result.code == 200
@@ -662,7 +662,7 @@ async def test_tokens(server_multi, client_multi, environment_multi, request):
 
     client_multi._transport_instance.token = agent_jot
     result = await client_multi.list_versions(environment_multi)
-    assert result.code == 401
+    assert result.code == 403
 
 
 async def test_token_without_auth(server, client, environment):


### PR DESCRIPTION
# Description

Currently, we raise the same exception for a not-authenticated and not-authorized user.
This causes issues for the front-end

closes #6861

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
