### PR TITLE
Fix bug on environment clear/delete endpoints

### DIFF
--- a/changelogs/unreleased/fix-race-on-environment-clear.yml
+++ b/changelogs/unreleased/fix-race-on-environment-clear.yml
@@ -1,0 +1,6 @@
+---
+description: "Fix bug that makes the endpoints to clear or delete an environment fail with the error message `(39, 'Directory not empty')`"
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -289,6 +289,7 @@ def clear_environment(id: uuid.UUID):
     This method deletes various components associated with the specified environment from the database,
     including agents, compile data, parameters, notifications, code, resources, and configuration models.
     However, it retains the entry in the Environment table itself and settings are kept.
+    The environment will be temporarily halted during the decommissioning process.
 
     :param id: The id of the environment to be cleared.
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -267,7 +267,7 @@ def resume_environment(tid: uuid.UUID) -> None:
 )
 def environment_clear(id: uuid.UUID) -> None:
     """
-    Clear all data from this environment.
+    Clear all data from this environment. The environment will be temporarily halted during the decommissioning process.
 
     :param id: The uuid of the environment.
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -1071,7 +1071,9 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
 
     async def cancel_compile(self, env_id: uuid.UUID) -> None:
         """
-        Cancel the ongoing compile for the given environment (if any) and don't start any new compiles.
+        Cancel the ongoing compile for the given environment (if any). After the cancellation, this method
+        will not start the execution of a new compile, if a compile request would be present in the compile
+        queue for the given environment.
 
         :param env_id: The id of the environment for which the compile should be cancelled.
         """

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -520,9 +520,9 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
     def __init__(self) -> None:
         super().__init__(SLICE_COMPILER)
 
-        self._compiling_envs: set[uuid.UUID] = set()
+        self._env_to_compile_task: dict[uuid.UUID, asyncio.Task[None | protocol.Result]] = {}
         # write lock only, writers take care to uphold consistency so that readers don't need the lock
-        self._write_lock_compiling_envs = asyncio.locks.Lock()
+        self._write_lock_env_to_compile_task = asyncio.locks.Lock()
 
         # boolean indicating when everything is up and compile execution can start
         self.fully_ready = False
@@ -773,7 +773,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
 
         # acquire connection before lock to ensure lock contention remains short lived
         async with data.Environment.get_connection(connection) as con:
-            async with self._write_lock_compiling_envs:
+            async with self._write_lock_env_to_compile_task:
                 started_new_compile_run: bool = False
 
                 try:
@@ -800,18 +800,17 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
 
                         if (
                             # no compile is running for this environment
-                            compile.environment not in self._compiling_envs
+                            compile.environment not in self._env_to_compile_task
                             # the previously running compile is finished
                             or (finish_current_compile and compile.environment == environment)
                         ):
-                            self._compiling_envs.add(compile.environment)
                             # Run the compile. self._run will call back into this method when done
-                            self.add_background_task(self._run(compile))
+                            self._env_to_compile_task[compile.environment] = self.add_background_task(self._run(compile))
                             started_new_compile_run = True
                 finally:
                     if finish_current_compile and not started_new_compile_run:
                         assert environment is not None
-                        self._compiling_envs.discard(environment)
+                        del self._env_to_compile_task[environment]
 
     async def _notify_listeners(self, compile: data.Compile) -> None:
         async def notify(listener: CompileStateListener) -> None:
@@ -861,7 +860,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
 
     @protocol.handle(methods.is_compiling, environment_id="id")
     async def is_compiling(self, environment_id: uuid.UUID) -> Apireturn:
-        if environment_id in self._compiling_envs:
+        if environment_id in self._env_to_compile_task:
             return 200
         return 204
 
@@ -1095,11 +1094,12 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
 
         :param env_id: The id of the environment for which the compile should be cancelled.
         """
-        compile_task: Optional[Task[None | Result]] = self._recompiles.pop(env_id, None)
+        compile_task: Optional[asyncio.Task[None | protocol.Result]] = self._env_to_compile_task.pop(env_id, None)
         if compile_task:
             compile_task.cancel()
             try:
                 # Wait until cancellation has finished
                 await compile_task
             except asyncio.CancelledError:
