### PR TITLE
Fix confusing code regaring handling of environment variables in compilerservice

### DIFF
--- a/changelogs/unreleased/fix-handling-used-environment-variables.yml
+++ b/changelogs/unreleased/fix-handling-used-environment-variables.yml
@@ -1,0 +1,4 @@
+---
+description: Fix confusing code regaring the hanlding of environment variables in the compilerservice.
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -706,7 +706,12 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         """
         return c.to_dto().model_dump_json(
             include={
-                "environment", "started", "do_export", "requested_environment_variables", "partial", "removed_resource_sets"
+                "environment",
+                "started",
+                "do_export",
+                "requested_environment_variables",
+                "partial",
+                "removed_resource_sets",
             },
         )
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -658,7 +658,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
             force_update=force_update,
             metadata=metadata,
             requested_environment_variables=env_vars,
-            used_environment_variables=env_vars,
+            used_environment_variables=None,
             mergeable_environment_variables=mergeable_env_vars,
             partial=partial,
             removed_resource_sets=removed_resource_sets,
@@ -705,7 +705,9 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         _compile_merge_key(c1) == _compile_merge_key(c2).
         """
         return c.to_dto().model_dump_json(
-            include={"environment", "started", "do_export", "environment_variables", "partial", "removed_resource_sets"}
+            include={
+                "environment", "started", "do_export", "requested_environment_variables", "partial", "removed_resource_sets"
+            },
         )
 
     async def _queue(self, compile: data.Compile) -> None:


### PR DESCRIPTION
# Description

According to the docstring of `data.Compile`, the `used_environment_variables` field should be set to None until the compile starts. This was not in-line with the implementation. This in its turn made the interpretation of the `CompilerService._compile_merge_key()` method rather difficult. This PR fixes this issue by making the implementation in-line with the docstring.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
