### PR TITLE
Improve support four-digit version on 'inmanta module release' command

### DIFF
--- a/changelogs/unreleased/7521-4-digits-module-release.yml
+++ b/changelogs/unreleased/7521-4-digits-module-release.yml
@@ -1,0 +1,7 @@
+---
+description: Improve support for four-digit version on 'inmanta module release' command. If the 'use_four_digit' is set to 'True' in the modules metadata, the version will be bumped to a 4 digit format after a release.
+issue-nr: 7521
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1390,13 +1390,13 @@ class ModuleV2Metadata(ModuleMetadata):
     :param freeze_operator: (Optional) This key determines the comparison operator used by the freeze command.
       Valid values are [==, ~=, >=]. *Default is '~='*
     :param install_requires: The Python packages this module depends on.
-    :param use_four_digit_version: Whether to use a four-digit version format (e.g. 23.4.1.0) instead of the standard
+    :param use_four_digit: Whether to use a four-digit version format (e.g. 23.4.1.0) instead of the standard
         three-digit format (e.g. 23.4.1).
     """
 
     install_requires: list[str]
     version_tag: str = ""
-    use_four_digit_version: bool = False
+    use_four_digit: bool = False
     _raw_parser: typing.ClassVar[type[CfgParser]] = CfgParser
 
     @field_validator("version")

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1458,9 +1458,7 @@ class ModuleV2Metadata(ModuleMetadata):
     @classmethod
     def _substitute_version(cls: type[TModuleMetadata], source: str, new_version: str, version_tag: str = "") -> str:
         result = re.sub(
-            r"(\[metadata\][^\[]*[ \t\f\v]*version[ \t\f\v]*=[ \t\f\v]*)[\S]+(\n|$)",
-            rf"\g<1>{new_version}\n",
-            source,
+            r"(\[metadata\][^\[]*?\bversion[ \t\f\v]*=[ \t\f\v]*)[\S]+(\n|$)", rf"\g<1>{new_version}\n", source, flags=re.DOTALL
         )
         if "[egg_info]" not in result:
             result = f"{result}\n[egg_info]\ntag_build = {version_tag}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1389,13 +1389,13 @@ class ModuleV2Metadata(ModuleMetadata):
     :param freeze_operator: (Optional) This key determines the comparison operator used by the freeze command.
       Valid values are [==, ~=, >=]. *Default is '~='*
     :param install_requires: The Python packages this module depends on.
-    :param use_four_digit: Whether to use a four-digit version format (e.g. 23.4.1.0) instead of the standard
+    :param use_four_digits: Whether to use a four-digit version format (e.g. 23.4.1.0) instead of the standard
         three-digit format (e.g. 23.4.1).
     """
 
     install_requires: list[str]
     version_tag: str = ""
-    use_four_digit: bool = False
+    use_four_digits: bool = False
     _raw_parser: typing.ClassVar[type[CfgParser]] = CfgParser
 
     @field_validator("version")

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1288,8 +1288,7 @@ class ModuleMetadata(ABC, Metadata):
 
         try:
             new_metadata = cls.parse(result)
-        except Exception as e:
-            print(e)
+        except Exception:
             raise Exception("Unable to rewrite module definition.")
 
         # Validate whether the version and version_tag field was updated correctly in metadata file

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1389,13 +1389,17 @@ class ModuleV2Metadata(ModuleMetadata):
     :param freeze_operator: (Optional) This key determines the comparison operator used by the freeze command.
       Valid values are [==, ~=, >=]. *Default is '~='*
     :param install_requires: The Python packages this module depends on.
-    :param use_four_digits: Whether to use a four-digit version format (e.g. 23.4.1.0) instead of the standard
+    :param four_digit_version: Whether to use a four-digit version format (e.g. 23.4.1.0) instead of the standard
         three-digit format (e.g. 23.4.1).
