### PR TITLE
issue/7274-Add command that output default logger config

### DIFF
--- a/changelogs/unreleased/7274-add-command-default-logger-config.yml
+++ b/changelogs/unreleased/7274-add-command-default-logger-config.yml
@@ -1,0 +1,8 @@
+---
+description: Add a command "show-default-logger-config" that outputs the default logger config
+issue-nr: 7274
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  feature: "{{description}}"

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -324,6 +324,32 @@ def help_command(options: argparse.Namespace) -> None:
     sys.exit(0)
 
 
+@command("show-default-logger-config", help_msg="Display the default logger configuration")
+def show_default_logger_config(options: argparse.Namespace) -> None:
+    default_config = """
+version: 1
+formatters:
+  console_formatter:
+    (): inmanta.logging.MultiLineFormatter
+    fmt: "%(log_color)s%(name)-25s%(levelname)-8s%(reset)s%(blue)s%(message)s"
+    log_colors: {"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}
+    reset: True
+    no_color: False
+    keep_logger_names: False
+handlers:
+  console_handler:
+    class: logging.StreamHandler
+    formatter: console_formatter
+    level: INFO
+    stream: ext://sys.stdout
+root:
+  handlers: ["console_handler"]
+  level: "INFO"
+disable_existing_loggers: False
+"""
+    print(default_config)
+
+
 @command(
     "modules",
     help_msg="Subcommand to manage modules",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -28,6 +28,7 @@ import yaml
 import inmanta
 from inmanta import config
 from inmanta.logging import InmantaLoggerConfig, MultiLineFormatter, Options
+from test_app_cli import app
 
 
 @pytest.fixture(autouse=True)
@@ -326,3 +327,33 @@ def test_handling_logging_config_option(tmpdir, monkeypatch) -> None:
         )
         logger.info("test")
         assert "HHH test" in stream.getvalue()
+
+
+def test_output_default_logger_config(capsys) -> None:
+    app(["show-default-logger-config"])
+
+    captured = capsys.readouterr()
+
+    expected_config = """
+version: 1
+formatters:
+  console_formatter:
+    (): inmanta.logging.MultiLineFormatter
+    fmt: "%(log_color)s%(name)-25s%(levelname)-8s%(reset)s%(blue)s%(message)s"
+    log_colors: {"DEBUG": "cyan", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}
+    reset: True
+    no_color: False
+    keep_logger_names: False
+handlers:
+  console_handler:
+    class: logging.StreamHandler
+    formatter: console_formatter
+    level: INFO
+    stream: ext://sys.stdout
+root:
+  handlers: ["console_handler"]
+  level: "INFO"
+disable_existing_loggers: False
+"""
+
+    assert expected_config in captured.out


### PR DESCRIPTION
# Description

Add command that output default logger config

closes #7274 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
