### PR TITLE
Remove venv of autostarted agent on clear or delete

### DIFF
--- a/changelogs/unreleased/7043-remove-venv-autostarted-agents.yml
+++ b/changelogs/unreleased/7043-remove-venv-autostarted-agents.yml
@@ -1,0 +1,8 @@
+---
+description: Remove the venv of an auto-started agent when its environment is deleted or cleared or when its project is deleted.
+issue-nr: 7043
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -993,7 +993,7 @@ class AutostartedAgentManager(ServerSlice):
         """
         Return the state dir to be used by the auto-started agent in the given environment.
         """
-        state_dir: str = Config.get("config", "state-dir", "/var/lib/inmanta")
+        state_dir: str = cast(str, Config.get("config", "state-dir", "/var/lib/inmanta"))
         return os.path.join(state_dir, str(env_id))
 
     def _remove_venv_for_agent_in_env(self, env_id: uuid.UUID) -> None:

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -32,6 +32,7 @@ from uuid import UUID
 
 import asyncpg.connection
 
+import inmanta.config
 from inmanta import const, data
 from inmanta.agent import config as agent_cfg
 from inmanta.config import Config
@@ -993,7 +994,7 @@ class AutostartedAgentManager(ServerSlice):
         """
         Return the state dir to be used by the auto-started agent in the given environment.
         """
-        state_dir: str = cast(str, Config.get("config", "state-dir", "/var/lib/inmanta"))
+        state_dir: str = inmanta.config.state_dir.get()
         return os.path.join(state_dir, str(env_id))
 
     def _remove_venv_for_agent_in_env(self, env_id: uuid.UUID) -> None:

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -505,7 +505,10 @@ class EnvironmentService(protocol.ServerSlice):
 
                 await env.mark_for_deletion(connection=connection)
                 self._disable_schedules(env)
-                await asyncio.gather(self.autostarted_agent_manager.stop_agents(env), env.delete_cascade(connection=connection))
+                await asyncio.gather(
+                    self.autostarted_agent_manager.stop_agents(env, delete_venv=True),
+                    env.delete_cascade(connection=connection),
+                )
 
             self.resource_service.close_resource_action_logger(environment_id)
             await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
@@ -521,7 +524,7 @@ class EnvironmentService(protocol.ServerSlice):
         if is_protected_environment:
             raise Forbidden(f"Environment {env.id} is protected. See environment setting: {data.PROTECTED_ENVIRONMENT}")
 
-        await self.autostarted_agent_manager.stop_agents(env)
+        await self.autostarted_agent_manager.stop_agents(env, delete_venv=True)
         await env.clear()
 
         await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -111,7 +111,7 @@ class ProjectService(protocol.ServerSlice):
 
         environments = await data.Environment.get_list(project=project.id)
         for env in environments:
-            await asyncio.gather(self.autostarted_agent_manager.stop_agents(env), env.delete_cascade())
+            await asyncio.gather(self.autostarted_agent_manager.stop_agents(env, delete_venv=True), env.delete_cascade())
             self.resource_service.close_resource_action_logger(env.id)
 
         await project.delete()


### PR DESCRIPTION
# Description

Remove the venv of an auto-started agent when its environment is deleted or cleared or when its project is deleted.

closes #7043 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
