### PR TITLE
Clean up and patch compiler service queue processing

### DIFF
--- a/changelogs/unreleased/7536-compiler-service-race-condition-fix.yml
+++ b/changelogs/unreleased/7536-compiler-service-race-condition-fix.yml
@@ -1,0 +1,5 @@
+description: Clean up and patch compiler service queue processing
+change-type: patch
+destination-branches:
+  - master
+  - iso7

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3686,25 +3686,29 @@ class Compile(BaseDocument):
         return results[0]
 
     @classmethod
-    async def get_next_run(cls, environment_id: uuid.UUID) -> Optional["Compile"]:
+    async def get_next_run(cls, environment_id: uuid.UUID, *, connection: Optional[asyncpg.Connection] = None) -> Optional["Compile"]:
         """Get the next compile in the queue for the given environment"""
-        results = await cls.select_query(
-            f"SELECT * FROM {cls.table_name()} WHERE environment=$1 AND completed IS NULL ORDER BY requested ASC LIMIT 1",
-            [cls._get_value(environment_id)],
-        )
-        if not results:
-            return None
-        return results[0]
+        async with cls.get_connection(connection) as con:
+            results = await cls.select_query(
+                f"SELECT * FROM {cls.table_name()} WHERE environment=$1 AND completed IS NULL ORDER BY requested ASC LIMIT 1",
+                [cls._get_value(environment_id)],
+                connection=con,
+            )
+            if not results:
+                return None
+            return results[0]
 
     @classmethod
-    async def get_next_run_all(cls) -> "Sequence[Compile]":
+    async def get_next_run_all(cls, *, connection: Optional[asyncpg.Connection] = None) -> "Sequence[Compile]":
         """Get the next compile in the queue for each environment"""
-        results = await cls.select_query(
-            f"SELECT DISTINCT ON (environment) * FROM {cls.table_name()} WHERE completed IS NULL ORDER BY environment, "
-            f"requested ASC",
-            [],
-        )
-        return results
+        async with cls.get_connection(connection) as con:
+            results = await cls.select_query(
+                f"SELECT DISTINCT ON (environment) * FROM {cls.table_name()} WHERE completed IS NULL ORDER BY environment, "
+                f"requested ASC",
+                [],
+                connection=con,
+            )
+            return results
 
     @classmethod
     async def get_unhandled_compiles(cls) -> "Sequence[Compile]":

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3686,7 +3686,9 @@ class Compile(BaseDocument):
         return results[0]
 
     @classmethod
