### PR TITLE
Fix race in test

### DIFF
--- a/changelogs/unreleased/bm_race_in_increment_interactions.yml
+++ b/changelogs/unreleased/bm_race_in_increment_interactions.yml
@@ -1,0 +1,3 @@
+description: Add no_agent_backoff to testcase on increment interactions, fixed in ISO6 on https://github.com/inmanta/inmanta-core/pull/6561
+change-type: patch
+destination-branches: [master, iso7]

--- a/tests/agent_server/test_increment_interactions.py
+++ b/tests/agent_server/test_increment_interactions.py
@@ -32,7 +32,15 @@ LOGGER = logging.getLogger("test")
 @pytest.mark.slowtest
 @pytest.mark.parametrize("change_state", [False, True])
 async def test_6475_deploy_with_failure_masking(
-    server, agent: Agent, environment, resource_container, clienthelper, client, monkeypatch, change_state: bool
+    server,
+    agent: Agent,
+    environment,
+    resource_container,
+    clienthelper,
+    client,
+    monkeypatch,
+    change_state: bool,
+    no_agent_backoff,
 ):
     """
     Consider:


### PR DESCRIPTION
# Description

Add no agent backoff 

was done on iso6 already: https://github.com/inmanta/inmanta-core/pull/6561


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
