### PR TITLE
[WIP] increase timeout in test_s_incremental_deploy_interrupts_full_d…

### DIFF
--- a/changelogs/unreleased/build-master-increase-timout-in-test.yml
+++ b/changelogs/unreleased/build-master-increase-timout-in-test.yml
@@ -1,0 +1,3 @@
+description: Increase deploy timeout limit in ``test_s_incremental_deploy_interrupts_full_deploy``.
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -2668,7 +2668,7 @@ async def test_s_incremental_deploy_interrupts_full_deploy(
         # incremental deploy + full deploy resumed
         return len(end_run_lines) >= 2
 
-    await retry_limited(resume_waiters_and_wait_until_deploy_finishes, timeout=10)
+    await retry_limited(resume_waiters_and_wait_until_deploy_finishes, timeout=15)
 
     log_contains(caplog, "inmanta.agent.agent.agent1", logging.INFO, "Interrupting run 'Initial Deploy' for 'Second Deploy'")
 


### PR DESCRIPTION
…eploy

This job: https://jenkins.inmanta.com/job/core/job/inmanta-core-postgresql-versions/job/iso7/
failed on the `test_s_incremental_deploy_interrupts_full_deploy` test a couple of times by taking slightly more than the timeout limit of 10s


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
