### PR TITLE
Cleanup code folder on agent restart

### DIFF
--- a/changelogs/unreleased/7388-stale-code-warning.yml
+++ b/changelogs/unreleased/7388-stale-code-warning.yml
@@ -1,0 +1,6 @@
+description: Remove stale code warning
+issue-nr: 7388
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: Ensure agent code folder is cleaned up on restart

--- a/docs/model_developers/modules.rst
+++ b/docs/model_developers/modules.rst
@@ -372,4 +372,4 @@ python environment of the agent can get corrupt in the following way:
    mod-a-1.0 is exported again, mod-b-2.0 is not (again because it doesn't have any resources). The old x.py file still
    exists in the agent code directory. It is loaded by the agent instead of the one from mod-b-2.0.
 
-This issue will persist after a restart of the agent process.
+This issue will be resolved by a restart of the agent process.

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -1401,7 +1401,7 @@ class Agent(SessionEndpoint):
         if code_loader:
             self._env = env.VirtualEnv(self._storage["env"])
             self._env.use_virtual_env()
-            self._loader = CodeLoader(self._storage["code"])
+            self._loader = CodeLoader(self._storage["code"], clean=True)
             # Lock to ensure only one actual install runs at a time
             self._loader_lock = Lock()
             # Keep track for each resource type of the last loaded version
@@ -1662,11 +1662,6 @@ class Agent(SessionEndpoint):
         if self._loader is None:
             return failed_to_load
 
-        # The names of the modules that are included in the requirements list of a module source.
-        all_required_modules: set[str] = set()
-        # The names of the modules for which the source code was installed.
-        all_installed_modules: set[str] = set()
-
         for resource_install_spec in code:
             # only one logical thread can load a particular resource type at any time
             async with self._resource_loader_lock.get(resource_install_spec.resource_type):
@@ -1707,45 +1702,6 @@ class Agent(SessionEndpoint):
                     )
                     failed_to_load.add(resource_install_spec.resource_type)
                     self._last_loaded_version[resource_install_spec.resource_type] = -1
-
-                for source in resource_install_spec.sources:
-                    module_name: str = loader.get_inmanta_module_name(source.name)
-                    all_installed_modules.add(module_name)
-
-                all_required_modules.update(
-                    {
-                        module.ModuleV2Source.get_inmanta_module_name(r)
-                        for r in resource_install_spec.requirements
-                        if r.startswith("inmanta-module-")
-                    }
-                )
-
-        # If a certain module A depends on the plugin code of another module B, then the source of B must either:
-        #  * Be exported to the server (because module B has resources or providers)
-        #  * Or, not be exported and never been exported in any previous version.
-        # Otherwise there is the possibility that stale code in the code directory of the agent gets picket up,
-        # instead of the code from the Python package (V2 module) installed in the venv of the agent.
-        modules_not_expected_in_code_directory: set[str] = all_required_modules - all_installed_modules
-        modules_present_in_code_dir: set[str] = {d for d in os.listdir(self._loader.mod_dir)}
-        modules_with_stale_python_code: set[str] = modules_present_in_code_dir & modules_not_expected_in_code_directory
-        if modules_with_stale_python_code:
-            warning_message = f"""
-The source code for the modules {', '.join(modules_with_stale_python_code)} is present in the modules directory of the agent \
-({self._loader.mod_dir}), but these modules were not exported to the server in the latest version. This is likely \
-caused by the fact that the above-mentioned modules contained resources or providers in a previous version, but not \
-anymore in the current version, while there exists an inter-module dependency from another module to the above-mentioned \
-modules. If this is the case, the agent might pick up stale Python code for any of the above-mentioned modules. If this \
-problem occurs, a manual cleanup of the agent's code directory is required to resolve this problem.
-""".strip()
-            LOGGER.warning(warning_message)
-            result = await self._client.send_notification(
-                tid=self.environment,
-                title="Stale code in agent's code directory",
-                message=warning_message,
-                severity=const.NotificationSeverity.warning,
-            )
-            if result.code != 200:
-                LOGGER.error("Failed to send notification message regarding stale Python code in the agent code directory.")
 
         return failed_to_load
 

--- a/src/inmanta/agent/agent.py
+++ b/src/inmanta/agent/agent.py
@@ -37,7 +37,7 @@ from typing import Any, Collection, Dict, Optional, Self, TypeAlias, Union, cast
 
 import pkg_resources
 
-from inmanta import const, data, env, loader, module, protocol
+from inmanta import const, data, env, protocol
 from inmanta.agent import config as cfg
 from inmanta.agent import handler
 from inmanta.agent.cache import AgentCache, CacheVersionContext

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -24,6 +24,7 @@ import inspect
 import logging
 import os
 import pathlib
