### PR TITLE
Issue/6999 cad performance

### DIFF
--- a/changelogs/unreleased/6999-cad-performance.yml
+++ b/changelogs/unreleased/6999-cad-performance.yml
@@ -1,0 +1,7 @@
+description: Improve performance of cross agent dependency resolution
+issue-nr: 6999
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"
+

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -562,7 +562,7 @@ class ResourceScheduler:
                 self.deferred = None
 
     async def resolve_cads(self, version: int, cads: dict[ResourceIdStr, RemoteResourceAction]) -> None:
-        """ Batch resolve all CAD's """
+        """Batch resolve all CAD's"""
         async with self.agent.process.cad_ratelimiter:
             result = await self.get_client().resources_status(
                 tid=self.agent._env_id,
@@ -575,10 +575,9 @@ class ResourceScheduler:
 
             for rid_raw, status_raw in result.result["data"].items():
                 status = const.ResourceState[status_raw]
-                rra = cads.get(rid_raw, None)
-                if rra is not None:
-                    if status not in const.TRANSIENT_STATES:
-                        rra.notify(status)
+                rra = cads[rid_raw]
+                if status not in const.TRANSIENT_STATES:
+                    rra.notify(status)
 
     def notify_ready(
         self,

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -562,9 +562,8 @@ class ResourceScheduler:
                 self.deferred = None
 
     async def resolve_cads(self, version: int, cads: dict[ResourceIdStr, RemoteResourceAction]) -> None:
-
+        """ Batch resolve all CAD's """
         async with self.agent.process.cad_ratelimiter:
-
             result = await self.get_client().resources_status(
                 tid=self.agent._env_id,
                 model_version=version,

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -842,6 +842,7 @@ class ResourceScheduler:
             ra.cancel()
         if self.cad_resolver is not None:
             self.cad_resolver.cancel()
+            self.cad_resolver = None
         self.generation = {}
         self.cad = {}
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -695,9 +695,7 @@ class RemoteResourceAction(ResourceActionBase):
     def __init__(self, scheduler: "ResourceScheduler", resource_id: Id, gid: uuid.UUID, reason: str) -> None:
         super().__init__(scheduler, resource_id, gid, reason)
 
-    async def execute(
-        self, dummy: "ResourceActionBase", generation: "Dict[ResourceIdStr, ResourceActionBase]", cache: AgentCache
-    ) -> None:
+    async def execute(self, dummy: "ResourceActionBase", generation: "Dict[ResourceIdStr, ResourceActionBase]") -> None:
         pass
 
     def notify(
@@ -907,7 +905,7 @@ class ResourceScheduler:
             self.generation[resource.rid] = local_resource_action
 
         # hook up Cross Agent Dependencies
-        cross_agent_dependencies: Set[Id] = {q for r in resources for q in r.requires if q.get_agent_name() != self.name}
+        cross_agent_dependencies: set[Id] = {q for r in resources for q in r.requires if q.get_agent_name() != self.name}
         cads_by_rid: dict[ResourceIdStr, RemoteResourceAction] = {}
         for cad in cross_agent_dependencies:
             ra = RemoteResourceAction(self, cad, gid, self.running.reason)

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4630,10 +4630,10 @@ class Resource(BaseDocument):
         rids: list[ResourceIdStr],
     ) -> dict[ResourceIdStr, ResourceState]:
         query = (
-            f"SELECT r.resource_id, r.status FROM resource r"
-            f" WHERE r.environment=$1"
-            f" AND r.model=$2"
-            f" AND r.resource_id = ANY($3);"
+            "SELECT r.resource_id, r.status FROM resource r"
+            " WHERE r.environment=$1"
+            " AND r.model=$2"
+            " AND r.resource_id = ANY($3);"
         )
         out = await cls.select_query(query, [env, model_version, rids], no_obj=True)
         return {ResourceIdStr(r["resource_id"]): ResourceState[r["status"]] for r in out}

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4622,7 +4622,6 @@ class Resource(BaseDocument):
         return out
 
     @classmethod
-    @classmethod
     async def get_status_for(
         cls,
         env: uuid.UUID,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4628,11 +4628,16 @@ class Resource(BaseDocument):
         model_version: int,
         rids: list[ResourceIdStr],
     ) -> dict[ResourceIdStr, ResourceState]:
+        if not rids:
+            return {}
         query = (
-            "SELECT r.resource_id, r.status FROM resource r"
-            " WHERE r.environment=$1"
-            " AND r.model=$2"
-            " AND r.resource_id = ANY($3);"
+            """
+            SELECT r.resource_id, r.status
+            FROM resource r
+            WHERE r.environment=$1
+                AND r.model=$2
+                AND r.resource_id = ANY($3);
+            """
         )
         out = await cls.select_query(query, [env, model_version, rids], no_obj=True)
         return {ResourceIdStr(r["resource_id"]): ResourceState[r["status"]] for r in out}

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4630,15 +4630,13 @@ class Resource(BaseDocument):
     ) -> dict[ResourceIdStr, ResourceState]:
         if not rids:
             return {}
-        query = (
-            """
+        query = """
             SELECT r.resource_id, r.status
             FROM resource r
             WHERE r.environment=$1
                 AND r.model=$2
                 AND r.resource_id = ANY($3);
             """
-        )
         out = await cls.select_query(query, [env, model_version, rids], no_obj=True)
         return {ResourceIdStr(r["resource_id"]): ResourceState[r["status"]] for r in out}
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4622,6 +4622,23 @@ class Resource(BaseDocument):
         return out
 
     @classmethod
+    @classmethod
+    async def get_status_for(
+        cls,
+        env: uuid.UUID,
+        model_version: int,
+        rids: list[ResourceIdStr],
+    ) -> dict[ResourceIdStr, ResourceState]:
+        query = (
+            f"SELECT r.resource_id, r.status FROM resource r"
+            f" WHERE r.environment=$1"
+            f" AND r.model=$2"
+            f" AND r.resource_id = ANY($3);"
+        )
+        out = await cls.select_query(query, [env, model_version, rids], no_obj=True)
+        return {ResourceIdStr(r["resource_id"]): ResourceState[r["status"]] for r in out}
+
+    @classmethod
     async def set_deployed_multi(
         cls,
         environment: uuid.UUID,

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -19,7 +19,6 @@
 """
 
 import datetime
-import typing
 import uuid
 from typing import Literal, Optional, Union
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -872,14 +872,14 @@ def get_fact(tid: uuid.UUID, rid: model.ResourceIdStr, id: uuid.UUID) -> model.F
 )
 def resources_status(
     tid: uuid.UUID,
-    model_version: int,
+    version: int,
     rids: list[model.ResourceIdStr],
 ) -> dict[model.ResourceIdStr, ResourceState]:
     """
     Get the deployment status for a batch of resource ids
 
     :param tid: The id of the environment the resources belong to
-    :param model_version: Version of the model to get the status for
+    :param version: Version of the model to get the status for
     :param rids: List of resource ids to fetch the status for.
     """
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -19,6 +19,7 @@
 """
 
 import datetime
+import typing
 import uuid
 from typing import Literal, Optional, Union
 
@@ -859,6 +860,28 @@ def get_fact(tid: uuid.UUID, rid: model.ResourceIdStr, id: uuid.UUID) -> model.F
     :param id: The id of the fact
     :return: A specific fact corresponding to the id
     :raise NotFound: This status code is returned when the referenced environment or fact is not found
+    """
+
+
+@typedmethod(
+    path="/resources/status",
+    operation="GET",
+    agent_server=True,
+    arg_options={**methods.ENV_OPTS},
+    client_types=[ClientType.agent],
+    api_version=2,
+)
+def resources_status(
+    tid: uuid.UUID,
+    model_version: int,
+    rids: list[model.ResourceIdStr],
+) -> dict[model.ResourceIdStr, ResourceState]:
+    """
+    Get the deployment status for a batch of resource ids
+
+    :param tid: The id of the environment the resources belong to
+    :param model_version: Version of the model to get the status for
+    :param rids: List of resource ids to fetch the status for.
     """
 
 

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -21,7 +21,6 @@ import datetime
 import logging
 import os
 import re
-import typing
 import uuid
 from collections import abc, defaultdict
 from collections.abc import Sequence

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -1237,7 +1237,7 @@ class ResourceService(protocol.ServerSlice):
         env: data.Environment,
         model_version: int,
         rids: list[ResourceIdStr],
-    ) -> dict[ResourceIdStr, ResourceState]:
+    ) -> dict[str, ResourceState]:
         try:
             rids = [Id.parse_id(rid).resource_str() for rid in rids]
         except ValueError as e:

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -21,6 +21,7 @@ import datetime
 import logging
 import os
 import re
