### PR TITLE
Add get_current_resource_state() method

### DIFF
--- a/changelogs/unreleased/add_get_current_resource_state.yml
+++ b/changelogs/unreleased/add_get_current_resource_state.yml
@@ -1,4 +1,4 @@
 ---
-description: Add the get_status_for_v2() method to the database layer.
+description: Add the Resource.get_current_resource_state() method to the database layer.
 change-type: minor
 destination-branches: [master, iso7]

--- a/changelogs/unreleased/add_get_current_resource_state.yml
+++ b/changelogs/unreleased/add_get_current_resource_state.yml
@@ -1,4 +1,4 @@
 ---
-description: Add the get_current_resource_state() method to the database layer.
+description: Add the get_status_for_v2() method to the database layer.
 change-type: minor
 destination-branches: [master, iso7]

--- a/changelogs/unreleased/add_get_current_resource_state.yml
+++ b/changelogs/unreleased/add_get_current_resource_state.yml
@@ -1,0 +1,4 @@
+---
+description: Add the get_current_resource_state() method to the database layer.
+change-type: minor
+destination-branches: [master, iso7]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4635,12 +4635,18 @@ class Resource(BaseDocument):
         return {ResourceIdStr(r["resource_id"]): ResourceState[r["status"]] for r in out}
 
     @classmethod
-    async def get_current_resource_state(
+    async def get_status_for_v2(
         cls,
         env: uuid.UUID,
         model_version: int,
         rid: ResourceIdStr,
     ) -> Optional[ResourceState]:
+        """
+        Retrieve the ResourceState for the given resource. The difference between
+        this method and the get_status_for() method is that this method relies on the
+        resource_persistent_state table if the state is requested for a resource
+        in the latest released version of the configurationmodel.
+        """
         query = f"""
             SELECT (
                 SELECT max(c.version) AS version

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4634,6 +4634,7 @@ class Resource(BaseDocument):
         out = await cls.select_query(query, [env, model_version, rids], no_obj=True)
         return {ResourceIdStr(r["resource_id"]): ResourceState[r["status"]] for r in out}
 
+    @stable_api
     @classmethod
     async def get_current_resource_state(cls, env: uuid.UUID, rid: ResourceIdStr) -> Optional[ResourceState]:
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3168,6 +3168,9 @@ async def test_retrieve_optional_field_no_default(init_dataclasses_and_load_sche
 
 
 async def test_get_status_for_v2(server, environment, client, clienthelper, agent):
+    """
+    Verify the behavior of the Resource.get_status_for_v2() method.
+    """
     # Create version 1 with undefined resource and release the version.
     version1 = await clienthelper.get_version()
     result = await client.put_version(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3167,7 +3167,7 @@ async def test_retrieve_optional_field_no_default(init_dataclasses_and_load_sche
     assert report.returncode is None
 
 
-async def test_get_current_resource_state(server, environment, client, clienthelper, agent):
+async def test_get_status_for_v2(server, environment, client, clienthelper, agent):
     # Create version 1 with undefined resource and release the version.
     version1 = await clienthelper.get_version()
     result = await client.put_version(
@@ -3240,24 +3240,24 @@ async def test_get_current_resource_state(server, environment, client, clienthel
     )
     assert result.code == 200, result.result
 
-    # Assert get_current_resource_state() for version 1
-    state: Optional[const.ResourceState] = await data.Resource.get_current_resource_state(
+    # Assert get_status_for_v2() for version 1
+    state: Optional[const.ResourceState] = await data.Resource.get_status_for_v2(
         env=environment,
         model_version=version1,
         rid="std::testing::NullResource[agent1,name=test1]",
     )
     assert state is const.ResourceState.undefined
 
-    # Assert get_current_resource_state() for version 2
-    state: Optional[const.ResourceState] = await data.Resource.get_current_resource_state(
+    # Assert get_status_for_v2() for version 2
+    state: Optional[const.ResourceState] = await data.Resource.get_status_for_v2(
         env=environment,
         model_version=version2,
         rid="std::testing::NullResource[agent1,name=test1]",
     )
     assert state is const.ResourceState.deployed
 
-    # Assert get_current_resource_state() for version 3
-    state: Optional[const.ResourceState] = await data.Resource.get_current_resource_state(
+    # Assert get_status_for_v2() for version 3
+    state: Optional[const.ResourceState] = await data.Resource.get_status_for_v2(
         env=environment,
         model_version=version3,
         rid="std::testing::NullResource[agent1,name=test1]",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3180,9 +3180,7 @@ async def test_get_current_resource_state(server, environment, client, clienthel
                 "requires": [],
             },
         ],
-        resource_state={
-            "std::testing::NullResource[agent1,name=test1]": const.ResourceState.undefined
-        },
+        resource_state={"std::testing::NullResource[agent1,name=test1]": const.ResourceState.undefined},
         compiler_version=util.get_compiler_version(),
     )
     assert result.code == 200, result.result
@@ -3237,9 +3235,7 @@ async def test_get_current_resource_state(server, environment, client, clienthel
                 "requires": [],
             },
         ],
-        resource_state={
-            "std::testing::NullResource[agent1,name=test1]": const.ResourceState.undefined
-        },
+        resource_state={"std::testing::NullResource[agent1,name=test1]": const.ResourceState.undefined},
         compiler_version=util.get_compiler_version(),
     )
     assert result.code == 200, result.result


### PR DESCRIPTION
# Description

Add the get_current_resource_state() method to the database layer. This method is required by https://github.com/inmanta/inmanta-lsm/pull/1718.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
