### PR TITLE
Issue/bump version to v11.0.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.0.1
+current_version = 11.0.2
 
 [bumpversion:file:setup.py]
 search = version = "{current_version}"

--- a/changelogs/unreleased/bump-version-to-11-0-2.yml
+++ b/changelogs/unreleased/bump-version-to-11-0-2.yml
@@ -1,0 +1,4 @@
+---
+description: Bump version to v11.0.2
+change-type: patch
+destination-branches: [master, iso7]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 # This version is managed by bumpversion. Should you ever update it manually, make sure to consistently update it everywhere
 # (See the bumpversion.cfg file for relevant locations).
-version = "11.0.1"
+version = "11.0.2"
 
 setup(
     version=version,

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -19,7 +19,7 @@
 COMPILER_VERSION = "2024.1"
 # This version is managed by bumpversion. Should you ever update it manually, make sure to consistently update it everywhere
 # (See the bumpversion.cfg file for relevant locations).
-__version__ = "11.0.1"
+__version__ = "11.0.2"
 
 RUNNING_TESTS = False
 """

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -19,7 +19,7 @@ from os import path
 
 from setuptools import find_namespace_packages, setup
 
-version = "11.0.1"
+version = "11.0.2"
 
 requires = [
     "asyncpg",


### PR DESCRIPTION
# Description

Bump the version on `v11.0.2`, because the version on the next branch was bumped to `v11.0.1` for a patch release.

Part of inmanta/inmanta-service-orchestrator#466

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
