### PR TITLE
Change the default value of server.auth_method config option

### DIFF
--- a/changelogs/unreleased/update-default-auth-method.yml
+++ b/changelogs/unreleased/update-default-auth-method.yml
@@ -1,0 +1,6 @@
+---
+description: Changed the default value of the `server.auth_method` config option from `None` to `oidc`.
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -127,7 +127,7 @@ server_tz_aware_timestamps = Option(
 )
 
 server_enable_auth = Option("server", "auth", False, "Enable authentication on the server API", is_bool)
-server_auth_method = Option("server", "auth_method", None, "The authentication method to use: oidc or database", is_str_opt)
+server_auth_method = Option("server", "auth_method", "oidc", "The authentication method to use: oidc or database", is_str)
 
 server_ssl_key = Option(
     "server", "ssl_key_file", None, "Server private key to use for this server Leave blank to disable SSL", is_str_opt


### PR DESCRIPTION
# Description

Changed the default value of the `server.auth_method` config option from `None` to `oidc`. This is not a breaking change because the default has always bee oidc. This PR makes that more explicit and fixes a bug in https://github.com/inmanta/inmanta-ui/pull/538.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