+                # Don't propagate CancelledError raised by invoking compile_task.cancel()
                 pass

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -265,7 +265,11 @@ class EnvironmentService(protocol.ServerSlice):
             await self._halt(env, connection)
 
     async def _halt(
-        self, env: data.Environment, connection: Optional[asyncpg.connection.Connection] = None, delete_agent_venv: bool = False
+        self,
+        env: data.Environment,
+        connection: Optional[asyncpg.connection.Connection] = None,
+        *,
+        delete_agent_venv: bool = False,
     ) -> None:
         """
         Halts the specified environment without acquiring the environment_state_operation_lock.

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -269,6 +269,8 @@ class EnvironmentService(protocol.ServerSlice):
         Halts the specified environment without acquiring the environment_state_operation_lock.
         This method is designed to be an internal helper that allows for halting an environment
         as part of a larger operation (e.g., deletion), where the lock is managed by the caller and prevent double locking.
+
+        :param delete_agent_venv: True iff also delete the venv of the agent after stopping it.
         """
         async with data.Environment.get_connection(connection=connection) as con:
             async with con.transaction():

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -552,6 +552,8 @@ class EnvironmentService(protocol.ServerSlice):
                     LOGGER.info("Halting environment %s for clear operation", str(env.id))
                     await self._halt(env, connection=connection, delete_agent_venv=True)
 
+                # Keep this method call under the self.environment_state_operation_lock lock, because cancel_compile()
+                # must be called on halted environments only.
                 await self.compiler_service.cancel_compile(env.id)
                 # Delete the environment directory before deleting the database records. This ensures that
                 # this operation can be retried if the deletion of the environment directory fails. Otherwise,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1582,8 +1582,8 @@ def monkey_patch_compiler_service(monkeypatch, server, make_compile_fail, runner
     async def _run(compile: data.Compile) -> None:
         compilerslice._running_compiles[compile.environment] = compile
         await original_run(compile)
-        async with compilerslice._write_lock_compiling_envs:
-            if compile.environment not in compilerslice._compiling_envs:
+        async with compilerslice._write_lock_env_to_compile_task:
+            if compile.environment not in compilerslice._env_to_compile_task:
                 # Clear self._running_compiles iff the compiler service has deleted the environment from the compiling
                 # environments set.
                 del compilerslice._running_compiles[compile.environment]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -381,7 +381,7 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
     e2.append(extra_compile)
 
     # We haven't started, because we hang on a handler,
-    assert len(cs._compiling_envs) == 0
+    assert len(cs._env_to_compile_task) == 0
 
     # Continue
     hanging_collector.release()
@@ -1100,7 +1100,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     # finish 7th compile
     await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
-    while env.id in compilerslice._compiling_envs:
+    while env.id in compilerslice._env_to_compile_task:
         await asyncio.sleep(0.2)
 
     # 0 in the queue, 0 running
@@ -1223,14 +1223,14 @@ async def test_compileservice_queue_count_on_trx_based_api(mocked_compiler_servi
             )
             assert compile_id is not None, warnings
             assert compiler_service._queue_count_cache == 0
-            assert len(compiler_service._compiling_envs) == 0
+            assert len(compiler_service._env_to_compile_task) == 0
     # Transaction committed
     await compiler_service.notify_compile_request_committed(compile_id)
     assert compiler_service._queue_count_cache == 1
-    assert len(compiler_service._compiling_envs) == 1
+    assert len(compiler_service._env_to_compile_task) == 1
 
     await run_compile_and_wait_until_compile_is_done(compiler_service, mocked_compiler_service_block, env.id)
-    assert len(compiler_service._compiling_envs) == 0
+    assert len(compiler_service._env_to_compile_task) == 0
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# Description

* Fix bug that makes the endpoints to clear or delete an environment fail with the error message `(39, 'Directory not empty')`. This bug triggers when the compiler service updates the files in the environment directory, while the API endpoint to delete/clear the environment performs a `shutil.rmtree()` on that directory.
* Add the `SLICE_AGENT_MANAGER` to the dependencies of the EnvironmentService. It think this is a bug.
* Make the endpoint to delete an environment first calls into `mark_for_deletion()` and only then halt the environment, because the former is a guard to make sure that an environment, that is marked for deletion, cannot be resumed. The original implementation did it the other way around. This was not an issue, because these calls are protected by the `environment_state_operation_lock`, but having them swapped make the code easier to read.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
