### PR TITLE
[FIX] fix comments in docs code example using old double slash syntax (#7006)

### DIFF
--- a/changelogs/unreleased/6973-replace-double-slash-by-hash-symbol.yml
+++ b/changelogs/unreleased/6973-replace-double-slash-by-hash-symbol.yml
@@ -1,0 +1,4 @@
+description: Fix comments in docs code examples using old ``//`` syntax with ``#``.
+issue-nr: 6973
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -514,7 +514,7 @@ any values to the relation attribute.
     f2 = File(host=h1, path="/opt/2")
     f3 = File(host=h1, path="/opt/3")
 
-    // h1.files equals [f1, f2, f3]
+    # h1.files equals [f1, f2, f3]
 
     FileSet.files [0:] -- File.set [1]
 
@@ -522,11 +522,11 @@ any values to the relation attribute.
     s1.files = [f1,f2]
     s1.files = f3
 
-    // s1.files equals [f1, f2, f3]
+    # s1.files equals [f1, f2, f3]
 
     s1.files = f3
-    // adding a value twice does not affect the relation,
-    // s1.files still equals [f1, f2, f3]
+    # adding a value twice does not affect the relation,
+    # s1.files still equals [f1, f2, f3]
 
 In addition, attributes can be assigned in a constructor using keyword arguments by using ``**dct`` where ``dct`` is a dictionary that contains
 attribute names as keys and the desired values as values. For example:
@@ -550,7 +550,7 @@ It is also possible to add elements to a relation with the ``+=`` operator:
     h1.files += f2
     h1.files += f3
 
-    // h1.files equals [f1, f2, f3]
+    # h1.files equals [f1, f2, f3]
 
 
 .. note::


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #7006