### PR TITLE
Don't purge latest released version

### DIFF
--- a/changelogs/unreleased/7324-dont-purge-latest-released-version.yml
+++ b/changelogs/unreleased/7324-dont-purge-latest-released-version.yml
@@ -1,0 +1,8 @@
+---
+description: Fix bug where the latest released version of the configurationmodel could be removed by the cleanup job.
+issue-nr: 7324
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2676,7 +2676,7 @@ class Environment(BaseDocument):
             default=100,
             typ="int",
             validator=convert_int,
-            doc="The number of versions to keep stored in the database",
+            doc="The number of versions to keep stored in the database, excluding the latest released version.",
         ),
         PROTECTED_ENVIRONMENT: Setting(
             name=PROTECTED_ENVIRONMENT,

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -426,9 +426,7 @@ class OrchestrationService(protocol.ServerSlice):
                     delete_list = sorted(version_dict.keys())
                     delete_list = delete_list[:-n_versions]
                     if delete_list:
-                        LOGGER.info(
-                            "Removing %s available versions from environment %s", len(delete_list), env_item.id
-                        )
+                        LOGGER.info("Removing %s available versions from environment %s", len(delete_list), env_item.id)
                     for v in delete_list:
                         await version_dict[v].delete_cascade(connection=connection)
 

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -415,14 +415,20 @@ class OrchestrationService(protocol.ServerSlice):
                 n_versions = await env_item.get(AVAILABLE_VERSIONS_TO_KEEP, connection=connection)
                 assert isinstance(n_versions, int)
                 versions = await data.ConfigurationModel.get_list(
-                    environment=env_item.id, connection=connection, no_status=True
+                    environment=env_item.id, connection=connection, no_status=True, order_by_column="version", order="DESC"
                 )
                 if len(versions) > n_versions:
-                    LOGGER.info("Removing %s available versions from environment %s", len(versions) - n_versions, env_item.id)
                     version_dict = {x.version: x for x in versions}
+                    latest_released_version: Optional[int] = next((v.version for v in versions if v.released), None)
+                    if latest_released_version is not None:
+                        # Never cleanup the latest released version
+                        del version_dict[latest_released_version]
                     delete_list = sorted(version_dict.keys())
                     delete_list = delete_list[:-n_versions]
-
+                    if delete_list:
+                        LOGGER.info(
+                            "Removing %s available versions from environment %s", len(delete_list), env_item.id
+                        )
                     for v in delete_list:
                         await version_dict[v].delete_cascade(connection=connection)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -209,6 +209,9 @@ async def test_create_too_many_versions(client, server, n_versions_to_keep, n_ve
     env_1_id = result.result["environment"]["id"]
     result = await client.set_setting(tid=env_1_id, id=data.AVAILABLE_VERSIONS_TO_KEEP, value=n_versions_to_keep)
     assert result.code == 200
+    # Make sure we don't have a released version. _purge_versions() always keeps the latest released version.
+    result = await client.set_setting(env_1_id, AUTO_DEPLOY, False)
+    assert result.code == 200
 
     # make a second environment to be sure we don't do cross env deletes
     # as it is empty, if it leaks, it will likely take everything with it on the other one
@@ -357,10 +360,16 @@ async def test_n_versions_env_setting_scope(client, server):
     env_1_id = result.result["environment"]["id"]
     result = await client.set_setting(tid=env_1_id, id=data.AVAILABLE_VERSIONS_TO_KEEP, value=n_versions_to_keep_env1)
     assert result.code == 200
+    # Make sure we don't have a released version. _purge_versions() always keeps the latest released version.
+    result = await client.set_setting(env_1_id, AUTO_DEPLOY, False)
+    assert result.code == 200
 
     result = await client.create_environment(project_id=project_id, name="env_2")
     env_2_id = result.result["environment"]["id"]
     result = await client.set_setting(tid=env_2_id, id=data.AVAILABLE_VERSIONS_TO_KEEP, value=n_versions_to_keep_env2)
+    assert result.code == 200
+    # Make sure we don't have a released version. _purge_versions() always keeps the latest released version.
+    result = await client.set_setting(env_2_id, AUTO_DEPLOY, False)
     assert result.code == 200
 
     # Create a lot of versions in both environments


### PR DESCRIPTION
# Description

Fix bug where the latest released version of the configurationmodel could be removed by the cleanup job.

closes #7324

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
