### PR TITLE
issue/5558-Logging-improvement-for-nullable-list

### DIFF
--- a/changelogs/unreleased/5558-logging-improvement-for-nullable-list.yml
+++ b/changelogs/unreleased/5558-logging-improvement-for-nullable-list.yml
@@ -1,4 +1,4 @@
-description: Add a hint telling that an attribute is null in the TypingException when trying to iterate over it using a for loop
+description: Add a hint to the TypingException telling that an attribute is null when trying to iterate over it using a for loop
 issue-nr: 5558
 change-type: patch
 destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/5558-logging-improvement-for-nullable-list.yml
+++ b/changelogs/unreleased/5558-logging-improvement-for-nullable-list.yml
@@ -1,0 +1,4 @@
+description: Add a hint telling that an attribute is null in the TypingException when trying to iterate over it using a for loop
+issue-nr: 5558
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -253,8 +253,8 @@ class For(RequiresEmitStatement):
 
         if not isinstance(var, (list, Unknown)):
             msg = "A for loop can only be applied to lists and relations."
-            if isinstance(var, NoneValue):
-                msg += " Hint: '%s' is null." % self.base
+            if not isinstance(self.base, Literal):
+                msg += " Hint: '%s' is '%s'." % (self.base, str(var))
             raise TypingException(self, msg)
 
         # we're done here: base's execute has reported results to helper

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -74,7 +74,7 @@ from inmanta.execute.runtime import (
     WrappedValueVariable,
 )
 from inmanta.execute.tracking import ImplementsTracker
-from inmanta.execute.util import NoneValue, Unknown
+from inmanta.execute.util import Unknown
 
 try:
     from typing import TYPE_CHECKING

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -74,7 +74,7 @@ from inmanta.execute.runtime import (
     WrappedValueVariable,
 )
 from inmanta.execute.tracking import ImplementsTracker
-from inmanta.execute.util import Unknown
+from inmanta.execute.util import NoneValue, Unknown
 
 try:
     from typing import TYPE_CHECKING
@@ -252,7 +252,10 @@ class For(RequiresEmitStatement):
         var = self.base.execute(requires, resolver, queue)
 
         if not isinstance(var, (list, Unknown)):
-            raise TypingException(self, "A for loop can only be applied to lists and relations")
+            msg = "A for loop can only be applied to lists and relations."
+            if isinstance(var, NoneValue):
+                msg += " Hint: '%s' is null." % self.base
+            raise TypingException(self, msg)
 
         # we're done here: base's execute has reported results to helper
         return None

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -253,8 +253,10 @@ class For(RequiresEmitStatement):
 
         if not isinstance(var, (list, Unknown)):
             msg = "A for loop can only be applied to lists and relations."
-            if not isinstance(self.base, Literal):
-                msg += " Hint: '%s' is '%s'." % (self.base, str(var))
+            if isinstance(self.base, Reference):
+                msg += " Hint: '%s' resolves to '%s'." % (self.base, str(var))
+            else:
+                msg += " Hint: '%s' is not a list." % str(var)
             raise TypingException(self, msg)
 
         # we're done here: base's execute has reported results to helper

--- a/tests/compiler/test_loops.py
+++ b/tests/compiler/test_loops.py
@@ -47,7 +47,7 @@ def test_for_error(snippetcompiler):
         for i in a:
         end
     """,
-        "A for loop can only be applied to lists and relations (reported in For(i) ({dir}/main.cf:7))",
+        "A for loop can only be applied to lists and relations. (reported in For(i) ({dir}/main.cf:7))",
     )
 
 
@@ -57,7 +57,7 @@ def test_for_error_2(snippetcompiler):
         for i in "foo":
         end
     """,
-        "A for loop can only be applied to lists and relations (reported in For(i) ({dir}/main.cf:2))",
+        "A for loop can only be applied to lists and relations. (reported in For(i) ({dir}/main.cf:2))",
     )
 
 
@@ -74,7 +74,8 @@ def test_for_error_nullable_list(snippetcompiler):
             std::print(element)
         end
     """,
-        "A for loop can only be applied to lists and relations. Hint: 'a.elements' is null. (reported in For(element) ({dir}/main.cf:8))",
+        "A for loop can only be applied to lists and relations. "
+        "Hint: 'a.elements' is null. (reported in For(element) ({dir}/main.cf:8))",
     )
 
 

--- a/tests/compiler/test_loops.py
+++ b/tests/compiler/test_loops.py
@@ -61,6 +61,23 @@ def test_for_error_2(snippetcompiler):
     )
 
 
+def test_for_error_nullable_list(snippetcompiler):
+    snippetcompiler.setup_for_error(
+        """
+        entity A:
+            string[]? elements=null
+        end
+        implement A using std::none
+
+        a = A()
+        for element in a.elements:
+            std::print(element)
+        end
+    """,
+        "A for loop can only be applied to lists and relations. Hint: 'a.elements' is null. (reported in For(element) ({dir}/main.cf:8))",
+    )
+
+
 def test_for_loop_on_list_attribute(snippetcompiler) -> None:
     """
     Verify the basic workings of the for loop statement when applied to a plain list attribute.

--- a/tests/compiler/test_loops.py
+++ b/tests/compiler/test_loops.py
@@ -47,7 +47,7 @@ def test_for_error(snippetcompiler):
         for i in a:
         end
     """,
-        "A for loop can only be applied to lists and relations. Hint: 'a' is "
+        "A for loop can only be applied to lists and relations. Hint: 'a' resolves to "
         "'__config__::A (instantiated at {dir}/main.cf:6)'. (reported in "
         "For(i) ({dir}/main.cf:7))",
     )
@@ -59,7 +59,8 @@ def test_for_error_2(snippetcompiler):
         for i in "foo":
         end
     """,
-        "A for loop can only be applied to lists and relations. (reported in For(i) ({dir}/main.cf:2))",
+        "A for loop can only be applied to lists and relations. Hint: 'foo' is not a "
+        "list. (reported in For(i) ({dir}/main.cf:2))",
     )
 
 
@@ -77,7 +78,7 @@ def test_for_error_nullable_list(snippetcompiler):
         end
     """,
         "A for loop can only be applied to lists and relations. "
-        "Hint: 'a.elements' is 'null'. (reported in For(element) ({dir}/main.cf:8))",
+        "Hint: 'a.elements' resolves to 'null'. (reported in For(element) ({dir}/main.cf:8))",
     )
 
 

--- a/tests/compiler/test_loops.py
+++ b/tests/compiler/test_loops.py
@@ -47,7 +47,9 @@ def test_for_error(snippetcompiler):
         for i in a:
         end
     """,
-        "A for loop can only be applied to lists and relations. (reported in For(i) ({dir}/main.cf:7))",
+        "A for loop can only be applied to lists and relations. Hint: 'a' is "
+        "'__config__::A (instantiated at {dir}/main.cf:6)'. (reported in "
+        "For(i) ({dir}/main.cf:7))",
     )
 
 
@@ -75,7 +77,7 @@ def test_for_error_nullable_list(snippetcompiler):
         end
     """,
         "A for loop can only be applied to lists and relations. "
-        "Hint: 'a.elements' is null. (reported in For(element) ({dir}/main.cf:8))",
+        "Hint: 'a.elements' is 'null'. (reported in For(element) ({dir}/main.cf:8))",
     )
 
 


### PR DESCRIPTION
# Description

Currently when we loop over a nullable list attribute which is not set, the current message is the following : "A for loop can only be applied to lists and relations". Now there will also be a hint telling that the attribute is null

closes #5558 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
