### PR TITLE
Fix invalid syntax in documentation

### DIFF
--- a/changelogs/unreleased/fix-invalid-syntax-in-docs.yml
+++ b/changelogs/unreleased/fix-invalid-syntax-in-docs.yml
@@ -1,0 +1,4 @@
+---
+description: Fix issue in the docs where invalid syntax is used to defined a regex-based type
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/docs/lsm/validation_types/validation_types.rst
+++ b/docs/lsm/validation_types/validation_types.rst
@@ -55,7 +55,7 @@ Example
 
 .. code-block:: inmanta
 
-    typedef lowercase as string matching "/^[a-z]+$/"
+    typedef lowercase as string matching /^[a-z]+$/
 
 ------------
 


### PR DESCRIPTION
# Description

Fix issue in the docs where invalid syntax is used to defined a regex-based type.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x]  Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