+import typing
 import uuid
 from collections import abc, defaultdict
 from collections.abc import Sequence
@@ -1230,6 +1231,19 @@ class ResourceService(protocol.ServerSlice):
             raise BadRequest(e.message) from e
 
         # TODO: optimize for no orphans
+
+    @handle(methods_v2.resources_status, env="tid")
+    async def resources_status(
+        self,
+        env: data.Environment,
+        model_version: int,
+        rids: list[ResourceIdStr],
+    ) -> dict[ResourceIdStr, ResourceState]:
+        try:
+            rids = [Id.parse_id(rid).resource_str() for rid in rids]
+        except ValueError as e:
+            raise BadRequest(str(e))
+        return await data.Resource.get_status_for(env.id, model_version, rids)
 
     @handle(methods_v2.resource_details, env="tid")
     async def resource_details(self, env: data.Environment, rid: ResourceIdStr) -> ReleasedResourceDetails:

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -1235,14 +1235,14 @@ class ResourceService(protocol.ServerSlice):
     async def resources_status(
         self,
         env: data.Environment,
-        model_version: int,
+        version: int,
         rids: list[ResourceIdStr],
     ) -> dict[str, ResourceState]:
         try:
             rids = [Id.parse_id(rid).resource_str() for rid in rids]
         except ValueError as e:
             raise BadRequest(str(e))
