### PR TITLE
Use updated env variable containing path for constraint file in tox.ini

### DIFF
--- a/changelogs/unreleased/1921-extend-version-overview-with-more-versions.yml
+++ b/changelogs/unreleased/1921-extend-version-overview-with-more-versions.yml
@@ -2,4 +2,4 @@ description: Add information to the compatibility page in the documentation.
 issue-nr: 1921
 issue-repo: irt
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/1921-master-stage-2.yml
+++ b/changelogs/unreleased/1921-master-stage-2.yml
@@ -1,0 +1,5 @@
+change-type: patch
+description: Update constraint file path in tox.ini file.
+destination-branches:
+- master
+sections: {}

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ requires = pip
 deps=
     -rrequirements.dev.txt
     -rrequirements.txt
-    -c {env:INMANTA_REQUIREMENTS_COMPONENTS_TXT:/dev/null}
+    -c {env:INMANTA_REQUIREMENTS_TXT:/dev/null}
 extras=
     dataflow_graphic
 # Set the environment variable INMANTA_EXTRA_PYTEST_ARGS='--fast' to run in fast mode


### PR DESCRIPTION
# Description

Follow up to https://github.com/inmanta/inmanta-core/pull/7569
Original ticket https://github.com/inmanta/irt/issues/1921

The following PRs close the core part of the ticket:

* (this PR) master pr update tox ini https://github.com/inmanta/inmanta-core/pull/7582
* iso7 pr compat page improvement changes https://github.com/inmanta/inmanta-core/pull/7583
* iso6 pr compat page improvement changes https://github.com/inmanta/inmanta-core/pull/7584

This PR closes the irt part of the ticket:

- PR adding generation of new content for compat files: https://github.com/inmanta/irt/pull/2027

This PR adds a fix for autoclasses not being rendered properly for inmanta modules:

- fix autoclass docs PR https://github.com/inmanta/irt/pull/2028

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
