### PR TITLE
Increased the default value of the max-connection-pool-size database setting

### DIFF
--- a/changelogs/unreleased/7248-increase-default-max-connection-pool-size.yml
+++ b/changelogs/unreleased/7248-increase-default-max-connection-pool-size.yml
@@ -1,4 +1,4 @@
-description: "Increased the default value of the max-connection-pool-size database setting"
+description: "Increased the default value of the database.connection_pool_max_size setting to 70"
 change-type: patch
 sections:
   minor-improvement: "{{description}}"

--- a/changelogs/unreleased/7248-increase-default-max-connection-pool-size.yml
+++ b/changelogs/unreleased/7248-increase-default-max-connection-pool-size.yml
@@ -1,0 +1,9 @@
+description: "Increased the default value of the max-connection-pool-size database setting"
+change-type: patch
+sections:
+  minor-improvement: "{{description}}"
+issue-nr: 7248
+destination-branches:
+  - master
+  - iso7
+  - iso6

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -48,7 +48,7 @@ db_connection_pool_min_size = Option(
     "database", "connection_pool_min_size", 10, "Number of connections the pool will be initialized with", is_int
 )
 db_connection_pool_max_size = Option(
-    "database", "connection_pool_max_size", 10, "Max number of connections in the pool", is_int
+    "database", "connection_pool_max_size", 70, "Max number of connections in the pool", is_int
 )
 db_connection_timeout = Option("database", "connection_timeout", 60, "Connection timeout in seconds", is_float)
 


### PR DESCRIPTION
# Description

* Short description here *

closes #7248

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
