### PR TITLE
Make agent more resilient to resource loading issues

### DIFF
--- a/changelogs/unreleased/agent_resilience.yml
+++ b/changelogs/unreleased/agent_resilience.yml
@@ -1,0 +1,5 @@
+description: Make agent more resilient to resource loading issues
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -114,7 +114,7 @@ class ResourceActionBase(abc.ABC):
 
     def cancel(self) -> None:
         if not self.is_running() and not self.is_done():
-            LOGGER.info("Cancelled deploy of %s %s", self.gid, self.resource_id)
+            self.logger.info("Cancelled deploy of %s %s %s", self.__class__.__name__, self.gid, self.resource_id)
             self.future.set_result(ResourceActionResult(cancel=True))
 
     def long_string(self) -> str:

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1062,7 +1062,7 @@ class AgentInstance:
                     resource = Resource.deserialize(res["attributes"], use_generic=True)
                     loaded_resources.append(resource)
 
-            except TypeError:
+            except Exception:
                 failed_resources.append(res["id"])
                 undeployable[res["id"]] = const.ResourceState.unavailable
                 resource = Resource.deserialize(res["attributes"], use_generic=True)

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -208,7 +208,7 @@ class SessionEndpoint(Endpoint, CallTarget):
         Connect to the server and use a heartbeat and long-poll for two-way communication
         """
         assert self._env_id is not None
-        LOGGER.log(3, "Starting agent for %s", str(self.sessionid))
+        LOGGER.info("Starting agent for %s", str(self.sessionid))
         self._client = SessionClient(self.name, self.sessionid, timeout=self.server_timeout)
         self._heartbeat_client = SessionClient(self.name, self.sessionid, timeout=self.server_timeout, force_instance=True)
         await self.start_connected()


### PR DESCRIPTION
# Description

Ensure exception produced by resource construction are properly handled 

Previously, exceptions could escape, making deployments hang

```
Traceback (most recent call last):
  File "/opt/inmanta/lib64/python3.11/site-packages/inmanta/agent/agent.py", line 737, in deploy_action
    await self.get_latest_version_for_agent(
  File "/opt/inmanta/lib64/python3.11/site-packages/inmanta/agent/agent.py", line 860, in get_latest_version_for_agent
    undeployable, resources = await self.load_resources(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/inmanta/lib64/python3.11/site-packages/inmanta/agent/agent.py", line 1053, in load_resources
    resource: Resource = Resource.deserialize(res["attributes"])
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/inmanta/lib64/python3.11/site-packages/inmanta/resources.py", line 353, in deserialize
    obj.populate(obj_map, force_fields)
  File "/opt/inmanta/lib64/python3.11/site-packages/inmanta/resources.py", line 386, in populate
    raise Exception("Resource with id {} does not have field {}".format(fields["id"], field))
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