-    async def get_next_run(cls, environment_id: uuid.UUID, *, connection: Optional[asyncpg.Connection] = None) -> Optional["Compile"]:
+    async def get_next_run(
+        cls, environment_id: uuid.UUID, *, connection: Optional[asyncpg.Connection] = None
+    ) -> Optional["Compile"]:
         """Get the next compile in the queue for the given environment"""
         async with cls.get_connection(connection) as con:
             results = await cls.select_query(

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -26,7 +26,7 @@ import re
 import subprocess
 import traceback
 import uuid
-from asyncio import CancelledError, Task
+from asyncio import CancelledError
 from asyncio.subprocess import Process
 from collections.abc import AsyncIterator, Awaitable, Hashable, Mapping, Sequence
 from itertools import chain
@@ -44,7 +44,7 @@ from inmanta import config, const, data, protocol, server
 from inmanta.data import APILIMIT, InvalidSort
 from inmanta.data.dataview import CompileReportView
 from inmanta.env import PipCommandBuilder, PythonEnvironment, VenvCreationFailedError, VirtualEnv
-from inmanta.protocol import Result, encode_token, methods, methods_v2
+from inmanta.protocol import encode_token, methods, methods_v2
 from inmanta.protocol.common import ReturnValue
 from inmanta.protocol.exceptions import BadRequest, NotFound
 from inmanta.server import SLICE_COMPILER, SLICE_DATABASE, SLICE_ENVIRONMENT, SLICE_SERVER, SLICE_TRANSPORT
@@ -501,7 +501,8 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
     General design of compile scheduling:
 
     1. all compile request are stored in the database.
-    2. when compile is queued, _process_next_compile_in_queue is called, if no job is executing for that environment, it is started
+    2. when compile is queued, _process_next_compile_in_queue is called: if no job is executing for that environment, it is
+        started
     3. when a compile run ends:
         a. it is marked as completed in the database
         b. _notify_listeners notifies blocking listeners and schedules notification of async listeners as a background task.
@@ -509,8 +510,8 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         c. _process_next_compile_in_queue is called again to start the next queued compile, if any
 
     Upon restart
-    1. call _process_next_compile_in_queue in all-environments mode to find a runnable (incomplete) request for every environment
-        and start it.
+    1. call _process_next_compile_in_queue in all-environments mode to find a runnable (incomplete) request for every
+        environment and start it.
     2. find all unhandled but complete jobs and run _notify_listeners on them
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1575,6 +1575,23 @@ def monkey_patch_compiler_service(monkeypatch, server, make_compile_fail, runner
         return CompileRunnerMock(compile, make_compile_fail, runner_queue)
 
     monkeypatch.setattr(compilerslice, "_get_compile_runner", patch, raising=True)
+    monkeypatch.setattr(compilerslice, "_running_compiles", {}, raising=False)
+
+    original_run = compilerslice._run
+
+    async def _run(compile: data.Compile) -> None:
+        compilerslice._running_compiles[compile.environment] = compile
+        await original_run(compile)
+        async with compilerslice._write_lock_compiling_envs:
+            if compile.environment not in compilerslice._compiling_envs:
+                # Clear self._running_compiles iff the compiler service has deleted the environment from the compiling
+                # environments set.
+                del compilerslice._running_compiles[compile.environment]
+            else:
+                # Otherwise, a new _run will have overwritten the running compile => do nothing
+                assert compilerslice._running_compiles[compile.environment] is not compile
+
+    monkeypatch.setattr(compilerslice, "_run", _run, raising=True)
 
 
 @pytest.fixture

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -381,7 +381,7 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
     e2.append(extra_compile)
 
     # We haven't started, because we hang on a handler,
-    assert [rc for rc in cs._recompiles.values() if rc is not None] == []
+    assert [rc for rc in cs._compile_run_tasks.values() if rc is not None] == []
 
     # Continue
     hanging_collector.release()
@@ -963,7 +963,7 @@ async def run_compile_and_wait_until_compile_is_done(
     """
     Unblock the first compile in the compiler queue and wait until the compile finishes.
     """
-    current_task = compiler_service._recompiles[env_id]
+    current_task = compiler_service._compile_run_tasks[env_id]
 
     # prevent race conditions where compile request is not yet in queue
     await retry_limited(lambda: not compiler_queue.empty(), timeout=10)
@@ -974,9 +974,9 @@ async def run_compile_and_wait_until_compile_is_done(
     run.block = False
 
     def _is_compile_finished() -> bool:
-        if env_id not in compiler_service._recompiles:
+        if env_id not in compiler_service._compile_run_tasks:
             return True
-        if current_task is not compiler_service._recompiles[env_id]:
+        if current_task is not compiler_service._compile_run_tasks[env_id]:
             return True
         return False
 
@@ -1100,7 +1100,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     # finish 7th compile
     await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
-    while env.id in compilerslice._recompiles:
+    while env.id in compilerslice._compile_run_tasks:
         await asyncio.sleep(0.2)
 
     # 0 in the queue, 0 running
@@ -1223,14 +1223,14 @@ async def test_compileservice_queue_count_on_trx_based_api(mocked_compiler_servi
             )
             assert compile_id is not None, warnings
             assert compiler_service._queue_count_cache == 0
-            assert len(compiler_service._recompiles) == 0
+            assert len(compiler_service._compile_run_tasks) == 0
     # Transaction committed
     await compiler_service.notify_compile_request_committed(compile_id)
     assert compiler_service._queue_count_cache == 1
-    assert len(compiler_service._recompiles) == 1
+    assert len(compiler_service._compile_run_tasks) == 1
 
     await run_compile_and_wait_until_compile_is_done(compiler_service, mocked_compiler_service_block, env.id)
-    assert len(compiler_service._recompiles) == 0
+    assert len(compiler_service._compile_run_tasks) == 0
 
 
 @pytest.fixture(scope="function")

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -381,7 +381,7 @@ async def test_scheduler(server_config, init_dataclasses_and_load_schema, caplog
     e2.append(extra_compile)
 
     # We haven't started, because we hang on a handler,
-    assert [rc for rc in cs._compile_run_tasks.values() if rc is not None] == []
+    assert len(cs._compiling_envs) == 0
 
     # Continue
     hanging_collector.release()
@@ -963,7 +963,7 @@ async def run_compile_and_wait_until_compile_is_done(
     """
     Unblock the first compile in the compiler queue and wait until the compile finishes.
     """
-    current_task = compiler_service._compile_run_tasks[env_id]
+    current_compile = compiler_service._running_compiles[env_id]
 
     # prevent race conditions where compile request is not yet in queue
     await retry_limited(lambda: not compiler_queue.empty(), timeout=10)
@@ -974,9 +974,9 @@ async def run_compile_and_wait_until_compile_is_done(
     run.block = False
 
     def _is_compile_finished() -> bool:
-        if env_id not in compiler_service._compile_run_tasks:
+        if env_id not in compiler_service._running_compiles:
             return True
-        if current_task is not compiler_service._compile_run_tasks[env_id]:
+        if current_compile is not compiler_service._running_compiles[env_id]:
             return True
         return False
 
@@ -1100,7 +1100,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     # finish 7th compile
     await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id)
 
-    while env.id in compilerslice._compile_run_tasks:
+    while env.id in compilerslice._compiling_envs:
         await asyncio.sleep(0.2)
 
     # 0 in the queue, 0 running
@@ -1223,14 +1223,14 @@ async def test_compileservice_queue_count_on_trx_based_api(mocked_compiler_servi
             )
             assert compile_id is not None, warnings
             assert compiler_service._queue_count_cache == 0
-            assert len(compiler_service._compile_run_tasks) == 0
+            assert len(compiler_service._compiling_envs) == 0
     # Transaction committed
     await compiler_service.notify_compile_request_committed(compile_id)
     assert compiler_service._queue_count_cache == 1
-    assert len(compiler_service._compile_run_tasks) == 1
+    assert len(compiler_service._compiling_envs) == 1
 
     await run_compile_and_wait_until_compile_is_done(compiler_service, mocked_compiler_service_block, env.id)
-    assert len(compiler_service._compile_run_tasks) == 0
+    assert len(compiler_service._compiling_envs) == 0
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# Description

- Unify compiler service queue methods `_queue`, `__queue_no_lock` and `process_next_compile_in_queue` (very similar with subtle differences) to a single method. This change is intended to make the entire flow easier to understand.
- Fix potential (may or may not be related to actual observed problematic behavior, tbc) race condition between compiler service recovery and `request_recompile`. See https://github.com/inmanta/inmanta-core/pull/7466/files#r1570373482.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~
- [x] ~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~ (It does fix a race condition, but one not present on the stable branches.)
