### PR TITLE
Bump compiler_version to 2025.0

### DIFF
--- a/changelogs/unreleased/bump-compiler-version-2025-0.yml
+++ b/changelogs/unreleased/bump-compiler-version-2025-0.yml
@@ -1,4 +1,6 @@
 ---
 description: Bump the compiler version to 2025.0
+issue-nr: 693
+issue-repo: lsm
 change-type: patch
 destination-branches: [master]

--- a/changelogs/unreleased/bump-compiler-version-2025-0.yml
+++ b/changelogs/unreleased/bump-compiler-version-2025-0.yml
@@ -1,0 +1,4 @@
+---
+description: Bump the compiler version to 2025.0
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-COMPILER_VERSION = "2024.1.1"
+COMPILER_VERSION = "2025.0"
 # This version is managed by bumpversion. Should you ever update it manually, make sure to consistently update it everywhere
 # (See the bumpversion.cfg file for relevant locations).
 __version__ = "12.0.0"


### PR DESCRIPTION
# Description

Bump compiler version to `2025.0`, because master diverged from iso7.

# Self Check:

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
