### PR TITLE
Issue/wait until model is released

### DIFF
--- a/changelogs/unreleased/fix-test-resource-count-metric.yml
+++ b/changelogs/unreleased/fix-test-resource-count-metric.yml
@@ -1,0 +1,4 @@
+---
+description: "Make sure that test case test_resource_count_metric waits until the configurationmodel is released"
+change-type: patch
+destination-branches: [master, iso7]

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -43,7 +43,7 @@ from inmanta.server.services.environment_metrics_service import (
     ResourceCountMetricsCollector,
 )
 from inmanta.util import get_compiler_version, parse_timestamp
-from utils import ClientHelper
+from utils import ClientHelper, wait_until_version_is_released
 
 env_uuid = uuid.uuid4()
 
@@ -460,6 +460,10 @@ async def test_resource_count_metric(clienthelper, client, agent):
     )
     assert result.code == 200
     assert len(await data.Resource.get_list()) == 6
+
+    # Wait until the latest version in each environment is released
+    await wait_until_version_is_released(client, environment=env_uuid1, version=version_env1)
+    await wait_until_version_is_released(client, environment=env_uuid2, version=version_env2)
 
     # adds the ResourceCountMetricsCollector
     rcmc = ResourceCountMetricsCollector()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -278,6 +278,7 @@ async def wait_until_version_is_released(client, environment: uuid.UUID, version
     """
     Wait until the configurationmodel with the given version and environment is released.
     """
+
     async def _is_version_released() -> bool:
         result = await client.get_version(tid=environment, id=version)
         if result.code == 404:


### PR DESCRIPTION
# Description

Make sure that test case `test_resource_count_metric` waits until the configurationmodel is released. This commit made the auto_deploy of a configuration model asynchronous with respect to the `put_version()` and `put_partial()` API call.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
