### PR TITLE
Bump cryptography from 41.0.7 to 42.0.0 (#7028)

### DIFF
--- a/changelogs/unreleased/7028-dependabot.yml
+++ b/changelogs/unreleased/7028-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump cryptography from 41.0.7 to 42.0.0
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==8.1.7
 colorlog==6.8.0
 cookiecutter==2.5.0
 crontab==1.0.1
-cryptography==41.0.7
+cryptography==42.0.0
 docstring-parser==0.15
 email-validator==2.1.0.post1
 execnet==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = [
     "colorlog~=6.4",
     "cookiecutter>=1,<3",
     "crontab>=0.23,<2.0",
-    "cryptography>=36,<42",
+    "cryptography>=36,<43",
     # docstring-parser has been known to publish non-backwards compatible minors in the past
     "docstring-parser>=0.10,<0.16",
     "email-validator>=1,<3",


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #7028