### PR TITLE
Build fix

### DIFF
--- a/changelogs/unreleased/build-fix.yml
+++ b/changelogs/unreleased/build-fix.yml
@@ -1,0 +1,5 @@
+description: Fixed compatibility with latest build release
+change-type: patch
+destination-branches:
+  - master
+  - iso7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1671,15 +1671,9 @@ def tmpvenv_active(
     env.mock_process_env(python_path=str(python_path))
     env.process_env.notify_change()
 
-    # Force refresh build's decision on whether it should use virtualenv or venv. This decision is made based on the active
-    # environment, which we're changing now.
-    #build.env._PipBackend_should_use_virtualenv.cache_clear()
-
     yield tmpvenv
 
     loader.unload_modules_for_path(site_packages)
-    # Force refresh build's cache once more
-    build.env._should_use_virtualenv.cache_clear()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1673,7 +1673,7 @@ def tmpvenv_active(
 
     # Force refresh build's decision on whether it should use virtualenv or venv. This decision is made based on the active
     # environment, which we're changing now.
-    build.env._should_use_virtualenv.cache_clear()
+    #build.env._PipBackend_should_use_virtualenv.cache_clear()
 
     yield tmpvenv
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,6 @@ from pkg_resources import Requirement
 from pyformance.registry import MetricsRegistry
 from tornado import netutil
 
-import build.env
 import inmanta
 import inmanta.agent
 import inmanta.app


### PR DESCRIPTION
# Description

`build` version 1.2.1 moved `_should_use_virtualenv`. They also changed it from a module-level field to an instance-level field on a class that is recreated every time you enter the build context (see [here](https://github.com/pypa/build/compare/1.1.1...1.2.0#diff-4f1bb46d65de7fbb1573dfc2a2bca9f63c7b03d55e74c53339f0c8ee4fa054d8R90) and [here](https://github.com/pypa/build/compare/1.1.1...1.2.0#diff-4f1bb46d65de7fbb1573dfc2a2bca9f63c7b03d55e74c53339f0c8ee4fa054d8R165)). Therefore we no longer need to clear the cache.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
