### PR TITLE
Fix bug on environment clear/delete endpoints (iso6)

### DIFF
--- a/changelogs/unreleased/fix-race-on-environment-clear.yml
+++ b/changelogs/unreleased/fix-race-on-environment-clear.yml
@@ -1,6 +1,6 @@
 ---
 description: "Fix bug that makes the endpoints to clear or delete an environment fail with the error message `(39, 'Directory not empty')`"
 change-type: patch
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-race-on-environment-clear.yml
+++ b/changelogs/unreleased/fix-race-on-environment-clear.yml
@@ -1,0 +1,6 @@
+---
+description: "Fix bug that makes the endpoints to clear or delete an environment fail with the error message `(39, 'Directory not empty')`"
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -307,6 +307,7 @@ def clear_environment(id: uuid.UUID):
     This method deletes various components associated with the specified environment from the database,
     including agents, compile data, parameters, notifications, code, resources, and configuration models.
     However, it retains the entry in the Environment table itself and settings are kept.
+    The environment will be temporarily halted during the decommissioning process.
 
     :param id: The id of the environment to be cleared.
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -285,7 +285,7 @@ def environment_decommission(id: uuid.UUID, metadata: Optional[model.ModelMetada
 )
 def environment_clear(id: uuid.UUID) -> None:
     """
-    Clear all data from this environment.
+    Clear all data from this environment. The environment will be temporarily halted during the decommissioning process.
 
     :param id: The uuid of the environment.
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -981,10 +981,10 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
 
         :param env_id: The id of the environment for which the compile should be cancelled.
         """
-        async with self._write_lock_env_to_compile_task:
-            compile_task: Optional[asyncio.Task[None | protocol.Result]] = self._env_to_compile_task.pop(env_id, None)
+        async with self._global_lock:
+            compile_task: Optional[asyncio.Task[None | protocol.Result]] = self._recompiles.pop(env_id, None)
         if compile_task:
-            # We cancel the compile_task outside of the self._write_lock_env_to_compile_task lock to prevent lock contention.
+            # We cancel the compile_task outside of the self._global_lock to prevent lock contention.
             # This is only safe if no new compiles can be scheduled on the given environment, otherwise there is the
             # possibility that multiple compiles run concurrently on the same environment. Hence the pre-condition that
             # this method can only be called on halted environments.

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -970,3 +970,28 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
     async def recalculate_queue_count_cache(self) -> None:
         async with self._queue_count_cache_lock:
             self._queue_count_cache = await data.Compile.get_total_length_of_all_compile_queues()
+
+    async def cancel_compile(self, env_id: uuid.UUID) -> None:
+        """
+        Cancel the ongoing compile for the given environment (if any). After the cancellation, this method
+        will not start the execution of a new compile, if a compile request would be present in the compile
+        queue for the given environment.
+
+        pre-condition: The given environment is halted.
+
+        :param env_id: The id of the environment for which the compile should be cancelled.
+        """
+        async with self._write_lock_env_to_compile_task:
+            compile_task: Optional[asyncio.Task[None | protocol.Result]] = self._env_to_compile_task.pop(env_id, None)
+        if compile_task:
+            # We cancel the compile_task outside of the self._write_lock_env_to_compile_task lock to prevent lock contention.
+            # This is only safe if no new compiles can be scheduled on the given environment, otherwise there is the
+            # possibility that multiple compiles run concurrently on the same environment. Hence the pre-condition that
+            # this method can only be called on halted environments.
+            compile_task.cancel()
+            try:
+                # Wait until cancellation has finished
+                await compile_task
+            except asyncio.CancelledError:
+                # Don't propagate CancelledError raised by invoking compile_task.cancel()
+                pass

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -31,7 +31,7 @@ from collections.abc import AsyncIterator, Awaitable, Hashable, Mapping, Sequenc
 from itertools import chain
 from logging import Logger
 from tempfile import NamedTemporaryFile
-from typing import Optional, cast
+from typing import Optional, Union, cast
 
 import dateutil
 import dateutil.parser
@@ -982,7 +982,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         :param env_id: The id of the environment for which the compile should be cancelled.
         """
         async with self._global_lock:
-            compile_task: Optional[asyncio.Task[None | protocol.Result]] = self._recompiles.pop(env_id, None)
+            compile_task: Optional[asyncio.Task[Union[None, protocol.Result]]] = self._recompiles.pop(env_id, None)
         if compile_task:
             # We cancel the compile_task outside of the self._global_lock to prevent lock contention.
             # This is only safe if no new compiles can be scheduled on the given environment, otherwise there is the

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -543,8 +543,6 @@ class EnvironmentService(protocol.ServerSlice):
             self.resource_service.close_resource_action_logger(environment_id)
             await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
 
-            self._delete_environment_dir(environment_id)
-
     @handle(methods_v2.environment_decommission, env="id")
     async def environment_decommission(self, env: data.Environment, metadata: Optional[model.ModelMetadata]) -> int:
         is_protected_environment = await env.get(data.PROTECTED_ENVIRONMENT)

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -26,6 +26,7 @@ import uuid
 import warnings
 from collections import defaultdict
 from collections.abc import Set
+from concurrent import futures
 from enum import Enum
 from re import Pattern
 from typing import Optional, cast
@@ -131,6 +132,7 @@ class EnvironmentService(protocol.ServerSlice):
         super().__init__(SLICE_ENVIRONMENT)
         self.listeners = defaultdict(list)
         self.environment_state_operation_lock = asyncio.Lock()
+        self.thread_pool = futures.ThreadPoolExecutor(max_workers=1)
 
     def get_dependencies(self) -> list[str]:
         return [
@@ -140,6 +142,7 @@ class EnvironmentService(protocol.ServerSlice):
             SLICE_AUTOSTARTED_AGENT_MANAGER,
             SLICE_ORCHESTRATION,
             SLICE_RESOURCE,
+            SLICE_AGENT_MANAGER,
         ]
 
     def get_depended_by(self) -> list[str]:
@@ -261,11 +264,19 @@ class EnvironmentService(protocol.ServerSlice):
         async with self.environment_state_operation_lock:
             await self._halt(env, connection)
 
-    async def _halt(self, env: data.Environment, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+    async def _halt(
+        self,
+        env: data.Environment,
+        connection: Optional[asyncpg.connection.Connection] = None,
+        *,
+        delete_agent_venv: bool = False,
+    ) -> None:
         """
         Halts the specified environment without acquiring the environment_state_operation_lock.
         This method is designed to be an internal helper that allows for halting an environment
         as part of a larger operation (e.g., deletion), where the lock is managed by the caller and prevent double locking.
+
+        :param delete_agent_venv: True iff also delete the venv of the agent after stopping it.
         """
         async with data.Environment.get_connection(connection=connection) as con:
             async with con.transaction():
@@ -279,25 +290,31 @@ class EnvironmentService(protocol.ServerSlice):
 
                 await refreshed_env.update_fields(halted=True, connection=con)
                 await self.agent_manager.halt_agents(refreshed_env, connection=con)
-        await self.autostarted_agent_manager.stop_agents(refreshed_env)
+        await self.autostarted_agent_manager.stop_agents(refreshed_env, delete_agent_venv)
 
     @handle(methods_v2.resume_environment, env="tid")
     async def resume(self, env: data.Environment) -> None:
         async with self.environment_state_operation_lock:
-            async with data.Environment.get_connection() as connection:
-                async with connection.transaction():
-                    refreshed_env: Optional[data.Environment] = await data.Environment.get_by_id(env.id, connection=connection)
-                    if refreshed_env is None:
-                        raise NotFound("Environment %s does not exist" % env.id)
-                    if refreshed_env.is_marked_for_deletion:
-                        raise BadRequest("Cannot resume an environment that is marked for deletion.")
-                    # silently ignore requests if this environment has already been resumed
-                    if not refreshed_env.halted:
-                        return
+            await self._resume(env)
 
-                    await refreshed_env.update_fields(halted=False, connection=connection)
-                    await self.agent_manager.resume_agents(refreshed_env, connection=connection)
-            await self.autostarted_agent_manager.restart_agents(refreshed_env)
+    async def _resume(self, env: data.Environment, connection: Optional[asyncpg.connection.Connection] = None) -> None:
+        """
+        Internal helper to resume an environment. This method must be called under the self.environment_state_operation_lock.
+        """
+        async with data.Environment.get_connection(connection) as con:
+            async with con.transaction():
+                refreshed_env: Optional[data.Environment] = await data.Environment.get_by_id(env.id, connection=con)
+                if refreshed_env is None:
+                    raise NotFound("Environment %s does not exist" % env.id)
+                if refreshed_env.is_marked_for_deletion:
+                    raise BadRequest("Cannot resume an environment that is marked for deletion.")
+                # silently ignore requests if this environment has already been resumed
+                if not refreshed_env.halted:
+                    return
+
+                await refreshed_env.update_fields(halted=False, connection=con)
+                await self.agent_manager.resume_agents(refreshed_env, connection=con)
+        await self.autostarted_agent_manager.restart_agents(refreshed_env)
         await self.server_slice.compiler.resume_environment(refreshed_env.id)
 
     @handle(methods.decomission_environment, env="id")
@@ -507,17 +524,21 @@ class EnvironmentService(protocol.ServerSlice):
                         f"Environment {environment_id} is protected. See environment setting: {data.PROTECTED_ENVIRONMENT}"
                     )
 
+                await env.mark_for_deletion(connection=connection)
+
                 # Check if the environment is halted; if not, halt it
                 if not env.halted:
                     LOGGER.info("Halting Environment %s", str(environment_id))
-                    await self._halt(env, connection=connection)
+                    await self._halt(env, connection=connection, delete_agent_venv=True)
 
-                await env.mark_for_deletion(connection=connection)
                 self._disable_schedules(env)
-                await asyncio.gather(
-                    self.autostarted_agent_manager.stop_agents(env, delete_venv=True),
-                    env.delete_cascade(connection=connection),
-                )
+                await self.compiler_service.cancel_compile(env.id)
+                # Delete the environment directory before deleting the database records. This ensures that
+                # this operation can be retried if the deletion of the environment directory fails. Otherwise,
+                # the environment directory would be left in an inconsistent state. This can cause problems if
+                # the user later on recreates an environment with the same environment id.
+                await self._delete_environment_dir(environment_id)
+                await env.delete_cascade(connection=connection)
 
             self.resource_service.close_resource_action_logger(environment_id)
             await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
@@ -541,15 +562,35 @@ class EnvironmentService(protocol.ServerSlice):
         """
         Clear the environment
         """
-        is_protected_environment = await env.get(data.PROTECTED_ENVIRONMENT)
-        if is_protected_environment:
-            raise Forbidden(f"Environment {env.id} is protected. See environment setting: {data.PROTECTED_ENVIRONMENT}")
+        async with self.environment_state_operation_lock:
+            async with data.Environment.get_connection() as connection:
+                is_protected_environment = await env.get(data.PROTECTED_ENVIRONMENT, connection=connection)
+                if is_protected_environment:
+                    raise Forbidden(f"Environment {env.id} is protected. See environment setting: {data.PROTECTED_ENVIRONMENT}")
 
-        await self.autostarted_agent_manager.stop_agents(env, delete_venv=True)
-        await env.clear()
+                initial_halted_state = env.halted
 
-        await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
-        self._delete_environment_dir(env.id)
+                # Check if the environment is halted; if not, halt it
+                if not env.halted:
+                    LOGGER.info("Halting environment %s for clear operation", str(env.id))
+                    await self._halt(env, connection=connection, delete_agent_venv=True)
+
+                # Keep this method call under the self.environment_state_operation_lock lock, because cancel_compile()
+                # must be called on halted environments only.
+                await self.compiler_service.cancel_compile(env.id)
+                # Delete the environment directory before deleting the database records. This ensures that
+                # this operation can be retried if the deletion of the environment directory fails. Otherwise,
+                # the environment directory would be left in an inconsistent state. This can cause problems if
+                # the user later on recreates an environment with the same environment id.
+                await self._delete_environment_dir(env.id)
+                await env.clear(connection=connection)
+
+                await self.notify_listeners(EnvironmentAction.cleared, env.to_dto())
+
+                if not initial_halted_state:
+                    # Make sure to restore the environment to its initial state
+                    LOGGER.info("Resume environment %s because clear operation finished", str(env.id))
+                    await self._resume(env, connection=connection)
 
     @handle(methods_v2.environment_create_token, env="tid")
     async def environment_create_token(self, env: data.Environment, client_types: list[str], idempotent: bool) -> str:
@@ -627,7 +668,7 @@ class EnvironmentService(protocol.ServerSlice):
     def remove_listener(self, action: EnvironmentAction, listener: EnvironmentListener) -> None:
         self.listeners[action].remove(listener)
 
-    def _delete_environment_dir(self, environment_id: uuid.UUID) -> None:
+    async def _delete_environment_dir(self, environment_id: uuid.UUID) -> None:
         """
         Deletes an environment from the server's state_dir directory. This method should be called after
         notify_listeners() to ensure that the listeners are notified.
@@ -641,10 +682,15 @@ class EnvironmentService(protocol.ServerSlice):
         environment_dir = os.path.join(state_dir, "server", "environments", str(environment_id))
 
         if os.path.exists(environment_dir):
-            # This call might fail when someone manually creates a directory or file that is owned
-            # by another user than the user running the inmanta server.
+            loop = asyncio.get_running_loop()
             try:
-                shutil.rmtree(environment_dir)
+                # This call might fail when someone manually creates a directory or file that is owned
+                # by another user than the user running the inmanta server.
+                await loop.run_in_executor(
+                    self.thread_pool,
+                    shutil.rmtree,
+                    environment_dir,
+                )
             except PermissionError:
                 raise ServerError(
                     f"Environment {environment_id} cannot be deleted because it contains files owned"


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/7526 but applied on the iso6 branch due to a merge conflict.**

* Fix bug that makes the endpoints to clear or delete an environment fail with the error message `(39, 'Directory not empty')`. This bug triggers when the compiler service updates the files in the environment directory, while the API endpoint to delete/clear the environment performs a `shutil.rmtree()` on that directory.
* Add the `SLICE_AGENT_MANAGER` to the dependencies of the EnvironmentService. It think this is a bug.
* Make the endpoint to delete an environment first calls into `mark_for_deletion()` and only then halt the environment, because the former is a guard to make sure that an environment, that is marked for deletion, cannot be resumed. The original implementation did it the other way around. This was not an issue, because these calls are protected by the `environment_state_operation_lock`, but having them swapped make the code easier to read.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
