### PR TITLE
Support configuring the logging framework using a config file

### DIFF
--- a/changelogs/unreleased/7271-add-support-loggging-config-option.yml
+++ b/changelogs/unreleased/7271-add-support-loggging-config-option.yml
@@ -1,0 +1,8 @@
+---
+description: Add support to configure the logging framework using a configuration file.
+issue-nr: 7271
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  feature: "{{description}}"

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -720,8 +720,8 @@ def cmd_parser() -> argparse.ArgumentParser:
         "--logging-config",
         dest="logging_config",
         help="The path to the configuration file for the logging framework. This is a YAML file that follows "
-             "the dictionary-schema accepted by logging.config.dictConfig(). All other log-related configuration "
-             "arguments will be ignored when this argument is provided.",
+        "the dictionary-schema accepted by logging.config.dictConfig(). All other log-related configuration "
+        "arguments will be ignored when this argument is provided.",
     )
     parser.add_argument(
         "--log-file-level",

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -717,6 +717,13 @@ def cmd_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--log-file", dest="log_file", help="Path to the logfile")
     parser.add_argument(
+        "--logging-config",
+        dest="logging_config",
+        help="The path to the configuration file for the logging framework. This is a YAML file that follows "
+             "the dictionary-schema accepted by logging.config.dictConfig(). All other log-related configuration "
+             "arguments will be ignored when this argument is provided.",
+    )
+    parser.add_argument(
         "--log-file-level",
         dest="log_file_level",
         choices=["0", "1", "2", "3", "4", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"],

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -415,8 +415,8 @@ logging_config = Option(
     name="logging_config",
     default=None,
     documentation="The path to the configuration file for the logging framework. This is a YAML file that follows "
-                  "the dictionary-schema accepted by logging.config.dictConfig(). All other log-related configuration "
-                  "options will be ignored when this option is set.",
+    "the dictionary-schema accepted by logging.config.dictConfig(). All other log-related configuration "
+    "options will be ignored when this option is set.",
     validator=is_str_opt,
 )
 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -410,6 +410,16 @@ log_dir = Option(
     is_str,
 )
 
+logging_config = Option(
+    section="config",
+    name="logging_config",
+    default=None,
+    documentation="The path to the configuration file for the logging framework. This is a YAML file that follows "
+                  "the dictionary-schema accepted by logging.config.dictConfig(). All other log-related configuration "
+                  "options will be ignored when this option is set.",
+    validator=is_str_opt,
+)
+
 
 def get_executable() -> Optional[str]:
     """``os.path.abspath(sys.argv[0])``"""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -232,9 +232,9 @@ def test_handling_logging_config_option(tmpdir, monkeypatch) -> None:
 
     stream = StringIO()
     # In order to reference an object in the logging_config file, it needs to be part of a module.
-    # For this reason we add the 'stream' attribute to the inmanta module. It's referenced in the
-    # logging_config file using ext://inmanta.stream
-    monkeypatch.setattr(inmanta, "stream", stream, raising=False)
+    # For this reason we add the 'pytest_stream' attribute to the inmanta module. It's referenced in the
+    # logging_config file using ext://inmanta.pytest_stream
+    monkeypatch.setattr(inmanta, "pytest_stream", stream, raising=False)
 
     def write_logging_config_file(path: str, formatter: str) -> None:
         config = {
@@ -249,7 +249,7 @@ def test_handling_logging_config_option(tmpdir, monkeypatch) -> None:
                     "class": "logging.StreamHandler",
                     "formatter": "console_formatter",
                     "level": "INFO",
-                    "stream": "ext://inmanta.stream",
+                    "stream": "ext://inmanta.pytest_stream",
                 },
             },
             "root": {


### PR DESCRIPTION
# Description

This PR adds support to configure the logging framework using the `--logging-config` CLI option and using the `logging_config` option in the configuration files.

Part of #7271

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
