### PR TITLE
Fix incompatiblity pytest asyncpg

### DIFF
--- a/changelogs/unreleased/fix-incompatiblity-pytest-postgresql.yml
+++ b/changelogs/unreleased/fix-incompatiblity-pytest-postgresql.yml
@@ -1,0 +1,6 @@
+---
+description: "Fix incompatibilty with pytest-postgresql when using pytest8. Due to a bugfix in pytest8, the postgresql_proc_with_log fixture now returns None instead of an empty string."
+issue-nr: 372
+issue-repo: inmanta-dev-dependencies
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/fix-incompatiblity-pytest-postgresql.yml
+++ b/changelogs/unreleased/fix-incompatiblity-pytest-postgresql.yml
@@ -1,5 +1,5 @@
 ---
-description: "Fix incompatibilty with pytest-postgresql when using pytest8. Due to a bugfix in pytest8, the postgresql_proc_with_log fixture now returns None instead of an empty string."
+description: "Fix incompatibility with pytest-postgresql when using pytest8. Due to a bugfix in pytest8, the postgresql_proc_with_log fixture now returns None instead of an empty string."
 issue-nr: 372
 issue-repo: inmanta-dev-dependencies
 change-type: patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -766,11 +766,14 @@ async def server_config(event_loop, inmanta_config, postgres_db, database_name, 
     with tempfile.TemporaryDirectory() as state_dir:
         port = str(unused_tcp_port_factory())
 
+        # Config.set() always expects a string value
+        pg_password = "" if postgres_db.password is None else postgres_db.password
+
         config.Config.set("database", "name", database_name)
         config.Config.set("database", "host", "localhost")
         config.Config.set("database", "port", str(postgres_db.port))
         config.Config.set("database", "username", postgres_db.user)
-        config.Config.set("database", "password", postgres_db.password)
+        config.Config.set("database", "password", pg_password)
         config.Config.set("database", "connection_timeout", str(3))
         config.Config.set("config", "state-dir", state_dir)
         config.Config.set("config", "log-dir", os.path.join(state_dir, "logs"))
@@ -861,12 +864,15 @@ async def server_multi(
                 token = protocol.encode_token(ct)
                 config.Config.set(x, "token", token)
 
+        # Config.set() always expects a string value
+        pg_password = "" if postgres_db.password is None else postgres_db.password
+
         port = str(unused_tcp_port_factory())
         config.Config.set("database", "name", database_name)
         config.Config.set("database", "host", "localhost")
         config.Config.set("database", "port", str(postgres_db.port))
         config.Config.set("database", "username", postgres_db.user)
-        config.Config.set("database", "password", postgres_db.password)
+        config.Config.set("database", "password", pg_password)
         config.Config.set("database", "connection_timeout", str(3))
         config.Config.set("config", "state-dir", state_dir)
         config.Config.set("config", "log-dir", os.path.join(state_dir, "logs"))


### PR DESCRIPTION
# Description

Due to a bugfix in pytest8, the `postgresql_proc_with_log` fixture now returns None instead of an empty string. This PR ensure that None values are correctly converted into an empty string.

Part of inmanta/inmanta-dev-dependencies#372

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
