### PR TITLE
Add sub to login token

### DIFF
--- a/changelogs/unreleased/add-sub-jwt.yml
+++ b/changelogs/unreleased/add-sub-jwt.yml
@@ -1,0 +1,5 @@
+description: Add sub claim to jwt token on login
+change-type: patch
+destination-branches:
+  - master
+  - iso7

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -117,7 +117,7 @@ class UserService(server_protocol.ServerSlice):
         except nacl.exceptions.InvalidkeyError:
             raise exceptions.UnauthorizedException()
 
-        token = auth.encode_token([str(const.ClientType.api.value)], expire=None)
+        token = auth.encode_token([str(const.ClientType.api.value)], expire=None, custom_claims={"sub": username})
         return common.ReturnValue(
             status_code=200,
             headers={"Authentication": f"Bearer {token}"},

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -111,6 +111,10 @@ async def test_login(server: protocol.Server, client: endpoints.Client, auth_cli
     assert "user" in response.result["data"]
     assert response.result["data"]["user"]["username"] == "admin"
 
+    data = auth.decode_token(response.result["data"]["token"])
+    assert "sub" in data
+    assert data["sub"] == "admin"
+
     token = response.result["data"]["token"]
     config.Config.set("client_rest_transport", "token", token)
 


### PR DESCRIPTION
# Description

This adds the sub claim to the auth token on login

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
