### PR TITLE
Fix incorrect merging of undefined resources by put_partial

### DIFF
--- a/changelogs/unreleased/bugfix-put-partial-defined-resources.yml
+++ b/changelogs/unreleased/bugfix-put-partial-defined-resources.yml
@@ -1,0 +1,8 @@
+---
+description: Fix bug where undefined and skipped_for_undefined resources are not correctly merged by the put_partial endpoint.
+issue-nr: 7416
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/bugfix-put-partial-defined-resources.yml
+++ b/changelogs/unreleased/bugfix-put-partial-defined-resources.yml
@@ -3,6 +3,6 @@ description: Fix bug where undefined and skipped_for_undefined resources are not
 issue-nr: 7416
 issue-repo: inmanta-core
 change-type: patch
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]
 sections:
   bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5365,7 +5365,8 @@ class ConfigurationModel(BaseDocument):
         undeployable: abc.Sequence[ResourceIdStr],
         skipped_for_undeployable: abc.Sequence[ResourceIdStr],
         partial_base: int,
-        rids_in_partial_compile: abc.Set[ResourceIdStr],
+        updated_resource_sets: abc.Set[str],
+        deleted_resource_sets: abc.Set[str],
         connection: Optional[Connection] = None,
     ) -> "ConfigurationModel":
         """
@@ -5382,14 +5383,42 @@ class ConfigurationModel(BaseDocument):
                 ) AS base_version_found
             ),
             rids_undeployable_base_version AS (
-                SELECT DISTINCT unnest(c2.undeployable) AS rid
-                FROM {cls.table_name()} AS c2
-                WHERE c2.environment=$1 AND c2.version=$8
+                SELECT t.rid
+                FROM (
+                    SELECT DISTINCT unnest(c2.undeployable) AS rid
+                    FROM {cls.table_name()} AS c2
+                    WHERE c2.environment=$1 AND c2.version=$8
+                ) AS t(rid)
+                WHERE (
+                    EXISTS (
+                        SELECT 1
+                        FROM {Resource.table_name()} AS r
+                        WHERE r.environment=$1
+                            AND r.model=$8
+                            AND r.resource_id=t.rid
+                            -- Keep only resources that belong to the shared resource set or a resource set that was not updated
+                            AND (r.resource_set IS NULL OR NOT r.resource_set=ANY($9))
+                    )
+                )
             ),
             rids_skipped_for_undeployable_base_version AS (
-                SELECT DISTINCT unnest(c3.skipped_for_undeployable) AS rid
-                FROM {cls.table_name()} AS c3
-                WHERE c3.environment=$1 AND c3.version=$8
+                SELECT t.rid
+                FROM(
+                    SELECT DISTINCT unnest(c3.skipped_for_undeployable) AS rid
+                    FROM {cls.table_name()} AS c3
+                    WHERE c3.environment=$1 AND c3.version=$8
+                ) AS t(rid)
+                WHERE (
+                    EXISTS (
+                        SELECT 1
+                        FROM {Resource.table_name()} AS r
+                        WHERE r.environment=$1
+                            AND r.model=$8
+                            AND r.resource_id=t.rid
+                            -- Keep resources that belong to the shared resource set or a resource set that was not updated
+                            AND (r.resource_set IS NULL OR NOT r.resource_set=ANY($9))
+                    )
+                )
             )
             INSERT INTO {cls.table_name()}(
                 environment,
@@ -5412,9 +5441,7 @@ class ConfigurationModel(BaseDocument):
                     FROM (
                         -- Undeployables in previous version of the model that are not part of the partial compile.
                         (
-                            SELECT rid
-                            FROM rids_undeployable_base_version AS undepl
-                            WHERE NOT undepl.rid=ANY($9)
+                            SELECT rid FROM rids_undeployable_base_version AS undepl
                         )
                         UNION
                         -- Undeployables part of the partial compile.
@@ -5429,9 +5456,7 @@ class ConfigurationModel(BaseDocument):
                         -- skipped_for_undeployables in previous version of the model that are not part of the partial
                         -- compile.
                         (
-                            SELECT skipped.rid
-                            FROM rids_skipped_for_undeployable_base_version AS skipped
-                            WHERE NOT skipped.rid=ANY($9)
+                            SELECT skipped.rid FROM rids_skipped_for_undeployable_base_version AS skipped
                         )
                         UNION
                         -- Skipped_for_undeployables part of the partial compile.
@@ -5469,7 +5494,7 @@ class ConfigurationModel(BaseDocument):
                 undeployable,
                 skipped_for_undeployable,
                 partial_base,
-                list(rids_in_partial_compile),
+                updated_resource_sets | deleted_resource_sets,
             )
             # Make mypy happy
             assert result is not None

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -761,15 +761,15 @@ class OrchestrationService(protocol.ServerSlice):
                 # Make mypy happy
                 assert partial_base_version is not None
                 # This dict maps a resource id to its resource set for unchanged resource sets.
-                rids_unchanged_resource_sets: dict[ResourceIdStr, str] = (
-                    await data.Resource.copy_resources_from_unchanged_resource_set(
-                        environment=env.id,
-                        source_version=partial_base_version,
-                        destination_version=version,
-                        updated_resource_sets=updated_resource_sets,
-                        deleted_resource_sets=deleted_resource_sets_as_set,
-                        connection=connection,
-                    )
+                rids_unchanged_resource_sets: dict[
+                    ResourceIdStr, str
+                ] = await data.Resource.copy_resources_from_unchanged_resource_set(
+                    environment=env.id,
+                    source_version=partial_base_version,
+                    destination_version=version,
+                    updated_resource_sets=updated_resource_sets,
+                    deleted_resource_sets=deleted_resource_sets_as_set,
+                    connection=connection,
                 )
                 resources_that_moved_resource_sets = rids_unchanged_resource_sets.keys() & rid_to_resource.keys()
                 if resources_that_moved_resource_sets:

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -405,6 +405,8 @@ class ResourceService(protocol.ServerSlice):
         :param version: Version of the resources to consider.
         :param filter: Filter function that takes a resource id as an argument and returns True if it should be kept.
         """
