### PR TITLE
inmanta deploy command ignores f option iso6

### DIFF
--- a/changelogs/unreleased/6993-inmanta-deploy-command-ignores-f-option.yml
+++ b/changelogs/unreleased/6993-inmanta-deploy-command-ignores-f-option.yml
@@ -1,0 +1,7 @@
+description: Deploy command no longer ignores ``-f`` option.
+issue-nr: 6993
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"
+

--- a/changelogs/unreleased/6993-inmanta-deploy-command-ignores-f-option.yml
+++ b/changelogs/unreleased/6993-inmanta-deploy-command-ignores-f-option.yml
@@ -1,7 +1,7 @@
 description: Deploy command no longer ignores ``-f`` option.
 issue-nr: 6993
 change-type: patch
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]
 sections:
   bugfix: "{{description}}"
 

--- a/src/inmanta/deploy.py
+++ b/src/inmanta/deploy.py
@@ -318,7 +318,7 @@ host=localhost
 
         return True
 
-    def export(self) -> bool:
+    def export(self, main_file: str) -> bool:
         """
         Export a version to the embedded server
         """
@@ -335,6 +335,8 @@ host=localhost
             "localhost",
             "--server_port",
             str(self._server_port),
+            "-f",
+            main_file,
         ]
 
         sub_process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -484,7 +486,7 @@ host=localhost
         raise FinishedException()
 
     def run(self) -> None:
-        self.export()
+        self.export(main_file=self._options.main_file)
         self.deploy(dry_run=self._options.dryrun)
 
     def stop(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1148,6 +1148,7 @@ class SnippetCompilationTest(KeepOnFail):
         install_mode: Optional[InstallMode] = None,
         relation_precedence_rules: Optional[list[RelationPrecedenceRule]] = None,
         strict_deps_check: Optional[bool] = None,
+        main_file: str = "main.cf",
     ) -> Project:
         """
         Sets up the project to compile a snippet of inmanta DSL. Activates the compiler environment (and patches
@@ -1166,6 +1167,8 @@ class SnippetCompilationTest(KeepOnFail):
         :param relation_precedence_policy: The relation precedence policy that should be stored in the project.yml file of the
                                            Inmanta project.
         :param strict_deps_check: True iff the returned project should have strict dependency checking enabled.
+        :param main_file: Path to the .cf file to use as main entry point. A relative or an absolute path can be provided.
+            If a relative path is used, it's interpreted relative to the root of the project directory.
         """
         self.setup_for_snippet_external(
             snippet,
@@ -1175,8 +1178,11 @@ class SnippetCompilationTest(KeepOnFail):
             python_requires,
             install_mode,
             relation_precedence_rules,
+            main_file,
         )
-        return self._load_project(autostd, install_project, install_v2_modules, strict_deps_check=strict_deps_check)
+        return self._load_project(
+            autostd, install_project, install_v2_modules, strict_deps_check=strict_deps_check, main_file=main_file
+        )
 
     def _load_project(
         self,
@@ -1230,6 +1236,7 @@ class SnippetCompilationTest(KeepOnFail):
         python_requires: Optional[list[Requirement]] = None,
         install_mode: Optional[InstallMode] = None,
         relation_precedence_rules: Optional[list[RelationPrecedenceRule]] = None,
+        main_file: str = "main.cf",
     ) -> None:
         add_to_module_path = add_to_module_path if add_to_module_path is not None else []
         python_package_sources = python_package_sources if python_package_sources is not None else []
@@ -1266,7 +1273,7 @@ class SnippetCompilationTest(KeepOnFail):
                 cfg.write(f"\n            install_mode: {install_mode.value}")
         with open(os.path.join(self.project_dir, "requirements.txt"), "w", encoding="utf-8") as fd:
             fd.write("\n".join(str(req) for req in python_requires))
-        self.main = os.path.join(self.project_dir, "main.cf")
+        self.main = os.path.join(self.project_dir, main_file)
         with open(self.main, "w", encoding="utf-8") as x:
             x.write(snippet)
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -26,21 +26,26 @@ from tornado import process
 from inmanta import deploy
 
 
-def test_deploy(snippetcompiler, tmpdir, postgres_db):
+@pytest.mark.parametrize("default_main_file", [True, False])
+def test_deploy(snippetcompiler, tmpdir, postgres_db, default_main_file: bool):
+    """
+    Test the deploy command. The default_main_file parameter checks that the deploy command accepts
+    files other than `main.cf` through its `-f` cli option.
+    """
     file_name = tmpdir.join("test_file")
     # TODO: when agentconfig deploys no longer require an agent restart, define a new agent. Currently this makes the
     # test to slow.
-    snippetcompiler.setup_for_snippet(
-        """
-    host = std::Host(name="internal", os=std::linux)
-    file = std::Symlink(host=host, source="/dev/null", target="%s")
+    code = f"""
+        host = std::Host(name="internal", os=std::linux)
+        file = std::Symlink(host=host, source="/dev/null", target="{file_name}")
     """
-        % file_name
-    )
+
+    main_file = "main.cf" if default_main_file else "other.cf"
+    project = snippetcompiler.setup_for_snippet(code, main_file=main_file)
 
     os.chdir(snippetcompiler.project_dir)
-    Options = collections.namedtuple("Options", ["dryrun", "dashboard"])
-    options = Options(dryrun=False, dashboard=False)
+    Options = collections.namedtuple("Options", ["dryrun", "dashboard", "main_file"])
+    options = Options(dryrun=False, dashboard=False, main_file=main_file)
 
     assert not file_name.exists()
 
@@ -53,6 +58,8 @@ def test_deploy(snippetcompiler, tmpdir, postgres_db):
         run.stop()
 
     assert file_name.exists()
+
+    assert project.main_file == main_file
 
 
 @pytest.mark.slowtest


### PR DESCRIPTION
# Description

iso6 part for https://github.com/inmanta/inmanta-core/pull/7254

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
