### PR TITLE
[FIX] fix exception type used in plugins.py

### DIFF
--- a/changelogs/unreleased/6971-fix-plugins-exception-type.yml
+++ b/changelogs/unreleased/6971-fix-plugins-exception-type.yml
@@ -1,0 +1,4 @@
+description: Fix exception type used in plugins.py
+issue-nr: 6971
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -26,15 +26,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Type, TypeVa
 
 import inmanta.ast.type as inmanta_type
 from inmanta import const, protocol, util
-from inmanta.ast import (
-    LocatableString,
-    Location,
-    Namespace,
-    Range,
-    RuntimeException,
-    TypeNotFoundException,
-    WithComment,
-)
+from inmanta.ast import LocatableString, Location, Namespace, Range, RuntimeException, TypeNotFoundException, WithComment
 from inmanta.ast.type import NamedType
 from inmanta.config import Config
 from inmanta.execute.proxy import DynamicProxy
@@ -244,8 +236,9 @@ class PluginValue:
         """
         if self._resolved_type is None:
             raise RuntimeException(
-                f"{type(self).__name__} {self.VALUE_NAME} ({repr(self.type_expression)}) has not been normalized, "
-                "its resolved type can't be accessed."
+                stmt=None,
+                msg=f"{type(self).__name__} {self.VALUE_NAME} ({repr(self.type_expression)}) has not been normalized, "
+                "its resolved type can't be accessed.",
             )
         return self._resolved_type
 
@@ -265,8 +258,9 @@ class PluginValue:
 
         if not isinstance(self.type_expression, str):
             raise RuntimeException(
-                "Bad annotation in plugin %s for %s, expected str but got %s (%s)"
-                % (plugin.get_full_name(), self.VALUE_NAME, type(self.type_expression).__name__, self.type_expression)
+                stmt=None,
+                msg="Bad annotation in plugin %s for %s, expected str but got %s (%s)"
+                % (plugin.get_full_name(), self.VALUE_NAME, type(self.type_expression).__name__, self.type_expression),
             )
 
         plugin_line: Range = Range(plugin.location.file, plugin.location.lnr, 1, plugin.location.lnr + 1, 1)
@@ -424,8 +418,9 @@ class Plugin(NamedType, WithComment, metaclass=PluginMeta):
             """
             if arg not in arg_spec.annotations:
                 raise RuntimeException(
-                    f"All arguments of plugin {repr(self.get_full_name())} should be annotated: "
-                    f"{repr(arg)} has no annotation"
+                    stmt=None,
+                    msg=f"All arguments of plugin {repr(self.get_full_name())} should be annotated: "
+                    f"{repr(arg)} has no annotation",
                 )
 
             return arg_spec.annotations[arg]

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Type, TypeVa
 import inmanta.ast.type as inmanta_type
 from inmanta import const, protocol, util
 from inmanta.ast import (
-    CompilerException,
     LocatableString,
     Location,
     Namespace,
@@ -244,7 +243,7 @@ class PluginValue:
         once this object has been normalized (which happens during the plugin normalization).
         """
         if self._resolved_type is None:
-            raise CompilerException(
+            raise RuntimeException(
                 f"{type(self).__name__} {self.VALUE_NAME} ({repr(self.type_expression)}) has not been normalized, "
                 "its resolved type can't be accessed."
             )
@@ -265,7 +264,7 @@ class PluginValue:
             return self._resolved_type
 
         if not isinstance(self.type_expression, str):
-            raise CompilerException(
+            raise RuntimeException(
                 "Bad annotation in plugin %s for %s, expected str but got %s (%s)"
                 % (plugin.get_full_name(), self.VALUE_NAME, type(self.type_expression).__name__, self.type_expression)
             )
@@ -424,7 +423,7 @@ class Plugin(NamedType, WithComment, metaclass=PluginMeta):
             Get the annotation for a specific argument, and if none exists, raise an exception
             """
             if arg not in arg_spec.annotations:
-                raise CompilerException(
+                raise RuntimeException(
                     f"All arguments of plugin {repr(self.get_full_name())} should be annotated: "
                     f"{repr(arg)} has no annotation"
                 )


### PR DESCRIPTION
# Description

Change `CompilerException`s in plugins.py to `RuntimeException`s

closes https://github.com/inmanta/inmanta-core/issues/6971

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
