### PR TITLE
Fix incorrect merging of undefined resources by put_partial

### DIFF
--- a/changelogs/unreleased/bugfix-put-partial-defined-resources.yml
+++ b/changelogs/unreleased/bugfix-put-partial-defined-resources.yml
@@ -1,0 +1,8 @@
+---
+description: Fix bug where undefined and skipped_for_undefined resources are not correctly merged by the put_partial endpoint.
+issue-nr: 7416
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5404,7 +5404,7 @@ class ConfigurationModel(BaseDocument):
                         WHERE r.environment=$1
                             AND r.model=$8
                             AND r.resource_id=t.rid
-                            -- Keep resources that belong to the shared resource set or a resource set that was not updated
+                            -- Keep only resources that belong to the shared resource set or a resource set that was not updated
                             AND (r.resource_set IS NULL OR NOT r.resource_set=ANY($9))
                     )
                 )

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -732,6 +732,8 @@ class OrchestrationService(protocol.ServerSlice):
         undeployable_ids: abc.Sequence[ResourceIdStr] = [
             res.resource_id for res in rid_to_resource.values() if res.status in const.UNDEPLOYABLE_STATES
         ]
+        updated_resource_sets: abc.Set[str] = {sr for sr in resource_sets.values() if sr is not None}
+        deleted_resource_sets_as_set: abc.Set[str] = set(removed_resource_sets)
         async with connection.transaction():
             try:
                 if is_partial_update:
@@ -749,8 +751,9 @@ class OrchestrationService(protocol.ServerSlice):
                             self._get_skipped_for_undeployable(list(rid_to_resource.values()), undeployable_ids)
                         ),
                         partial_base=partial_base_version,
-                        rids_in_partial_compile=set(rid_to_resource.keys()),
                         pip_config=pip_config,
+                        updated_resource_sets=updated_resource_sets,
+                        deleted_resource_sets=deleted_resource_sets_as_set,
                         connection=connection,
                     )
                 else:
@@ -781,8 +784,8 @@ class OrchestrationService(protocol.ServerSlice):
                         environment=env.id,
                         source_version=partial_base_version,
                         destination_version=version,
-                        updated_resource_sets={sr for sr in resource_sets.values() if sr is not None},
-                        deleted_resource_sets=set(removed_resource_sets),
+                        updated_resource_sets=updated_resource_sets,
+                        deleted_resource_sets=deleted_resource_sets_as_set,
                         connection=connection,
                     )
                 )

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -60,7 +60,7 @@ from inmanta.data.model import (
 from inmanta.db.util import ConnectionMaybeInTransaction, ConnectionNotInTransaction
 from inmanta.protocol import handle, methods, methods_v2
 from inmanta.protocol.common import ReturnValue
-from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound
+from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound, ServerError
 from inmanta.protocol.return_value_meta import ReturnValueWithMeta
 from inmanta.resources import Id
 from inmanta.server import SLICE_AGENT_MANAGER, SLICE_DATABASE, SLICE_RESOURCE, SLICE_TRANSPORT
@@ -902,12 +902,9 @@ class ResourceService(protocol.ServerSlice):
                     connection=inner_connection,
                 )
                 if len(resources) == 0 or (len(resources) != len(resource_ids)):