+        Even without setting this option to True, a fourth digit is allowed as a revision digit. However, the tooling
+        will not use it by default. For example, you can use the '--revision' flag with the command
+        'inmanta module release --dev --revision' even if 'four_digit_version' is set to False. But if you don't specify
+        '--revision' explicitly, the tooling will consider 'patch' to be the lowest increment.
     """
 
     install_requires: list[str]
     version_tag: str = ""
-    use_four_digits: bool = False
+    four_digit_version: bool = False
     _raw_parser: typing.ClassVar[type[CfgParser]] = CfgParser
 
     @field_validator("version")

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1288,7 +1288,8 @@ class ModuleMetadata(ABC, Metadata):
 
         try:
             new_metadata = cls.parse(result)
-        except Exception:
+        except Exception as e:
+            print(e)
             raise Exception("Unable to rewrite module definition.")
 
         # Validate whether the version and version_tag field was updated correctly in metadata file
@@ -1389,11 +1390,13 @@ class ModuleV2Metadata(ModuleMetadata):
     :param freeze_operator: (Optional) This key determines the comparison operator used by the freeze command.
       Valid values are [==, ~=, >=]. *Default is '~='*
     :param install_requires: The Python packages this module depends on.
+    :param use_four_digit_version: Whether to use a four-digit version format (e.g. 23.4.1.0) instead of the standard
+        three-digit format (e.g. 23.4.1).
     """
 
     install_requires: list[str]
     version_tag: str = ""
-
+    use_four_digit_version: bool = False
     _raw_parser: typing.ClassVar[type[CfgParser]] = CfgParser
 
     @field_validator("version")

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1272,7 +1272,10 @@ version: 0.0.1dev0"""
         requested_version_bump: Optional[ChangeType] = ChangeType.parse_from_bools(revision, patch, minor, major)
         if not requested_version_bump and dev:
             # Dev always bumps
-            requested_version_bump = ChangeType.PATCH
+            if hasattr(module.metadata, "four_digit_version") and module.metadata.four_digit_version:
+                requested_version_bump = ChangeType.REVISION
+            else:
+                requested_version_bump = ChangeType.PATCH
 
         if requested_version_bump:
             new_version: Version = self._get_dev_version_with_minimal_distance_to_previous_stable_release(
@@ -1323,7 +1326,7 @@ version: 0.0.1dev0"""
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
             print(f"Tag created successfully: {release_tag}")
             # bump to the next dev version
