### PR TITLE
Add dedicated documentation page for compatibility iso6

### DIFF
--- a/changelogs/unreleased/1888-add-dedicated-doc-page-for-config-requirements.yml
+++ b/changelogs/unreleased/1888-add-dedicated-doc-page-for-config-requirements.yml
@@ -1,0 +1,5 @@
+description: Add dedicated documentation page for compatibility.
+issue-repo: irt
+issue-nr: 1888
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/1888-add-dedicated-doc-page-for-config-requirements.yml
+++ b/changelogs/unreleased/1888-add-dedicated-doc-page-for-config-requirements.yml
@@ -2,4 +2,4 @@ description: Add dedicated documentation page for compatibility.
 issue-repo: irt
 issue-nr: 1888
 change-type: patch
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]

--- a/docs/_templates/components_requirements.tmpl
+++ b/docs/_templates/components_requirements.tmpl
@@ -1,0 +1,28 @@
+.. -*- mode: rst -*-
+
+Inmanta core and extensions versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+{% if data['component_requirements']%}
+.. list-table:: Inmanta core and extensions versions
+   :header-rows: 1
+
+   * - Component
+     - Required version
+
+   {% for key, value in data["component_requirements"] | dictsort %}
+   * - {{ key }}
+     - {{ value }}
+   {% endfor %}
+
+.. note::
+
+    This information is also available as a constraints file in `requirements.components.txt <./requirements.components.txt>`_
+    and in json format in the `compatibility.json <./compatibility.json>`_ file.
+
+
+{% else %}
+Components are not pinned for major version |version_major| because it is not released yet.
+{% endif %}
+

--- a/docs/_templates/system_requirements.tmpl
+++ b/docs/_templates/system_requirements.tmpl
@@ -1,0 +1,24 @@
+.. -*- mode: rst -*-
+
+
+System requirements
+~~~~~~~~~~~~~~~~~~~
+
+
+{% if data['system_requirements']%}
+.. list-table:: System requirements
+   :header-rows: 1
+
+   * - Component
+     - Required version
+
+   {% for key, value in data["system_requirements"] | dictsort %}
+   * - {{ key }}
+     - {{ value }}
+   {% endfor %}
+{% endif %}
+
+.. note::
+
+    This information is also available in a machine-consumable format in the `compatibility.json <./compatibility.json>`_ file.
+

--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -1,0 +1,4 @@
+{
+    "component_requirements": {},
+    "system_requirements": {}
+}

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -1,0 +1,23 @@
+Compatibility
+*************
+
+.. only:: iso
+
+    This page shows the compatibility for version |version_major| of the Inmanta Service Orchestrator with other components.
+    These compatible versions are defined for the whole lifetime of this major version i.e.
+    they are not pinned to a specific three-digit version. Upper bounds may be added when a new major version is released.
+
+
+.. only:: oss
+
+    This page shows the compatibility of Inmanta version |release| with other components.
+
+
+.. datatemplate:json:: compatibility.json
+   :template: system_requirements.tmpl
+
+.. only:: iso
+
+    .. datatemplate:json:: compatibility.json
+       :template: components_requirements.tmpl
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.graphviz', 'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode', 'sphinxarg.ext', 'sphinxcontrib.contentui', 'sphinxcontrib.inmanta.config',
     'sphinxcontrib.inmanta.dsl', 'sphinxcontrib.inmanta.environmentsettings', 'sphinx_click.ext', 'sphinx_design',
-    'myst_parser', 'sphinx_substitution_extensions',
+    'myst_parser', 'sphinx_substitution_extensions', 'sphinxcontrib.datatemplates',
 ]
 
 myst_enable_extensions = ["colon_fence"]
@@ -140,6 +140,7 @@ rst_prolog = f"""\
 .. |version_major| replace:: {version_major}
 .. |iso_gpg_key| replace:: {iso_gpg_key}
 .. |oss_gpg_key| replace:: {oss_gpg_key}
+.. |release| replace:: {release}
 """
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,7 @@
     reference/index
     troubleshooting
     changelogs
-
+    compatibility
 
 PDF version
 -----------

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -22,3 +22,4 @@ sphinx-autodoc-annotation==1.0-1
 sphinx-click==5.1.0
 sphinx-design==0.5.0
 Sphinx-Substitution-Extensions==2022.2.16
+sphinxcontrib.datatemplates==0.11.0


### PR DESCRIPTION
ISO6 specific pr for https://github.com/inmanta/irt/issues/1888


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
