### PR TITLE
Issue/6743 improve error message when installing module in editable mode

### DIFF
--- a/changelogs/unreleased/6743-improve-error-message-installing-module-in-editable-mode.yml
+++ b/changelogs/unreleased/6743-improve-error-message-installing-module-in-editable-mode.yml
@@ -1,0 +1,4 @@
+description: Fix error when adding a v1 module that doesn't require other modules.
+issue-nr: 6743
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1886,7 +1886,7 @@ class ModuleLikeWithYmlMetadataFile(ABC):
         # Parse cfg file
         content: CommentedMap = PreservativeYamlParser.parse(self.get_metadata_file_path())
         # Update requires
-        if "requires" in content:
+        if "requires" in content and content["requires"]:
             existing_matching_reqs: list[str] = [
                 r for r in content["requires"] if InmantaModuleRequirement.parse(r).key == requirement.key
             ]


### PR DESCRIPTION
# Description

Tried running `inmanta module add` for some v1 and v2 modules.
I noticed the following issue with v1 module with no "requires" field in their module.yml:

```
(.env) hugo@hugo-Latitude-5421:~/tmp/tmp_project/module_install_test$ inmanta module add --v1 net
inmanta.warnings         WARNING ProjectConfigurationWarning: Setting a pip index through the `repo.url` option with type `package` in the project.yml file is no longer supported and will be ignored. Please set the pip index url through the `pip.index_url` option instead.
inmanta.warnings         WARNING ModuleDeprecationWarning: Module net has been deprecated
'NoneType' object is not iterable

```


closes https://github.com/inmanta/inmanta-core/issues/6743

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
