### PR TITLE
Issue/5946 duplicatedexception tell duplicated attr

### DIFF
--- a/changelogs/unreleased/5946-duplicateException-tell-deplicated.yml
+++ b/changelogs/unreleased/5946-duplicateException-tell-deplicated.yml
@@ -1,0 +1,5 @@
+description: When an entity defines two times the same attribute, the raised DuplicateException will not tell which attribute is duplicated
+issue-nr: 5946
+change-type: patch
+destination-branches: [master, iso7, iso6]
+

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -239,7 +239,9 @@ class Entity(NamedType, WithComment):
             self._attributes[attribute.name] = attribute
         else:
             raise DuplicateException(
-                self._attributes[attribute.name], attribute, "attribute '%s' already exists" % attribute.name
+                self._attributes[attribute.name],
+                attribute,
+                "attribute '%s' already exists on entity '%s'" % (attribute.name, self.name),
             )
 
     def get_attribute(self, name: str) -> Optional["Attribute"]:

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -238,7 +238,9 @@ class Entity(NamedType, WithComment):
         if attribute.name not in self._attributes:
             self._attributes[attribute.name] = attribute
         else:
-            raise DuplicateException(self._attributes[attribute.name], attribute, "attribute already exists")
+            raise DuplicateException(
+                self._attributes[attribute.name], attribute, "attribute '%s' already exists" % attribute.name
+            )
 
     def get_attribute(self, name: str) -> Optional["Attribute"]:
         """

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -719,6 +719,6 @@ def test_implementation_import_missing_error(snippetcompiler) -> None:
 
     with pytest.raises(RuntimeException) as exception:
         snippetcompiler.do_export()
-    assert exception.value.msg == "could not find type tests::length in namespace __config__"
+    assert "could not find type tests::length in namespace __config__" in exception.value.msg
     assert exception.value.location.lnr == 6
     assert exception.value.location.start_char == 20

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -36,7 +36,7 @@ end
     with pytest.raises(
         DuplicateException,
         match=re.escape(
-            f"attribute 'test' already exists (original at ({dir}/main.cf:3:12)) (duplicate at ({dir}/main.cf:4:10))"
+            f"attribute 'test' already exists on entity 'Test' (original at ({dir}/main.cf:3:12)) (duplicate at ({dir}/main.cf:4:10))"
         ),
     ):
         compiler.do_compile()

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -35,7 +35,9 @@ end
     dir: str = snippetcompiler.project_dir
     with pytest.raises(
         DuplicateException,
-        match=re.escape(f"attribute already exists (original at ({dir}/main.cf:3:12)) (duplicate at ({dir}/main.cf:4:10))"),
+        match=re.escape(
+            f"attribute 'test' already exists (original at ({dir}/main.cf:3:12)) (duplicate at ({dir}/main.cf:4:10))"
+        ),
     ):
         compiler.do_compile()
 

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -36,7 +36,8 @@ end
     with pytest.raises(
         DuplicateException,
         match=re.escape(
-            f"attribute 'test' already exists on entity 'Test' (original at ({dir}/main.cf:3:12)) (duplicate at ({dir}/main.cf:4:10))"
+            f"attribute 'test' already exists on entity 'Test' (original at ({dir}/main.cf:3:12)) "
+            f"(duplicate at ({dir}/main.cf:4:10))"
         ),
     ):
         compiler.do_compile()


### PR DESCRIPTION
# Description

If an entity defines two times the same attribute, a duplicate exception is raised. The exception will now also tell which attribute is duplicated

closes  #5946 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