+        if not resources_id:
+            return
         resources_version_ids: list[ResourceVersionIdStr] = [
             ResourceVersionIdStr(f"{res_id},v={version}") for res_id in resources_id if filter(res_id)
         ]

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -405,11 +405,11 @@ class ResourceService(protocol.ServerSlice):
         :param version: Version of the resources to consider.
         :param filter: Filter function that takes a resource id as an argument and returns True if it should be kept.
         """
-        if not resources_id:
-            return
         resources_version_ids: list[ResourceVersionIdStr] = [
             ResourceVersionIdStr(f"{res_id},v={version}") for res_id in resources_id if filter(res_id)
         ]
+        if not resources_version_ids:
+            return
         logline = {
             "level": "INFO",
             "msg": "Setting deployed due to known good status",

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1298,6 +1298,177 @@ async def test_put_partial_with_resource_state_set(server, client, environment, 
     assert rid_to_res["test::Resource[agent1,key=key7]"].status is const.ResourceState.available
 
 
+async def test_put_partial_with_undeployable_resources(server, client, environment, clienthelper, agent) -> None:
+    """
+    Test whether the put_partial() endpoint correctly merges the undeployable and skipped_for_undeployable list
+    of a configurationmodel.
+    """
+    version = await clienthelper.get_version()
+    resources = [
+        {
+            "key": "key1",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key1],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key2",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key2],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key1],v={version}"],
+        },
+        {
+            "key": "key3",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key3],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key4",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key4],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key3],v={version}"],
+        },
+        {
+            "key": "key91",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key91],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key92",
+            "version": version,
+            "id": f"test::Resource[agent1,key=key92],v={version}",
+            "send_event": False,
+            "purged": False,
+            "requires": [f"test::Resource[agent1,key=key91],v={version}"],
+        },
+    ]
+    resource_sets = {
+        "test::Resource[agent1,key=key1]": "set-a",
+        "test::Resource[agent1,key=key2]": "set-a",
+        "test::Resource[agent1,key=key3]": "set-a",
+        "test::Resource[agent1,key=key4]": "set-a",
+    }
+    resource_states = {
+        "test::Resource[agent1,key=key1]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key2]": const.ResourceState.available,
+        "test::Resource[agent1,key=key3]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key4]": const.ResourceState.available,
+        "test::Resource[agent1,key=key91]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key92]": const.ResourceState.available,
+    }
+    result = await client.put_version(
+        tid=environment,
+        version=version,
+        resources=resources,
+        resource_state=resource_states,
+        unknowns=[],
+        version_info={},
+        compiler_version=get_compiler_version(),
+        resource_sets=resource_sets,
+    )
+    assert result.code == 200, result.result
+
+    cm = await data.ConfigurationModel.get_one(environment=environment, version=version)
+    assert cm is not None
+    assert sorted(cm.undeployable) == sorted(
+        ["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key3]", "test::Resource[agent1,key=key91]"]
+    )
+    assert sorted(cm.skipped_for_undeployable) == sorted(
+        ["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key4]", "test::Resource[agent1,key=key92]"]
+    )
+
+    # Partial compile
+    resources_partial = [
+        {
+            "key": "key1",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key1],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key2",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key2],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": ["test::Resource[agent1,key=key1],v=0"],
+        },
+        {
+            "key": "key5",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key5],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+        {
+            "key": "key6",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key6],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": ["test::Resource[agent1,key=key5],v=0"],
+        },
+        {
+            "key": "key91",
+            "version": 0,
+            "id": "test::Resource[agent1,key=key91],v=0",
+            "send_event": False,
+            "purged": False,
+            "requires": [],
+        },
+    ]
+    resource_sets = {
+        "test::Resource[agent1,key=key1]": "set-a",
+        "test::Resource[agent1,key=key2]": "set-a",
+        "test::Resource[agent1,key=key5]": "set-a",
+        "test::Resource[agent1,key=key6]": "set-a",
+    }
+    resource_states = {
+        "test::Resource[agent1,key=key1]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key2]": const.ResourceState.available,
+        "test::Resource[agent1,key=key5]": const.ResourceState.undefined,
+        "test::Resource[agent1,key=key6]": const.ResourceState.available,
+        "test::Resource[agent1,key=key91]": const.ResourceState.undefined,
+    }
+    result = await client.put_partial(
+        tid=environment,
+        resources=resources_partial,
+        resource_state=resource_states,
+        unknowns=[],
+        version_info=None,
+        resource_sets=resource_sets,
+    )
+    assert result.code == 200, result.result
+    version = result.result["data"]
+
+    result = await client.release_version(tid=environment, id=version)
+    assert result.code == 200, result.result
+
+    cm = await data.ConfigurationModel.get_one(environment=environment, version=version)
+    assert cm is not None
+    assert sorted(cm.undeployable) == sorted(
+        ["test::Resource[agent1,key=key1]", "test::Resource[agent1,key=key5]", "test::Resource[agent1,key=key91]"]
+    )
+    assert sorted(cm.skipped_for_undeployable) == sorted(
+        ["test::Resource[agent1,key=key2]", "test::Resource[agent1,key=key6]", "test::Resource[agent1,key=key92]"]
+    )
+
+
 async def test_put_partial_with_unknowns(server, client, environment, clienthelper) -> None:
     """
     Test whether the put_partial() endpoint correctly merges unknowns.


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/7429 but applied on the iso6 branch due to a merge conflict.**

Fix bug where `undefined` and `skipped_for_undefined` resources are not correctly merged by the put_partial endpoint.

closes #7416 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
