### PR TITLE
Poc stage 2

### DIFF
--- a/changelogs/unreleased/agent_executor_ipc_2.yml
+++ b/changelogs/unreleased/agent_executor_ipc_2.yml
@@ -1,0 +1,3 @@
+description: Added logging and config to agent fork infrastructure
+change-type: minor
+destination-branches: [master]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,20 +6,11 @@ tag_date = 0
 tag_svn_revision = 0
 
 [flake8]
-# H101 Include your name with TODOs as in # TODO(yourname). This makes it easier to find out who the author of the comment was.
-# H302 Do not import objects, only modules DEPRICATED
-# H404 Multi line docstrings should start without a leading new line.
-# H405 multi line docstring summary not separated with an empty line
-# H301 Do not import more than one module per line (*)
-# H306 Alphabetically order your imports by the full module path.
-# H904 Wrap long lines in parentheses instead of a backslash
-# E203 whitespace before ':' " on list slice.
-# E266 too many leading ‘#’ for block comment
-# E252 missing whitespace around parameter equals
-# w503 line break occurred before a binary operator
+# W503 line break occurred before a binary operator
 # E402 module level import not at top of file
 # E203 whitespaces and the slice operator. black and flake disagree
-ignore = H405,H404,H302,H306,H301,H101,H801,E402,W503,E252,E203
+# E704 black and flake disagree: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#e701-e704
+ignore = E402,W503,E704,E203
 max-line-length = 128
 exclude = **/.env,.venv,.git,.tox,dist,doc,**egg,src/inmanta/parser/parsetab.py,tests/data/**
 copyright-check=True

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -25,7 +25,9 @@ import socket
 import typing
 from typing import Awaitable
 
+import inmanta.config
 import inmanta.const
+import inmanta.protocol.ipc_light
 import inmanta.signals
 from inmanta.logging import InmantaLoggerConfig
 from inmanta.protocol.ipc_light import IPCClient, IPCServer
@@ -48,7 +50,16 @@ Pipe break: go to 3a and 3b
 """
 
 
-class ExecutorServer(IPCServer):
+class ExecutorContext:
+
+    def __init__(self, server: "ExecutorServer") -> None:
+        self.server = server
+
+    async def stop(self) -> None:
+        await self.server.stop()
+
+
+class ExecutorServer(IPCServer[ExecutorContext]):
     """The IPC server running on the executor"""
 
     def __init__(self, name: str) -> None:
@@ -56,14 +67,18 @@ class ExecutorServer(IPCServer):
         self.stopping = False
         self.stopped = asyncio.Event()
 
-    async def stop(self):
+    def get_context(self) -> ExecutorContext:
+        return ExecutorContext(self)
+
+    async def stop(self) -> None:
         """Perform shutdown"""
         self._sync_stop()
 
-    def _sync_stop(self):
+    def _sync_stop(self) -> None:
         """Actual shutdown, not async"""
         if not self.stopping:
             self.logger.info("Stopping")
+            assert self.transport is not None  # Mypy
             self.transport.close()
             self.stopping = True
 
@@ -73,24 +88,30 @@ class ExecutorServer(IPCServer):
         self._sync_stop()
         self.stopped.set()
 
-    def get_method(self, name: str) -> typing.Callable[[...], typing.Coroutine[typing.Any, typing.Any, object]]:
-        if name == "stop":
-            return self.stop
 
-        async def echo(*args):
-            return list(args)
+class StopCommand(inmanta.protocol.ipc_light.IPCMethod[None, ExecutorContext]):
 
-        return echo
+    async def call(self, context: ExecutorContext) -> None:
+        await context.stop()
 
 
-def mp_worker_entrypoint(socket, name):
+def mp_worker_entrypoint(
+    socket: socket.socket,
+    name: str,
+    logfile: str,
+    inmanta_log_level: str,
+    config: typing.Mapping[str, typing.Mapping[str, typing.Any]],
+) -> None:
     """Entry point for child processes"""
-    # TODO: set up logging
-    InmantaLoggerConfig.get_instance()
+    log_config = InmantaLoggerConfig.get_instance()
+    log_config.configure_file_logger(logfile, inmanta_log_level)
+    logging.captureWarnings(True)
     logger = logging.getLogger(f"agent.executor.{name}")
     logger.info(f"Started with PID: {os.getpid()}")
 
-    async def serve():
+    inmanta.config.Config.load_config_from_dict(config)
+
+    async def serve() -> None:
         loop = asyncio.get_running_loop()
         # Start serving
         transport, protocol = await loop.connect_accepted_socket(functools.partial(ExecutorServer, name), socket)
@@ -102,12 +123,12 @@ def mp_worker_entrypoint(socket, name):
     exit(0)
 
 
-class FinalizingIPCClient(IPCClient):
+class FinalizingIPCClient(IPCClient[ExecutorContext]):
     """IPC client that can signal shutdown"""
 
     def __init__(self, name: str):
         super().__init__(name)
-        self.finalizers: list[typing.Callable[[], Awaitable[None]]] = []
+        self.finalizers: list[typing.Callable[[], typing.Coroutine[typing.Any, typing.Any, None]]] = []
 
     def connection_lost(self, exc: Exception | None) -> None:
         print("Client lost connection")
@@ -126,11 +147,11 @@ class MPExecutor:
 
     async def stop(self) -> None:
         """Stop by shutdown"""
-        self.connection.call("stop", [], False)
+        self.connection.call(StopCommand(), False)
 
     async def force_stop(self, grace_time: float = inmanta.const.SHUTDOWN_GRACE_HARD) -> None:
         """Stop by process close"""
-        await asyncio.get_running_loop().run_in_executor(None, functools.partial(self.force_stop, grace_time))
+        await asyncio.get_running_loop().run_in_executor(None, functools.partial(self._force_stop, grace_time))
 
     def _force_stop(self, grace_time: float) -> None:
         try:
@@ -149,8 +170,11 @@ class MPExecutor:
 
 
 class MPManager:
-    def __init__(self):
+    def __init__(self, log_folder: str, inmanta_log_level: str = "DEBUG") -> None:
         self.children: list[MPExecutor] = []
+        self.log_folder = log_folder
+        os.makedirs(self.log_folder, exist_ok=True)
+        self.inmanta_log_level = inmanta_log_level
 
     def _init_once(self) -> None:
         try:
@@ -163,9 +187,13 @@ class MPManager:
     async def make_child_and_connect(self, name: str) -> MPExecutor:
         """Async code to make a child process as share a socker with it"""
         loop = asyncio.get_running_loop()
+
         # Start child
         # TODO: do we need a specific thread pool?
-        process, parent_conn = await loop.run_in_executor(None, functools.partial(self._make_child, name))
+        logfile = os.path.join(self.log_folder, f"{name}.log")
+        process, parent_conn = await loop.run_in_executor(
+            None, functools.partial(self._make_child, name, logfile, self.inmanta_log_level)
+        )
         # Hook up the connection
         transport, protocol = await loop.connect_accepted_socket(
             functools.partial(FinalizingIPCClient, f"executor.{name}"), parent_conn
@@ -175,10 +203,14 @@ class MPManager:
         self.children.append(child_handle)
         return child_handle
 
-    def _make_child(self, name: str) -> tuple[multiprocessing.Process, socket.socket]:
+    def _make_child(self, name: str, log_file: str, log_level: int) -> tuple[multiprocessing.Process, socket.socket]:
         """Sync code to make a child process and share a socket with it"""
         parent_conn, child_conn = socket.socketpair()
-        p = multiprocessing.Process(target=mp_worker_entrypoint, args=(child_conn, name), name=f"agent.executor.{name}")
+        p = multiprocessing.Process(
+            target=mp_worker_entrypoint,
+            args=(child_conn, name, log_file, log_level, inmanta.config.Config.config_as_dict()),
+            name=f"agent.executor.{name}",
+        )
         p.start()
         child_conn.close()
         return p, parent_conn

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -23,7 +23,6 @@ import multiprocessing
 import os
 import socket
 import typing
-from typing import Awaitable
 
 import inmanta.config
 import inmanta.const

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -173,7 +173,8 @@ class MPManager:
         self.inmanta_log_level = inmanta_log_level
         self.cli_log = cli_log
 
-    def _init_once(self) -> None:
+    @classmethod
+    def init_once(cls) -> None:
         try:
             multiprocessing.set_start_method("forkserver")
             multiprocessing.set_forkserver_preload(["inmanta", "inmanta.config"])

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -97,7 +97,8 @@ class Config:
         input_config: typing.Mapping[str, typing.Mapping[str, typing.Any]],
     ) -> None:
         """
-        Load the configuration from a dict, used to copy config
+        Load the configuration from a dict, used to copy config.
+        Replaces all existing config.
         """
         config = LenientConfigParser(interpolation=Interpolation())
         config.read_dict(input_config)

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import sys
+import typing
 import uuid
 import warnings
 from collections import abc, defaultdict
@@ -89,6 +90,27 @@ class Config:
         config.read(files)
         cls.__instance = config
         cls._config_dir = config_dir
+
+    @classmethod
+    def load_config_from_dict(
+        cls,
+        input_config: typing.Mapping[str, typing.Mapping[str, typing.Any]],
+    ) -> None:
+        """
+        Load the configuration from a dict, used to copy config
+        """
+        config = LenientConfigParser(interpolation=Interpolation())
+        config.read_dict(input_config)
+        cls.__instance = config
+        cls._config_dir = None
+
+    @classmethod
+    def config_as_dict(cls) -> typing.Mapping[str, typing.Mapping[str, typing.Any]]:
+        """
+        Return the config as a dict, to be used with load_config_from_dict
+        """
+        assert cls.__instance is not None
+        return dict(cls.__instance.items())
 
     @classmethod
     def _get_instance(cls) -> ConfigParser:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -264,6 +264,14 @@ class InmantaLoggerConfig:
         self.set_log_formatter(formatter)
         self.set_log_level(inmanta_log_level, cli=False)
 
+    def add_cli_logger(self, inmanta_log_level: str) -> logging.Handler:
+        """Add a simple cli logger, used for debugging subprocesses"""
+        handler = logging.StreamHandler()
+        handler.setLevel(self.convert_inmanta_log_level(inmanta_log_level))
+        handler.setFormatter(self._get_log_formatter_for_stream_handler(False))
+        logging.root.addHandler(handler)
+        return handler
+
     @stable_api
     def set_log_level(self, inmanta_log_level: str, cli: bool = True) -> None:
         """
@@ -274,18 +282,26 @@ class InmantaLoggerConfig:
         :param inmanta_log_level: The inmanta logging level
         :param cli: True if the logs will be outputted to the CLI.
         """
+        python_log_level = self.convert_inmanta_log_level(inmanta_log_level, cli)
+        self._handler.setLevel(python_log_level)
+        logging.root.setLevel(python_log_level)
+
+    def convert_inmanta_log_level(self, inmanta_log_level: str, cli: bool = False) -> int:
+        """
+        :param inmanta_log_level: The inmanta logging level
+        :param cli: True if the logs will be outputted to the CLI.
+
+        :return: python log level
+        """
         # maximum of 4 v's
         if inmanta_log_level.isdigit() and int(inmanta_log_level) > 4:
             inmanta_log_level = "4"
-
         # The minimal log level on the CLI is always WARNING
         if cli and (inmanta_log_level == "ERROR" or (inmanta_log_level.isdigit() and int(inmanta_log_level) < 1)):
             inmanta_log_level = "WARNING"
-
         # Converts the Inmanta log level to the Python log level
         python_log_level = log_levels[inmanta_log_level]
-        self._handler.setLevel(python_log_level)
-        logging.root.setLevel(python_log_level)
+        return python_log_level
 
     @stable_api
     def set_log_formatter(self, formatter: logging.Formatter) -> None:

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -236,11 +236,10 @@ class InmantaLoggerConfig:
             raise Exception("Options can only be applied once to a handler.")
         self._options_applied = True
         self._keep_logger_names = options.keep_logger_names
-        if options.log_file:
-            self.set_logfile_location(options.log_file)
-            formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
-            self.set_log_formatter(formatter)
-            self.set_log_level(options.log_file_level, cli=False)
+        log_file = options.log_file
+        log_file_level = options.log_file_level
+        if log_file:
+            self.configure_file_logger(log_file, log_file_level)
         else:
             # Use a shorter space padding if we know that we will use short names as the logger name.
             # Otherwise the log records contains too much white spaces.
@@ -258,6 +257,12 @@ class InmantaLoggerConfig:
             )
             self.set_log_formatter(formatter)
             self.set_log_level(str(options.verbose))
+
+    def configure_file_logger(self, log_file: str, inmanta_log_level: str) -> None:
+        self.set_logfile_location(log_file)
+        formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
+        self.set_log_formatter(formatter)
+        self.set_log_level(inmanta_log_level, cli=False)
 
     @stable_api
     def set_log_level(self, inmanta_log_level: str, cli: bool = True) -> None:

--- a/src/inmanta/protocol/ipc_light.py
+++ b/src/inmanta/protocol/ipc_light.py
@@ -25,7 +25,7 @@ import typing
 import uuid
 from asyncio import Future, Protocol, transports
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, Optional
+from typing import Optional
 
 
 class IPCException(Exception):

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -49,7 +49,7 @@ class GetConfig(inmanta.protocol.ipc_light.IPCMethod[str, None]):
 
 async def test_executor_server(tmp_path):
     manager = MPManager(log_folder=str(tmp_path), cli_log=True)
-    manager._init_once()
+    manager.init_once()
 
     inmanta.config.Config.set("test", "aaa", "bbbb")
 
@@ -73,7 +73,7 @@ async def test_executor_server(tmp_path):
 
 async def test_executor_server_dirty_shutdown(tmp_path):
     manager = MPManager(log_folder=str(tmp_path))
-    manager._init_once()
+    manager.init_once()
 
     child1 = await manager.make_child_and_connect("Testchild")
 

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -20,19 +20,45 @@ import asyncio
 
 import pytest
 
+import inmanta.config
+import inmanta.protocol.ipc_light
 from inmanta.agent.executor import MPManager
 from inmanta.protocol.ipc_light import ConnectionLost
 
 
-async def test_executor_server():
-    manager = MPManager()
+class Echo(inmanta.protocol.ipc_light.IPCMethod[list[str], None]):
+
+    def __init__(self, args: list[str]) -> None:
+        self.args = args
+
+    async def call(self, ctx) -> list[str]:
+        return self.args
+
+
+class GetConfig(inmanta.protocol.ipc_light.IPCMethod[str, None]):
+
+    def __init__(self, section: str, name: str) -> None:
+        self.section = section
+        self.name = name
+
+    async def call(self, ctx) -> str:
+        return inmanta.config.Config.get(self.section, self.name)
+
+
+async def test_executor_server(tmp_path):
+    manager = MPManager(log_folder=str(tmp_path))
     manager._init_once()
+
+    inmanta.config.Config.set("test", "aaa", "bbbb")
 
     child1 = await manager.make_child_and_connect("Testchild")
 
-    result = await child1.connection.call("echo", ["aaaa"])
+    result = await child1.connection.call(Echo(["aaaa"]))
 
     assert ["aaaa"] == result
+
+    result = await child1.connection.call(GetConfig("test", "aaa"))
+    assert "bbbb" == result
 
     print("stopping")
     await manager.stop()
@@ -43,13 +69,13 @@ async def test_executor_server():
     assert child1.connection.transport.is_closing()
 
 
-async def test_executor_server_dirty_shutdown():
-    manager = MPManager()
+async def test_executor_server_dirty_shutdown(tmp_path):
+    manager = MPManager(log_folder=str(tmp_path))
     manager._init_once()
 
     child1 = await manager.make_child_and_connect("Testchild")
 
-    result = await child1.connection.call("echo", ["aaaa"])
+    result = await child1.connection.call(Echo(["aaaa"]))
     assert ["aaaa"] == result
     print("Child there")
 

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -17,6 +17,7 @@
 """
 
 import asyncio
+import logging
 
 import pytest
 
@@ -32,6 +33,7 @@ class Echo(inmanta.protocol.ipc_light.IPCMethod[list[str], None]):
         self.args = args
 
     async def call(self, ctx) -> list[str]:
+        logging.getLogger(__name__).info("Echo ")
         return self.args
 
 
@@ -46,7 +48,7 @@ class GetConfig(inmanta.protocol.ipc_light.IPCMethod[str, None]):
 
 
 async def test_executor_server(tmp_path):
-    manager = MPManager(log_folder=str(tmp_path))
+    manager = MPManager(log_folder=str(tmp_path), cli_log=True)
     manager._init_once()
 
     inmanta.config.Config.set("test", "aaa", "bbbb")

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -23,7 +23,7 @@ import pytest
 
 import inmanta.config
 import inmanta.protocol.ipc_light
-from inmanta.agent.executor import MPManager
+from inmanta.agent.forking_executor import MPManager
 from inmanta.protocol.ipc_light import ConnectionLost
 
 


### PR DESCRIPTION
1. make sure we load config
2. make sure we configure logging
3. move to typed IPC (still a bit weird)


@bartv the IPC feels a bit weird to me like this. WDYT

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
Mypy can't figure these out
```
src/inmanta/protocol/ipc_light.py:212: error: Invalid index type "UUID | None" for "dict[UUID, Future[object]]"; expected type "UUID"  [index]
src/inmanta/server/services/resourceservice.py:986: error: Argument 6 to "propagate_resource_state_if_stale" of "ResourceService" has incompatible type "ResourceState | None"; expected "ResourceState"  [arg-type]
```
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
