### PR TITLE
Fix inconsistent state reporting on the resource endpoints

### DIFF
--- a/changelogs/unreleased/fix-move-back-to-available-states.yml
+++ b/changelogs/unreleased/fix-move-back-to-available-states.yml
@@ -1,0 +1,6 @@
+---
+description: Fix bug where the `GET /api/v2/resource/<rid>` and `GET /api/v2/resource` endpoints return an incorrect resourcestate if a resource moved back to the available state in a new version of the configurationmodel.
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5111,7 +5111,7 @@ class Resource(BaseDocument):
         inner_query = f"""
         SELECT r.resource_id as resource_id,
         (
-            CASE WHEN (r.status = 'deploying')
+            CASE WHEN r.status IN ('deploying', 'undefined', 'skipped_for_undefined')
                 THEN
                     r.status::text
                 ELSE

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -568,12 +568,10 @@ class ResourceView(DataView[ResourceStatusOrder, model.LatestReleasedResource]):
                                 -- resource_persistent_state table.
                                 WHEN r.model < (SELECT version FROM latest_version)
                                     THEN 'orphaned'
-                                WHEN r.status::text = 'deploying'
+                                WHEN r.status::text IN('deploying', 'undefined', 'skipped_for_undefined')
+                                    -- The deploying, undefined and skipped_for_undefined states are not tracked in the
+                                    -- resource_persistent_state table.
                                     THEN r.status::text
-                                WHEN r.status = 'available'
-                                    AND rps.last_non_deploying_status IN('undefined', 'skipped_for_undefined')
-                                    -- The resource moved from undefined or skipped_for_undefined to available
-                                    THEN 'available'
                                 WHEN rps.last_deployed_attribute_hash != r.attribute_hash
                                    -- The hash changed since the last deploy -> new desired state
                                    THEN 'available'

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -562,17 +562,19 @@ class ResourceView(DataView[ResourceStatusOrder, model.LatestReleasedResource]):
                         rps.environment,
                         (
                             CASE
+                                -- The resource_persistent_state.last_non_deploying_status column is only populated for
+                                -- actual deployment operations to prevent locking issues. This case-statement calculates
+                                -- the correct state from the combination of the resource table and the
+                                -- resource_persistent_state table.
                                 WHEN r.model < (SELECT version FROM latest_version)
                                     THEN 'orphaned'
-                                WHEN r.status::text IN('deploying', 'undefined', 'skipped_for_undefined')
-                                    -- The deploying, undefined and skipped_for_undefined states can be tracked accurately
-                                    -- via the resource table.
+                                WHEN r.status::text = 'deploying'
                                     THEN r.status::text
-                                WHEN r.status NOT IN('undefined', 'skipped_for_undefined')
+                                WHEN r.status = 'available'
                                     AND rps.last_non_deploying_status IN('undefined', 'skipped_for_undefined')
                                     -- The resource moved from undefined or skipped_for_undefined to available
                                     THEN 'available'
-                               WHEN rps.last_deployed_attribute_hash != r.attribute_hash
+                                WHEN rps.last_deployed_attribute_hash != r.attribute_hash
                                    -- The hash changed since the last deploy -> new desired state
                                    THEN 'available'
                                    -- No override required, use last known state from actual deployment

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -573,10 +573,10 @@ class ResourceView(DataView[ResourceStatusOrder, model.LatestReleasedResource]):
                                     -- resource_persistent_state table.
                                     THEN r.status::text
                                 WHEN rps.last_deployed_attribute_hash != r.attribute_hash
-                                   -- The hash changed since the last deploy -> new desired state
-                                   THEN 'available'
-                                   -- No override required, use last known state from actual deployment
-                                   ELSE rps.last_non_deploying_status::text
+                                    -- The hash changed since the last deploy -> new desired state
+                                    THEN r.status::text
+                                    -- No override required, use last known state from actual deployment
+                                    ELSE rps.last_non_deploying_status::text
                             END
                         ) as status
                     FROM versioned_resource_state AS rps

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -943,7 +943,11 @@ class ResourceService(protocol.ServerSlice):
                             if not is_increment_notification:
                                 if status == ResourceState.deployed:
                                     extra_fields["last_success"] = resource_action.started
-                                if status != ResourceState.deploying:
+                                if status not in {
+                                    ResourceState.deploying,
+                                    ResourceState.undefined,
+                                    ResourceState.skipped_for_undefined,
+                                }:
                                     extra_fields["last_non_deploying_status"] = const.NonDeployingResourceState(status)
 
                             await res.update_persistent_state(

--- a/tests/server/test_resource_list.py
+++ b/tests/server/test_resource_list.py
@@ -183,7 +183,17 @@ async def env_with_resources(server, client):
             await res.insert()
             await res.update_persistent_state(
                 last_deploy=datetime.now(tz=UTC),
-                last_non_deploying_status=status if status not in [ResourceState.available, ResourceState.deploying] else None,
+                last_non_deploying_status=(
+                    status
+                    if status
+                    not in [
+                        ResourceState.available,
+                        ResourceState.deploying,
+                        ResourceState.undefined,
+                        ResourceState.skipped_for_undefined,
+                    ]
+                    else None
+                ),
             )
 
     await create_resource("agent1", "/etc/file1", "test::File", ResourceState.available, [1, 2, 3])


### PR DESCRIPTION
# Description

Fix bug where the `GET /api/v2/resource/<rid>` and `GET /api/v2/resource` endpoints return an incorrect resourcestate if a resource moved back to the available state in a new version of the configurationmodel.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
