### PR TITLE
Fix: deploy command no longer ignores `-f` option

### DIFF
--- a/changelogs/unreleased/6993-inmanta-deploy-command-ignores-f-option.yml
+++ b/changelogs/unreleased/6993-inmanta-deploy-command-ignores-f-option.yml
@@ -1,0 +1,7 @@
+description: Deploy command no longer ignores ``-f`` option.
+issue-nr: 6993
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"
+

--- a/src/inmanta/deploy.py
+++ b/src/inmanta/deploy.py
@@ -319,7 +319,7 @@ host=localhost
 
         return True
 
-    def export(self) -> bool:
+    def export(self, main_file: str) -> bool:
         """
         Export a version to the embedded server
         """
@@ -336,6 +336,8 @@ host=localhost
             "localhost",
             "--server_port",
             str(self._server_port),
+            "-f",
+            main_file,
         ]
 
         sub_process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -485,7 +487,7 @@ host=localhost
         raise FinishedException()
 
     def run(self) -> None:
-        self.export()
+        self.export(main_file=self._options.main_file)
         self.deploy(dry_run=self._options.dryrun)
 
     def stop(self) -> None:


### PR DESCRIPTION
# Description


closes https://github.com/inmanta/inmanta-core/issues/6993

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
