### PR TITLE
Prevent deadlock on Agent tables

### DIFF
--- a/changelogs/unreleased/7024-prevent-deadlock-agent-logs.yml
+++ b/changelogs/unreleased/7024-prevent-deadlock-agent-logs.yml
@@ -1,0 +1,8 @@
+---
+description: Prevent deadlock between the `_log_session_expiry_to_db` and the `_log_session_seen_to_db` and `_log_session_creation_to_db` methods.
+issue-nr: 7024
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -87,7 +87,7 @@ In general, locks should be acquired consistently with delete cascade lock order
 are as follows. This list should be extended when new locks (explicit or implicit) are introduced. The rules below are written
 as `A -> B`, meaning A should be locked before B in any transaction that acquires a lock on both.
 - Code -> ConfigurationModel
-- Agent -> Agentprocess -> Agentinstance
+- Agentprocess -> Agentinstance -> Agent
 """
 
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2815,7 +2815,8 @@ class Environment(BaseDocument):
         """
         async with self.get_connection(connection=connection) as con:
             await Agent.delete_all(environment=self.id, connection=con)
-            await AgentProcess.delete_all(environment=self.id, connection=con)  # Triggers cascading delete on agentinstance
+            await AgentInstance.delete_all(tid=self.id, connection=con)
+            await AgentProcess.delete_all(environment=self.id, connection=con)
             await Compile.delete_all(environment=self.id, connection=con)  # Triggers cascading delete on report table
             await Parameter.delete_all(environment=self.id, connection=con)
             await Notification.delete_all(environment=self.id, connection=con)

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -495,18 +495,18 @@ class AgentManager(ServerSlice, SessionListener):
         """
         async with data.AgentProcess.get_connection() as connection:
             async with connection.transaction():
-                await data.Agent.update_primary(tid, endpoints_with_new_primary, now, connection)
                 await data.AgentProcess.expire_process(session.id, now, connection)
                 await data.AgentInstance.log_instance_expiry(session.id, session.endpoint_names, now, connection)
+                await data.Agent.update_primary(tid, endpoints_with_new_primary, now, connection)
 
     async def _expire_all_sessions_in_db(self) -> None:
         async with self.session_lock:
             LOGGER.debug("Cleaning server session DB")
             async with data.AgentProcess.get_connection() as connection:
                 async with connection.transaction():
-                    await data.Agent.mark_all_as_non_primary(connection=connection)
                     await data.AgentProcess.expire_all(now=datetime.now().astimezone(), connection=connection)
                     await data.AgentInstance.expire_all(now=datetime.now().astimezone(), connection=connection)
+                    await data.Agent.mark_all_as_non_primary(connection=connection)
 
     # Util
     async def _use_new_active_session_for_agent(self, tid: uuid.UUID, endpoint_name: str) -> Optional[protocol.Session]:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -495,6 +495,8 @@ class AgentManager(ServerSlice, SessionListener):
         """
         async with data.AgentProcess.get_connection() as connection:
             async with connection.transaction():
+                # Make sure to access the database tables in the order defined in docs string of inmanta/data/__init__.py
+                # to prevent deadlock issues.
                 await data.AgentProcess.expire_process(session.id, now, connection)
                 await data.AgentInstance.log_instance_expiry(session.id, session.endpoint_names, now, connection)
                 await data.Agent.update_primary(tid, endpoints_with_new_primary, now, connection)


### PR DESCRIPTION
# Description

The `_log_session_expiry_to_db`, `_log_session_seen_to_db` and `_log_session_creation_to_db` methods manipulate the `Agent`, `AgentInstance` and `AgentProcess` tables. But they don't modify these tables in the same order. This can result in deadlocks. This PR makes sure that all three methods manipulate the different database tables in the same order.

I must admit I didn't manage to reproduce this issue in a test case. So I am not sure whether this actually resolves the deadlock. But it's an improvement anyway. Let's see whether this change makes the deadlock disappear on our CI.

closes #7024 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
