### PR TITLE
Migrate to configdict-based logging config (iso7)

### DIFF
--- a/changelogs/unreleased/7265-add-dict-based-logging-framework.yml
+++ b/changelogs/unreleased/7265-add-dict-based-logging-framework.yml
@@ -1,0 +1,6 @@
+---
+description: Migrate Inmanta logging framework to Python's dictConfig based logging framework.
+issue-nr: 7265
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso7]

--- a/changelogs/unreleased/7265-add-dict-based-logging-framework.yml
+++ b/changelogs/unreleased/7265-add-dict-based-logging-framework.yml
@@ -3,4 +3,4 @@ description: Migrate Inmanta logging framework to Python's dictConfig based logg
 issue-nr: 7265
 issue-repo: inmanta-core
 change-type: patch
-destination-branches: [master, iso7]
+destination-branches: [iso7]

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -69,7 +69,7 @@ from inmanta.compiler import do_compile
 from inmanta.config import Config, Option
 from inmanta.const import EXIT_START_FAILED
 from inmanta.export import cfg_env
-from inmanta.logging import InmantaLoggerConfig, LoggerMode, _is_on_tty
+from inmanta.logging import InmantaLoggerConfig, LoggerMode, LoggerModeManager, _is_on_tty
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
 from inmanta.warnings import WarningsManager
@@ -343,8 +343,8 @@ def compiler_config(parser: argparse.ArgumentParser, parent_parsers: abc.Sequenc
     "compile", help_msg="Compile the project to a configuration model", parser_config=compiler_config, require_project=True
 )
 def compile_project(options: argparse.Namespace) -> None:
-    inmanta_logger_config = InmantaLoggerConfig.get_current_instance()
-    with inmanta_logger_config.run_in_logger_mode(LoggerMode.COMPILER):
+    logger_mode_manager = LoggerModeManager.get_instance()
+    with logger_mode_manager.run_in_logger_mode(LoggerMode.COMPILER):
         if options.environment is not None:
             Config.set("config", "environment", options.environment)
 
