### PR TITLE
Add inmanta_lsm.const.LSM_ENV_VARS to the Programmatic API reference

### DIFF
--- a/changelogs/unreleased/add-lsm-env-vars-to-docs.yml
+++ b/changelogs/unreleased/add-lsm-env-vars-to-docs.yml
@@ -1,0 +1,6 @@
+description: Add inmanta_lsm.const.LSM_ENV_VARS to the Programmatic API reference.
+change-type: patch
+destination-branches:
+  - master
+  - iso7
+  - iso6

--- a/changelogs/unreleased/add-lsm-env-vars-to-docs.yml
+++ b/changelogs/unreleased/add-lsm-env-vars-to-docs.yml
@@ -1,5 +1,6 @@
 description: Add inmanta_lsm.const.LSM_ENV_VARS to the Programmatic API reference.
 change-type: patch
+issue-nr: 6732
 destination-branches:
   - master
   - iso7

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -20,6 +20,12 @@ Constants
     :members:
     :undoc-members:
 
+.. data:: inmanta_lsm.const.LSM_ENV_VARS
+    :annotation: : Sequence[str]
+
+    This sequence contains a list of all environment variables passed to the compiler by inmanta-lsm
+
+
 
 .. _compiler-exceptions:
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -23,7 +23,7 @@ Constants
 .. data:: inmanta_lsm.const.LSM_ENV_VARS
     :annotation: : Sequence[str]
 
-    This sequence contains a list of all environment variables passed to the compiler by inmanta-lsm
+    This sequence contains all environment variables passed to the compiler by inmanta-lsm
 
 
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -20,10 +20,12 @@ Constants
     :members:
     :undoc-members:
 
-.. data:: inmanta_lsm.const.LSM_ENV_VARS
-    :annotation: : Sequence[str]
+.. only:: iso
 
-    This sequence contains all environment variables passed to the compiler by inmanta-lsm
+    .. data:: inmanta_lsm.const.LSM_ENV_VARS
+        :annotation: : Sequence[str]
+
+        This sequence contains all environment variables passed to the compiler by inmanta-lsm
 
 
 


### PR DESCRIPTION
# Description

Add inmanta_lsm.const.LSM_ENV_VARS to the Programmatic API reference
closes https://github.com/inmanta/inmanta-core/issues/6732
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
