### PR TITLE
Issue/reference configuration reference

### DIFF
--- a/changelogs/unreleased/update-config-documentation.yml
+++ b/changelogs/unreleased/update-config-documentation.yml
@@ -1,0 +1,4 @@
+---
+description: Update config documentation.
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/docs/administrators/configuration.rst
+++ b/docs/administrators/configuration.rst
@@ -1,6 +1,9 @@
 Configuration
 ===================
 
+.. note::
+    The documentation of the configuration options themselves can be found in the :ref:`inmanta config reference<config_reference>`.
+
 Inmanta server and Inmanta agent
 --------------------------------
 
@@ -12,7 +15,7 @@ The Inmanta server and the Inmanta agent, started via systemd, will read their c
 
 The configuration options specified in the ``/etc/inmanta/inmanta.d/`` directory override the configuration options specified in
 ``/etc/inmanta/inmanta.cfg``. If the directory ``/etc/inmanta/inmanta.d/`` contains two files with the same configuration option, the
-conflict is resolved using the alfabetical order of the filesnames. Filenames which appear later in the alfabetical order
+conflict is resolved using the alphabetical order of the filenames. Filenames which appear later in the alfabetical order
 override the configuration options from their predecessors in that order.
 
 After having read the configuration files, inmanta will read environment variables.
@@ -42,7 +45,7 @@ executed.
 
 Configuration files which are ranked lower in the above-mentioned list override the configuration options specified by their
 predecessors. If the directory ``/etc/inmanta/inmanta.d/`` contains two files with the same configuration option, the conflict is
-resolved using the alfabetical order of the filenames. Filenames which appear later in the alfabetical order override the
+resolved using the alphabetical order of the filenames. Filenames which appear later in the alphabetical order override the
 configuration options from their predecessors in that order.
 
 The number 2 (``/etc/inmanta/inmanta.d/*.cfg``) in the above-mentioned list can be overridden using the ``--config-dir``

--- a/docs/administrators/configuration.rst
+++ b/docs/administrators/configuration.rst
@@ -2,7 +2,7 @@ Configuration
 ===================
 
 .. note::
-    The documentation of the configuration options themselves can be found in the :ref:`inmanta config reference<config_reference>`.
+    The documentation of the configuration options themselves can be found in the :ref:`Inmanta configuration reference<config_reference>`.
 
 Inmanta server and Inmanta agent
 --------------------------------


### PR DESCRIPTION
# Description

The first page you land on when searching for the configuration documentation is https://docs.inmanta.com/inmanta-service-orchestrator/7/administrators/configuration.html#configuration

And it doesn't refer to the actual config options documentation.  This PR adds the missing link.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
