### PR TITLE
fixed empty div appearing at top of docs pages (#7016)

### DIFF
--- a/changelogs/unreleased/docs-empty-div-fix.yml
+++ b/changelogs/unreleased/docs-empty-div-fix.yml
@@ -1,0 +1,6 @@
+description: Fixed empty div appearing at top of docs pages
+change-type: patch
+destination-branches:
+  - master
+  - iso7
+  - iso6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,10 +134,10 @@ except NameError:
 
 
 version_major = int(version.split(".")[0])
-rst_prolog = f"""
-    .. |version_major| replace:: {version_major}
-    .. |iso_gpg_key| replace:: {iso_gpg_key}
-    .. |oss_gpg_key| replace:: {oss_gpg_key}
+rst_prolog = f"""\
+.. |version_major| replace:: {version_major}
+.. |iso_gpg_key| replace:: {iso_gpg_key}
+.. |oss_gpg_key| replace:: {oss_gpg_key}
 """
 
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #7016