-        return await data.Resource.get_status_for(env.id, model_version, rids)
+        return await data.Resource.get_status_for(env.id, version, rids)
 
     @handle(methods_v2.resource_details, env="tid")
     async def resource_details(self, env: data.Environment, rid: ResourceIdStr) -> ReleasedResourceDetails:

--- a/tests/server/test_resourceservice.py
+++ b/tests/server/test_resourceservice.py
@@ -162,6 +162,25 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
     # Finish deployment r1
     await resource_deployer.deployment_finished(rvid=rvid_r1_v1, action_id=action_id)
 
+    # request 3
+    # only two exist
+    result = await agent._client.resources_status(
+        tid=environment,
+        model_version=version,
+        rids=["std::File[agent1,path=/etc/file2]", "std::File[agent1,path=/etc/file3]", "std::File[agent1,path=/etc/file4]"],
+    )
+    assert result.code == 200
+    assert result.result["data"] == {
+        "std::File[agent1,path=/etc/file2]": "deployed",
+        "std::File[agent1,path=/etc/file3]": "deployed",
+    }
+
+    result = await agent._client.resources_status(
+        tid=environment, model_version=version, rids=["std::File[agent1,path=/etc/file2]", "Resource WITH invalid id"]
+    )
+    assert result.code == 400
+    assert result.result["message"] == "Invalid request: Invalid id for resource Resource WITH invalid id"
+
 
 async def test_events_api_endpoints_increment(server, client, environment, clienthelper, agent, resource_deployer):
     """

--- a/tests/server/test_resourceservice.py
+++ b/tests/server/test_resourceservice.py
@@ -166,7 +166,7 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
     # only two exist
     result = await agent._client.resources_status(
         tid=environment,
-        model_version=version,
+        version=version,
         rids=["std::File[agent1,path=/etc/file2]", "std::File[agent1,path=/etc/file3]", "std::File[agent1,path=/etc/file4]"],
     )
     assert result.code == 200
@@ -176,7 +176,7 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
     }
 
     result = await agent._client.resources_status(
-        tid=environment, model_version=version, rids=["std::File[agent1,path=/etc/file2]", "Resource WITH invalid id"]
+        tid=environment, version=version, rids=["std::File[agent1,path=/etc/file2]", "Resource WITH invalid id"]
     )
     assert result.code == 400
     assert result.result["message"] == "Invalid request: Invalid id for resource Resource WITH invalid id"


### PR DESCRIPTION
# Description

Attempt to improve CAD performance by batching 

closes #6999 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)

```
src/inmanta/protocol/methods_v2.py:1522: error: Missing return statement  [empty-body]
src/inmanta/data/__init__.py:4639: error: Argument 1 to "ResourceIdStr" has incompatible type "object"; expected "str"  [arg-type]
src/inmanta/data/__init__.py:5724: error: Enum index should be a string (actual index type "object")  [misc]
src/inmanta/server/services/resourceservice.py:1245: error: Incompatible return value type (got "dict[ResourceIdStr, ResourceState]", expected "dict[str, ResourceState]")  [return-value]

``` 
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
