### PR TITLE
Use a custom regex type

### DIFF
--- a/changelogs/unreleased/improve_type_validation.yml
+++ b/changelogs/unreleased/improve_type_validation.yml
@@ -1,0 +1,5 @@
+description: Improve performance of type validation
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/validation_type.py
+++ b/src/inmanta/validation_type.py
@@ -105,7 +105,7 @@ def parametrize_type(
     if base_type is pydantic.constr and validation_parameters is not None and "regex" in validation_parameters:
         regex: object = validation_parameters["regex"]
         if regex is not None:
-            custom_annotations.append(regex_string(str(validation_parameters["regex"])))
+            custom_annotations.append(Regex(str(regex)))
         del validation_parameters["regex"]
 
     parametrized_type: object

--- a/src/inmanta/validation_type.py
+++ b/src/inmanta/validation_type.py
@@ -34,6 +34,10 @@ from pydantic_core import CoreSchema, PydanticCustomError, core_schema
 
 @dataclass
 class Regex:
+    """Custom regex class that uses python regexes. This implementation also ensure that a json schema is generated
+    for the regex.
+    """
+
     pattern: str
 
     def __get_pydantic_core_schema__(self, source_type: object, handler: pydantic.GetCoreSchemaHandler) -> CoreSchema:


### PR DESCRIPTION
# Description

- Use re directly instead of an additional type adaptor
- Can generate json schema

- [x] TODO: have an openapi test case here (or in inmanta-lsm) that uses a regex to verify we create correct jsonschema

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
