### PR TITLE
improved f-string error reporting

### DIFF
--- a/changelogs/unreleased/7418-f-string-error-reporting.yml
+++ b/changelogs/unreleased/7418-f-string-error-reporting.yml
@@ -1,0 +1,9 @@
+description: "Improved f-string error reporting"
+issue-nr: 7418
+change-type: patch
+sections:
+  bugfix: "{{description}}"
+destination-branches:
+  - master
+  - iso7
+  - iso6

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -930,7 +930,11 @@ def p_constant_fstring(p: YaccProduction) -> None:
     formatter = string.Formatter()
 
     # formatter.parse returns an iterable of tuple (literal_text, field_name, format_spec, conversion)
-    parsed: Iterable[tuple[str, Optional[str], Optional[str], Optional[str]]] = formatter.parse(str(p[1]))
+    parsed: Sequence[tuple[str, Optional[str], Optional[str], Optional[str]]]
+    try:
+        parsed = list(formatter.parse(str(p[1])))
+    except ValueError as e:
+        raise ParserException(p[1].location, str(p[1]), f"Invalid f-string: {e}")
 
     start_lnr = p[1].location.lnr
     start_char_pos = p[1].location.start_char + 2  # FSTRING tokens begin with `f"` or `f'` of length 2

--- a/src/inmanta/parser/plyInmantaParser.py
+++ b/src/inmanta/parser/plyInmantaParser.py
@@ -930,7 +930,7 @@ def p_constant_fstring(p: YaccProduction) -> None:
     formatter = string.Formatter()
 
     # formatter.parse returns an iterable of tuple (literal_text, field_name, format_spec, conversion)
-    parsed: Sequence[tuple[str, Optional[str], Optional[str], Optional[str]]]
+    parsed: abc.Sequence[tuple[str, Optional[str], Optional[str], Optional[str]]]
     try:
         parsed = list(formatter.parse(str(p[1])))
     except ValueError as e:

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -668,7 +668,7 @@ end
 implement Test using test
 Test()
 """,
-        r"variable n not found (reported in Format(This is test {{{{n}}}}) ({dir}/main.cf:5))",
+        r"variable n not found (reported in Format('This is test {{{{n}}}}') ({dir}/main.cf:5))",
     )
 
 

--- a/tests/compiler/test_exception.py
+++ b/tests/compiler/test_exception.py
@@ -88,7 +88,10 @@ def test_direct_execute_error(snippetcompiler):
 
         A()
         """,
-        "The statement Format({{{{a}}}}) can not be executed in this context (reported in Format({{{{a}}}}) ({dir}/main.cf:4))",
+        (
+            "The statement Format('{{{{a}}}}') can not be executed in this context"
+            " (reported in Format('{{{{a}}}}') ({dir}/main.cf:4))"
+        ),
     )
 
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -21,7 +21,7 @@ from typing import Union
 import pytest
 
 import inmanta.compiler as compiler
-from inmanta.ast import Namespace, NotFoundException
+from inmanta.ast import Namespace
 from inmanta.ast.variables import AttributeReference, Reference
 from test_parser import parse_code
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -224,7 +224,7 @@ def test_fstring_expected_error(snippetcompiler, capsys):
         'f"{}{}"',
         (
             "f-strings do not support positional substitutions via '{{}}', use variable or attribute keys instead"
-            " (reported in 'hello {{}}' ({dir}/main.cf:1:1))"
+            " (reported in '{{}}{{}}' ({dir}/main.cf:1:1))"
         ),
     )
 

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -187,6 +187,7 @@ std::print(z)
         (r"f'{arg}'", "123\n"),
         (r"f'{arg}{arg}{arg}'", "123123123\n"),
         (r"f'{arg:@>5}'", "@@123\n"),
+        (r"f'{arg:@>{width}}'", "@@@@@@@123\n"),
         (r"f'{arg:^5}'", " 123 \n"),
         (r"f' {  \t\narg  \n  } '", " 123 \n"),
     ],