+import shutil
 import sys
 import types
 from collections import abc
@@ -241,19 +242,22 @@ class CodeLoader:
     :param code_dir: The directory where the code is stored
     """
 
-    def __init__(self, code_dir: str) -> None:
+    def __init__(self, code_dir: str, clean: bool = False) -> None:
         self.__code_dir = code_dir
         self.__modules: dict[str, tuple[str, types.ModuleType]] = {}  # A map with all modules we loaded, and its hv
 
-        self.__check_dir()
+        self.__check_dir(clean)
 
         self.mod_dir = os.path.join(self.__code_dir, MODULE_DIR)
         PluginModuleFinder.configure_module_finder(modulepaths=[self.mod_dir], prefer=True)
 
-    def __check_dir(self) -> None:
+    def __check_dir(self, clean: bool = False) -> None:
         """
         Check if the code directory
         """
+        if clean and os.path.exists(self.__code_dir):
+            shutil.rmtree(self.__code_dir)
+
         # check for the code dir
         if not os.path.exists(self.__code_dir):
             os.makedirs(self.__code_dir, exist_ok=True)

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1395,34 +1395,6 @@ def update_notification(
 
 
 @typedmethod(
-    path="/notification",
-    operation="POST",
-    agent_server=True,
-    arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.agent],
-    api_version=2,
-)
-def send_notification(
-    tid: uuid.UUID,
-    title: str,
-    message: str,
-    uri: Optional[str] = None,
-    severity: NotificationSeverity = NotificationSeverity.message,
-) -> None:
-    """
-    Create a new notification.
-
-    :param tid: The id of the environment.
-    :param title: The title of the notification message.
-    :param message: The message of the notification.
-    :param uri: A link to an api endpoint of the server, that is relevant to the message,
-                and can be used to get further information about the problem.
-                For example a compile related problem should have the uri: `/api/v2/compilereport/<compile_id>`
-    :param severity: The severity level of the notification message.
-    """
-
-
-@typedmethod(
     path="/code/<version>",
     operation="GET",
     agent_server=True,

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -22,7 +22,7 @@ import datetime
 import uuid
 from typing import Literal, Optional, Union
 
-from inmanta.const import AgentAction, ApiDocsFormat, Change, ClientType, NotificationSeverity, ParameterSource, ResourceState
+from inmanta.const import AgentAction, ApiDocsFormat, Change, ClientType, ParameterSource, ResourceState
 from inmanta.data import model
 from inmanta.data.model import DiscoveredResource, PipConfig, ResourceIdStr
 from inmanta.protocol import methods

--- a/src/inmanta/server/services/notificationservice.py
+++ b/src/inmanta/server/services/notificationservice.py
@@ -108,17 +108,6 @@ class NotificationService(protocol.ServerSlice, CompileStateListener):
                     uri=f"/api/v2/compilereport/{compile.id}",
                 )
 
-    @handle(methods_v2.send_notification, env="tid")
-    async def send_notification(
-        self,
-        env: data.Environment,
-        title: str,
-        message: str,
-        uri: Optional[str] = None,
-        severity: const.NotificationSeverity = const.NotificationSeverity.message,
-    ) -> None:
-        await self.notify(env.id, title, message, uri, severity)
-
     async def notify(
         self,
         environment: uuid.UUID,

--- a/tests/agent_server/test_agent_code_loading.py
+++ b/tests/agent_server/test_agent_code_loading.py
@@ -16,10 +16,8 @@
     Contact: code@inmanta.com
 """
 
-import asyncio
 import base64
 import hashlib
-import logging
 import os
 import py_compile
 import tempfile
@@ -29,14 +27,12 @@ from logging import DEBUG, INFO
 import pytest
 
 import inmanta
-from inmanta import const
 from inmanta.agent import Agent
 from inmanta.agent.agent import ResourceInstallSpec
 from inmanta.data import PipConfig
-from inmanta.data.model import Notification
 from inmanta.protocol import Client
 from inmanta.util import get_compiler_version
