### PR TITLE
Re-add the agent_install_dependency_modules project config option

### DIFF
--- a/changelogs/unreleased/7026-agent-install-dependency-modules.yml
+++ b/changelogs/unreleased/7026-agent-install-dependency-modules.yml
@@ -1,8 +1,9 @@
 ---
-description: Dropped the project configuration option `agent_install_dependency_modules`. The installation of module dependencies is now always enabled.
+description: "The default value of the project configuration option `agent_install_dependency_modules` changed to True."
 issue-nr: 7026
 issue-repo: inmanta-core
 change-type: patch
 destination-branches: [master, iso7]
 sections:
   upgrade-note: "{{description}}"
+  deprecation-note: "The project configuration option `agent_install_dependency_modules` is deprecated and will be removed in a next major release."

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -105,7 +105,10 @@ class SourceInfo:
         if self._requires is None:
             project: module.Project = module.Project.get()
             mod: module.Module = project.modules[self._get_module_name()]
-            self._requires = mod.get_all_python_requirements_as_list()
+            if project.metadata.agent_install_dependency_modules:
+                self._requires = mod.get_all_python_requirements_as_list()
+            else:
+                self._requires = mod.get_strict_python_requirements_as_list()
         return self._requires
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1618,6 +1618,21 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
         result in an error.
         When a non-strict check is done, only version conflicts in a direct dependency will result in an error.
         All other violations will only result in a warning message.
+    :param agent_install_dependency_modules: [DEPRECATED] If true, when a module declares Python dependencies on
+        other (v2) modules, the agent will install these dependency modules with pip. This option should only be enabled
+        if the agent is configured with the appropriate pip related environment variables. The option allows to an extent
+        for inter-module dependencies within handler code, even if the dependency module doesn't have any handlers that
+        would otherwise be considered relevant for this agent.
+        Care should still be taken when you use inter-module imports. The current code loading mechanism does not explicitly
+        order reloads. A general guideline is to use qualified imports where you can (import the module rather than objects
+        from the module). When this is not feasible, you should be aware of
+        `Python's reload semantics <https://docs.python.org/3/library/importlib.html#importlib.reload>`_ and take this into
+        account when making changes to handler code.
+        Another caveat is that if the dependency module does contain code that is relevant for the agent, it will be loaded
+        like any other handler code and it will be this code that is imported by any dependent modules (though depending on
+        the load order the very first import may use the version installed by pip). If at some point this dependency module's
+        handlers cease to be relevant for this agent, its code will remain stale. Therefore this feature should not be depended
+        on in transient scenarios like this.
     :param pip: A configuration section that holds information about the pip configuration that should be taken into account
                 when installing Python packages (See: :py:class:`inmanta.module.ProjectPipConfig` for more details).
     """
@@ -1640,6 +1655,7 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
         Annotated[str, StringConstraints(strip_whitespace=True, pattern=_re_relation_precedence_rule, min_length=1)]
     ] = []
     strict_deps_check: bool = True
+    agent_install_dependency_modules: bool = True
     pip: ProjectPipConfig = ProjectPipConfig()
 
     @field_validator("modulepath", mode="before")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -106,7 +106,13 @@ def test_code_manager(tmpdir: py.path.local):
 
     # verify requirements behavior
     source_info: SourceInfo = single_type_list[0]
+    # by default only install non-module dependencies
     assert source_info.requires == ["inmanta-module-std", "lorem"]
+    project._metadata.agent_install_dependency_modules = False
+    # reset cache
+    source_info._requires = None
+    # when enabled, also install dependencies on other modules
+    assert source_info.requires == ["lorem"]
 
 
 def test_code_loader(tmp_path, caplog):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -106,12 +106,12 @@ def test_code_manager(tmpdir: py.path.local):
 
     # verify requirements behavior
     source_info: SourceInfo = single_type_list[0]
-    # by default only install non-module dependencies
+    # by default also install dependencies on other modules
     assert source_info.requires == ["inmanta-module-std", "lorem"]
     project._metadata.agent_install_dependency_modules = False
     # reset cache
     source_info._requires = None
-    # when enabled, also install dependencies on other modules
+    # when disabled only install non-module dependencies
     assert source_info.requires == ["lorem"]
 
 


### PR DESCRIPTION
# Description

Re-add `agent_install_dependency_modules` project config option for backwards compatibility.

Mergetool is going to reject this, because I modified an existing changelog entry. So I will merge this by hand.

Part of https://github.com/inmanta/inmanta-core/issues/7026

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
