### PR TITLE
Clear ResourcePersistentState table on clear or delete of environment

### DIFF
--- a/changelogs/unreleased/clear-resourcepersistentstate-table.yml
+++ b/changelogs/unreleased/clear-resourcepersistentstate-table.yml
@@ -1,0 +1,4 @@
+---
+description: Fix bug where the ResourcePersistentState table is not clear when an environment is cleared or deleted.
+change-type: patch
+destination-branches: [master, iso7]

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -31,15 +31,15 @@ A complete V2 module might contain the following files:
     |__ pyproject.toml
     |
     |__ model
-    |    |__ _init.cf
-    |    |__ services.cf
+    |    |__ _init.cf
+    |    |__ services.cf
     |
     |__ inmanta_plugins/<module-name>/
-    |    |__ __init__.py
-    |    |__ functions.py
+    |    |__ __init__.py
+    |    |__ functions.py
     |
     |__ files
-    |    |__ file1.txt
+    |    |__ file1.txt
     |
     |__ templates
          |__ conf_file.conf.tmpl
@@ -155,17 +155,17 @@ A complete module might contain the following files:
     |__ module.yml
     |
     |__ model
-    |    |__ _init.cf
-    |    |__ services.cf
+    |    |__ _init.cf
+    |    |__ services.cf
     |
     |__ plugins
-    |    |__ functions.py
+    |    |__ functions.py
     |
     |__ files
-    |    |__ file1.txt
+    |    |__ file1.txt
     |
     |__ templates
-    |    |__ conf_file.conf.tmpl
+    |    |__ conf_file.conf.tmpl
     |
     |__ requirements.txt
 

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -347,10 +347,25 @@ Add the following content to the file:
   login <username>
   password <password>
 
-For more information see the doc about`pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
+For more information see the doc about `pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
 
 You will also need to specify the url of the repository in the ``project.yml`` file of your project (See: :ref:`specify_location_pip`).
 
 By following the previous steps, the Inmanta server will be able to install modules from a private Python package repository.
 
 
+Inter-module dependencies
+#########################
+
+The plugins code of a V2 module A can have a dependency on the plugins code of another V2 module B. When doing this,
+care should be taken that the Python module(s) you depend on, do not define any resources or providers. Otherwise the
+python environment of the agent can get corrupt in the following way:
+
+1. Module A-1.0 depends on X.py of module B-1.0
+2. A-1.0 and B-1.0 are exported: The exporter exports the X.py file to the server and the agent puts the X.py file in its code directory.
+3. In a later version of module B (B-2.0) the X.py file doesn't have any resources anymore.
+4. A-1.0 and B-2.0 are exported: The exporter doesn't export X.py anymore, because it doesn't have any resources. The agent doesn't modify
+   the X.py present in its code directory, but the old version of X.py is still present. The results is that the stale version of X.py is loaded
+   instead of the version present in the agents python environment.
+
+This issue will persist after a restart of the agent process.

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -354,4 +354,3 @@ You will also need to specify the url of the repository in the ``project.yml`` f
 By following the previous steps, the Inmanta server will be able to install modules from a private Python package repository.
 
 
-

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -31,15 +31,15 @@ A complete V2 module might contain the following files:
     |__ pyproject.toml
     |
     |__ model
-    |    |__ _init.cf
-    |    |__ services.cf
+    |    |__ _init.cf
+    |    |__ services.cf
     |
     |__ inmanta_plugins/<module-name>/
-    |    |__ __init__.py
-    |    |__ functions.py
+    |    |__ __init__.py
+    |    |__ functions.py
     |
     |__ files
-    |    |__ file1.txt
+    |    |__ file1.txt
     |
     |__ templates
          |__ conf_file.conf.tmpl
@@ -155,17 +155,17 @@ A complete module might contain the following files:
     |__ module.yml
     |
     |__ model
-    |    |__ _init.cf
-    |    |__ services.cf
+    |    |__ _init.cf
+    |    |__ services.cf
     |
     |__ plugins
-    |    |__ functions.py
+    |    |__ functions.py
     |
     |__ files
-    |    |__ file1.txt
+    |    |__ file1.txt
     |
     |__ templates
-    |    |__ conf_file.conf.tmpl
+    |    |__ conf_file.conf.tmpl
     |
     |__ requirements.txt
 
@@ -347,25 +347,11 @@ Add the following content to the file:
   login <username>
   password <password>
 
-For more information see the doc about `pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
+For more information see the doc about`pip authentication <https://pip.pypa.io/en/stable/topics/authentication/>`_.
 
 You will also need to specify the url of the repository in the ``project.yml`` file of your project (See: :ref:`specify_location_pip`).
 
 By following the previous steps, the Inmanta server will be able to install modules from a private Python package repository.
 
 
-Inter-module dependencies
-#########################
 
-The plugins code of a V2 module A can have a dependency on the plugins code of another V2 module B. When doing this,
-care should be taken that the Python module(s) you depend on, do not define any resources or providers. Otherwise the
-python environment of the agent can get corrupt in the following way:
-
-1. Module A-1.0 depends on X.py of module B-1.0
-2. A-1.0 and B-1.0 are exported: The exporter exports the X.py file to the server and the agent puts the X.py file in its code directory.
-3. In a later version of module B (B-2.0) the X.py file doesn't have any resources anymore.
-4. A-1.0 and B-2.0 are exported: The exporter doesn't export X.py anymore, because it doesn't have any resources. The agent doesn't modify
-   the X.py present in its code directory, but the old version of X.py is still present. The results is that the stale version of X.py is loaded
-   instead of the version present in the agents python environment.
-
-This issue will persist after a restart of the agent process.

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2832,6 +2832,7 @@ class Environment(BaseDocument):
             await ResourceAction.delete_all(environment=self.id, connection=con)
             await Resource.delete_all(environment=self.id, connection=con)
             await ConfigurationModel.delete_all(environment=self.id, connection=con)
+            await ResourcePersistentState.delete_all(environment=self.id, connection=con)
 
     async def get_next_version(self, connection: Optional[asyncpg.connection.Connection] = None) -> int:
         """


### PR DESCRIPTION
# Description

Fix bug where the ResourcePersistentState table is not clear when an environment is cleared or deleted.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x  No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
