### PR TITLE
Add support to show a old version banner

### DIFF
--- a/changelogs/unreleased/add-support-for-old-iso-version-banner.yml
+++ b/changelogs/unreleased/add-support-for-old-iso-version-banner.yml
@@ -1,0 +1,8 @@
+---
+description: Added support display a banner that notifies the user when the build belongs to an old major iso version.
+issue-nr: 201
+issue-repo: infra-tickets
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,11 +212,8 @@ html_theme_options = {
     }
 }
 
-try:
-    if tags.has("iso") and "INMANTA_ADD_OLD_VERSION_BANNER" in os.environ:
-        html_theme_options["announcement"] = "This is the documentation for an old ISO version. You may want to consult the documentation for the <a href='https://docs.inmanta.com/inmanta-service-orchestrator/latest/'>latest ISO release</a>."
-except NameError as e:
-    pass
+if tags.has("iso") and "INMANTA_ADD_OLD_VERSION_BANNER" in os.environ:
+    html_theme_options["announcement"] = "This is the documentation for an old ISO version. You may want to consult the documentation for the <a href='https://docs.inmanta.com/inmanta-service-orchestrator/latest/'>latest ISO release</a>."
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,7 +206,17 @@ html_theme_options = {
             "class": "fa-brands fa-github",
         },
     ],
+    "light_css_variables": {
+        "color-announcement-background": "#2b9af3",
+        "color-announcement-text": "#000000",
+    }
 }
+
+try:
+    if tags.has("iso") and "INMANTA_ADD_OLD_VERSION_BANNER" in os.environ:
+        html_theme_options["announcement"] = "This is the documentation for an old ISO version. You may want to consult the documentation for the <a href='https://docs.inmanta.com/inmanta-service-orchestrator/latest/'>latest ISO release</a>."
+except NameError as e:
+    pass
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,7 +207,7 @@ html_theme_options = {
         },
     ],
     "light_css_variables": {
-        "color-announcement-background": "#2b9af3",
+        "color-announcement-background": "#f0ab00",
         "color-announcement-text": "#000000",
     }
 }


### PR DESCRIPTION
# Description

Added support display a banner that notifies the user when the build belongs to an old major iso version.

closes inmanta/infra-tickets#201

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
