### PR TITLE
Lexer fix

### DIFF
--- a/changelogs/unreleased/lexer-fix.yml
+++ b/changelogs/unreleased/lexer-fix.yml
@@ -1,0 +1,5 @@
+description: Fixed lexing of matching keyword
+change-type: patch
+destination-branches:
+  - master
+  - iso7

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -35,6 +35,7 @@ keyworldlist = [
     "in",
     "implementation",
     "for",
+    "matching",
     "index",
     "implement",
     "using",
@@ -69,7 +70,6 @@ tokens = [
     "MLS",
     "CMP_OP",
     "REGEX",
-    "MATCHING",
     "REL",
     "PEQ",
     "RSTRING",
@@ -104,11 +104,6 @@ def t_REGEX(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
         line_nr_regex = t.lexer.lineno + part_before_regex.count("\n")
         r: Range = Range(t.lexer.inmfile, line_nr_regex, start, line_nr_regex, end)
         raise ParserException(r, t.value, f"Regex error in {t.value}: '{error}'")
-
-
-def t_MATCHING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802
-    r"matching"
-    return t
 
 
 def t_FSTRING(t: lex.LexToken) -> lex.LexToken:  # noqa: N802

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -484,7 +484,7 @@ def test_matching_keyword_in_identifier(snippetcompiler):
     Verify that 'matching' is allowed as part of an identifier even though it's a keyword.
     """
     statements = parse_code(
-        f"""
+        """
 entity A:
     int matching_attribute
 end

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -479,6 +479,24 @@ typedef test as string matching{sep}/[a-fA-F0-9]{{8}}-[a-fA-F0-9]{{4}}-[a-fA-F0-
     assert regex_expr.regex == re.compile(r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
 
 
+def test_matching_keyword_in_identifier(snippetcompiler):
+    """
+    Verify that 'matching' is allowed as part of an identifier even though it's a keyword.
+    """
+    statements = parse_code(
+        f"""
+entity A:
+    int matching_attribute
+end
+"""
+    )
+
+    assert len(statements) == 1
+    assert isinstance(statements[0], DefineEntity)
+    assert len(statements[0].attributes) == 1
+    compare_attr(statements[0].attributes[0], "matching_attribute", "int", lambda _: True)
+
+
 def test_regex_backslash():
     statements = parse_code(
         r"""


### PR DESCRIPTION
# Description

Turns out the new implementation of the lexer for the `matching` keyword was a bit too eager. Indeed, I now see that the [PLY lexer docs](https://ply.readthedocs.io/en/latest/ply.html#lex) state "You should avoid writing individual rules for reserved words. [If you do] those rules will be triggered for identifiers that include those words as a prefix such as “forget” or “printed”. This is probably not what you want."

This is breaking some tests on the solutions team so if approved in the morning before I start working, feel free to just trigger the merge tool.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
