### PR TITLE
[FIX] fix migration test

### DIFF
--- a/changelogs/unreleased/fix-202403110-db-migration-tests.yml
+++ b/changelogs/unreleased/fix-202403110-db-migration-tests.yml
@@ -1,0 +1,3 @@
+description: Migration test was not using latest dump
+change-type: patch
+destination-branches: [master, iso7]

--- a/tests/db/migration_tests/dumps/v202403110.sql
+++ b/tests/db/migration_tests/dumps/v202403110.sql
@@ -616,7 +616,7 @@ COPY public.dryrun (id, environment, model, date, total, todo, resources) FROM s
 
 COPY public.environment (id, name, project, repo_url, repo_branch, settings, last_version, halted, description, icon) FROM stdin;
 834fde5a-e5d3-4443-9ab7-04034bfdbec9	dev-2	0873d9b8-1964-4fbb-b26a-193ed5307d90			{"auto_full_compile": ""}	0	f		
-e03eabc9-5342-4e6b-b72e-6a062bab9e52	dev-1	0873d9b8-1964-4fbb-b26a-193ed5307d90			{"auto_deploy": false, "server_compile": true, "auto_full_compile": "", "recompile_backoff": 0.1, "autostart_agent_map": {"internal": "local:", "localhost": "local:"}, "autostart_agent_deploy_interval": "0", "autostart_agent_repair_interval": "600", "autostart_agent_deploy_splay_time": 0, "autostart_agent_repair_splay_time": 0}	7	f		
+e03eabc9-5342-4e6b-b72e-6a062bab9e52	dev-1	0873d9b8-1964-4fbb-b26a-193ed5307d90			{"auto_deploy": false, "server_compile": true, "auto_full_compile": "", "recompile_backoff": 0.1, "autostart_agent_map": {"internal": "local:", "localhost": "local:"}, "autostart_agent_deploy_interval": "0", "autostart_agent_repair_interval": "600", "autostart_agent_deploy_splay_time": 0, "autostart_agent_repair_splay_time": 0}	7	t		
 \.
 
 

--- a/tests/db/migration_tests/test_v202403110_to_v202403120.py
+++ b/tests/db/migration_tests/test_v202403110_to_v202403120.py
@@ -30,7 +30,7 @@ part = file_name_regex.match(__name__)[1]
 
 
 @pytest.mark.db_restore_dump(os.path.join(os.path.dirname(__file__), f"dumps/v{part}.sql"))
-async def test_drop_not_null_constraint(
+async def test_add_column(
     postgresql_client: asyncpg.Connection,
     migrate_db_from: abc.Callable[[], abc.Awaitable[None]],
 ) -> None:
@@ -38,7 +38,7 @@ async def test_drop_not_null_constraint(
     await migrate_db_from()
 
     client = Client("client")
-    result = await client.get_reports(tid="4d6d694b-0915-495a-909c-582832c504fe")
+    result = await client.get_reports(tid="e03eabc9-5342-4e6b-b72e-6a062bab9e52")
     assert result.result["reports"]
     assert result.code == 200
     for report in result.result["reports"]:


### PR DESCRIPTION
# Description

The latest db migration test was not based on the latest dump

- Rename  `test_v202403010_to_v202403120.py` to `test_v202403110_to_v202403120.py` so that it uses the correct dump.
- Halt the env used in the test so that the cleanup task doesn't remove old compiles 


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