-from utils import LogSequence, log_contains, log_doesnt_contain
+from utils import LogSequence
 
 
 async def make_source_structure(

--- a/tests/agent_server/test_agent_code_loading.py
+++ b/tests/agent_server/test_agent_code_loading.py
@@ -16,6 +16,7 @@
     Contact: code@inmanta.com
 """
 
+import asyncio
 import base64
 import hashlib
 import logging
@@ -263,6 +264,14 @@ inmanta.test_agent_code_loading = 15
     await agent.ensure_code(code=resource_install_specs_6)
     assert getattr(inmanta, "test_agent_code_loading") == 10
 
+    # ensure we clean up on restart
+    assert os.path.exists(os.path.join(agent._loader.mod_dir, "tests/plugins/__init__.py"))
+    await agent.stop()
+    await agent_factory(
+        environment=environment, agent_map={"agent1": "localhost"}, hostname="host", agent_names=["agent1"], code_loader=True
+    )
+    assert not os.path.exists(os.path.join(agent._loader.mod_dir, "tests"))
+
 
 @pytest.mark.slowtest
 async def test_agent_installs_dependency_containing_extras(
@@ -318,115 +327,3 @@ def test():
 
     assert agent._env.are_installed(["pkg", "dep-a"])
     assert not agent._env.are_installed(["dep-b", "dep-c"])
-
-
-async def test_warning_message_stale_python_code(
-    server,
-    client,
-    environment,
-    agent_factory,
-    clienthelper,
-    caplog,
-    local_module_package_index,
-) -> None:
-    """
-    If a certain module A depends on the plugin code of another module B, then the source of B must either:
-      * Be exported to the server (because module B has resources or providers)
-      * Or, not be exported and never been exported in any previous version.
-    Otherwise there is the possibility that stale code in the code directory of the agent gets picket up,
-    instead of the code from the Python package (V2 module) installed in the venv of the agent.
-
-    This test case verifies that a warning message is written the agent's log file when this scenario occurs.
-    """
-
-    sources_test_mod = {}
-    await make_source_structure(
-        into=sources_test_mod,
-        file="inmanta_plugins/test/__init__.py",
-        module="inmanta_plugins.test",
-        source="",
-        dependencies=["inmanta-module-minimalv2module"],
-        client=client,
-    )
-    sources_minimalv2module_mod = {}
-    await make_source_structure(
-        into=sources_minimalv2module_mod,
-        file="inmanta_plugins/minimalv2module/__init__.py",
-        module="inmanta_plugins.minimalv2module",
-        source="",
-        dependencies=[],
-        client=client,
-    )
-
-    version = await clienthelper.get_version()
-
-    res = await client.put_version(
-        tid=environment,
-        version=version,
-        resources=[],
-        pip_config=PipConfig(index_url=local_module_package_index),
-        compiler_version=get_compiler_version(),
-    )
-    assert res.code == 200
-
-    res = await client.upload_code_batched(
-        tid=environment,
-        id=version,
-        resources={"test::Test": sources_test_mod, "minimalv2module::Test": sources_minimalv2module_mod},
-    )
-    assert res.code == 200
-
-    agent: Agent = await agent_factory(
-        environment=environment, agent_map={"agent1": "localhost"}, hostname="host", agent_names=["agent1"], code_loader=True
-    )
-
-    install_specs, _ = await agent.get_code(
-        environment=uuid.UUID(environment),
-        version=version,
-        resource_types=["test::Test", "minimalv2module::Test"],
-    )
-    await agent.ensure_code(install_specs)
-
-    expected_warning_message = (
-        f"The source code for the modules minimalv2module is present in the modules directory of the agent "
-        f"({agent._loader.mod_dir})"
-    )
-    log_doesnt_contain(caplog, "agent", logging.WARNING, expected_warning_message)
-    result = await client.list_notifications(tid=environment)
-    assert result.code == 200
-    assert len(result.result["data"]) == 0
-
-    # Don't upload code for modb anymore in new version
-    version = await clienthelper.get_version()
-
-    res = await client.put_version(
-        tid=environment,
-        version=version,
-        resources=[],
-        pip_config=PipConfig(index_url=local_module_package_index),
-        compiler_version=get_compiler_version(),
-    )
-    assert res.code == 200
-
-    res = await client.upload_code_batched(tid=environment, id=version, resources={"test::Test": sources_test_mod})
-    assert res.code == 200
-
-    install_specs, _ = await agent.get_code(
-        environment=uuid.UUID(environment),
-        version=version,
-        resource_types=["test::Test"],
-    )
-    await agent.ensure_code(install_specs)
-
-    log_contains(caplog, "agent", logging.WARNING, expected_warning_message)
-    result = await client.list_notifications(tid=environment)
-    assert result.code == 200
-    assert len(result.result["data"]) == 1
-    notification = Notification(**result.result["data"][0])
-    assert notification.environment == uuid.UUID(environment)
-    assert notification.title == "Stale code in agent's code directory"
-    assert expected_warning_message in notification.message
-    assert notification.uri is None
-    assert notification.severity == const.NotificationSeverity.warning.value
-    assert not notification.read
-    assert not notification.cleared


### PR DESCRIPTION
# Description

Cleanup code folder on agent restart

closes  #7388 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [X] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
