### PR TITLE
Iso6 assertion 3.11 compatibility

### DIFF
--- a/changelogs/unreleased/assertion-3.11-compatibility.yml
+++ b/changelogs/unreleased/assertion-3.11-compatibility.yml
@@ -1,0 +1,4 @@
+description: Made assertion compatible with Python 3.11
+change-type: patch
+destination-branches:
+  - iso6

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -15,6 +15,7 @@
 
     Contact: code@inmanta.com
 """
+import sys
 from typing import Union
 
 import pytest
@@ -243,7 +244,10 @@ def test_fstring_expected_error(snippetcompiler, capsys):
         world = "myworld"
         f"hello {world:invalid_specifier}"
         """,
-        "Invalid f-string: Invalid format specifier (reported in 'hello {{world:invalid_specifier}}' ({dir}/main.cf:3:9))",
+        "Invalid f-string: Invalid format specifier%s (reported in 'hello {{world:invalid_specifier}}' ({dir}/main.cf:3:9))"
+        % (
+            " 'invalid_specifier' for object of type 'str'" if (sys.version_info.major, sys.version_info.minor) > (3, 9) else ""
+        ),
     )
 
 


### PR DESCRIPTION
# Description

Make test case compatible with both 3.9 and 3.11 for pytest in docker. I'll cherry-pick this to iso6-stable.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
