### PR TITLE
Issue/5778 option delegate to config

### DIFF
--- a/changelogs/unreleased/5778-bugfix-option-env-vars.yml
+++ b/changelogs/unreleased/5778-bugfix-option-env-vars.yml
@@ -1,0 +1,7 @@
+description: Made config.Option behave like config.Config
+change-type: patch
+sections:
+  bugfix: Fixed bug where certain config options could not be set through environment variables
+destination-branches:
+  - master
+  - iso7

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -118,7 +118,7 @@ class Config:
 
     @overload
     @classmethod
-    def get(cls, section: str, name: str, default_value: Optional[str] = None) -> Optional[str]:
+    def get(cls, section: str, name: str, default_value: Optional[str] = None) -> Optional[object]:
         ...
 
     # noinspection PyNoneFunctionAssignment
@@ -326,7 +326,7 @@ class Option(Generic[T]):
 
     def get(self) -> T:
         # TODO: clean up! Option calls into Config and Config calls into Option
-        raw_config: ConfigParser = Config._get_instance()
+        raw_config: ConfigParser = Config.get()
         if self.predecessor_option:
             has_deprecated_option = raw_config.has_option(self.predecessor_option.section, self.predecessor_option.name)
             has_new_option = raw_config.has_option(self.section, self.name)

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -136,7 +136,7 @@ class Config:
         name = _normalize_name(name)
 
         option: Optional[Option] = cls.validate_option_request(section, name, default_value)
-        return self.get_for_option(option) if option is not None else self._get_value(section, name, default_value)
+        return cls.get_for_option(option) if option is not None else cls._get_value(section, name, default_value)
 
     @classmethod
     def _get_value(cls, section: str, name: str, default_value: Optional[str] = None) -> str:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -319,17 +319,17 @@ class Option(Generic[T]):
         Config.register_option(self)
 
     def get(self) -> T:
-        cfg = Config._get_instance()
+        raw_config: ConfigParser = Config._get_instance()
         if self.predecessor_option:
-            has_deprecated_option = cfg.has_option(self.predecessor_option.section, self.predecessor_option.name)
-            has_new_option = cfg.has_option(self.section, self.name)
+            has_deprecated_option = raw_config.has_option(self.predecessor_option.section, self.predecessor_option.name)
+            has_new_option = raw_config.has_option(self.section, self.name)
             if has_deprecated_option and not has_new_option:
                 warnings.warn(
                     f"Config option {self.predecessor_option.name} is deprecated. Use {self.name} instead.",
                     category=DeprecationWarning,
                 )
                 return self.predecessor_option.get()
-        out = cfg.get(self.section, self.name, fallback=self.get_default_value())
+        out = Config.get(self.section, self.name, default_value=self.get_default_value())
         return self.validate(out)
 
     def get_type(self) -> Optional[str]:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -319,6 +319,7 @@ class Option(Generic[T]):
         Config.register_option(self)
 
     def get(self) -> T:
+        # TODO: clean up! Option calls into Config and Config calls into Option
         raw_config: ConfigParser = Config._get_instance()
         if self.predecessor_option:
             has_deprecated_option = raw_config.has_option(self.predecessor_option.section, self.predecessor_option.name)
@@ -329,8 +330,7 @@ class Option(Generic[T]):
                     category=DeprecationWarning,
                 )
                 return self.predecessor_option.get()
-        out = Config.get(self.section, self.name, default_value=self.get_default_value())
-        return self.validate(out)
+        return Config.get(self.section, self.name, default_value=self.get_default_value())
 
     def get_type(self) -> Optional[str]:
         if callable(self.validator):

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -139,6 +139,11 @@ class Config:
         return cls.get_for_option(option) if option is not None else cls._get_value(section, name, default_value)
 
     @classmethod
+    def get_for_option(cls, option: "Option[T]") -> T:
+        raw_value: str = cls._get_value(option.section, option.name, option.get_default_value())
+        return option.validate(raw_value)
+
+    @classmethod
     def _get_value(cls, section: str, name: str, default_value: Optional[str] = None) -> str:
         cfg: ConfigParser = cls._get_instance()
         val: Optional[str] = _get_from_env(section, name)
@@ -148,11 +153,6 @@ class Config:
             val = cfg.get(section, name, fallback=default_value)
 
         return val
-
-    @classmethod
-    def get_for_option(cls, option: "Option[T]") -> T:
-        raw_value: str = cls._get_value(option.section, option.name, option.get_default_value())
-        return option.validate(raw_value)
 
     @classmethod
     def is_set(cls, section: str, name: str) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,9 +55,12 @@ def test_environment_deprecated_options(caplog):
         assert f"Config option {deprecated_option.name} is deprecated. Use {new_option.name} instead." not in caplog.text
 
 
-def test_options():
+def test_options(monkeypatch):
     configa = Option("test", "a", "markerA", "test a docs")
     configb = Option("test", "B", option_as_default(configa), "test b docs")
+    configc = Option("test", "c", "defaultc", "docstringc")
+
+    monkeypatch.setenv("INMANTA_TEST_C", "environ_c")
 
     assert "test.a" in configb.get_default_desc()
 
@@ -68,6 +71,7 @@ def test_options():
     assert configb.get() == "MA2"
     configb.set("MB2")
     assert configb.get() == "MB2"
+    assert configc.get() == "environ_c"
 
 
 def test_configfile_hierarchy(monkeypatch, tmpdir):


### PR DESCRIPTION
# Description

- Made config.Option behave like config.Config
- improved typing for Config and Option. There are still some errors in there but it's a step in the right direction
- minor refactor of Config and Option to decrease coupling

closes #5778 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~
- [x] ~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~