-            if hasattr(module.metadata, "use_four_digits") and module.metadata.use_four_digits:
+            if hasattr(module.metadata, "four_digit_version") and module.metadata.four_digit_version:
                 self.release(dev=True, message="Bump version to next development version", revision=True)
             else:
                 self.release(dev=True, message="Bump version to next development version", patch=True)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -70,6 +70,7 @@ from inmanta.module import (
     ModuleNotFoundException,
     ModuleV1,
     ModuleV2,
+    ModuleV2Metadata,
     ModuleV2Source,
     Project,
     gitprovider,
@@ -1272,7 +1273,7 @@ version: 0.0.1dev0"""
         requested_version_bump: Optional[ChangeType] = ChangeType.parse_from_bools(revision, patch, minor, major)
         if not requested_version_bump and dev:
             # Dev always bumps
-            if hasattr(module.metadata, "four_digit_version") and module.metadata.four_digit_version:
+            if isinstance(module.metadata, ModuleV2Metadata) and module.metadata.four_digit_version:
                 requested_version_bump = ChangeType.REVISION
             else:
                 requested_version_bump = ChangeType.PATCH
@@ -1326,7 +1327,7 @@ version: 0.0.1dev0"""
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
             print(f"Tag created successfully: {release_tag}")
             # bump to the next dev version
-            if hasattr(module.metadata, "four_digit_version") and module.metadata.four_digit_version:
+            if isinstance(module.metadata, ModuleV2Metadata) and module.metadata.four_digit_version:
                 self.release(dev=True, message="Bump version to next development version", revision=True)
             else:
                 self.release(dev=True, message="Bump version to next development version", patch=True)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1273,6 +1273,7 @@ version: 0.0.1dev0"""
         if not requested_version_bump and dev:
             # Dev always bumps
             requested_version_bump = ChangeType.PATCH
+
         if requested_version_bump:
             new_version: Version = self._get_dev_version_with_minimal_distance_to_previous_stable_release(
                 current_version, stable_releases, requested_version_bump
@@ -1322,9 +1323,10 @@ version: 0.0.1dev0"""
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
             print(f"Tag created successfully: {release_tag}")
             # bump to the next dev version
-            if module.metadata.use_four_digit_version:
+            if hasattr(module.metadata, "use_four_digit") and module.metadata.use_four_digit:
                 self.release(dev=True, message="Bump version to next development version", revision=True)
-            self.release(dev=True, message="Bump version to next development version", patch=True)
+            else:
+                self.release(dev=True, message="Bump version to next development version", patch=True)
 
 
 class Changelog:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1273,7 +1273,6 @@ version: 0.0.1dev0"""
         if not requested_version_bump and dev:
             # Dev always bumps
             requested_version_bump = ChangeType.PATCH
-
         if requested_version_bump:
             new_version: Version = self._get_dev_version_with_minimal_distance_to_previous_stable_release(
                 current_version, stable_releases, requested_version_bump
@@ -1323,6 +1322,8 @@ version: 0.0.1dev0"""
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
             print(f"Tag created successfully: {release_tag}")
             # bump to the next dev version
+            if module.metadata.use_four_digit_version:
+                self.release(dev=True, message="Bump version to next development version", revision=True)
             self.release(dev=True, message="Bump version to next development version", patch=True)
 
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1323,7 +1323,7 @@ version: 0.0.1dev0"""
             gitprovider.tag(repo=module_dir, tag=str(release_tag))
             print(f"Tag created successfully: {release_tag}")
             # bump to the next dev version
-            if hasattr(module.metadata, "use_four_digit") and module.metadata.use_four_digit:
+            if hasattr(module.metadata, "use_four_digits") and module.metadata.use_four_digits:
                 self.release(dev=True, message="Bump version to next development version", revision=True)
             else:
                 self.release(dev=True, message="Bump version to next development version", patch=True)

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -50,6 +50,7 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
 @pytest.mark.parametrize_any("four_digit_version", [True, False])
+@pytest.mark.parametrize_any("four_digits_before_release", [True, False])
 def test_release_stable_version(
     tmpdir,
     modules_dir: str,
@@ -59,6 +60,7 @@ def test_release_stable_version(
     changelog_file_exists: bool,
     previous_stable_version_exists: bool,
     four_digit_version: bool,
+    four_digits_before_release: bool,
 ) -> None:
     """
     Test normal scenario where `inmanta module release` is used to release a stable version of a module.
@@ -70,10 +72,10 @@ def test_release_stable_version(
             return f"""
 # Changelog
 
-## {"v1.2.3." if four_digit_version and not v1_module else "v1.2.4"} - ?
+## {"v1.2.3.1" if four_digit_version and not v1_module else "v1.2.4"} - ?
 
 
-## v1.2.3 - {datetime.date.today().isoformat()}
+## {"v1.2.3.0" if four_digits_before_release else "v1.2.3"} - {datetime.date.today().isoformat()}
 
 - Release
 
@@ -82,10 +84,10 @@ def test_release_stable_version(
 - Release
             """.strip()
         else:
-            return """
+            return f"""
 # Changelog
 
-## v1.2.3.0 - ?
+## {"v1.2.3.0" if four_digits_before_release else "v1.2.3"} - ?
 
 - Release
 
@@ -100,14 +102,14 @@ def test_release_stable_version(
         v1_module_from_template(
             source_dir=os.path.join(modules_dir, "minimalv1module"),
             dest_dir=path_module,
-            new_version=Version("1.2.3.dev0"),
+            new_version=Version("v1.2.3.0.dev0" if four_digits_before_release else "v1.2.3.dev0"),
             new_name=module_name,
         )
     else:
         module_from_template(
             source_dir=os.path.join(modules_v2_dir, "minimalv2module"),
             dest_dir=path_module,
-            new_version=Version("1.2.3.dev0"),
+            new_version=Version("v1.2.3.0.dev0" if four_digits_before_release else "v1.2.3.dev0"),
             new_name=module_name,
             four_digit_version=four_digit_version,
         )

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -46,9 +46,10 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
     return subprocess.check_output(["git", "log", "-1", f"--skip={nb_previous_commit}", "--pretty=%B"], cwd=path).decode()
 
 
-@pytest.mark.parametrize_any("v1_module", [True, False])
+@pytest.mark.parametrize_any("v1_module", [False])
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
+@pytest.mark.parametrize_any("use_four_digit_version", [True, False])
 def test_release_stable_version(
     tmpdir,
     modules_dir: str,
@@ -57,6 +58,7 @@ def test_release_stable_version(
     v1_module: bool,
     changelog_file_exists: bool,
     previous_stable_version_exists: bool,
+    use_four_digit_version: bool,
 ) -> None:
     """
     Test normal scenario where `inmanta module release` is used to release a stable version of a module.
@@ -106,6 +108,7 @@ def test_release_stable_version(
             dest_dir=path_module,
             new_version=Version("1.2.3.dev0"),
             new_name=module_name,
+            use_four_digit_version=use_four_digit_version,
         )
     gitprovider.git_init(repo=path_module)
     path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -46,7 +46,7 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
     return subprocess.check_output(["git", "log", "-1", f"--skip={nb_previous_commit}", "--pretty=%B"], cwd=path).decode()
 
 
-@pytest.mark.parametrize_any("v1_module", [False, True])
+@pytest.mark.parametrize_any("v1_module", [True, False])
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
 @pytest.mark.parametrize_any("four_digit_version", [True, False])

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -46,10 +46,10 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
     return subprocess.check_output(["git", "log", "-1", f"--skip={nb_previous_commit}", "--pretty=%B"], cwd=path).decode()
 
 
-@pytest.mark.parametrize_any("v1_module", [False])
+@pytest.mark.parametrize_any("v1_module", [True, False])
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
-@pytest.mark.parametrize_any("use_four_digit_version", [True, False])
+@pytest.mark.parametrize_any("use_four_digit", [True, False])
 def test_release_stable_version(
     tmpdir,
     modules_dir: str,
@@ -58,10 +58,11 @@ def test_release_stable_version(
     v1_module: bool,
     changelog_file_exists: bool,
     previous_stable_version_exists: bool,
-    use_four_digit_version: bool,
+    use_four_digit: bool,
 ) -> None:
     """
     Test normal scenario where `inmanta module release` is used to release a stable version of a module.
+    use_four_digit only works for v2 modules
     """
 
     def get_changelog_content(after_release: bool) -> str:
@@ -69,7 +70,7 @@ def test_release_stable_version(
             return f"""
 # Changelog
 
-## v1.2.4 - ?
+## {"v1.2.3.1" if use_four_digit and not v1_module else "v1.2.4"} - ?
 
 
 ## v1.2.3 - {datetime.date.today().isoformat()}
@@ -108,7 +109,7 @@ def test_release_stable_version(
             dest_dir=path_module,
             new_version=Version("1.2.3.dev0"),
             new_name=module_name,
-            use_four_digit_version=use_four_digit_version,
+            use_four_digit=use_four_digit,
         )
     gitprovider.git_init(repo=path_module)
     path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)
@@ -143,7 +144,7 @@ def test_release_stable_version(
     assert gitprovider.get_version_tags(repo=path_module) == expected_tags
     # Verify version
     mod = Module.from_path(path_module)
-    assert mod.version == Version("1.2.4.dev0")
+    assert mod.version == Version("1.2.3.1dev0") if use_four_digit and not v1_module else Version("1.2.4.dev0")
     # Verify changelog file
     if changelog_file_exists:
         with open(path_changelog_file, encoding="utf-8") as fh:

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -49,7 +49,7 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
 @pytest.mark.parametrize_any("v1_module", [True, False])
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
-@pytest.mark.parametrize_any("use_four_digit", [True, False])
+@pytest.mark.parametrize_any("use_four_digits", [True, False])
 def test_release_stable_version(
     tmpdir,
     modules_dir: str,
@@ -58,11 +58,11 @@ def test_release_stable_version(
     v1_module: bool,
     changelog_file_exists: bool,
     previous_stable_version_exists: bool,
-    use_four_digit: bool,
+    use_four_digits: bool,
 ) -> None:
     """
     Test normal scenario where `inmanta module release` is used to release a stable version of a module.
-    use_four_digit only works for v2 modules
+    use_four_digits only works for v2 modules
     """
 
     def get_changelog_content(after_release: bool) -> str:
@@ -70,7 +70,7 @@ def test_release_stable_version(
             return f"""
 # Changelog
 
-## {"v1.2.3.1" if use_four_digit and not v1_module else "v1.2.4"} - ?
+## {"v1.2.3.1" if use_four_digits and not v1_module else "v1.2.4"} - ?
 
 
 ## v1.2.3 - {datetime.date.today().isoformat()}
@@ -109,7 +109,7 @@ def test_release_stable_version(
             dest_dir=path_module,
             new_version=Version("1.2.3.dev0"),
             new_name=module_name,
-            use_four_digit=use_four_digit,
+            use_four_digit=use_four_digits,
         )
     gitprovider.git_init(repo=path_module)
     path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)
@@ -144,7 +144,7 @@ def test_release_stable_version(
     assert gitprovider.get_version_tags(repo=path_module) == expected_tags
     # Verify version
     mod = Module.from_path(path_module)
-    assert mod.version == Version("1.2.3.1dev0") if use_four_digit and not v1_module else Version("1.2.4.dev0")
+    assert mod.version == Version("1.2.3.1dev0") if use_four_digits and not v1_module else Version("1.2.4.dev0")
     # Verify changelog file
     if changelog_file_exists:
         with open(path_changelog_file, encoding="utf-8") as fh:

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -144,7 +144,7 @@ def test_release_stable_version(
     assert gitprovider.get_version_tags(repo=path_module) == expected_tags
     # Verify version
     mod = Module.from_path(path_module)
-    assert mod.version == Version("1.2.3.1dev0") if use_four_digits and not v1_module else Version("1.2.4.dev0")
+    assert mod.version == Version("1.2.3.1.dev0") if use_four_digits and not v1_module else Version("1.2.4.dev0")
     # Verify changelog file
     if changelog_file_exists:
         with open(path_changelog_file, encoding="utf-8") as fh:

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -109,7 +109,7 @@ def test_release_stable_version(
             dest_dir=path_module,
             new_version=Version("1.2.3.dev0"),
             new_name=module_name,
-            use_four_digit=use_four_digits,
+            use_four_digits=use_four_digits,
         )
     gitprovider.git_init(repo=path_module)
     path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -49,7 +49,7 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
 @pytest.mark.parametrize_any("v1_module", [True, False])
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
-@pytest.mark.parametrize_any("use_four_digits", [True, False])
+@pytest.mark.parametrize_any("four_digit_version", [True, False])
 def test_release_stable_version(
     tmpdir,
     modules_dir: str,
@@ -58,11 +58,11 @@ def test_release_stable_version(
     v1_module: bool,
     changelog_file_exists: bool,
     previous_stable_version_exists: bool,
-    use_four_digits: bool,
+    four_digit_version: bool,
 ) -> None:
     """
     Test normal scenario where `inmanta module release` is used to release a stable version of a module.
-    use_four_digits only works for v2 modules
+    four_digit_version only works for v2 modules
     """
 
     def get_changelog_content(after_release: bool) -> str:
@@ -70,7 +70,7 @@ def test_release_stable_version(
             return f"""
 # Changelog
 
-## {"v1.2.3.1" if use_four_digits and not v1_module else "v1.2.4"} - ?
+## {"v1.2.3.1" if four_digit_version and not v1_module else "v1.2.4"} - ?
 
 
 ## v1.2.3 - {datetime.date.today().isoformat()}
@@ -109,7 +109,7 @@ def test_release_stable_version(
             dest_dir=path_module,
             new_version=Version("1.2.3.dev0"),
             new_name=module_name,
-            use_four_digits=use_four_digits,
+            four_digit_version=four_digit_version,
         )
     gitprovider.git_init(repo=path_module)
     path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)
@@ -144,8 +144,9 @@ def test_release_stable_version(
     assert gitprovider.get_version_tags(repo=path_module) == expected_tags
     # Verify version
     mod = Module.from_path(path_module)
-    assert mod.version == Version("1.2.3.1.dev0") if use_four_digits and not v1_module else Version("1.2.4.dev0")
+    assert mod.version == Version("1.2.3.1.dev0") if four_digit_version and not v1_module else Version("1.2.4.dev0")
     # Verify changelog file
+    assert mod.metadata.version == "1.2.3.1.dev0" if four_digit_version and not v1_module else "1.2.4.dev0"
     if changelog_file_exists:
         with open(path_changelog_file, encoding="utf-8") as fh:
             assert fh.read() == get_changelog_content(after_release=True)

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -46,7 +46,7 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
     return subprocess.check_output(["git", "log", "-1", f"--skip={nb_previous_commit}", "--pretty=%B"], cwd=path).decode()
 
 
-@pytest.mark.parametrize_any("v1_module", [True, False])
+@pytest.mark.parametrize_any("v1_module", [False, True])
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
 @pytest.mark.parametrize_any("four_digit_version", [True, False])
@@ -70,7 +70,7 @@ def test_release_stable_version(
             return f"""
 # Changelog
 
-## {"v1.2.3.1" if four_digit_version and not v1_module else "v1.2.4"} - ?
+## {"v1.2.3." if four_digit_version and not v1_module else "v1.2.4"} - ?
 
 
 ## v1.2.3 - {datetime.date.today().isoformat()}
@@ -85,7 +85,7 @@ def test_release_stable_version(
             return """
 # Changelog
 
-## v1.2.3 - ?
+## v1.2.3.0 - ?
 
 - Release
 
@@ -145,8 +145,6 @@ def test_release_stable_version(
     # Verify version
     mod = Module.from_path(path_module)
     assert mod.version == Version("1.2.3.1.dev0") if four_digit_version and not v1_module else Version("1.2.4.dev0")
-    # Verify changelog file
-    assert mod.metadata.version == "1.2.3.1.dev0" if four_digit_version and not v1_module else "1.2.4.dev0"
     if changelog_file_exists:
         with open(path_changelog_file, encoding="utf-8") as fh:
             assert fh.read() == get_changelog_content(after_release=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -524,7 +524,7 @@ def module_from_template(
     new_content_init_cf: Optional[str] = None,
     new_content_init_py: Optional[str] = None,
     in_place: bool = False,
-    use_four_digits: bool = False,
+    four_digit_version: bool = False,
 ) -> module.ModuleV2Metadata:
     """
     Creates a v2 module from a template.
@@ -542,7 +542,7 @@ def module_from_template(
     :param new_content_init_cf: The new content of the _init.cf file.
     :param new_content_init_py: The new content of the __init__.py file.
     :param in_place: Modify the module in-place instead of copying it.
-    :param use_four_digits: if the version uses 4 digits (3 by default)
+    :param four_digit_version: if the version uses 4 digits (3 by default)
     """
 
     def to_python_requires(
@@ -559,8 +559,8 @@ def module_from_template(
     config_file: str = os.path.join(dest_dir, module.ModuleV2.MODULE_FILE)
     config: configparser.ConfigParser = configparser.ConfigParser()
     config.read(config_file)
-    if use_four_digits:
-        config["metadata"]["use_four_digits"] = "True"
+    if four_digit_version:
+        config["metadata"]["four_digit_version"] = "True"
     if new_version is not None:
         base, tag = module.ModuleV2Metadata.split_version(new_version)
         config["metadata"]["version"] = base

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -524,6 +524,7 @@ def module_from_template(
     new_content_init_cf: Optional[str] = None,
     new_content_init_py: Optional[str] = None,
     in_place: bool = False,
+    use_four_digit_version: bool = False,
 ) -> module.ModuleV2Metadata:
     """
     Creates a v2 module from a template.
@@ -541,6 +542,7 @@ def module_from_template(
     :param new_content_init_cf: The new content of the _init.cf file.
     :param new_content_init_py: The new content of the __init__.py file.
     :param in_place: Modify the module in-place instead of copying it.
+    :param use_four_digit_version: if the version uses 4 digits (3 by default)
     """
 
     def to_python_requires(
@@ -557,6 +559,8 @@ def module_from_template(
     config_file: str = os.path.join(dest_dir, module.ModuleV2.MODULE_FILE)
     config: configparser.ConfigParser = configparser.ConfigParser()
     config.read(config_file)
+    if use_four_digit_version:
+        config["metadata"]["use_four_digit_version"] = "True"
     if new_version is not None:
         base, tag = module.ModuleV2Metadata.split_version(new_version)
         config["metadata"]["version"] = base

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -524,7 +524,7 @@ def module_from_template(
     new_content_init_cf: Optional[str] = None,
     new_content_init_py: Optional[str] = None,
     in_place: bool = False,
-    use_four_digit: bool = False,
+    use_four_digits: bool = False,
 ) -> module.ModuleV2Metadata:
     """
     Creates a v2 module from a template.
@@ -542,7 +542,7 @@ def module_from_template(
     :param new_content_init_cf: The new content of the _init.cf file.
     :param new_content_init_py: The new content of the __init__.py file.
     :param in_place: Modify the module in-place instead of copying it.
-    :param use_four_digit: if the version uses 4 digits (3 by default)
+    :param use_four_digits: if the version uses 4 digits (3 by default)
     """
 
     def to_python_requires(
@@ -559,8 +559,8 @@ def module_from_template(
     config_file: str = os.path.join(dest_dir, module.ModuleV2.MODULE_FILE)
     config: configparser.ConfigParser = configparser.ConfigParser()
     config.read(config_file)
-    if use_four_digit:
-        config["metadata"]["use_four_digit"] = "True"
+    if use_four_digits:
+        config["metadata"]["use_four_digits"] = "True"
     if new_version is not None:
         base, tag = module.ModuleV2Metadata.split_version(new_version)
         config["metadata"]["version"] = base

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -524,7 +524,7 @@ def module_from_template(
     new_content_init_cf: Optional[str] = None,
     new_content_init_py: Optional[str] = None,
     in_place: bool = False,
-    use_four_digit_version: bool = False,
+    use_four_digit: bool = False,
 ) -> module.ModuleV2Metadata:
     """
     Creates a v2 module from a template.
@@ -542,7 +542,7 @@ def module_from_template(
     :param new_content_init_cf: The new content of the _init.cf file.
     :param new_content_init_py: The new content of the __init__.py file.
     :param in_place: Modify the module in-place instead of copying it.
-    :param use_four_digit_version: if the version uses 4 digits (3 by default)
+    :param use_four_digit: if the version uses 4 digits (3 by default)
     """
 
     def to_python_requires(
@@ -559,8 +559,8 @@ def module_from_template(
     config_file: str = os.path.join(dest_dir, module.ModuleV2.MODULE_FILE)
     config: configparser.ConfigParser = configparser.ConfigParser()
     config.read(config_file)
-    if use_four_digit_version:
-        config["metadata"]["use_four_digit_version"] = "True"
+    if use_four_digit:
+        config["metadata"]["use_four_digit"] = "True"
     if new_version is not None:
         base, tag = module.ModuleV2Metadata.split_version(new_version)
         config["metadata"]["version"] = base


### PR DESCRIPTION
# Description

The inmanta module release command performs a patch-level version bump right after applying the git tag. But some modules use four-digit version numbers in general. This ticket should make sure that the inmanta module release command has support to bump to a four digit version number after a release.
Make this configurable in the module metadata file (setup.cfg -> inmanta.module.ModuleV2Metadata)

closes #7521 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
