### PR TITLE
Bump types-python-dateutil from 2.8.19.14 to 2.8.19.20240106 (#6945)

### DIFF
--- a/changelogs/unreleased/6945-dependabot.yml
+++ b/changelogs/unreleased/6945-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump types-python-dateutil from 2.8.19.14 to 2.8.19.20240106
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,7 +3,7 @@ bumpversion==0.6.0
 openapi_spec_validator==0.7.1
 pip2pi==0.8.2
 types-PyYAML==6.0.12.12
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.8.19.20240106
 types-setuptools==69.0.0.0
 types-toml==0.10.8.7
 flake8-junit-report==2.1.0


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #6945