### PR TITLE
issue/7325-release-tool-version-tag

### DIFF
--- a/changelogs/unreleased/7325-release-tool-version-tag.yml
+++ b/changelogs/unreleased/7325-release-tool-version-tag.yml
@@ -1,0 +1,5 @@
+description: Remove the version_tag from the metadata of the .cfg files.
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/7325-release-tool-version-tag.yml
+++ b/changelogs/unreleased/7325-release-tool-version-tag.yml
@@ -1,4 +1,4 @@
-description: Remove the version_tag from the metadata of the .cfg files.
+description: "Module release tool: do not write internal field `version_tag` to `setup.cfg`."
 change-type: patch
 destination-branches: [master, iso7, iso6]
 sections:

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1476,7 +1476,7 @@ class ModuleV2Metadata(ModuleMetadata):
 
         if not out.has_section("metadata"):
             out.add_section("metadata")
-        for k, v in self.dict(exclude_none=True, exclude={"install_requires"}).items():
+        for k, v in self.dict(exclude_none=True, exclude={"install_requires", "version_tag"}).items():
             out.set("metadata", k, str(v))
 
         if self.version_tag:

--- a/tests/moduletool/test_convert_v1_v2.py
+++ b/tests/moduletool/test_convert_v1_v2.py
@@ -285,3 +285,11 @@ def test_module_conversion_build_tags(tmpdir: py.path.local, modules_dir: str, f
     metadata: ModuleV2Metadata = ModuleV2.from_path(new_mod_dir).metadata
     assert metadata.version == base
     assert metadata.version_tag == tag
+
+    config = metadata.to_config()
+    assert "metadata" in config
+    assert "name" in config["metadata"]
+    assert config["metadata"]["name"] == "inmanta-module-mytaggedmodule"
+    assert "version" in config["metadata"]
+    assert config["metadata"]["version"] == base
+    assert "version_tag" not in config["metadata"]


### PR DESCRIPTION
# Description

The version_tag field is supposed to be internal and should only be written to file as egg_info.tag_build

closes #7325 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