-                    return (
-                        404,
-                        {
-                            "message": "The resources with the given ids do not exist in the given environment. "
-                            "Only %s of %s resources found." % (len(resources), len(resource_ids))
-                        },
+                    raise NotFound(
+                        message="The resources with the given ids do not exist in the given environment. "
+                                f"Only {len(resources)} of {len(resource_ids)} resources found."
                     )
 
                 if only_update_from_states is not None:
@@ -928,7 +925,7 @@ class ResourceService(protocol.ServerSlice):
                 if resource_action is None:
                     # new
                     if started is None:
-                        return 500, {"message": "A resource action can only be created with a start datetime."}
+                        raise ServerError(message="A resource action can only be created with a start datetime.")
 
                     version = Id.parse_id(resource_ids[0]).version
                     resource_action = data.ResourceAction(
@@ -943,16 +940,10 @@ class ResourceService(protocol.ServerSlice):
                 else:
                     # existing
                     if resource_action.finished is not None:
-                        return (
-                            500,
-                            {
-                                "message": (
-                                    "An resource action can only be updated when it has not been finished yet. This action "
-                                    "finished at %s" % resource_action.finished
-                                )
-                            },
+                        raise ServerError(
+                            message="An resource action can only be updated when it has not been finished yet. This action "
+                                    f"finished at {resource_action.finished}"
                         )
-
                 for msg in messages:
                     # All other data is stored in the database. The msg was already formatted at the client side.
                     self.log_resource_action(

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -904,7 +904,7 @@ class ResourceService(protocol.ServerSlice):
                 if len(resources) == 0 or (len(resources) != len(resource_ids)):
                     raise NotFound(
                         message="The resources with the given ids do not exist in the given environment. "
-                                f"Only {len(resources)} of {len(resource_ids)} resources found."
+                        f"Only {len(resources)} of {len(resource_ids)} resources found."
                     )
 
                 if only_update_from_states is not None:
@@ -942,7 +942,7 @@ class ResourceService(protocol.ServerSlice):
                     if resource_action.finished is not None:
                         raise ServerError(
                             message="An resource action can only be updated when it has not been finished yet. This action "
-                                    f"finished at {resource_action.finished}"
+                            f"finished at {resource_action.finished}"
                         )
                 for msg in messages:
                     # All other data is stored in the database. The msg was already formatted at the client side.

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1372,6 +1372,22 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
             "purged": False,
             "requires": [f"test::Resource[agent1,key=key3],v={version}"],
         },
+        {
+            "key": "key91",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key91],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key92",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key92],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key91],v={version}"],
+        },
     ]
     resource_sets = {
         "test::Resource[agent1,key=key1]": "set-a",
@@ -1384,6 +1400,8 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
         "test::Resource[agent1,key=key2]": const.ResourceState.available,
         "test::Resource[agent1,key=key3]": const.ResourceState.undefined,
         "test::Resource[agent1,key=key4]": const.ResourceState.available,
+        "test::Resource[agent1,key=key91]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key92]": const.ResourceState.available,
     }
     result = await client.put_version(
         tid=environment,
@@ -1399,8 +1417,12 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
 
     cm = await data.ConfigurationModel.get_one(environment=environment, version=version)
     assert cm is not None
-    assert sorted(cm.undeployable) == sorted(["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key3]"])
-    assert sorted(cm.skipped_for_undeployable) == sorted(["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key4]"])
+    assert sorted(cm.undeployable) == sorted(
+        ["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key3]", "test::Resource[agent1,key=key91]"]
+    )
+    assert sorted(cm.skipped_for_undeployable) == sorted(
+        ["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key4]", "test::Resource[agent1,key=key92]"]
+    )
 
     # Partial compile
     resources_partial = [
@@ -1465,8 +1487,12 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
 
     cm = await data.ConfigurationModel.get_one(environment=environment, version=version)
     assert cm is not None
-    assert sorted(cm.undeployable) == sorted(["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key5]"])
-    assert sorted(cm.skipped_for_undeployable) == sorted(["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key6]"])
+    assert sorted(cm.undeployable) == sorted(
+        ["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key5]", "test::Resource[agent1,key=key91]"]
+    )
+    assert sorted(cm.skipped_for_undeployable) == sorted(
+        ["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key6]", "test::Resource[agent1,key=key92]"]
+    )
 
 
 async def test_put_partial_with_unknowns(server, client, environment, clienthelper) -> None:

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1458,6 +1458,14 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
             "purged": False,
             "requires": ["test::Resource[agent1,key=key5],v=0"],
         },
+        {
+            "key": "key91",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key91],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
     ]
     resource_sets = {
         "test::Resource[agent1,key=key1]": "set-a",
@@ -1470,6 +1478,7 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
         "test::Resource[agent1,key=key2]": const.ResourceState.available,
         "test::Resource[agent1,key=key5]": const.ResourceState.undefined,
         "test::Resource[agent1,key=key6]": const.ResourceState.available,
+        "test::Resource[agent1,key=key91]": const.ResourceState.undefined,
     }
     result = await client.put_partial(
         tid=environment,

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1371,7 +1371,7 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
             "send_event": False,
             "purged": False,
             "requires": [f"test::Resource[agent1,key=key3],v={version}"],
-        }
+        },
     ]
     resource_sets = {
         "test::Resource[agent1,key=key1]": "set-a",
@@ -1435,7 +1435,7 @@ async def test_put_partial_with_undeployable_resources(server, client, environme
             "send_event": False,
             "purged": False,
             "requires": ["test::Resource[agent1,key=key5],v=0"],
-        }
+        },
     ]
     resource_sets = {
         "test::Resource[agent1,key=key1]": "set-a",

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1333,6 +1333,142 @@ async def test_put_partial_with_resource_state_set(server, client, environment, 
     assert rid_to_res["test::Resource[agent1,key=key7]"].status is const.ResourceState.available
 
 
+async def test_put_partial_with_undeployable_resources(server, client, environment, clienthelper, agent) -> None:
+    """
+    Test whether the put_partial() endpoint correctly merges the undeployable and skipped_for_undeployable list
+    of a configurationmodel.
+    """
+    version = await clienthelper.get_version()
+    resources = [
+        {
+            "key": "key1",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key1],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key2",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key2],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key1],v={version}"],
+        },
+        {
+            "key": "key3",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key3],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key4",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key4],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key3],v={version}"],
+        }
+    ]
+    resource_sets = {
+        "test::Resource[agent1,key=key1]": "set-a",
+        "test::Resource[agent1,key=key2]": "set-a",
+        "test::Resource[agent1,key=key3]": "set-a",
+        "test::Resource[agent1,key=key4]": "set-a",
+    }
+    resource_states = {
+        "test::Resource[agent1,key=key1]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key2]": const.ResourceState.available,
+        "test::Resource[agent1,key=key3]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key4]": const.ResourceState.available,
+    }
+    result = await client.put_version(
+        tid=environment,
+        version=version,
+        resources=resources,
+        resource_state=resource_states,
+        unknowns=[],
+        version_info={},
+        compiler_version=get_compiler_version(),
+        resource_sets=resource_sets,
+    )
+    assert result.code == 200, result.result
+
+    cm = await data.ConfigurationModel.get_one(environment=environment, version=version)
+    assert cm is not None
+    assert sorted(cm.undeployable) == sorted(["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key3]"])
+    assert sorted(cm.skipped_for_undeployable) == sorted(["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key4]"])
+
+    # Partial compile
+    resources_partial = [
+        {
+            "key": "key1",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key1],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key2",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key2],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": ["test::Resource[agent1,key=key1],v=0"],
+        },
+        {
+            "key": "key5",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key5],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key6",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key6],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": ["test::Resource[agent1,key=key5],v=0"],
+        }
+    ]
+    resource_sets = {
+        "test::Resource[agent1,key=key1]": "set-a",
+        "test::Resource[agent1,key=key2]": "set-a",
+        "test::Resource[agent1,key=key5]": "set-a",
+        "test::Resource[agent1,key=key6]": "set-a",
+    }
+    resource_states = {
+        "test::Resource[agent1,key=key1]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key2]": const.ResourceState.available,
+        "test::Resource[agent1,key=key5]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key6]": const.ResourceState.available,
+    }
+    result = await client.put_partial(
+        tid=environment,
+        resources=resources_partial,
+        resource_state=resource_states,
+        unknowns=[],
+        version_info=None,
+        resource_sets=resource_sets,
+    )
+    assert result.code == 200, result.result
+    version = result.result["data"]
+
+    result = await client.release_version(tid=environment, id=version)
+    assert result.code == 200, result.result
+
+    cm = await data.ConfigurationModel.get_one(environment=environment, version=version)
+    assert cm is not None
+    assert sorted(cm.undeployable) == sorted(["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key5]"])
+    assert sorted(cm.skipped_for_undeployable) == sorted(["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key6]"])
+
+
 async def test_put_partial_with_unknowns(server, client, environment, clienthelper) -> None:
     """
     Test whether the put_partial() endpoint correctly merges unknowns.


### PR DESCRIPTION
# Description

Fix bug where `undefined` and `skipped_for_undefined` resources are not correctly merged by the put_partial endpoint.

closes #7416 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