@@ -195,6 +196,7 @@ def test_fstring_formatting(snippetcompiler, capsys, f_string, expected_output):
     snippetcompiler.setup_for_snippet(
         f"""
 arg = 123
+width = 10
 z={f_string}
 std::print(z)
         """,
@@ -205,13 +207,48 @@ std::print(z)
 
 
 def test_fstring_expected_error(snippetcompiler, capsys):
-    with pytest.raises(NotFoundException):
-        snippetcompiler.setup_for_snippet(
-            """
-std::print(f"{unknown}")
-            """,
-        )
-        compiler.do_compile()
+    snippetcompiler.setup_for_error(
+        'std::print(f"{unknown}")',
+        "variable unknown not found (reported in '{{unknown}}' ({dir}/main.cf:1:12))",
+    )
+
+    snippetcompiler.setup_for_error(
+        'f"hello {}"',
+        (
+            "f-strings do not support positional substitutions via '{{}}', use variable or attribute keys instead"
+            " (reported in 'hello {{}}' ({dir}/main.cf:1:1))"
+        ),
+    )
+
+    snippetcompiler.setup_for_error(
+        'f"{}{}"',
+        (
+            "f-strings do not support positional substitutions via '{{}}', use variable or attribute keys instead"
+            " (reported in 'hello {{}}' ({dir}/main.cf:1:1))"
+        ),
+    )
+
+    snippetcompiler.setup_for_error(
+        """
+        world = "myworld"
+        f"hello { world:{} }"
+        """,
+        (
+            "f-strings do not support positional substitutions via '{{}}', use variable or attribute keys instead"
+            " (reported in 'hello {{ world:{{}} }}' ({dir}/main.cf:3:9))"
+        ),
+    )
+
+    snippetcompiler.setup_for_error(
+        """
+        world = "myworld"
+        f"hello {world:invalid_specifier}"
+        """,
+        (
+            "Invalid f-string: Invalid format specifier 'invalid_specifier' for object of type 'str'"
+            " (reported in 'hello {{world:invalid_specifier}}' ({dir}/main.cf:3:9))"
+        ),
+    )
 
 
 def test_fstring_relations(snippetcompiler, capsys):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1059,7 +1059,6 @@ def test_string_format_v2():
     stmt = statements[0]
     assert isinstance(stmt, StringFormatV2)
     assert len(stmt._variables) == 2
-    variables = {ref.name: full_name for ref, full_name in stmt._variables.items()}
     assert {ref.name: full_name for ref, full_name in stmt._variables.items()} == {"world": " world", "width": "width "}
     assert stmt._format_string == "hello { world:>{width }}"
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,7 @@ from inmanta.ast.statements.assign import (
     SetAttribute,
     ShortIndexLookup,
     StringFormat,
+    StringFormatV2,
 )
 from inmanta.ast.statements.call import FunctionCall
 from inmanta.ast.statements.define import DefineEntity, DefineImplement, DefineIndex, DefineTypeConstraint, TypeDeclaration
@@ -1039,6 +1040,31 @@ a="j{{c.d}}s"
     assert str(stmt.value._variables[0][0].attribute) == "d"
     assert stmt.value._variables[0][0].instance.locatable_name.location == Range("test", 2, 7, 2, 8)
     assert stmt.value._variables[0][0].attribute.location == Range("test", 2, 9, 2, 10)
+
+
+def test_string_format_v2():
+    statements = parse_code('f"hello { world }"')
+    assert len(statements) == 1
+    stmt = statements[0]
+    assert isinstance(stmt, StringFormatV2)
+    assert len(stmt._variables) == 1
+    ref: Reference
+    full_name: str
+    ref, full_name = list(stmt._variables.items())[0]
+    assert ref.name == "world"
+    assert full_name == " world "
+
+    statements = parse_code('f"hello { world:>{width }}"')
+    assert len(statements) == 1
+    stmt = statements[0]
+    assert isinstance(stmt, StringFormatV2)
+    assert len(stmt._variables) == 2
+    variables = {ref.name: full_name for ref, full_name in stmt._variables.items()}
+    assert {ref.name: full_name for ref, full_name in stmt._variables.items()} == {"world": " world", "width": "width "}
+    assert stmt._format_string == "hello { world:>{width }}"
+
+    with pytest.raises(ParserException, match=r"Syntax error: Invalid f-string:.*\(test:1:1\)"):
+        statements = parse_code('f"hello {"')
 
 
 def test_attribute_reference():


### PR DESCRIPTION
# Description

Catch Python's string format errors and report them as compiler exceptions (with location information) to the user.

@bartv I assigned you as reviewer for the error messages and the exhaustiveness of test scenarios. For both, see the test cases.

closes #7418

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~
- [x] ~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~
