### PR TITLE
issue/6096-log-which-pip-index-iso6

### DIFF
--- a/changelogs/unreleased/6096-log-pip-index.yml
+++ b/changelogs/unreleased/6096-log-pip-index.yml
@@ -1,0 +1,6 @@
+description: Report which pip indexes were used to install a V2 module or third-party Python dependency if that package could not be found.
+issue-nr: 6096
+change-type: patch
+destination-branches: [iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -537,6 +537,7 @@ class PythonEnvironment:
         if return_code != 0:
             not_found: list[str] = []
             conflicts: list[str] = []
+            indexes: str = ""
             for line in full_output:
                 m = re.search(r"No matching distribution found for ([\S]+)", line)
                 if m:
@@ -545,8 +546,15 @@ class PythonEnvironment:
 
                 if "versions have conflicting dependencies" in line:
                     conflicts.append(line)
+                # Get the indexes line from full_output
+                if "Looking in indexes:" in line:
+                    indexes = line
             if not_found:
-                raise PackageNotFound("Packages %s were not found in the given indexes." % ", ".join(not_found))
+                if indexes:
+                    msg = "Packages %s were not found in the given indexes. (%s)" % (", ".join(not_found), indexes)
+                else:
+                    msg = "Packages %s were not found at PyPI." % (", ".join(not_found))
+                raise PackageNotFound(msg)
             if conflicts:
                 raise ConflictingRequirements("\n".join(conflicts))
             raise PipInstallError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1646,12 +1646,41 @@ def tmpvenv_active_inherit(deactive_venv, tmpdir: py.path.local) -> Iterator[env
     loader.unload_modules_for_path(venv.site_packages_dir)
 
 
+@pytest.fixture
+def create_empty_local_package_index_factory() -> Callable[[], str]:
+    """
+    A fixture that acts as a factory to create empty local pip package indexes.
+    Each call creates a new index in a different temporary directory.
+    """
+
+    created_directories: list[str] = []
+
+    def _create_local_package_index(prefix: str = "test"):
+        """
+        Creates an empty pip index. The prefix argument is used as a prefix for the temporary directory name
+        for clarity and debugging purposes. The 'dir2pi' tool will then create a 'simple' directory inside
+        this temporary directory, which contains the index files.
+        """
+        tmpdir = tempfile.mkdtemp(prefix=f"{prefix}-")
+        created_directories.append(tmpdir)  # Keep track of the tempdir for cleanup
+        dir2pi(argv=["dir2pi", tmpdir])
+        index_dir = os.path.join(tmpdir, "simple")  # The 'simple' directory is created inside the tmpdir by dir2pi
+        return index_dir
+
+    yield _create_local_package_index
+
+    # Cleanup after the session ends
+    for directory in created_directories:
+        shutil.rmtree(directory)
+
+
 @pytest.fixture(scope="session")
 def local_module_package_index(modules_v2_dir: str) -> Iterator[str]:
     """
     Creates a local pip index for all v2 modules in the modules v2 dir. The modules are built and published to the index.
     :return: The path to the index
     """
+
     cache_dir = os.path.abspath(os.path.join(os.path.dirname(modules_v2_dir), f"{os.path.basename(modules_v2_dir)}.cache"))
     build_dir = os.path.join(cache_dir, "build")
     index_dir = os.path.join(build_dir, "simple")
@@ -1672,8 +1701,7 @@ def local_module_package_index(modules_v2_dir: str) -> Iterator[str]:
         )
 
     if _should_rebuild_cache():
-        logger.info(f"Cache {cache_dir} is dirty. Rebuilding cache.")
-        # Remove cache
+        logger.info("Cache %s is dirty. Rebuilding cache.", cache_dir)  # Remove cache
         if os.path.exists(cache_dir):
             shutil.rmtree(cache_dir)
         os.makedirs(build_dir)
@@ -1686,7 +1714,7 @@ def local_module_package_index(modules_v2_dir: str) -> Iterator[str]:
         # Update timestamp file
         open(timestamp_file, "w").close()
     else:
-        logger.info(f"Using cache {cache_dir}")
+        logger.info("Using cache %s", cache_dir)
 
     yield index_dir
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -286,8 +286,7 @@ def test_process_env_install_from_index_not_found(
     use_extra_indexes: bool,
 ) -> None:
     """
-    Attempt to install a package that does not exist.
-    Assert the appropriate error is raised.
+    Attempt to install a package that does not exist from a pip index. Assert the appropriate error is raised.
     """
     index_urls = []
     if not use_env_url:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -26,7 +26,7 @@ import tempfile
 from importlib.abc import Loader
 from re import Pattern
 from subprocess import CalledProcessError
-from typing import Optional
+from typing import Callable, Optional
 from unittest.mock import patch
 
 import py
@@ -277,13 +277,50 @@ def test_process_env_install_from_index(
 
 
 @pytest.mark.slowtest
-def test_process_env_install_from_index_not_found(tmpvenv_active: tuple[py.path.local, py.path.local]) -> None:
+@pytest.mark.parametrize_any("use_env_url", [False, True])
+@pytest.mark.parametrize_any("use_extra_indexes", [False, True])
+def test_process_env_install_from_index_not_found(
+    create_empty_local_package_index_factory: Callable[[], str],
+    tmpvenv_active: tuple[py.path.local, py.path.local],
+    monkeypatch,
+    use_env_url: bool,
+    use_extra_indexes: bool,
+) -> None:
     """
-    Attempt to install a package that does not exist from a pip index. Assert the appropriate error is raised.
+    Attempt to install a package that does not exist.
+    Assert the appropriate error is raised.
     """
-    with pytest.raises(env.PackageNotFound):
-        # pass empty index list for security reasons (anyone could publish this package to PyPi)
-        env.process_env.install_from_index([Requirement.parse("this-package-does-not-exist")], index_urls=[])
+    index_urls = []
+    if not use_env_url:
+        index_urls.extend([create_empty_local_package_index_factory()])
+        if use_extra_indexes:
+            index_urls.extend(
+                [
+                    create_empty_local_package_index_factory("extra1"),
+                    create_empty_local_package_index_factory("extra2"),
+                ]
+            )
+    else:
+        env_url = create_empty_local_package_index_factory("env1")
+        monkeypatch.setenv("PIP_INDEX_URL", env_url)
+        index_urls.extend([env_url])
+        if use_extra_indexes:
+            extra_env_indexes = [
+                create_empty_local_package_index_factory("extra_env1"),
+                create_empty_local_package_index_factory("extra_env2"),
+            ]
+            monkeypatch.setenv("PIP_EXTRA_INDEX_URL", " ".join(extra_env_indexes))
+            index_urls.extend(extra_env_indexes)
+
+    expected = (
+        "Packages this-package-does-not-exist were not "
+        "found in the given indexes. (Looking in indexes: %s)" % ", ".join(index_urls)
+    )
+
+    with pytest.raises(env.PackageNotFound, match=re.escape(expected)):
+        env.process_env.install_from_index(
+            [Requirement.parse("this-package-does-not-exist")], index_urls=None if use_env_url else index_urls
+        )
 
 
 @pytest.mark.slowtest

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -281,7 +281,6 @@ def test_process_env_install_from_index(
 @pytest.mark.parametrize_any("use_extra_indexes", [False, True])
 def test_process_env_install_from_index_not_found(
     create_empty_local_package_index_factory: Callable[[], str],
-    tmpvenv_active: tuple[py.path.local, py.path.local],
     monkeypatch,
     use_env_url: bool,
     use_extra_indexes: bool,


### PR DESCRIPTION
# Description

**The test is different than for iso7/master as the pipconfig did not exist yet in iso6**

Add the used pip indexes to the PackageNotFound exception in run_pip

closes #6096 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
