### PR TITLE
Added fix for resource_details

### DIFF
--- a/changelogs/unreleased/fix_resource_details.yml
+++ b/changelogs/unreleased/fix_resource_details.yml
@@ -1,0 +1,5 @@
+description: Fix resource details endpoint status reporting
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5012,7 +5012,8 @@ class Resource(BaseDocument):
         SELECT DISTINCT ON (resource.resource_id) resource.resource_id, {status_sub_query('resource')}
         FROM resource
         INNER JOIN configurationmodel cm ON resource.model = cm.version AND resource.environment = cm.environment
-        INNER JOIN resource_persistent_state ps on ps.resource_id = resource.resource_id AND resource.environment = ps.environment
+        INNER JOIN resource_persistent_state ps
+              ON ps.resource_id = resource.resource_id AND resource.environment = ps.environment
         WHERE resource.environment = $1 AND cm.released = TRUE AND resource.resource_id = ANY($2)
         ORDER BY resource.resource_id, model DESC;
         """

--- a/tests/agent_server/test_resource_view.py
+++ b/tests/agent_server/test_resource_view.py
@@ -1,0 +1,108 @@
+"""
+    Copyright 2024 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+import datetime
+import uuid
+
+import utils
+from inmanta import const, data
+
+
+async def test_consistent_resource_state_reporting(
+    server, agent_factory, environment, resource_container, clienthelper, client, no_agent_backoff
+) -> None:
+
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.set(data.AUTOSTART_AGENT_MAP, {"internal": "", "agent1": ""})
+    await env.set(data.AUTO_DEPLOY, False)
+    await env.set(data.PUSH_ON_AUTO_DEPLOY, False)
+    await env.set(data.AUTOSTART_AGENT_DEPLOY_INTERVAL, 0)
+    await env.set(data.AUTOSTART_AGENT_REPAIR_INTERVAL, 0)
+    await env.set(data.AUTOSTART_ON_START, True)
+
+    agent = await agent_factory(environment=environment, hostname="agent1")
+
+    rid = "test::Resource[agent1,key=key1]"
+    rid2 = "test::Resource[agent1,key=key2]"
+
+    async def _put_version(version: int) -> None:
+        resources = [
+            {
+                "key": "key1",
+                "value": "value1",
+                "id": f"{rid},v={version}",
+                "change": False,
+                "send_event": True,
+                "purged": False,
+                "requires": [],
+                "purge_on_delete": False,
+            },
+            {
+                "key": "key2",
+                "value": "value1",
+                "id": f"{rid2},v={version}",
+                "change": False,
+                "send_event": True,
+                "purged": False,
+                "requires": [rid],
+                "purge_on_delete": False,
+            },
+        ]
+        await clienthelper.put_version_simple(resources, version)
+
+    version1 = await clienthelper.get_version()
+    await _put_version(version1)
+
+    version2 = await clienthelper.get_version()
+    await _put_version(version2)
+
+    result = await client.release_version(environment, version1, push=True)
+    assert result.code == 200
+    await utils._wait_until_deployment_finishes(client, environment, version1)
+
+    result = await client.release_version(environment, version2, push=False)
+    assert result.code == 200
+
+    result = await agent._client.resource_action_update(
+        tid=environment,
+        resource_ids=[f"{rid},v={version1}"],
+        action_id=uuid.uuid4(),
+        action=const.ResourceAction.deploy,
+        started=datetime.datetime.now(),
+        finished=datetime.datetime.now(),
+        messages=[],
+        status=const.ResourceState.failed,
+    )
+    assert result.code == 200
+
+    result = await client.resource_list(tid=environment)
+    assert result.code == 200
+    assert len(result.result["data"]) == 2
+    by_id = {r["resource_id"]: r for r in result.result["data"]}
+    assert by_id[rid]["status"] == const.ResourceState.failed.value
+
+    # V2 endpoint to get resource details
+    result = await client.resource_details(tid=environment, rid=rid)
+    assert result.code == 200
+    assert result.result["data"]["status"] == const.ResourceState.failed.value
+    assert result.result["data"]["requires_status"] == {}
+
+    result = await client.resource_details(tid=environment, rid=rid2)
+    assert result.code == 200
+    assert result.result["data"]["status"] == const.ResourceState.deployed.value
+    assert result.result["data"]["requires_status"] == {rid: const.ResourceState.failed}

--- a/tests/server/test_resource_details.py
+++ b/tests/server/test_resource_details.py
@@ -56,7 +56,7 @@ async def env_with_resources(server, client):
         )
 
     # nr 0 is not used
-    is_version_released = [None, False, True, True, True, False]
+    is_version_released = [None, False, True, True, True, False, True]
 
     # Add multiple versions of model, with 2 of them not released
     for i in range(1, 6):
@@ -130,6 +130,8 @@ async def env_with_resources(server, client):
         deploy_times[environment][key].append(last_deploy)
         if update_last_deployed:
             await res.update_persistent_state(last_deploy=last_deploy)
+        if is_version_released[version] and status != ResourceState.deploying:
+            await res.update_persistent_state(last_non_deploying_status=status)
 
         return res
 


### PR DESCRIPTION
# Description

Fix for incorrect reporting of resource state

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
