### PR TITLE
Halt environment in db migration test to prevent auto cleanup

### DIFF
--- a/changelogs/unreleased/halt-environment-used-in-db-migration-test.yml
+++ b/changelogs/unreleased/halt-environment-used-in-db-migration-test.yml
@@ -1,0 +1,3 @@
+description: Halt environment used in tests to prevent auto clean up.
+change-type: patch
+destination-branches: [iso6]

--- a/tests/db/migration_tests/dumps/v202402130.sql
+++ b/tests/db/migration_tests/dumps/v202402130.sql
@@ -580,7 +580,7 @@ COPY public.dryrun (id, environment, model, date, total, todo, resources) FROM s
 
 COPY public.environment (id, name, project, repo_url, repo_branch, settings, last_version, halted, description, icon) FROM stdin;
 73301adc-e537-4067-9654-2dec28b1f7ba	dev-2	72396b1e-41a1-41b9-b45e-0a6c457085a7			{"auto_full_compile": ""}	0	f		
-f015501d-e9e9-4016-914d-c7e214ae28bc	dev-1	72396b1e-41a1-41b9-b45e-0a6c457085a7			{"auto_deploy": false, "server_compile": true, "purge_on_delete": false, "auto_full_compile": "", "recompile_backoff": 0.1, "autostart_agent_map": {"internal": "local:", "localhost": "local:"}, "autostart_agent_deploy_interval": "0", "autostart_agent_repair_interval": "600", "autostart_agent_deploy_splay_time": 0, "autostart_agent_repair_splay_time": 0}	5	f		
+f015501d-e9e9-4016-914d-c7e214ae28bc	dev-1	72396b1e-41a1-41b9-b45e-0a6c457085a7			{"auto_deploy": false, "server_compile": true, "purge_on_delete": false, "auto_full_compile": "", "recompile_backoff": 0.1, "autostart_agent_map": {"internal": "local:", "localhost": "local:"}, "autostart_agent_deploy_interval": "0", "autostart_agent_repair_interval": "600", "autostart_agent_deploy_splay_time": 0, "autostart_agent_repair_splay_time": 0}	5	t		
 \.
 
 

--- a/tests/db/migration_tests/test_v202402130_to_v202403120.py
+++ b/tests/db/migration_tests/test_v202402130_to_v202403120.py
@@ -30,7 +30,7 @@ part = file_name_regex.match(__name__)[1]
 
 
 @pytest.mark.db_restore_dump(os.path.join(os.path.dirname(__file__), f"dumps/v{part}.sql"))
-async def test_drop_not_null_constraint(
+async def test_add_soft_delete_column(
     postgresql_client: asyncpg.Connection,
     migrate_db_from: abc.Callable[[], abc.Awaitable[None]],
 ) -> None:


### PR DESCRIPTION
# Description

The following jobs are failing because the test data got cleaned up automatically after 1 week:
- https://jenkins.inmanta.com/job/core/job/inmanta-core/job/iso6/1070/testReport/junit/tests.db.migration_tests/test_v202402130_to_v202403120/test_drop_not_null_constraint/
- https://jenkins.inmanta.com/job/core/job/inmanta-core-postgresql-versions/job/iso6/510/

This pr halts the environment to prevent auto deletion.
This will no longer be necessary when we [stop running background tasks in db migration tests](https://github.com/inmanta/inmanta-lsm/issues/1667)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
~~- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
