### PR TITLE
Add clear method to pluginmeta

### DIFF
--- a/changelogs/unreleased/add-clear-method-pluginmeta-class.yml
+++ b/changelogs/unreleased/add-clear-method-pluginmeta-class.yml
@@ -1,4 +1,4 @@
 ---
-description: Added clear() method to the PluginMeta class to support resetting its state after a compile.
+description: Added clear() method to the Exporter class to support resetting its state after a compile.
 change-type: patch
 destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/add-clear-method-pluginmeta-class.yml
+++ b/changelogs/unreleased/add-clear-method-pluginmeta-class.yml
@@ -1,0 +1,4 @@
+---
+description: Added clear() method to the PluginMeta class to support resetting its state after a compile.
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -130,6 +130,13 @@ class Exporter:
     __dep_manager: list[Callable[[ModelDict, ResourceDict], None]] = []
 
     @classmethod
+    def clear(cls):
+        cls.types = None
+        cls.scopes = None
+        cls.__export_functions = {}
+        cls.__dep_manager = []
+
+    @classmethod
     def add(cls, name: str, types: list[str], function: Callable[["Exporter", ProxiedType], None]) -> None:
         """
         Add a new export function

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -130,7 +130,7 @@ class Exporter:
     __dep_manager: list[Callable[[ModelDict, ResourceDict], None]] = []
 
     @classmethod
-    def clear(cls):
+    def clear(cls) -> None:
         cls.types = None
         cls.scopes = None
         cls.__export_functions = {}


### PR DESCRIPTION
# Description

Added `clear()` method to the `PluginMeta` class to support resetting its state after a compile.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
