### PR TITLE
Make feature typing more strict

### DIFF
--- a/changelogs/unreleased/update-feature-typing.yml
+++ b/changelogs/unreleased/update-feature-typing.yml
@@ -1,0 +1,5 @@
+description: Make feature typing more clear
+change-type: patch
+destination-branches:
+  - master
+  - iso7

--- a/src/inmanta/server/extensions.py
+++ b/src/inmanta/server/extensions.py
@@ -87,6 +87,9 @@ class StringListFeature(Feature[list[str]]):
         super().__init__(slice, name, description, default_value=["*"])
 
 
+FeatureValueTypes = bool | str | list[str]
+
+
 class ProductMetadata:
     def __init__(self, product: str, edition: str, license: str, version: Optional[str]) -> None:
         self.product = product
@@ -103,18 +106,19 @@ class FeatureManager:
 
         slices:
             slice_name:
-                feature_name: bool
+                feature_name: FeatureValueTypes
 
     """
 
     def __init__(self) -> None:
         self._features: dict[str, dict[str, Feature[object]]] = defaultdict(dict)
-        self._feature_config: dict[str, dict[str, Any]] = self._load_feature_config()
+        self._feature_config: dict[str, dict[str, FeatureValueTypes]] = self._load_feature_config()
 
     def get_features(self) -> list[Feature[object]]:
         return [feature for slice in self._features.values() for feature in slice.values()]
 
-    def _load_feature_config(self) -> dict[str, dict[str, Any]]:
+    def _load_feature_config(self) -> dict[str, dict[str, FeatureValueTypes]]:
+        """Return the value of the slices key in the feature config file"""
         feature_file = feature_file_config.get()
         if feature_file is None:
             return {}
@@ -124,7 +128,7 @@ class FeatureManager:
             return {}
 
         with open(feature_file, encoding="utf-8") as fd:
-            result = yaml.safe_load(fd)
+            result: dict[str, dict[str, dict[str, FeatureValueTypes]]] = yaml.safe_load(fd)
 
         if "slices" in result:
             return result["slices"]


### PR DESCRIPTION
# Description

The current typing is very complex. This typing only exposes what is currently used and could be used in the near feature.

Another PR introduces this in inmanta-license so that if we have to update it (for example because we need int), then this update is consistent.