### PR TITLE
Issue/6625 string concatenation

### DIFF
--- a/changelogs/unreleased/string-concatenation.yml
+++ b/changelogs/unreleased/string-concatenation.yml
@@ -1,0 +1,7 @@
+description: Add support for string concatenation in the Inmanta modelling language
+change-type: minor
+sections:
+  minor-improvement: "{{description}}"
+destination-branches:
+  - master
+  - iso7

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -147,6 +147,12 @@ Example:
 Note that the result of the division operation is cast to the type ``int``. This is done because a division always
 results in a value of type ``float``.
 
+In addition to arithmetic, the ``+`` operator is also supported for string concatenation.
+
+.. code-block:: inmanta
+
+    var = "hello " + "world"
+
 
 Primitive types
 ==============================

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -147,12 +147,6 @@ Example:
 Note that the result of the division operation is cast to the type ``int``. This is done because a division always
 results in a value of type ``float``.
 
-In addition to arithmetic, the ``+`` operator is also supported for string concatenation.
-
-.. code-block:: inmanta
-
-    var = "hello " + "world"
-
 
 Primitive types
 ==============================
@@ -334,6 +328,15 @@ included in:
 
     # Output when displayed:
     # Welcome to serv1.example.org
+
+String concatenation
+####################
+
+Strings can be concatenated with the ``+`` operator.
+
+.. code-block:: inmanta
+
+    hello_world = "hello " + "world"
 
 
 .. _lang-conditions:

--- a/src/inmanta/ast/constraint/expression.py
+++ b/src/inmanta/ast/constraint/expression.py
@@ -514,6 +514,7 @@ class NotEqual(BinaryOperator):
 class ArithmeticOperator(BinaryOperator):
     __slots__ = ()
 
+    # TODO: move this comment to where it makes sense, if it's even still relevant
     # single operand type ((T, T) -> T) does not allow us to express e.g. (int, float) -> float
     # but it's a lot simpler and it suffices for what we really need
 

--- a/tests/compiler/test_arithmetic.py
+++ b/tests/compiler/test_arithmetic.py
@@ -35,6 +35,9 @@ def test_plus(snippetcompiler) -> None:
             var2 = 1.5 + 2
             var2 = 3.5
 
+            var3 = "hello" + "world"
+            var3 = "helloworld"
+
             ###########
             # TestInt #
             ###########
@@ -594,3 +597,25 @@ def test_precedence_rules(snippetcompiler) -> None:
         )
     )
     compiler.do_compile()
+
+
+def test_error_reporting(snippetcompiler) -> None:
+    """
+    Verify the error reporting for the arithmetic operations.
+    """
+    snippetcompiler.setup_for_error(
+        "1 + [1, 2]",
+        "Unsupported operand type(s) for plus: 'int' (1) and 'list' ([1, 2]) (reported in (1 + [1, 2]) ({dir}/main.cf:1))",
+    )
+    snippetcompiler.setup_for_error(
+        "[1, 2] + 1",
+        "Unsupported operand type(s) for plus: 'list' ([1, 2]) and 'int' (1) (reported in ([1, 2] + 1) ({dir}/main.cf:1))",
+    )
+    snippetcompiler.setup_for_error(
+        "1 + 'hello'",
+        "Unsupported operand type(s) for plus: 'int' (1) and 'str' ('hello') (reported in (1 + 'hello') ({dir}/main.cf:1))",
+    )
+    snippetcompiler.setup_for_error(
+        "'hello' + 1",
+        "Can only concatenate str (not 'int' (1)) to str (reported in ('hello' + 1) ({dir}/main.cf:1))",
+    )


### PR DESCRIPTION
# Description

Extend '+' operator to allow concatenating strings. Includes small refactor of the `ArithmeticOperator` class.

Closes #6625. This ticket was deemed infeasible with the current state of the parser. This PR provides a functionality that satisfies the same need.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [x] ~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~
