### PR TITLE
issue/6096-log-which-pip-index-no-index-iso6

### DIFF
--- a/changelogs/unreleased/fix-log-pip-index.yml
+++ b/changelogs/unreleased/fix-log-pip-index.yml
@@ -2,3 +2,5 @@ description: Fix the reporting of the indexes that were used to install a V2 mod
 issue-nr: 6096
 change-type: patch
 destination-branches: [iso6]
+sections:
+  bugfix: "Fix a bug where PIP_NO_INDEX could be used by pip when index_urls where provided"

--- a/changelogs/unreleased/fix-log-pip-index.yml
+++ b/changelogs/unreleased/fix-log-pip-index.yml
@@ -1,0 +1,4 @@
+description: Fix the reporting of the indexes that were used to install a V2 module or third-party Python dependency if that package could not be found in the case of --no-index
+issue-nr: 6096
+change-type: patch
+destination-branches: [iso6]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -47,6 +47,7 @@ from inmanta import const
 from inmanta.ast import CompilerException
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.stable_api import stable_api
+from inmanta.util import strtobool
 from packaging import version
 
 try:
@@ -497,6 +498,8 @@ class PythonEnvironment:
             del sub_env["PIP_EXTRA_INDEX_URL"]
         if index_urls is not None and "PIP_INDEX_URL" in sub_env:
             del sub_env["PIP_INDEX_URL"]
+        if index_urls is not None and "PIP_NO_INDEX" in sub_env:
+            del sub_env["PIP_NO_INDEX"]
 
         def create_log_content_files(title: str, files: list[str]) -> list[str]:
             """
@@ -547,10 +550,14 @@ class PythonEnvironment:
                 if "versions have conflicting dependencies" in line:
                     conflicts.append(line)
                 # Get the indexes line from full_output
+                # This is not printed when not using any index or when only using PyPi
                 if "Looking in indexes:" in line:
                     indexes = line
             if not_found:
-                if indexes:
+                no_index: bool = "--no-index" in cmd or strtobool(sub_env.get("PIP_NO_INDEX", "false"))
+                if no_index:
+                    msg = "Packages %s were not found. No indexes were used." % ", ".join(not_found)
+                elif indexes:
                     msg = "Packages %s were not found in the given indexes. (%s)" % (", ".join(not_found), indexes)
                 else:
                     msg = "Packages %s were not found at PyPI." % (", ".join(not_found))

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -76,6 +76,43 @@ def is_sub_dict(subdct: dict[PrimitiveTypes, PrimitiveTypes], dct: dict[Primitiv
     return not any(True for k, v in subdct.items() if k not in dct or dct[k] != v)
 
 
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to True or False.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    This function is based on a function in the Python distutils package. Is is subject
+    to the following license:
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
 def hash_file(content: bytes) -> str:
     """
     Create a hash from the given content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1647,7 +1647,7 @@ def tmpvenv_active_inherit(deactive_venv, tmpdir: py.path.local) -> Iterator[env
 
 
 @pytest.fixture
-def create_empty_local_package_index_factory() -> Callable[[], str]:
+def create_empty_local_package_index_factory() -> Callable[[str], str]:
     """
     A fixture that acts as a factory to create empty local pip package indexes.
     Each call creates a new index in a different temporary directory.


### PR DESCRIPTION
# Description
**Different than for iso7/master as the pipconfig did not exist in iso6**
[Add the used pip indexes to the PackageNotFound exception in run_pip](https://github.com/inmanta/inmanta-core/pull/7064) didn't take --no-index into account. This Pr fixes this.

part of https://github.com/inmanta/inmanta-core/issues/6096

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
