### PR TITLE
Issue/build master investigate test server recompile

### DIFF
--- a/changelogs/unreleased/fix-failing-test-server-recompile.yml
+++ b/changelogs/unreleased/fix-failing-test-server-recompile.yml
@@ -1,0 +1,3 @@
+description: Fix failing test_server_recompile test reading config option from obsolete path.
+change-type: patch
+destination-branches: [master, iso7]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -36,9 +36,7 @@ from pytest import approx
 import inmanta.ast.export as ast_export
 import inmanta.data.model as model
 import utils
-from inmanta import config
-from inmanta import config as inmanta_config
-from inmanta import data
+from inmanta import config, data
 from inmanta.const import ParameterSource
 from inmanta.data import APILIMIT, Compile, Report
 from inmanta.data.model import PipConfig
@@ -791,7 +789,7 @@ async def test_server_recompile(server, client, environment, monkeypatch):
     assert result.result["count"] == 5
 
     # clear the environment
-    state_dir = inmanta_config.state_dir.get()
+    state_dir = config.state_dir.get()
     project_dir = os.path.join(state_dir, "server", "environments", environment)
     assert os.path.exists(project_dir)
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -45,6 +45,7 @@ from inmanta.export import cfg_env
 from inmanta.protocol import Result
 from inmanta.server import SLICE_COMPILER, SLICE_SERVER
 from inmanta.server import config as server_config
+from inmanta import config as inmanta_config
 from inmanta.server import protocol
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import Server
@@ -791,7 +792,7 @@ async def test_server_recompile(server, client, environment, monkeypatch):
     assert result.result["count"] == 5
 
     # clear the environment
-    state_dir = server_config.state_dir.get()
+    state_dir = inmanta_config.state_dir.get()
     project_dir = os.path.join(state_dir, "server", "environments", environment)
     assert os.path.exists(project_dir)
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -36,17 +36,16 @@ from pytest import approx
 import inmanta.ast.export as ast_export
 import inmanta.data.model as model
 import utils
-from inmanta import config, data
+from inmanta import config
+from inmanta import config as inmanta_config
+from inmanta import data
 from inmanta.const import ParameterSource
 from inmanta.data import APILIMIT, Compile, Report
 from inmanta.data.model import PipConfig
 from inmanta.env import PythonEnvironment
 from inmanta.export import cfg_env
 from inmanta.protocol import Result
-from inmanta.server import SLICE_COMPILER, SLICE_SERVER
-from inmanta.server import config as server_config
-from inmanta import config as inmanta_config
-from inmanta.server import protocol
+from inmanta.server import SLICE_COMPILER, SLICE_SERVER, protocol
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import Server
 from inmanta.server.services.compilerservice import CompilerService, CompileRun, CompileStateListener


### PR DESCRIPTION
# Description

https://github.com/inmanta/inmanta-core/blame/300668d49a59d73820b4c472442149d2b22ac522/src/inmanta/server/config.py#L23
removed the `state_dir` import from `inmanta.config`.

The test_server_recompile was relying on this import and failed as a result.

Fix -> import `inmanta.config` directly from the test



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