@@ -569,8 +569,8 @@ def export_parser_config(parser: argparse.ArgumentParser, parent_parsers: abc.Se
 
 @command("export", help_msg="Export the configuration", parser_config=export_parser_config, require_project=True)
 def export(options: argparse.Namespace) -> None:
-    inmanta_logger_config = InmantaLoggerConfig.get_current_instance()
-    with inmanta_logger_config.run_in_logger_mode(LoggerMode.COMPILER):
+    logger_mode_manager = LoggerModeManager.get_instance()
+    with logger_mode_manager.run_in_logger_mode(LoggerMode.COMPILER):
         if not options.partial_compile and options.delete_resource_set:
             raise CLIException(
                 "The --delete-resource-set option should always be used together with the --partial option", exitcode=1
@@ -640,7 +640,7 @@ def export(options: argparse.Namespace) -> None:
                 types, scopes = (None, None)
                 raise
 
-    with inmanta_logger_config.run_in_logger_mode(LoggerMode.EXPORTER):
+    with logger_mode_manager.run_in_logger_mode(LoggerMode.EXPORTER):
         # Even if the compile failed we might have collected additional data such as unknowns. So
         # continue the export
 

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -18,19 +18,25 @@
 
 import enum
 import logging
+import logging.config
 import os
 import re
 import sys
 from argparse import Namespace
+from collections import abc
 from collections.abc import Iterator
 from contextlib import contextmanager
+from logging import handlers
 from typing import Optional, TextIO
 
 import colorlog
 from colorlog.formatter import LogColors
 
-from inmanta import const
+from inmanta import config, const
+from inmanta.server import config as server_config
 from inmanta.stable_api import stable_api
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _is_on_tty() -> bool:
@@ -54,6 +60,131 @@ log_levels = {
 }
 
 
+@stable_api
+class LoggingConfigExtension:
+    """
+    This class is used by an extension to declare the default logging config that should be used when
+    no dict-based logging config was provided by the user. The FullLoggingConfig class provides support
+    to merge this logging config into the main logging config of inmanta-core. This class supports only
+    version 1 of Python's dictConfig format.
+    """
+
+    def __init__(
+        self,
+        *,
+        formatters: Optional[abc.Mapping[str, object]] = None,
+        handlers: Optional[abc.Mapping[str, object]] = None,
+        loggers: Optional[abc.Mapping[str, object]] = None,
+        root_handlers: Optional[abc.Set[str]] = None,
+        log_dirs_to_create: Optional[abc.Set[str]] = None,
+    ) -> None:
+        """
+        :param log_dirs_to_create: The log directories that should be created before the logging config can be used.
+        """
+        self.formatters = formatters if formatters else {}
+        self.handlers = handlers if handlers else {}
+        self.loggers = loggers if loggers else {}
+        self.root_handlers = root_handlers if root_handlers else set()
+        self.log_dirs_to_create = log_dirs_to_create if log_dirs_to_create else set()
+
+    def ensure_log_dirs(self) -> None:
+        """
+        This method makes sure that the log directories, required by this logging config, are present on disk.
+        The directories are created if they don't exist yet.
+        """
+        for directory in self.log_dirs_to_create:
+            os.makedirs(directory, exist_ok=True)
+
+    def validate_for_extension(self, extension_name: str) -> None:
+        """
+        Verify that the names of the formatters and handlers are prefixed with `<name-extension>_` and
+        raise an Exception in case this constraint is violated.
+        """
+        for logging_config_element in ["formatters", "handlers"]:
+            for name in getattr(self, logging_config_element):
+                if not name.startswith(f"{extension_name}_"):
+                    raise Exception(
+                        f"{logging_config_element.capitalize()} defined in the default logging config of an extension must be"
+                        f" prefixed with `{extension_name}_`. Extension {extension_name} defines a"
+                        f" {logging_config_element[0:-1]} with the invalid name {name}."
+                    )
+
+
+class FullLoggingConfig(LoggingConfigExtension):
+    """
+    A FullLoggingConfig that can be applied on Python's logging framework.
+
+    This class supports only version 1 of Python's dictConfig format.
+    """
+
+    def __init__(
+        self,
+        *,
+        formatters: Optional[abc.Mapping[str, object]] = None,
+        handlers: Optional[abc.Mapping[str, object]] = None,
+        loggers: Optional[abc.Mapping[str, object]] = None,
+        root_handlers: Optional[abc.Set[str]] = None,
+        log_dirs_to_create: Optional[abc.Set[str]] = None,
+        root_log_level: Optional[int | str] = None,
+    ):
+        super().__init__(
+            formatters=formatters,
+            handlers=handlers,
+            loggers=loggers,
+            root_handlers=root_handlers,
+            log_dirs_to_create=log_dirs_to_create,
+        )
+        self.root_log_level = root_log_level
+
+    def join(self, logging_config_extension: LoggingConfigExtension) -> "FullLoggingConfig":
+        """
+        Join this FullLoggingConfig and the given LoggingConfigExtension together into a single
+        FullLoggingConfig object that contains all the logging config of both objects.
+        """
+        common_formatter_names = set(self.formatters.keys()) & set(logging_config_extension.formatters.keys())
+        if common_formatter_names:
+            raise Exception(f"The following formatter names appear in multiple logging configs: {common_formatter_names}")
+        common_handler_names = set(self.handlers.keys()) & set(logging_config_extension.handlers.keys())
+        if common_handler_names:
+            raise Exception(f"The following handler names appear in multiple logging configs: {common_handler_names}")
+        common_logger_names = set(self.loggers.keys()) & set(logging_config_extension.loggers.keys())
+        if common_logger_names:
+            raise Exception(f"The following logger names appear in multiple logging configs: {common_logger_names}")
+        return FullLoggingConfig(
+            formatters=dict(**self.formatters, **logging_config_extension.formatters),
+            handlers=dict(**self.handlers, **logging_config_extension.handlers),
+            loggers=dict(**self.loggers, **logging_config_extension.loggers),
+            root_handlers=set(*self.root_handlers, *logging_config_extension.root_handlers),
+            log_dirs_to_create=set(*self.log_dirs_to_create, *logging_config_extension.log_dirs_to_create),
+            root_log_level=self.root_log_level,
+        )
+
+    def apply_config(self) -> None:
+        """
+        Configure the logging system with this logging config.
+        """
+        self.ensure_log_dirs()
+        dict_config = self._to_dict_config()
+        logging.config.dictConfig(dict_config)
+
+    def _to_dict_config(self) -> dict[str, object]:
+        """
+        Convert this object into a dictionary format that can be passed to logging.config.dictConfig() method
+        to configure logging.
+        """
+        return {
+            "version": 1,
+            "formatters": dict(self.formatters),
+            "handlers": dict(self.handlers),
+            "loggers": dict(self.loggers),
+            "root": {
+                "handlers": self.root_handlers,
+                **({"level": self.root_log_level} if self.root_log_level else {}),
+            },
+            "disable_existing_loggers": False,
+        }
+
+
 class Options(Namespace):
     """
     The Options class provides a way to configure the InmantaLoggerConfig with the following attributes:
@@ -68,7 +199,7 @@ class Options(Namespace):
     - `timed`: if true,  adds the time to the formatter in the log lines.
     """
 
-    log_file: Optional[str]
+    log_file: Optional[str] = None
     log_file_level: str = "INFO"
     verbose: int = 1
     timed: bool = False
@@ -89,10 +220,282 @@ class LoggerMode(enum.Enum):
     OTHER = "other"
 
 
+class LoggingConfigBuilder:
+
+    def get_bootstrap_logging_config(
+        self,
+        stream: TextIO = sys.stdout,
+        logging_config_extensions: Optional[abc.Sequence[LoggingConfigExtension]] = None,
+    ) -> FullLoggingConfig:
+        """
+        This method returns the logging config that should be used between the moment that the process starts,
+        and the moment that the logging-related config options are parsed and applied.
+
+        :param stream: The TextIO stream where the logs will be sent to.
+        :param logging_config_extensions: The logging config required by the extensions.
+        """
+        name_root_handler = "core_console_handler"
+        logging_config_core = FullLoggingConfig(
+            formatters={
+                "core_console_formatter": self._get_multiline_formatter_config(),
+            },
+            handlers={
+                name_root_handler: {
+                    "class": "logging.StreamHandler",
+                    "formatter": "core_console_formatter",
+                    "level": "INFO",
+                    "stream": stream,
+                },
+            },
+            loggers={},
+            root_handlers={name_root_handler},
+            root_log_level="INFO",
+        )
+        logging_config_core.validate_for_extension(extension_name="core")
+        return self._join_logging_configs(logging_config_core, logging_config_extensions)
+
+    def get_logging_config_from_options(
+        self,
+        stream: TextIO,
+        options: Options,
+        logging_config_extensions: Optional[abc.Sequence[LoggingConfigExtension]] = None,
+    ) -> FullLoggingConfig:
+        """
+        Return the logging config based on the given configuration options, passed on the CLI,
+        and the configuration options present in the config file.
+
+        :param stream: The TextIO stream where the logs will be sent to.
+        :param options: The config options passed on the CLI.
+        :param logging_config_extensions: The logging config required by the extensions.
+        """
+        handlers: dict[str, object] = {}
+        handler_root_logger: str
+        log_level: int
+        if options.log_file:
+            log_level = convert_inmanta_log_level(options.log_file_level)
+            handler_root_logger = "core_server_log"
+            handlers[handler_root_logger] = {
+                "class": "logging.handlers.WatchedFileHandler",
+                "level": log_level,
+                "formatter": "core_server_log_formatter",
+                "filename": options.log_file,
+                "mode": "a+",
+            }
+        else:
+            log_level = convert_inmanta_log_level(inmanta_log_level=str(options.verbose), cli=True)
+            handler_root_logger = "core_console"
+            handlers[handler_root_logger] = {
+                "class": "logging.StreamHandler",
+                "formatter": "core_console_formatter",
+                "level": log_level,
+                "stream": stream,
+            }
+
+        full_logging_config = FullLoggingConfig(
+            formatters={
+                # Always add all the formatters, even if they are not used by configuration. This way
+                # the formatters can be used if the user dumps the default logging config to file.
+                "core_resource_action_log_formatter": {
+                    "format": "%(asctime)s %(levelname)-8s %(name)-10s %(message)s",
+                },
+                "core_server_log_formatter": {
+                    "format": "%(asctime)s %(levelname)-8s %(name)-10s %(message)s",
+                },
+                "core_console_formatter": self._get_multiline_formatter_config(options),
+            },
+            handlers={
+                **handlers,
+                "core_resource_action_handler": {
+                    "class": "inmanta.logging.ParametrizedFileHandler",
+                    "level": "DEBUG",
+                    "formatter": "core_resource_action_log_formatter",
+                    "name_parent_logger": const.NAME_RESOURCE_ACTION_LOGGER,
+                    "log_file_template": os.path.join(
+                        config.log_dir.get(), server_config.server_resource_action_log_prefix.get() + "{child_logger_name}.log"
+                    ),
+                },
+                "core_tornado_debug_log_handler": {
+                    "class": "inmanta.logging.TornadoDebugLogHandler",
+                    "level": "DEBUG",
+                },
+            },
+            loggers={
+                const.NAME_RESOURCE_ACTION_LOGGER: {
+                    "level": "DEBUG",
+                    "propagate": True,
+                    "handlers": ["core_resource_action_handler"],
+                },
+                "tornado.general": {
+                    "level": "DEBUG",
+                    "propagate": True,
+                    "handlers": ["core_tornado_debug_log_handler"],
+                },
+            },
+            root_handlers={handler_root_logger},
+            root_log_level=log_level,
+        )
+        full_logging_config.validate_for_extension(extension_name="core")
+        return self._join_logging_configs(full_logging_config, logging_config_extensions)
+
+    def get_logging_config_for_agent(self, log_file: str, inmanta_log_level: str, cli_log: bool) -> FullLoggingConfig:
+        """
+        Returns the logging config for an agent.
+
+        :param log_file: The log file were the logs should be sent to.
+        :param inmanta_log_level: The Inmanta log level threshold, that indicates which log records should be ignored
+                                  and which should be logged. This log level is taking into account for log records sent
+                                  to file and to stderr.
+        :param cli_log: A boolean indicating whether logs should also be sent to stderr or not.
+        """
+        python_log_level: int = convert_inmanta_log_level(inmanta_log_level)
+        cli_handlers = {}
+        name_root_handler = "core_agent_log_handler"
+        root_loggers = {name_root_handler}
+        if cli_log:
+            cli_handlers["core_console_handler"] = {
+                "class": "logging.StreamHandler",
+                "formatter": "core_console_formatter",
+                "level": python_log_level,
+                "stream": "ext://sys.stderr",
+            }
+            root_loggers.add("core_console_handler")
+        full_logging_config = FullLoggingConfig(
+            formatters={
+                # Always add all the formatters, even if they are not used by configuration. This way
+                # the formatters can be used if the user dumps the default logging config to file.
+                "core_agent_log_formatter": {
+                    "format": "%(asctime)s %(levelname)-8s %(name)-10s %(message)s",
+                },
+                "core_console_formatter": self._get_multiline_formatter_config(),
+            },
+            handlers={
+                name_root_handler: {
+                    "class": "logging.handlers.WatchedFileHandler",
+                    "level": python_log_level,
+                    "formatter": "core_agent_log_formatter",
+                    "filename": log_file,
+                    "mode": "a+",
+                },
+                **cli_handlers,
+            },
+            loggers={},
+            root_handlers=root_loggers,
+            root_log_level=python_log_level,
+        )
+        full_logging_config.validate_for_extension(extension_name="core")
+        return full_logging_config
+
+    def _join_logging_configs(
+        self,
+        full_logger_config: FullLoggingConfig,
+        logging_config_extensions: Optional[abc.Sequence[LoggingConfigExtension]] = None,
+    ) -> FullLoggingConfig:
+        """
+        Join the given LoggingConfigCore and the LoggingConfigExtensions together into a single LoggingConfigCore
+        object that contains all the loging config.
+        """
+        logging_config_extensions = logging_config_extensions if logging_config_extensions else []
+        result = full_logger_config
+        for logging_config_ext in logging_config_extensions:
+            result = result.join(logging_config_ext)
+        return result
+
+    def _get_multiline_formatter_config(self, options: Optional[Options] = None) -> dict[str, object]:
+        """
+        Returns the dict-based formatter config for logs that will be sent to the console.
+
+        :param options: The config options requested by the user or None if the config options are not parsed yet and
+                        the bootstrap_logger_config should be used.
+        """
+        # Use a shorter space padding if we know that we will use short names as the logger name.
+        # Otherwise the log records contains too much white spaces.
+        space_padding_after_logger_name = (
+            15
+            if (
+                options
+                and not options.keep_logger_names
+                and hasattr(options, "func")
+                and options.func.__name__ in ["compile_project", "export"]
+            )
+            else 25
+        )
+        log_format = "%(asctime)s " if options and options.timed else ""
+        if _is_on_tty():
+            log_format += f"%(log_color)s%(name)-{space_padding_after_logger_name}s%(levelname)-8s%(reset)s%(blue)s%(message)s"
+            log_colors = {"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}
+        else:
+            log_format += f"%(name)-{space_padding_after_logger_name}s%(levelname)-8s%(message)s"
+            log_colors = None
+
+        return {
+            "()": "inmanta.logging.MultiLineFormatter",
+            "fmt": log_format,
+            "log_colors": log_colors,
+            "reset": _is_on_tty(),
+            "no_color": not _is_on_tty(),
+            "keep_logger_names": options.keep_logger_names if options else False,
+        }
+
+
+def convert_inmanta_log_level(inmanta_log_level: str, cli: bool = False) -> int:
+    """
+    Convert the given Inmanta log level to the corresponding Python log level.
+
+    :param inmanta_log_level: The inmanta logging level
+    :param cli: True if the logs will be outputted to the CLI.
+    :return: python log level
+    """
+    # maximum of 4 v's
+    if inmanta_log_level.isdigit() and int(inmanta_log_level) > 4:
+        inmanta_log_level = "4"
+    # The minimal log level on the CLI is always WARNING
+    if cli and (inmanta_log_level == "ERROR" or (inmanta_log_level.isdigit() and int(inmanta_log_level) < 1)):
+        inmanta_log_level = "WARNING"
+    # Converts the Inmanta log level to the Python log level
+    python_log_level = log_levels[inmanta_log_level]
+    return python_log_level
+
+
+class LoggerModeManager:
+    """
+    A singleton that keeps track of the current LoggerMode.
+    """
+
+    _instance: Optional["LoggerModeManager"] = None
+
+    def __init__(self) -> None:
+        self._logger_mode = LoggerMode.OTHER
+
+    def get_logger_mode(self) -> LoggerMode:
+        """
+        Returns the current logger mode.
+        """
+        return self._logger_mode
+
+    @contextmanager
+    def run_in_logger_mode(self, logger_mode: LoggerMode) -> Iterator[None]:
+        """
+        A contextmanager that can be used to temporarily change the LoggerMode within a code block.
+        This ContextManager updates the LoggerModeManager singleton and is therefore not async- or threadsafe.
+        """
+        prev_logger_mode = self._logger_mode
+        self._logger_mode = logger_mode
+        try:
+            yield
+        finally:
+            self._logger_mode = prev_logger_mode
+
+    @classmethod
+    def get_instance(cls) -> "LoggerModeManager":
+        if cls._instance is None:
+            cls._instance = LoggerModeManager()
+        return cls._instance
+
+
 @stable_api
 class InmantaLoggerConfig:
     """
-    A class that provides logging functionality for Inmanta projects.
+    This class is the entry-point for configuring the Python logging framework.
 
     Usage:
     To use this class, you first need to call the `get_instance`. This method takes a `stream` argument
@@ -103,11 +506,6 @@ class InmantaLoggerConfig:
 
     The setup is not done in one step as we want logs for the cmd_parser, which will provide the options needed to configure
     the 'final' logger with `apply_options`.
-
-    for more fine-grained configuration the following functions can be used as well:
-        - `set_log_level`
-        - `set_log_formatter`
-        - `set_logfile_location`
     """
 
     _instance: Optional["InmantaLoggerConfig"] = None
@@ -116,74 +514,13 @@ class InmantaLoggerConfig:
         """
         Set up the logging handler for Inmanta
 
-        :param stream: The stream to send log messages to. Default is standard output (sys.stdout).
+        :param stream: The TextIO stream where the logs will be sent to.
         """
-        self._options_applied = False
-        self._keep_logger_names = False
-        self._handler: logging.Handler = logging.StreamHandler(stream=stream)
-        self.set_log_level("INFO")
-        formatter = self._get_log_formatter_for_stream_handler(timed=False)
-        self.set_log_formatter(formatter)
-
-        self._logger_mode = LoggerMode.OTHER
-
-        logging.root.handlers = []
-        logging.root.addHandler(self._handler)
-
-        self._inmanta_plugin_pkg_regex = re.compile(r"^inmanta_plugins\.(?P<module_name>[^.]+)")
-        # Regex that extracts the name of the module from a fully qualified import of a Python
-        # module inside an Inmanta module.
-
-    def wrap_record(self, record: logging.LogRecord) -> logging.LogRecord:
-        """
-        Wrap a log record to perform renaming for specific formatter as determined by the _logger_mode
-
-        This is derived from the way the colorlog.ColoredFormatter works
-        """
-        old_name = record.name
-        new_name = self._get_logger_name_for(old_name)
-        if old_name == new_name:
-            return record
-        attributes = dict(record.__dict__)
-        attributes["name"] = new_name
-        return logging.makeLogRecord(attributes)
-
-    def _get_logger_name_for(self, logger_name: str) -> str:
-        """
-        Returns the logger name that should be used in the log record.
-
-        :attr logger_name: The name of the logger that was used to create the log record.
-        """
-        if not self._keep_logger_names and self._logger_mode in [LoggerMode.COMPILER, LoggerMode.EXPORTER]:
-            if not logger_name.startswith("inmanta"):
-                # This is a log record from a third-party library. Don't adjust the logger name.
-                return logger_name
-            if logger_name == "inmanta.pip":
-                # Log record created by a pip subprocess started by the inmanta.
-                return "pip"
-            match: Optional[re.Match[str]] = self._inmanta_plugin_pkg_regex.match(logger_name)
-            if match:
-                # Log record created by an Inmanta module.
-                return match.groupdict()["module_name"]
-            else:
-                # Log record created by Inmanta code.
-                return self._logger_mode.value
-        else:
-            # Don't modify the logger name
-            return logger_name
-
-    @contextmanager
-    def run_in_logger_mode(self, logger_mode: LoggerMode) -> Iterator[None]:
-        """
-        A contextmanager that can be used to temporarily change the LoggerMode within a code block.
-        This ContextManager updates the InmantaLoggerConfig singleton and is therefore not async- or threadsafe.
-        """
-        prev_logger_mode = self._logger_mode
-        self._logger_mode = logger_mode
-        try:
-            yield
-        finally:
-            self._logger_mode = prev_logger_mode
+        log_config: FullLoggingConfig = LoggingConfigBuilder().get_bootstrap_logging_config(stream)
+        self._stream = stream
+        self._handlers: abc.Sequence[logging.Handler] = self._apply_logging_config(log_config)
+        self._options_applied: bool = False
+        self._logging_configs_extensions: list[LoggingConfigExtension] = []
 
     @classmethod
     def get_current_instance(cls) -> "InmantaLoggerConfig":
@@ -204,9 +541,11 @@ class InmantaLoggerConfig:
         :param stream: The stream to send log messages to. Default is standard output (sys.stdout)
         """
         if cls._instance:
-            if not isinstance(cls._instance._handler, logging.StreamHandler):
+            if len(cls._instance._handlers) != 1:
+                raise Exception("More than one root handler configured.")
+            if not isinstance(cls._instance._handlers[0], logging.StreamHandler):
                 raise Exception("Instance already exists with a different handler")
-            elif isinstance(cls._instance._handler, logging.StreamHandler) and cls._instance._handler.stream != stream:
+            elif isinstance(cls._instance._handlers[0], logging.StreamHandler) and cls._instance._handlers[0].stream != stream:
                 raise Exception("Instance already exists with a different stream")
         else:
             cls._instance = cls(stream)
@@ -217,17 +556,20 @@ class InmantaLoggerConfig:
     def clean_instance(cls) -> None:
         """
         This method should be used to clean up an instance of this class
-
         """
-        if cls._instance and cls._instance._handler:
-            cls._instance._handler.close()
-            logging.root.removeHandler(cls._instance._handler)
+        for handler in logging.root.handlers:
+            # File-based handlers automatically re-open after close() if log records are written to them.
+            # As such, we explicitly remove the handler from the root logger here.
+            logging.root.removeHandler(handler)
+            handler.flush()
+            handler.close()
+        logging.shutdown()
         cls._instance = None
 
     @stable_api
     def apply_options(self, options: Options) -> None:
         """
-        Apply the logging options to the current handler. A handler should have been created before
+        Apply the given logging options.
 
         :param options: The Option object coming from the command line. This function uses the following
             attributes: log_file, log_file_level, verbose, timed
@@ -235,107 +577,77 @@ class InmantaLoggerConfig:
         if self._options_applied:
             raise Exception("Options can only be applied once to a handler.")
         self._options_applied = True
-        self._keep_logger_names = options.keep_logger_names
-        if options.log_file:
-            self.set_logfile_location(options.log_file)
-            formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s")
-            self.set_log_formatter(formatter)
-            self.set_log_level(options.log_file_level, cli=False)
-        else:
-            # Use a shorter space padding if we know that we will use short names as the logger name.
-            # Otherwise the log records contains too much white spaces.
-            space_padding_after_logger_name = (
-                15
-                if (
-                    not options.keep_logger_names
-                    and hasattr(options, "func")
-                    and options.func.__name__ in ["compile_project", "export"]
-                )
-                else 25
-            )
-            formatter = self._get_log_formatter_for_stream_handler(
-                timed=options.timed, space_padding_after_logger_name=space_padding_after_logger_name
-            )
-            self.set_log_formatter(formatter)
-            self.set_log_level(str(options.verbose))
+        config_builder = LoggingConfigBuilder()
+        logging_config: FullLoggingConfig = config_builder.get_logging_config_from_options(
+            self._stream, options, self._logging_configs_extensions
+        )
+        self._handlers = self._apply_logging_config(logging_config)
+
+    def _apply_logging_config(self, logging_config: FullLoggingConfig) -> abc.Sequence[logging.Handler]:
+        """
+        Apply the given logging_config as the current configuration of the logging system.
+
+        This method assume that the given config defines a single root handler.
+        """
+        logging_config.apply_config()
+        return logging.root.handlers
 
     @stable_api
     def set_log_level(self, inmanta_log_level: str, cli: bool = True) -> None:
         """
-        Set the logging level. A handler should have been created before.
+        [DEPRECATED] Set the logging level. A handler should have been created before.
         The possible inmanta log levels and their associated python log level
         are defined in the inmanta.logging.log_levels dictionary.
 
         :param inmanta_log_level: The inmanta logging level
         :param cli: True if the logs will be outputted to the CLI.
         """
-        # maximum of 4 v's
-        if inmanta_log_level.isdigit() and int(inmanta_log_level) > 4:
-            inmanta_log_level = "4"
-
-        # The minimal log level on the CLI is always WARNING
-        if cli and (inmanta_log_level == "ERROR" or (inmanta_log_level.isdigit() and int(inmanta_log_level) < 1)):
-            inmanta_log_level = "WARNING"
-
-        # Converts the Inmanta log level to the Python log level
-        python_log_level = log_levels[inmanta_log_level]
-        self._handler.setLevel(python_log_level)
+        python_log_level = convert_inmanta_log_level(inmanta_log_level, cli)
+        for handler in self._handlers:
+            handler.setLevel(python_log_level)
         logging.root.setLevel(python_log_level)
 
     @stable_api
     def set_log_formatter(self, formatter: logging.Formatter) -> None:
         """
-        Set the log formatter. A handler should have been created before
+        [DEPRECATED] Set the log formatter. A handler should have been created before
 
         :param formatter: The log formatter.
         """
-        self._handler.setFormatter(formatter)
+        for handler in self._handlers:
+            handler.setFormatter(formatter)
 
     @stable_api
     def set_logfile_location(self, location: str) -> None:
         """
-        Set the location of the log file. Be careful that this function will replace the current handler with a new one
-        This means that configurations done on the previous handler will be lost.
+        [DEPRECATED] Set the location of the log file. Be careful that this function will replace the current handler
+        with a new one. This means that configurations done on the previous handler will be lost.
 
         :param location: The location of the log file.
         """
         file_handler = logging.handlers.WatchedFileHandler(filename=location, mode="a+")
-        if self._handler:
-            self._handler.close()
-            logging.root.removeHandler(self._handler)
-        self._handler = file_handler
-        logging.root.addHandler(self._handler)
+        for handler in self._handlers:
+            handler.close()
+            logging.root.removeHandler(handler)
+        self._handlers = [file_handler]
+        logging.root.addHandler(file_handler)
 
     @stable_api
     def get_handler(self) -> logging.Handler:
         """
-        Get the logging handler
+        [DEPRECATED] Get the logging handler
 
         :return: The logging handler
         """
-        return self._handler
+        assert len(self._handlers) == 1, "This could happen if this method is used in combination with the caplog fixture."
+        return self._handlers[0]
 
-    def _get_log_formatter_for_stream_handler(
-        self, timed: bool, space_padding_after_logger_name: int = 25
-    ) -> logging.Formatter:
-        log_format = "%(asctime)s " if timed else ""
-        if _is_on_tty():
-            log_format += f"%(log_color)s%(name)-{space_padding_after_logger_name}s%(levelname)-8s%(reset)s%(blue)s%(message)s"
-            formatter = MultiLineFormatter(
-                self,
-                log_format,
-                reset=True,
-                log_colors={"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"},
-            )
-        else:
-            log_format += f"%(name)-{space_padding_after_logger_name}s%(levelname)-8s%(message)s"
-            formatter = MultiLineFormatter(
-                self,
-                log_format,
-                reset=False,
-                no_color=True,
-            )
-        return formatter
+    @stable_api
+    def register_default_logging_config(self, logging_config: LoggingConfigExtension) -> None:
+        """
+        Register the default logging config for a certain extension.
+        """
+        self._logging_configs_extensions.append(logging_config)
 
 
 class MultiLineFormatter(colorlog.ColoredFormatter):
@@ -346,15 +658,19 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
     span multiple lines.
     """
 
+    inmanta_plugin_pkg_regex = re.compile(r"^inmanta_plugins\.(?P<module_name>[^.]+)")
+    # Regex that extracts the name of the module from a fully qualified import of a Python
+    # module inside an Inmanta module.
+
     def __init__(
         self,
-        logger_config: InmantaLoggerConfig,
         fmt: Optional[str] = None,
         *,
         # keep interface minimal: only include fields we actually use
         log_colors: Optional[LogColors] = None,
         reset: bool = True,
         no_color: bool = False,
+        keep_logger_names: bool,
     ):
         """
         Initialize a new `MultiLineFormatter` instance.
@@ -363,10 +679,14 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
         :param log_colors: Optional `LogColors` object mapping log level names to color codes.
         :param reset: Boolean indicating whether to reset terminal colors at the end of each log record.
         :param no_color: Boolean indicating whether to disable colors in the output.
+        :param keep_logger_names: Display the log messages using the name of the logger that created the log message,
+                                  instead of the component of the compiler that was executing while the log record was created
+                                  or the name of the module that created the log message.
         """
         super().__init__(fmt, log_colors=log_colors, reset=reset, no_color=no_color)
-        self._logger_config = logger_config
         self.fmt = fmt
+        self._keep_logger_names = keep_logger_names
+        self._logger_mode_manager = LoggerModeManager.get_instance()
 
     def get_header_length(self, record: logging.LogRecord) -> int:
         """
@@ -402,7 +722,128 @@ class MultiLineFormatter(colorlog.ColoredFormatter):
         :param record: The `logging.LogRecord` object to format.
         :return: The formatted log record as a string.
         """
-        record = self._logger_config.wrap_record(record)
+        record = self._wrap_record(record)
         indent: str = " " * self.get_header_length(record)
         head, *tail = super().format(record).splitlines(True)
         return head + "".join(indent + line for line in tail)
+
+    def _wrap_record(self, record: logging.LogRecord) -> logging.LogRecord:
+        """
+        Wrap a log record to perform renaming for specific formatter as determined by the _logger_mode
+
+        This is derived from the way the colorlog.ColoredFormatter works
+        """
+        old_name = record.name
+        new_name = self._get_logger_name_for(old_name)
+        if old_name == new_name:
+            return record
+        attributes = dict(record.__dict__)
+        attributes["name"] = new_name
+        return logging.makeLogRecord(attributes)
+
+    def _get_logger_name_for(self, logger_name: str) -> str:
+        """
+        Returns the logger name that should be used in the log record.
+
+        :attr logger_name: The name of the logger that was used to create the log record.
+        """
+        logger_mode = self._logger_mode_manager.get_logger_mode()
+        if not self._keep_logger_names and logger_mode in [LoggerMode.COMPILER, LoggerMode.EXPORTER]:
+            if not logger_name.startswith("inmanta"):
+                # This is a log record from a third-party library. Don't adjust the logger name.
+                return logger_name
+            if logger_name == "inmanta.pip":
+                # Log record created by a pip subprocess started by the inmanta.
+                return "pip"
+            match: Optional[re.Match[str]] = self.inmanta_plugin_pkg_regex.match(logger_name)
+            if match:
+                # Log record created by an Inmanta module.
+                return match.groupdict()["module_name"]
+            else:
+                # Log record created by Inmanta code.
+                return logger_mode.value
+        else:
+            # Don't modify the logger name
+            return logger_name
+
+
+@stable_api
+class ParametrizedFileHandler(logging.Handler):
+    """
+    A file handler that writes to different files based on the last part of the logger name.
+    """
+
+    def __init__(self, name_parent_logger: str, log_file_template: str) -> None:
+        """
+        :param name_parent_logger: The log records created by children of this logger will be written to file by this handler.
+                                   This handler will ignore log records created by any other logger.
+        :param log_file_template: A template for the path to the log file. This is an f-string that holds the parameter
+                                  `child_logger_name`. This part will be replaced by the name of the direct child of
+                                  self.name_parent_logger that belongs to the logger that created the record.
+        """
+        super().__init__()
+        self.name_parent_logger = name_parent_logger
+        self.log_file_template: str = log_file_template
+        self.child_handlers: dict[str, handlers.WatchedFileHandler] = {}
+
+    def flush(self) -> None:
+        for child in self.child_handlers.values():
+            child.flush()
+
+    def setFormatter(self, fmt: Optional[logging.Formatter]) -> None:
+        super().setFormatter(fmt)
+        for child in self.child_handlers.values():
+            child.setFormatter(fmt)
+
+    def setLevel(self, level: str | int) -> None:
+        super().setLevel(level)
+        for child in self.child_handlers.values():
+            child.setLevel(level)
+
+    def close(self) -> None:
+        for child in self.child_handlers.values():
+            child.close()
+        self.child_handlers = {}
+        super().close()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if not record.name.startswith(f"{self.name_parent_logger}."):
+            return
+        logger_name_without_parent_prefix = record.name.removeprefix(f"{self.name_parent_logger}.")
+        logger_name_direct_child_of_parent_logger = logger_name_without_parent_prefix.split(".")[0]
+        path_logfile = self.log_file_template.format(child_logger_name=logger_name_direct_child_of_parent_logger)
+        if path_logfile not in self.child_handlers:
+            try:
+                handler = logging.handlers.WatchedFileHandler(filename=path_logfile, mode="a+")
+            except FileNotFoundError:
+                log_dir = os.path.dirname(self.log_file_template)
+                if not os.path.exists(log_dir):
+                    LOGGER.warning(
+                        "Cannot write to resource action log, because directory %s doesn't exist.",
+                        path_logfile,
+                    )
+                else:
+                    LOGGER.exception("Failed to write to resource action log file.")
+                return
+            handler.setFormatter(self.formatter)
+            handler.setLevel(self.level)
+            self.child_handlers[path_logfile] = handler
+        self.child_handlers[path_logfile].emit(record)
+
+
+class TornadoDebugLogHandler(logging.Handler):
+    """
+    A custom log handler for Tornados 'max_clients limit reached' debug logs.
+    """
+
+    def __init__(self, level: int = logging.NOTSET) -> None:
+        super().__init__(level)
+        self.logger = logging.getLogger("inmanta.protocol.endpoints")
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if (
+            record.levelno == logging.DEBUG
+            and record.name.startswith("tornado.general")
+            and record.msg.startswith("max_clients limit reached")
+        ):
+            self.logger.warning(record.msg)  # Log Tornado log as inmanta warnings

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -37,23 +37,6 @@ from . import common
 from .rest import client
 
 LOGGER: logging.Logger = logging.getLogger(__name__)
-TORNADO_LOGGER: logging.Logger = logging.getLogger("tornado.general")
-TORNADO_LOGGER.setLevel(logging.DEBUG)
-
-
-# Create a custom log handler for Tornados 'max_clients limit reached' debug logs
-class TornadoDebugLogHandler(logging.Handler):
-    def emit(self, record: logging.LogRecord) -> None:
-        if (
-            record.levelno == logging.DEBUG
-            and record.name.startswith("tornado.general")
-            and record.msg.startswith("max_clients limit reached")
-        ):
-            LOGGER.warning(record.msg)  # Log Tornado log as inmanta warnings
-
-
-tornado_logger = TornadoDebugLogHandler()
-TORNADO_LOGGER.addHandler(tornado_logger)
 
 
 class CallTarget:

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -27,6 +27,7 @@ from typing import Optional
 
 import asyncpg
 
+from inmanta import logging as inmanta_logging
 from inmanta.const import EXTENSION_MODULE, EXTENSION_NAMESPACE
 from inmanta.server import config
 from inmanta.server.extensions import ApplicationContext, FeatureManager, InvalidSliceNameException
@@ -64,6 +65,14 @@ class ConstrainedApplicationContext(ApplicationContext):
     def set_feature_manager(self, feature_manager: FeatureManager) -> None:
         self.parent.set_feature_manager(feature_manager)
 
+    def register_default_logging_config(self, logging_config: inmanta_logging.LoggingConfigExtension) -> None:
+        """
+        Used by an Inmanta extension to register the default configuration of specific loggers, formatters
+        and handlers it uses. The names of the formatters and handlers must be prefixed with `<name-extension>_`.
+        """
+        logging_config.validate_for_extension(self.namespace)
+        self.parent.register_default_logging_config(logging_config)
+
 
 @stable_api
 class InmantaBootloader:
@@ -77,10 +86,18 @@ class InmantaBootloader:
     # Cache field for available extensions
     AVAILABLE_EXTENSIONS: Optional[dict[str, str]] = None
 
-    def __init__(self) -> None:
+    def __init__(self, configure_logging: bool = False) -> None:
+        """
+        :param configure_logging: This config option is used by the tests to configure the logging framework.
+                                  In normal execution, the logging framework is configured by the app.py
+        """
         self.restserver = Server()
         self.started = False
         self.feature_manager: Optional[FeatureManager] = None
+
+        if configure_logging:
+            inmanta_logger_config = inmanta_logging.InmantaLoggerConfig.get_instance()
+            inmanta_logger_config.apply_options(inmanta_logging.Options())
 
     async def start(self) -> None:
         db_wait_time: int = config.db_wait_time.get()

--- a/src/inmanta/server/extensions.py
+++ b/src/inmanta/server/extensions.py
@@ -25,6 +25,7 @@ import pkg_resources
 import yaml
 
 from inmanta import data
+from inmanta import logging as inmanta_logging
 from inmanta.config import feature_file_config
 from inmanta.data.model import ExtensionStatus
 from inmanta.server.protocol import ServerSlice
@@ -226,3 +227,11 @@ class ApplicationContext:
         Returns the list of all available environment settings
         """
         return sorted(data.Environment._settings.values(), key=lambda x: x.name)
+
+    def register_default_logging_config(self, logging_config: inmanta_logging.LoggingConfigExtension) -> None:
+        """
+        Used by an Inmanta extension to register the default configuration of specific loggers, formatters
+        and handlers it uses.
+        """
+        inmanta_logger_config = inmanta_logging.InmantaLoggerConfig.get_current_instance()
+        inmanta_logger_config.register_default_logging_config(logging_config)

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -531,7 +531,6 @@ class EnvironmentService(protocol.ServerSlice):
                 await self._delete_environment_dir(environment_id)
                 await env.delete_cascade(connection=connection)
 
-            self.resource_service.close_resource_action_logger(environment_id)
             await self.notify_listeners(EnvironmentAction.deleted, env.to_dto())
 
     @handle(methods_v2.environment_clear, env="id")

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -112,7 +112,6 @@ class ProjectService(protocol.ServerSlice):
         environments = await data.Environment.get_list(project=project.id)
         for env in environments:
             await asyncio.gather(self.autostarted_agent_manager.stop_agents(env, delete_venv=True), env.delete_cascade())
-            self.resource_service.close_resource_action_logger(env.id)
 
         await project.delete()
 

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -19,7 +19,6 @@
 import asyncio
 import datetime
 import logging
-import os
 import re
 import uuid
 from collections import abc, defaultdict
@@ -31,7 +30,7 @@ from asyncpg.exceptions import UniqueViolationError
 from pydantic import ValidationError
 from tornado.httputil import url_concat
 
-from inmanta import config, const, data, util
+from inmanta import const, data, util
 from inmanta.const import STATE_UPDATE, TERMINAL_STATES, TRANSIENT_STATES, VALID_STATES_ON_STATE_UPDATE, Change, ResourceState
 from inmanta.data import APILIMIT, InvalidSort
 from inmanta.data.dataview import (
@@ -120,9 +119,6 @@ class ResourceService(protocol.ServerSlice):
     def __init__(self) -> None:
         super().__init__(SLICE_RESOURCE)
 
-        self._resource_action_loggers: dict[uuid.UUID, logging.Logger] = {}
-        self._resource_action_handlers: dict[uuid.UUID, logging.Handler] = {}
-
         # Dict: environment_id: (model_version, increment, negative_increment, negative_increment_per_agent, run_ahead_lock)
         self._increment_cache: dict[
             uuid.UUID,
@@ -138,6 +134,7 @@ class ResourceService(protocol.ServerSlice):
         ] = {}
         # lock to ensure only one inflight request
         self._increment_cache_locks: dict[uuid.UUID, asyncio.Lock] = defaultdict(lambda: asyncio.Lock())
+        self._resource_action_logger = logging.getLogger(const.NAME_RESOURCE_ACTION_LOGGER)
 
     def get_dependencies(self) -> list[str]:
         return [SLICE_DATABASE, SLICE_AGENT_MANAGER]
@@ -160,68 +157,17 @@ class ResourceService(protocol.ServerSlice):
 
     async def stop(self) -> None:
         await super().stop()
-        self._close_resource_action_loggers()
 
     def clear_env_cache(self, env: data.Environment) -> None:
         LOGGER.log(const.LOG_LEVEL_TRACE, "Clearing cache for %s", env.id)
         self._increment_cache[env.id] = None
 
-    @staticmethod
-    def get_resource_action_log_file(environment: uuid.UUID) -> str:
-        """Get the correct filename for the given environment
-        :param environment: The environment id to get the file for
-        :return: The path to the logfile
-        """
-        return os.path.join(config.log_dir.get(), opt.server_resource_action_log_prefix.get() + str(environment) + ".log")
-
     def get_resource_action_logger(self, environment: uuid.UUID) -> logging.Logger:
-        """Get the resource action logger for the given environment. If the logger was not created, create it.
+        """Get the resource action logger for the given environment.
         :param environment: The environment to get a logger for
         :return: The logger for the given environment.
         """
-        if environment in self._resource_action_loggers:
-            return self._resource_action_loggers[environment]
-
-        resource_action_log = self.get_resource_action_log_file(environment)
-
-        file_handler = logging.handlers.WatchedFileHandler(filename=resource_action_log, mode="a+")
-        # Most logs will come from agents. We need to use their level and timestamp and their formatted message
-        file_handler.setFormatter(logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(name)-10s %(message)s"))
-        file_handler.setLevel(logging.DEBUG)
-
-        resource_action_logger = logging.getLogger(const.NAME_RESOURCE_ACTION_LOGGER).getChild(str(environment))
-        resource_action_logger.setLevel(logging.DEBUG)
-        resource_action_logger.addHandler(file_handler)
-
-        self._resource_action_loggers[environment] = resource_action_logger
-        self._resource_action_handlers[environment] = file_handler
-
-        return resource_action_logger
-
-    def _close_resource_action_loggers(self) -> None:
-        """Close all resource action loggers and their associated handlers"""
-        try:
-            while True:
-                env, logger = self._resource_action_loggers.popitem()
-                self.close_resource_action_logger(env, logger)
-        except KeyError:
-            pass
-
-    def close_resource_action_logger(self, env: uuid.UUID, logger: Optional[logging.Logger] = None) -> None:
-        """Close the given logger for the given env.
-        :param env: The environment to close the logger for
-        :param logger: The logger to close, if the logger is none it is retrieved
-        """
-        if logger is None:
-            if env in self._resource_action_loggers:
-                logger = self._resource_action_loggers.pop(env)
-            else:
-                return
-
-        handler = self._resource_action_handlers.pop(env)
-        logger.removeHandler(handler)
-        handler.flush()
-        handler.close()
+        return self._resource_action_logger.getChild(str(environment))
 
     def log_resource_action(
         self, env: uuid.UUID, resource_ids: Sequence[str], log_level: int, ts: datetime.datetime, message: str

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -249,7 +249,7 @@ async def test_server_restart(
     resource_container.Provider.set("agent1", "key3", "value")
 
     await asyncio.wait_for(server.stop(), timeout=15)
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=False)
     server = ibl.restserver
     async_finalizer.add(agent.stop)
     async_finalizer.add(partial(ibl.stop, timeout=15))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,13 @@
     Contact: code@inmanta.com
 """
 
+import logging.config
 import warnings
 
 from tornado.httpclient import AsyncHTTPClient
 
 import toml
+from inmanta import logging as inmanta_logging
 from inmanta.logging import InmantaLoggerConfig
 from inmanta.protocol import auth
 
@@ -800,7 +802,7 @@ async def server(server_pre_start) -> abc.AsyncIterator[Server]:
     # fix for fact that pytest_tornado never set IOLoop._instance, the IOLoop of the main thread
     # causes handler failure
 
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=True)
 
     try:
         await ibl.start()
@@ -887,7 +889,7 @@ async def server_multi(
         config.Config.set("server", "agent-timeout", "2")
         config.Config.set("agent", "agent-repair-interval", "0")
 
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
 
         try:
             await ibl.start()
@@ -1801,7 +1803,7 @@ async def migrate_db_from(
         await PGRestore(fh.readlines(), postgresql_client).run()
         logger.debug("Restored %s", marker.args[0])
 
-    bootloader: InmantaBootloader = InmantaBootloader()
+    bootloader: InmantaBootloader = InmantaBootloader(configure_logging=True)
 
     async def migrate() -> None:
         # start boatloader, triggering db migration
@@ -1875,6 +1877,23 @@ async def set_running_tests():
     Ensure the RUNNING_TESTS variable is True when running tests
     """
     inmanta.RUNNING_TESTS = True
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def dont_override_root_logger(request, monkeypatch):
+    """
+    Make sure the inmanta.logging.FullLoggingConfig._to_dict_config() method doesn't override the root logger
+    when the caplog fixture is used, because caplog captures log messages by attaching a handler to the root logger.
+    """
+    original_to_dict_config_method = inmanta_logging.FullLoggingConfig._to_dict_config
+
+    def _to_dict_config_patched(self) -> dict[str, object]:
+        dict_config = original_to_dict_config_method(self)
+        dict_config.pop("root", None)
+        return dict_config
+
+    if "caplog" in request.fixturenames:
+        monkeypatch.setattr(inmanta_logging.FullLoggingConfig, "_to_dict_config", _to_dict_config_patched)
 
 
 @pytest.fixture(scope="session")

--- a/tests/db/migration_tests/test_v202211230_to_v202212010.py
+++ b/tests/db/migration_tests/test_v202211230_to_v202212010.py
@@ -38,7 +38,7 @@ async def migrate_v202211230_to_v202212010(
     with open(os.path.join(os.path.dirname(__file__), "dumps/v202211230.sql")) as fh:
         await PGRestore(fh.readlines(), postgresql_client).run()
 
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=True)
 
     # When the bootloader is started, it also executes the migration to v202212010
     yield ibl.start

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1237,7 +1237,7 @@ async def test_compileservice_queue_count_on_trx_based_api(mocked_compiler_servi
 async def server_with_frequent_cleanups(server_pre_start, server_config, async_finalizer):
     config.Config.set("server", "compiler-report-retention", "60")
     config.Config.set("server", "cleanup-compiler-reports_interval", "1")
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=True)
     await ibl.start()
     yield ibl.restserver
     await ibl.stop(timeout=15)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -108,7 +108,7 @@ async def startable_server(server_config):
     """
     This fixture returns the bootloader of a server which is not yet started.
     """
-    bootloader = InmantaBootloader()
+    bootloader = InmantaBootloader(configure_logging=True)
     yield bootloader
     try:
         await bootloader.stop(timeout=15)

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1339,7 +1339,7 @@ async def test_heartbeat_different_session(server_pre_start, async_finalizer, ca
 
     server = TestSlice(name="test_slice")
 
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=True)
     ctx = ibl.load_slices()
 
     for mypart in ctx.get_slices():

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -64,7 +64,7 @@ def test_discover_and_load():
     with splice_extension_in("test_module_path"):
         config.server_enabled_extensions.set("testplugin")
 
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
         print("plugins: ", ibl._discover_plugin_packages())
 
         assert "inmanta_ext.testplugin" in ibl._discover_plugin_packages()
@@ -82,7 +82,7 @@ def test_discover_and_load():
 
 def test_phase_1(caplog):
     with splice_extension_in("test_module_path"):
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
 
         config.server_enabled_extensions.set("testplugin,noext")
 
@@ -105,7 +105,7 @@ def test_phase_2():
     with splice_extension_in("test_module_path"):
         import inmanta_ext.testplugin.extension
 
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
         all = {"testplugin": inmanta_ext.testplugin.extension}
 
         ctx = ibl._collect_slices(all)
@@ -144,7 +144,7 @@ def test_phase_3():
 
 def test_end_to_end():
     with splice_extension_in("test_module_path"):
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
 
         config.server_enabled_extensions.set("testplugin")
 
@@ -157,7 +157,7 @@ def test_end_to_end_2():
     with splice_extension_in("bad_module_path"):
         config.server_enabled_extensions.set("badplugin")
 
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
         all = ibl._load_extensions()
         print(all)
         assert "badplugin" in all
@@ -171,7 +171,7 @@ async def test_startup_failure(async_finalizer, server_config):
     with splice_extension_in("bad_module_path"):
         config.server_enabled_extensions.set("badplugin")
 
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
         async_finalizer.add(partial(ibl.stop, timeout=15))
         with pytest.raises(Exception) as e:
             await ibl.start()
@@ -188,7 +188,7 @@ def test_load_and_filter(caplog):
     caplog.set_level(logging.INFO)
 
     with splice_extension_in("test_module_path"):
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
 
         plugin_pkgs = ibl._discover_plugin_packages()
         assert "inmanta_ext.core" in plugin_pkgs
@@ -263,7 +263,7 @@ async def test_custom_feature_manager(
         config.Config.set("server", "bind-address", "127.0.0.1")
         config.server_enabled_extensions.set("testfm")
 
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
         async_finalizer.add(partial(ibl.stop, timeout=15))
         await ibl.start()
         server = ibl.restserver
@@ -279,6 +279,6 @@ async def test_register_setting() -> None:
     Test registering a new setting.
     """
     with splice_extension_in("test_load_env_setting"):
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
         ibl.load_slices(load_all_extensions=True, only_register_environment_settings=True)
         assert "test" in data.Environment._settings

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,7 +42,6 @@ from inmanta.server import (
     SLICE_AGENT_MANAGER,
     SLICE_AUTOSTARTED_AGENT_MANAGER,
     SLICE_ORCHESTRATION,
-    SLICE_RESOURCE,
     SLICE_SERVER,
     SLICE_SESSION_MANAGER,
 )
@@ -852,7 +851,7 @@ async def test_resource_action_log(server, client, environment):
     )
     assert res.code == 200
 
-    resource_action_log = server.get_slice(SLICE_RESOURCE).get_resource_action_log_file(environment)
+    resource_action_log = os.path.join(config.log_dir.get(), f"{opt.server_resource_action_log_prefix.get()}{environment}.log")
     assert os.path.isfile(resource_action_log)
     assert os.stat(resource_action_log).st_size != 0
     with open(resource_action_log) as f:
@@ -915,7 +914,7 @@ async def test_get_param(server, client, environment, tz_aware_timestamp: bool):
 
 async def test_server_logs_address(server_config, caplog, async_finalizer):
     with caplog.at_level(logging.INFO):
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=True)
         async_finalizer.add(partial(ibl.stop, timeout=15))
         await ibl.start()
 
@@ -968,7 +967,7 @@ async def test_bootloader_db_wait(monkeypatch, tmpdir, caplog, db_wait_time: str
     monkeypatch.setattr("asyncpg.connect", mock_asyncpg_connect)
     caplog.set_level(logging.INFO)
     caplog.clear()
-    ibl: InmantaBootloader = InmantaBootloader()
+    ibl: InmantaBootloader = InmantaBootloader(configure_logging=True)
     start_task: asyncio.Task = asyncio.create_task(ibl.start())
     await start_task
 
@@ -993,7 +992,7 @@ async def test_bootlader_connect_running_db(server_config, postgres_db, caplog, 
     config.Config.set("database", "wait_time", db_wait_time)
     caplog.set_level(logging.INFO)
     caplog.clear()
-    ibl: InmantaBootloader = InmantaBootloader()
+    ibl: InmantaBootloader = InmantaBootloader(configure_logging=True)
     await ibl.start()
     await ibl.stop(timeout=15)
 

--- a/tests/test_usersetup.py
+++ b/tests/test_usersetup.py
@@ -79,7 +79,7 @@ def setup_config(tmpdir, postgres_db, database_name):
 
 
 async def test_user_setup(tmpdir, server_pre_start, postgres_db, database_name, hard_clean_db, hard_clean_db_post):
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=True)
     # we need the server to start so that all the migrations scripts are applied, but the server needs
     # to be shut down afterwards, otherwise the call to get_connection_pool() will result in an exception saying
     # that the connection pool is already set in the database layer.
@@ -112,7 +112,7 @@ async def test_user_setup_empty_username(
     tmpdir, server_pre_start, postgres_db, database_name, hard_clean_db, hard_clean_db_post
 ):
     """test that if no username is provided to the user setup tool, the username will default to admin"""
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=True)
     # we need the server to start so that all the migrations scripts are applied, but the server needs
     # to be shut down afterwards, otherwise the call to get_connection_pool() will result in an exception saying
     # that the connection pool is already set in the database layer.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -389,7 +389,7 @@ def get_resource(version: int, key: str = "key1", agent: str = "agent1", value: 
 @functools.lru_cache(1)
 def get_product_meta_data() -> ProductMetadata:
     """Get the produce meta-data"""
-    bootloader = InmantaBootloader()
+    bootloader = InmantaBootloader(configure_logging=True)
     context = bootloader.load_slices()
     return context.get_product_metadata()
 


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/7532 but applied on the iso7 branch due to a merge conflict.**

Migrate Inmanta logging framework to a dictconfig-based logging framework.

Part of #7265 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
