### PR TITLE
[FIX] fix out of sync lsm examples in the documentation

### DIFF
--- a/changelogs/unreleased/build-master-fix-out-of-sync-lsm-examples.yml
+++ b/changelogs/unreleased/build-master-fix-out-of-sync-lsm-examples.yml
@@ -1,0 +1,3 @@
+description: Fix out of sync lsm examples from the documentation.
+change-type: patch
+destination-branches: [master, iso7]

--- a/docs/lsm/embedded_entities/embedded_entities_sources/basic_example.cf
+++ b/docs/lsm/embedded_entities/embedded_entities_sources/basic_example.cf
@@ -1,6 +1,5 @@
 import lsm
 import lsm::fsm
-import ip
 
 entity ServiceX extends lsm::ServiceEntity:
     """
@@ -26,7 +25,7 @@ entity Router extends lsm::EmbeddedEntity:
         :attr chassis: The chassis of the router.
     """
     string name
-    ip::ip system_ip
+    std::ipv4_address system_ip
     lsm::attribute_modifier system_ip__modifier="rw+"
     string vendor
     string chassis

--- a/docs/lsm/embedded_entities/embedded_entities_sources/example_attribute_modifiers_on_relations.cf
+++ b/docs/lsm/embedded_entities/embedded_entities_sources/example_attribute_modifiers_on_relations.cf
@@ -1,6 +1,5 @@
 import lsm
 import lsm::fsm
-import ip
 
 entity ServiceX extends lsm::ServiceEntity:
     """
@@ -20,7 +19,7 @@ entity SubService extends lsm::EmbeddedEntity:
     """
         :attr ip: The IP address of the service
     """
-    ip::ip ip
+    std::ipv4_address ip
 end
 
 index SubService(ip)

--- a/docs/lsm/embedded_entities/embedded_entities_sources/example_bidirectional_relationship.cf
+++ b/docs/lsm/embedded_entities/embedded_entities_sources/example_bidirectional_relationship.cf
@@ -1,6 +1,5 @@
 import lsm
 import lsm::fsm
-import ip
 
 entity ServiceX extends lsm::ServiceEntity:
     """
@@ -25,7 +24,7 @@ entity Router extends lsm::EmbeddedEntity:
         :attr chassis: The chassis of the router.
     """
     string name
-    ip::ip system_ip
+    std::ipv4_address system_ip
     lsm::attribute_modifier system_ip__modifier="rw+"
     string vendor
     string chassis

--- a/docs/lsm/embedded_entities/embedded_entities_sources/example_key_attributes.cf
+++ b/docs/lsm/embedded_entities/embedded_entities_sources/example_key_attributes.cf
@@ -1,6 +1,5 @@
 import lsm
 import lsm::fsm
-import ip
 
 entity ServiceX extends lsm::ServiceEntity:
     """
@@ -22,7 +21,7 @@ entity SubService extends lsm::EmbeddedEntity:
         :attr ip: The IP address of the service
     """
     string name
-    ip::ip ip
+    std::ipv4_address ip
     string[]? __lsm_key_attributes = ["name"]
 end
 

--- a/docs/lsm/embedded_entities/embedded_entities_sources/example_with_duplication.cf
+++ b/docs/lsm/embedded_entities/embedded_entities_sources/example_with_duplication.cf
@@ -1,6 +1,5 @@
 import lsm
 import lsm::fsm
-import ip
 
 entity ServiceX extends lsm::ServiceEntity:
     """
@@ -21,13 +20,13 @@ entity ServiceX extends lsm::ServiceEntity:
     string service_id
 
     string customer_router_name
-    ip::ip customer_router_system_ip
+    std::ipv4_address customer_router_system_ip
     lsm::attribute_modifier customer_router_system_ip__modifier="rw+"
     string customer_router_vendor
     string customer_router_chassis
 
     string provider_router_name
-    ip::ip provider_router_system_ip
+    std::ipv4_address provider_router_system_ip
     lsm::attribute_modifier provider_router_system_ip__modifier="rw+"
     string provider_router_vendor
     string provider_router_chassis


### PR DESCRIPTION
# Description


This [PR](https://github.com/inmanta/lsm/commit/acfa62c83e1a393dbdac33fbf5a3a30a80f79887) updated some examples in the lsm repo.

Causing this build failure: https://jenkins.inmanta.com/job/docs/job/lsm-documentation-examples-verification/job/master/400/


The current pr syncs them up here in the core repo documentation


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
