### PR TITLE
Issue/7356 remove deprecated std iso6

### DIFF
--- a/changelogs/unreleased/7356-remove-deprecated-std.yml
+++ b/changelogs/unreleased/7356-remove-deprecated-std.yml
@@ -1,4 +1,4 @@
 description: remove the deprecated std resources from the codebase.
 issue-nr: 7356
 change-type: patch
-destination-branches: [iso7, iso6]
+destination-branches: [iso6]

--- a/changelogs/unreleased/7356-remove-deprecated-std.yml
+++ b/changelogs/unreleased/7356-remove-deprecated-std.yml
@@ -1,0 +1,4 @@
+description: remove the deprecated std resources from the codebase.
+issue-nr: 7356
+change-type: patch
+destination-branches: [iso7, iso6]

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -55,8 +55,8 @@ class provider:  # noqa: N801
     """
     A decorator that registers a new handler.
 
-    :param resource_type: The type of the resource this handler provides an implementation for.
-                          For example, :inmanta:entity:`std::File`
+    :param resource_type: The type of the resource this handler is responsible for.
+                          For example, :inmanta:entity:`std::testing::NullResource`
     :param name: A name to reference this provider.
     """
 

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -55,7 +55,7 @@ class provider:  # noqa: N801
     """
     A decorator that registers a new handler.
 
-    :param resource_type: The type of the resource this handler is responsible for.
+    :param resource_type: The type of the resource this handler provides an implementation for.
                           For example, :inmanta:entity:`std::testing::NullResource`
     :param name: A name to reference this provider.
     """

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -480,10 +480,17 @@ class IndexLookup(ReferenceStatement, Resumer):
 
 class ShortIndexLookup(IndexLookup):
     """lookup of the form
-    vm = ip::Host(...)
-    file = std::File(host=vm, path="/etc/motd", ...)
+    entity ExtendedHost extends ip::Host:
+    end
 
-    vm.files[path="/etc/motd"]
+    ExtendedHost.resources [0:] -- std::testing::NullResource.host[1]
+
+    host = ExtendedHost(...)
+    resource = std::testing::NullResource(name='test', host=host, ...)
+
+    index std::testing::NullResource(host, name)
+
+    host.resources[name="test"]
     """
 
     __slots__ = ("rootobject", "relation", "querypart", "wrapped_querypart")

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -117,7 +117,8 @@ class CodeManager:
     """This class is responsible for loading and packaging source code for types (resources, handlers, ...) that need to be
     available in a remote process (e.g. agent).
 
-    __type_file: Maps Inmanta type names (e.g., ``std::File``, ``mymodule::Mytype``) to sets of filenames containing
+    __type_file: Maps Inmanta type names (e.g., ``std::testing::NullResource``, ``mymodule::Mytype``)
+                 to sets of filenames containing
                  the necessary source code (all plugin files in the module).
     __file_info: Stores metadata about each individual source code file. The keys are file paths and the values
                  in this dictionary are ``SourceInfo`` objects.
@@ -130,7 +131,8 @@ class CodeManager:
     def register_code(self, type_name: str, instance: object) -> None:
         """Register the given type_object under the type_name and register the source associated with this type object.
 
-        :param type_name: The inmanta type name for which the source of type_object will be registered. For example std::File
+        :param type_name: The inmanta type name for which the source of type_object will be registered.
+            For example std::testing::NullResource
         :param instance: An instance for which the code needs to be registered.
         """
         file_name = self.get_object_source(instance)

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -51,7 +51,7 @@ class resource:  # noqa: N801
     :class:`~inmanta.resources.Resource`
 
     :param name: The name of the entity in the configuration model it creates a resources from. For example
-                 :inmanta:entity:`std::File`
+                 :inmanta:entity:`std::testing::NullResource`
     :param id_attribute: The attribute of `this` resource that uniquely identifies a resource on an agent. This attribute
                          can be mapped.
     :param agent: This string indicates how the agent of this resource is determined. This string points to an attribute,

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -30,7 +30,7 @@ from utils import module_from_template, v1_module_from_template
 def test_str_on_instance_pos(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-import std
+import std::testing
 
 entity Hg:
 end
@@ -47,19 +47,19 @@ end
 
 
 for i in hg.hosts:
-    std::ConfigFile(host=i, path="/fx", content="")
+    std::testing::NullResource(name=i.name)
 end
 """
     )
     (types, _) = compiler.do_compile()
-    files = types["std::File"].get_all_instances()
-    assert len(files) == 3
+    test_resources = types["std::testing::NullResource"].get_all_instances()
+    assert len(test_resources) == 3
 
 
 def test_str_on_instance_neg(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-import std
+import std::testing
 
 entity Hg:
 end
@@ -76,13 +76,13 @@ end
 
 
 for i in hg.hosts:
-    std::ConfigFile(host=i, path="/fx", content="")
+    std::testing::NullResource(name=i.name)
 end
 """
     )
     (types, _) = compiler.do_compile()
-    files = types["std::File"].get_all_instances()
-    assert len(files) == 1
+    test_resources = types["std::testing::NullResource"].get_all_instances()
+    assert len(test_resources) == 1
 
 
 def test_implements_inheritance(snippetcompiler):

--- a/tests/compiler/test_defaults.py
+++ b/tests/compiler/test_defaults.py
@@ -26,12 +26,23 @@ from inmanta.execute.proxy import UnsetException
 def test_issue_127_default_overrides(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-f1=std::ConfigFile(host=std::Host(name="jos",os=std::linux), path="/tmp/test", owner="wouter", content="blabla")
+import std::testing
+
+entity NullResourceBis extends std::testing::NullResource:
+    string agentname ="agentbis"
+end
+
+implementation a for NullResourceBis:
+end
+
+implement NullResourceBis using a
+
+f1=NullResourceBis(name="test", agentname="agent")
         """
     )
     (types, _) = compiler.do_compile()
-    instances = types["std::File"].get_all_instances()
-    assert instances[0].get_attribute("owner").get_value() == "wouter"
+    instances = types["__config__::NullResourceBis"].get_all_instances()
+    assert instances[0].get_attribute("agentname").get_value() == "agent"
 
 
 def test_issue_135_duplo_relations(snippetcompiler):

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -20,15 +20,8 @@ import re
 import pytest
 
 import inmanta.compiler as compiler
-from inmanta.ast import (
-    DuplicateException,
-    IndexException,
-    NotFoundException,
-    RuntimeException,
-    TypeNotFoundException,
-    TypingException,
-)
-from inmanta.ast.statements.generator import IndexCollisionException
+from inmanta.ast import DuplicateException, IndexException, NotFoundException, RuntimeException, TypeNotFoundException
+from inmanta.ast.statements.generator import IndexAttributeMissingInConstructorException, IndexCollisionException
 from inmanta.compiler.help.explainer import ExplainerFactory
 
 
@@ -49,39 +42,29 @@ def test_issue_121_non_matching_index(snippetcompiler):
 def test_issue_122_index_inheritance(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-entity Repository extends std::File:
+entity TopResource:
     string name
-    bool gpgcheck=false
+end
+
+index TopResource(name)
+
+entity TestResource extends TopResource:
     bool enabled=true
-    string baseurl
-    string gpgkey=""
-    int metadata_expire=7200
-    bool send_event=true
 end
 
-implementation redhatRepo for Repository:
-    self.mode = 644
-    self.owner = "root"
-    self.group = "root"
-
-    self.path = "/etc/yum.repos.d/{{ name }}.repo"
-    self.content = "{{name}}"
+implementation testRes for TestResource:
+    self.name="test"
 end
 
-implement Repository using redhatRepo
+implement TestResource using testRes
 
-h1 = std::Host(name="test", os=std::linux)
-
-Repository(host=h1, name="demo", baseurl="http://example.com")
-Repository(host=h1, name="demo", baseurl="http://example.com")
+TestResource()
         """
     )
 
-    try:
+    with pytest.raises(IndexAttributeMissingInConstructorException) as e:
         compiler.do_compile()
-        raise AssertionError("Should get exception")
-    except TypingException as e:
-        assert e.location.lnr == 25
+    assert e.value.location.lnr == 18
 
 
 def test_issue_140_index_error(snippetcompiler):
@@ -190,9 +173,13 @@ def test_index_on_subtype(snippetcompiler):
 def test_index_on_subtype2(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-        host = std::Host(name="a",os=std::linux)
-        a=std::DefaultDirectory(host=host,path="/etc")
-        b=std::Directory(host=host,path="/etc",mode=755 ,group="root",owner="root" )
+        import std::testing
+
+        entity NullResourceBis extends std::testing::NullResource:
+        end
+
+        a=std::testing::NullResource(name="test", agentname="agent1", fail=false)
+        b=NullResourceBis(name="test", agentname="agent1")
     """
     )
     with pytest.raises(DuplicateException):

--- a/tests/compiler/test_list.py
+++ b/tests/compiler/test_list.py
@@ -28,7 +28,7 @@ def test_list_atributes(snippetcompiler):
         """
 entity Jos:
   bool[] bar
-  std::package_state[] ips = ["installed"]
+  std::email_str[] ips = ["aaa@aaa.com"]
   string[] floom = []
   string[] floomx = ["a", "b"]
   string box = "a"
@@ -45,7 +45,7 @@ d = Jos(bar = [], floom=["test","test2"])
     )
     (_, root) = compiler.do_compile()
 
-    def check_jos(jos, bar, ips=["installed"], floom=[], floomx=["a", "b"], box="a"):
+    def check_jos(jos, bar, ips=["aaa@aaa.com"], floom=[], floomx=["a", "b"], box="a"):
         jos = jos.get_value()
         assert jos.get_attribute("bar").get_value() == bar
         assert jos.get_attribute("ips").get_value(), ips

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -473,37 +473,39 @@ def test_set_wrong_relation_type(snippetcompiler):
     # noqa: E501
     snippetcompiler.setup_for_error(
         """
+        import std::testing
         entity Credentials:
         end
 
-        Credentials.file [1] -- std::File
+        Credentials.null_resource [1] -- std::testing::NullResource
 
         implement Credentials using std::none
 
-        creds = Credentials(file=creds)
+        creds = Credentials(null_resource=creds)
         """,
-        """Could not set attribute `file` on instance `__config__::Credentials (instantiated at {dir}/main.cf:9)`"""
-        """ (reported in Construct(Credentials) ({dir}/main.cf:9))
+        """Could not set attribute `null_resource` on instance `__config__::Credentials (instantiated at {dir}/main.cf:10)`"""
+        """ (reported in Construct(Credentials) ({dir}/main.cf:10))
 caused by:
-  Invalid class type for __config__::Credentials (instantiated at {dir}/main.cf:9), should be std::File """
-        """(reported in Construct(Credentials) ({dir}/main.cf:9))""",
+  Invalid class type for __config__::Credentials (instantiated at {dir}/main.cf:10), should be std::testing::NullResource """
+        """(reported in Construct(Credentials) ({dir}/main.cf:10))""",
     )
 
     snippetcompiler.setup_for_error(
         """
+        import std::testing
         entity Credentials:
         end
 
-        Credentials.file [1] -- std::File
+        Credentials.null_resource [1] -- std::testing::NullResource
 
         implement Credentials using std::none
 
         creds = Credentials()
-        creds.file = creds
+        creds.null_resource = creds
         """,
-        r"""Could not set attribute `file` on instance `__config__::Credentials (instantiated at {dir}/main.cf:9)` (reported in creds.file = creds ({dir}/main.cf:10))
+        r"""Could not set attribute `null_resource` on instance `__config__::Credentials (instantiated at {dir}/main.cf:10)` (reported in creds.null_resource = creds ({dir}/main.cf:11))
 caused by:
-  Invalid class type for __config__::Credentials (instantiated at {dir}/main.cf:9), should be std::File (reported in creds.file = creds ({dir}/main.cf:10))""",  # noqa: E501
+  Invalid class type for __config__::Credentials (instantiated at {dir}/main.cf:10), should be std::testing::NullResource (reported in creds.null_resource = creds ({dir}/main.cf:11))""",  # noqa: E501
     )
 
 

--- a/tests/compiler/test_requires.py
+++ b/tests/compiler/test_requires.py
@@ -126,13 +126,12 @@ post.requires = inter
 def test_issue_220_dep_loops(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-import std
+import std::testing
 
-host = std::Host(name="Test", os=std::unix)
-f1 = std::ConfigFile(host=host, path="/f1", content="")
-f2 = std::ConfigFile(host=host, path="/f2", content="")
-f3 = std::ConfigFile(host=host, path="/f3", content="")
-f4 = std::ConfigFile(host=host, path="/f4", content="")
+f1 = std::testing::NullResource(name="f1")
+f2 = std::testing::NullResource(name="f2")
+f3 = std::testing::NullResource(name="f3")
+f4 = std::testing::NullResource(name="f4")
 f1.requires = f2
 f2.requires = f3
 f3.requires = f1
@@ -143,4 +142,8 @@ f4.requires = f1
         snippetcompiler.do_export()
 
     cyclenames = [r.id.resource_str() for r in e.value.cycle]
-    assert set(cyclenames) == {"std::File[Test,path=/f3]", "std::File[Test,path=/f2]", "std::File[Test,path=/f1]"}
+    assert set(cyclenames) == {
+        "std::testing::NullResource[internal,name=f1]",
+        "std::testing::NullResource[internal,name=f2]",
+        "std::testing::NullResource[internal,name=f3]",
+    }

--- a/tests/data/plugins_project/libs/multiple_plugin_files/model/_init.cf
+++ b/tests/data/plugins_project/libs/multiple_plugin_files/model/_init.cf
@@ -1,0 +1,17 @@
+entity NullResourceBis extends ManagedResource, PurgeableResource:
+    """
+        A resource that does nothing, for use in tests and examples
+
+        :attr name: the name of this resource
+        :attr agentname: the name of the agent to deploy this resource on
+        :attr fail: when true, this resource will always fail on both dryrun and deploy
+    """
+    string name = "null"
+    string agentname = "internal"
+    bool send_event = true
+    bool fail = false
+end
+
+index NullResourceBis(agentname, name)
+
+implement NullResourceBis using std::none

--- a/tests/data/plugins_project/libs/multiple_plugin_files/plugins/handlers.py
+++ b/tests/data/plugins_project/libs/multiple_plugin_files/plugins/handlers.py
@@ -2,6 +2,6 @@ from inmanta.agent.handler import ResourceHandler, provider
 from inmanta_plugins.multiple_plugin_files.helpers import helper
 
 
-@provider("std::Directory", name="myhandler")
+@provider("multiple_plugin_files::NullResourceBis", name="myhandler")
 class MyHandler(ResourceHandler):
     pass

--- a/tests/data/plugins_project/libs/single_plugin_file/plugins/__init__.py
+++ b/tests/data/plugins_project/libs/single_plugin_file/plugins/__init__.py
@@ -1,6 +1,6 @@
 from inmanta.agent.handler import ResourceHandler, provider
 
 
-@provider("std::File", name="myhandler")
+@provider("std::testing::NullResource", name="myhandler")
 class MyHandler(ResourceHandler):
     pass

--- a/tests/server/test_diff.py
+++ b/tests/server/test_diff.py
@@ -45,18 +45,18 @@ async def env_with_versions(environment):
 
 async def create_resource_in_multiple_versions(
     environment: uuid.UUID,
-    path: str,
+    name: str,
     version_attributes_map: dict[int, dict[str, object]],
     agent: str = "internal",
-    resource_type: str = "std::File",
+    resource_type: str = "std::testing::NullResource",
     status: ResourceState = ResourceState.deployed,
 ):
-    key = f"{resource_type}[{agent},path={path}]"
+    key = f"{resource_type}[{agent},name={name}]"
     for version, attributes in version_attributes_map.items():
         res = data.Resource.new(
             environment=environment,
             resource_version_id=ResourceVersionIdStr(f"{key},v={version}"),
-            attributes={**attributes, **{"path": path}},
+            attributes={**attributes, **{"name": name}},
             status=status,
             last_deploy=datetime.datetime.now(),
         )
@@ -70,9 +70,9 @@ async def test_list_attr_diff(client, environment, env_with_versions):
     constant_value = {"key2": "val2"}
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/dir1",
+        "dir1",
         {1: constant_value, 2: constant_value, 3: constant_value},
-        resource_type="std::Directory",
+        resource_type="std::testing::NullResource",
     )
     # from v1 to v2 a single value and a list are changed, a list added another deleted,
     # and there is another list where the data type changes from ints to strings.
@@ -80,28 +80,31 @@ async def test_list_attr_diff(client, environment, env_with_versions):
     # v2 and v3 have only one difference, the requires list
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/dir1/file1",
+        "file1",
         {
             1: {
                 "key1": "val1",
                 "list_attr_removed": [1, 2],
                 "list_attr_modified": [1, 2],
                 "simple_attr_type_change": True,
-                "requires": ["std::Directory[internal,path=/tmp/dir1]"],
+                "requires": ["std::testing::NullResource[internal,name=dir1]"],
             },
             2: {
                 "key1": "val2",
                 "list_attr_added": [3, 4],
                 "list_attr_modified": [5, 4, 3],
                 "simple_attr_type_change": "True",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]"],
+                "requires": ["std::testing::NullResource[internal,name=dir1]"],
             },
             3: {
                 "key1": "val2",
                 "list_attr_added": [3, 4],
                 "list_attr_modified": [5, 4, 3],
                 "simple_attr_type_change": "True",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::Directory[internal,path=/tmp/dir2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=dir2]",
+                ],
             },
         },
     )
@@ -148,10 +151,11 @@ async def test_list_attr_diff(client, environment, env_with_versions):
     assert result.result["data"][0]["status"] == "modified"
     assert len(result.result["data"][0]["attributes"]) == 1
     assert result.result["data"][0]["attributes"]["requires"] == {
-        "from_value": ["std::Directory[internal,path=/tmp/dir1]"],
-        "to_value": ["std::Directory[internal,path=/tmp/dir1]", "std::Directory[internal,path=/tmp/dir2]"],
-        "from_value_compare": '[\n    "std::Directory[internal,path=/tmp/dir1]"\n]',
-        "to_value_compare": '[\n    "std::Directory[internal,path=/tmp/dir1]",\n    "std::Directory[internal,path=/tmp/dir2]"\n'
+        "from_value": ["std::testing::NullResource[internal,name=dir1]"],
+        "to_value": ["std::testing::NullResource[internal,name=dir1]", "std::testing::NullResource[internal,name=dir2]"],
+        "from_value_compare": '[\n    "std::testing::NullResource[internal,name=dir1]"\n]',
+        "to_value_compare": '[\n    "std::testing::NullResource[internal,name=dir1]",\n    '
+        '"std::testing::NullResource[internal,name=dir2]"\n'
         "]",
     }
     v2_v3_diff = result.result["data"][0]["attributes"]
@@ -169,37 +173,46 @@ async def test_dict_attr_diff(client, environment, env_with_versions):
     constant_value = {"key2": "val2"}
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/dir1",
+        "dir1",
         {1: constant_value, 2: constant_value, 3: constant_value},
-        resource_type="std::Directory",
+        resource_type="std::testing::NullResource",
     )
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/dir2",
+        "dir2",
         {1: constant_value, 2: constant_value, 3: constant_value},
-        resource_type="std::Directory",
+        resource_type="std::testing::NullResource",
     )
     # v1 and v3 are identical
     # The changes from v1 to v2 are adding, removing and modifying dict attributes,
     # as well as a change in the order of the requires list: this shouldn't be included in the diff
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/dir1/file1",
+        "file1",
         {
             1: {
                 "dict_attr_removed": {"a": "b"},
                 "dict_attr_modified": {"x": [6, 7], "y": "y", "z": {"abc": "test1", "d": ["test2"]}},
-                "requires": ["std::Directory[internal,path=/tmp/dir2]", "std::Directory[internal,path=/tmp/dir1]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir2]",
+                    "std::testing::NullResource[internal,name=dir1]",
+                ],
             },
             2: {
                 "dict_attr_added": {"x": "y"},
                 "dict_attr_modified": {"x": [42], "z": {"abc": "test1", "d": ["test3"]}},
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::Directory[internal,path=/tmp/dir2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=dir2]",
+                ],
             },
             3: {
                 "dict_attr_removed": {"a": "b"},
                 "dict_attr_modified": {"x": [6, 7], "y": "y", "z": {"abc": "test1", "d": ["test2"]}},
-                "requires": ["std::Directory[internal,path=/tmp/dir2]", "std::Directory[internal,path=/tmp/dir1]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir2]",
+                    "std::testing::NullResource[internal,name=dir1]",
+                ],
             },
         },
     )
@@ -271,14 +284,14 @@ async def test_resources_diff(client, environment, env_with_versions):
     # The resource is only present in version 1 and 3, the attribute values don't change
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/dir1",
+        "dir1",
         {1: constant_value, 3: constant_value},
-        resource_type="std::Directory",
+        resource_type="std::testing::NullResource",
     )
     # The resource is only present in version 1 and 3, the attribute values change
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/dir1/file1",
+        "file1",
         {
             1: {
                 "dict_attr_modified": {
@@ -286,20 +299,20 @@ async def test_resources_diff(client, environment, env_with_versions):
                     "y": "z",
                 },
                 "removed": False,
-                "requires": ["std::Directory[internal,path=/tmp/dir1]"],
+                "requires": ["std::testing::NullResource[internal,name=dir1]"],
             },
             3: {
                 "dict_attr_modified": {
                     "x": [42],
                 },
-                "requires": ["std::Directory[internal,path=/tmp/dir1]"],
+                "requires": ["std::testing::NullResource[internal,name=dir1]"],
             },
         },
     )
     # The resource is only present in version 2 and 3, the attribute values don't change
     await create_resource_in_multiple_versions(
         env_id,
-        "/tmp/file2",
+        "file2",
         {
             2: {
                 "dict_attr_removed": {"a": "b"},
@@ -315,27 +328,27 @@ async def test_resources_diff(client, environment, env_with_versions):
     assert result.code == 200
     # 3 resource diffs: the directory and file1 are deleted, while file2 is added
     assert len(result.result["data"]) == 3
-    assert result.result["data"][0]["resource_id"] == "std::Directory[internal,path=/tmp/dir1]"
+    assert result.result["data"][0]["resource_id"] == "std::testing::NullResource[internal,name=dir1]"
     assert_resource_deleted(result.result["data"][0])
-    assert result.result["data"][1]["resource_id"] == "std::File[internal,path=/tmp/dir1/file1]"
+    assert result.result["data"][1]["resource_id"] == "std::testing::NullResource[internal,name=file1]"
     assert_resource_deleted(result.result["data"][1])
-    assert result.result["data"][2]["resource_id"] == "std::File[internal,path=/tmp/file2]"
+    assert result.result["data"][2]["resource_id"] == "std::testing::NullResource[internal,name=file2]"
     assert_resource_added(result.result["data"][2])
 
     # From 2 to 3, the directory and file1 are added and file2 doesn't change
     result = await client.get_diff_of_versions(environment, 2, 3)
     assert result.code == 200
     assert len(result.result["data"]) == 2
-    assert result.result["data"][0]["resource_id"] == "std::Directory[internal,path=/tmp/dir1]"
+    assert result.result["data"][0]["resource_id"] == "std::testing::NullResource[internal,name=dir1]"
     assert_resource_added(result.result["data"][0])
-    assert result.result["data"][1]["resource_id"] == "std::File[internal,path=/tmp/dir1/file1]"
+    assert result.result["data"][1]["resource_id"] == "std::testing::NullResource[internal,name=file1]"
     assert_resource_added(result.result["data"][1])
 
     # From 1 to 3, the directory doesn't change, file1 changes and file2 is added
     result = await client.get_diff_of_versions(environment, 1, 3)
     assert result.code == 200
     assert len(result.result["data"]) == 2
-    assert result.result["data"][0]["resource_id"] == "std::File[internal,path=/tmp/dir1/file1]"
+    assert result.result["data"][0]["resource_id"] == "std::testing::NullResource[internal,name=file1]"
     assert result.result["data"][0]["status"] == "modified"
     assert result.result["data"][0]["attributes"]["dict_attr_modified"] == {
         "from_value": {"x": [6, 7], "y": "z"},
@@ -357,7 +370,7 @@ async def test_resources_diff(client, environment, env_with_versions):
         "from_value_compare": "False",
         "to_value_compare": "",
     }
-    assert result.result["data"][1]["resource_id"] == "std::File[internal,path=/tmp/file2]"
+    assert result.result["data"][1]["resource_id"] == "std::testing::NullResource[internal,name=file2]"
     assert_resource_added(result.result["data"][1])
 
 

--- a/tests/server/test_facts_api.py
+++ b/tests/server/test_facts_api.py
@@ -43,27 +43,27 @@ async def env_with_facts(environment, client) -> tuple[str, list[str], list[str]
         is_suitable_for_partial_compiles=False,
     ).insert()
 
-    path = "/etc/file1"
-    resource_id = f"std::File[agent1,path={path}]"
+    name = "file1"
+    resource_id = f"std::testing::NullResource[agent1,name={name}]"
     res1_v1 = data.Resource.new(
-        environment=env_id, resource_version_id=ResourceVersionIdStr(f"{resource_id},v={version}"), attributes={"path": path}
+        environment=env_id, resource_version_id=ResourceVersionIdStr(f"{resource_id},v={version}"), attributes={"name": name}
     )
     await res1_v1.insert()
-    path = "/etc/file2"
-    resource_id_2 = f"std::File[agent1,path={path}]"
+    name = "file2"
+    resource_id_2 = f"std::testing::NullResource[agent1,name={name}]"
     await data.Resource.new(
         environment=env_id,
         resource_version_id=ResourceVersionIdStr(f"{resource_id_2},v={version}"),
-        attributes={"path": path},
+        attributes={"name": name},
     ).insert()
-    resource_id_3 = "std::File[agent1,path=/etc/file3]"
+    resource_id_3 = "std::testing::NullResource[agent1,name=file3]"
 
-    path = "/tmp/filex"
-    resource_id_4 = f"std::File[agent1,path={path}]"
+    name = "filex"
+    resource_id_4 = f"std::testing::NullResource[agent1,name={name}]"
     await data.Resource.new(
         environment=env_id,
         resource_version_id=ResourceVersionIdStr(f"{resource_id_4},v={version}"),
-        attributes={"path": path},
+        attributes={"name": name},
     ).insert()
 
     async def insert_param(

--- a/tests/server/test_purge_on_delete.py
+++ b/tests/server/test_purge_on_delete.py
@@ -70,7 +70,7 @@ async def test_purge_on_delete_requires(
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file1",
             "permissions": 644,
@@ -83,14 +83,14 @@ async def test_purge_on_delete_requires(
         {
             "group": "root",
             "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
-            "id": "std::File[vm2,path=/tmp/file2],v=%d" % version,
+            "id": "std::testing::NullResource[vm2,name=/tmp/file2],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file2",
             "permissions": 644,
             "purged": False,
             "reload": False,
             "purge_on_delete": True,
-            "requires": ["std::File[vm1,path=/tmp/file1],v=%d" % version],
+            "requires": ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
             "version": version,
         },
     ]
@@ -103,12 +103,28 @@ async def test_purge_on_delete_requires(
 
     now = datetime.now()
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm2,path=/tmp/file2],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm2,name=/tmp/file2],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
@@ -208,7 +224,7 @@ async def test_purge_on_delete_compile_failed(
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file1",
             "permissions": 644,
@@ -221,20 +237,20 @@ async def test_purge_on_delete_compile_failed(
         {
             "group": "root",
             "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
-            "id": "std::File[vm1,path=/tmp/file2],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file2],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file2",
             "permissions": 644,
             "purged": False,
             "reload": False,
             "purge_on_delete": True,
-            "requires": ["std::File[vm1,path=/tmp/file1],v=%d" % version],
+            "requires": ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
             "version": version,
         },
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file3],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file3],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file3",
             "permissions": 644,
@@ -254,17 +270,41 @@ async def test_purge_on_delete_compile_failed(
 
     now = datetime.now()
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file2],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file2],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file3],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file3],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
@@ -321,7 +361,7 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file1",
             "permissions": 644,
@@ -334,20 +374,20 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
         {
             "group": "root",
             "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
-            "id": "std::File[vm1,path=/tmp/file2],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file2],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file2",
             "permissions": 644,
             "purged": False,
             "reload": False,
             "purge_on_delete": True,
-            "requires": ["std::File[vm1,path=/tmp/file1],v=%d" % version],
+            "requires": ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
             "version": version,
         },
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file3],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file3],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file3",
             "permissions": 644,
@@ -375,17 +415,41 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
 
     now = datetime.now()
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file2],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file2],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file3],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file3],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
@@ -407,7 +471,7 @@ async def test_purge_on_delete(client: Client, clienthelper: ClientHelper, serve
     res3 = {
         "group": "root",
         "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-        "id": "std::File[vm1,path=/tmp/file3],v=%d" % version,
+        "id": "std::testing::NullResource[vm1,name=/tmp/file3],v=%d" % version,
         "owner": "root",
         "path": "/tmp/file3",
         "permissions": 644,
@@ -462,7 +526,7 @@ async def test_purge_on_delete_ignore(
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file1",
             "permissions": 644,
@@ -490,7 +554,15 @@ async def test_purge_on_delete_ignore(
 
     now = datetime.now()
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
@@ -514,7 +586,7 @@ async def test_purge_on_delete_ignore(
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file1",
             "permissions": 644,
@@ -542,7 +614,15 @@ async def test_purge_on_delete_ignore(
 
     now = datetime.now()
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 
@@ -604,7 +684,7 @@ async def test_disable_purge_on_delete(
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1,path=/tmp/file1],v=%d" % version,
+            "id": "std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version,
             "owner": "root",
             "path": "/tmp/file1",
             "permissions": 644,
@@ -632,7 +712,15 @@ async def test_disable_purge_on_delete(
 
     now = datetime.now()
     result = await aclient.resource_action_update(
-        environment, ["std::File[vm1,path=/tmp/file1],v=%d" % version], uuid.uuid4(), "deploy", now, now, "deployed", [], {}
+        environment,
+        ["std::testing::NullResource[vm1,name=/tmp/file1],v=%d" % version],
+        uuid.uuid4(),
+        "deploy",
+        now,
+        now,
+        "deployed",
+        [],
+        {},
     )
     assert result.code == 200
 

--- a/tests/server/test_resource_action_logs.py
+++ b/tests/server/test_resource_action_logs.py
@@ -28,7 +28,7 @@ from inmanta import const, data
 from inmanta.server.config import get_bind_port
 
 # This resource ID has some garbage characters, to make sure the queries are good
-resource_id_a = r"std::File[agent1,path=/tmp#/%%/\_file1.txt]"
+resource_id_a = r"std::testing::NullResource[agent1,name=/tmp#/%%/\_file1.txt]"
 
 
 @pytest.fixture
@@ -64,16 +64,16 @@ async def env_with_logs(client, server, environment: str):
             resource_version_id=f"{resource_id_a},v={i}",
             status=const.ResourceState.deployed,
             last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
-            attributes={"path": "/etc/file2"},
+            attributes={"name": "file2"},
         )
         await res1.insert()
 
         res2 = data.Resource.new(
             environment=uuid.UUID(environment),
-            resource_version_id=f"std::Directory[agent1,path=/tmp/dir2],v={i}",
+            resource_version_id=f"std::testing::NullResource[agent1,name=dir2],v={i}",
             status=const.ResourceState.deployed,
             last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
-            attributes={"path": "/etc/dir2"},
+            attributes={"name": "dir2"},
         )
         await res2.insert()
 
@@ -82,7 +82,7 @@ async def env_with_logs(client, server, environment: str):
             version=i,
             resource_version_ids=[
                 f"{resource_id_a},v={i}",
-                f"std::Directory[agent1,path=/tmp/dir2],v={i}",
+                f"std::testing::NullResource[agent1,name=dir2],v={i}",
             ],
             action_id=action_id,
             action=const.ResourceAction.deploy if i % 2 else const.ResourceAction.pull,
@@ -321,7 +321,7 @@ async def test_log_without_kwargs(server, client, environment: str):
 
     res2 = data.Resource.new(
         environment=uuid.UUID(environment),
-        resource_version_id="std::Directory[agent1,path=/tmp/dir2],v=1",
+        resource_version_id="std::testing::NullResource[agent1,name=dir2],v=1",
         status=const.ResourceState.deployed,
         last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
         attributes={"path": "/etc/file2"},
@@ -333,7 +333,7 @@ async def test_log_without_kwargs(server, client, environment: str):
         version=1,
         resource_version_ids=[
             f"{resource_id_a},v=1",
-            "std::Directory[agent1,path=/tmp/dir2],v=1",
+            "std::testing::NullResource[agent1,name=dir2],v=1",
         ],
         action_id=uuid.uuid4(),
         action=const.ResourceAction.deploy,
@@ -372,16 +372,16 @@ async def test_log_nested_kwargs(server, client, environment: str):
         resource_version_id=f"{resource_id_a},v=1",
         status=const.ResourceState.deployed,
         last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
-        attributes={"path": "/etc/file2"},
+        attributes={"name": "file2"},
     )
     await res1.insert()
 
     res2 = data.Resource.new(
         environment=uuid.UUID(environment),
-        resource_version_id="std::Directory[agent1,path=/tmp/dir2],v=1",
+        resource_version_id="std::testing::NullResource[agent1,name=dir2],v=1",
         status=const.ResourceState.deployed,
         last_deploy=datetime.datetime(2018, 7, 14, 14, 30),
-        attributes={"path": "/etc/file2"},
+        attributes={"name": "file2"},
     )
     await res2.insert()
 
@@ -390,7 +390,7 @@ async def test_log_nested_kwargs(server, client, environment: str):
         version=1,
         resource_version_ids=[
             f"{resource_id_a},v=1",
-            "std::Directory[agent1,path=/tmp/dir2],v=1",
+            "std::testing::NullResource[agent1,name=dir2],v=1",
         ],
         action_id=uuid.uuid4(),
         action=const.ResourceAction.deploy,

--- a/tests/server/test_resource_details.py
+++ b/tests/server/test_resource_details.py
@@ -105,19 +105,19 @@ async def env_with_resources(server, client):
         )
 
     async def create_resource(
-        path: str,
+        name: str,
         status: ResourceState,
         version: int,
         attributes: dict[str, object],
         agent: str = "internal",
-        resource_type: str = "std::File",
+        resource_type: str = "std::testing::NullResource",
         environment: UUID = env.id,
     ):
-        key = f"{resource_type}[{agent},path={path}]"
+        key = f"{resource_type}[{agent},name={name}]"
         res = data.Resource.new(
             environment=environment,
             resource_version_id=ResourceVersionIdStr(f"{key},v={version}"),
-            attributes={**attributes, **{"path": path}},
+            attributes={**attributes, **{"name": name}},
             status=status,
             last_deploy=resource_deploy_times[total_number_of_resources()],
         )
@@ -126,15 +126,15 @@ async def env_with_resources(server, client):
 
     # A resource with multiple resources in its requires list, and multiple versions where it was released,
     # and is also present in versions that were not released
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file1]"].append(
         await create_resource(
             "/tmp/dir1/file1",
             ResourceState.undefined,
             1,
-            {"key1": "val1", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key1": "val1", "requires": ["std::testing::NullResource[internal,name=/tmp/dir1]"]},
         )
     )
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file1]"].append(
         await create_resource(
             "/tmp/dir1/file1",
             ResourceState.skipped,
@@ -142,11 +142,14 @@ async def env_with_resources(server, client):
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=/tmp/dir1]",
+                    "std::testing::NullResource[internal,name=/tmp/dir1/file2]",
+                ],
             },
         )
     )
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file1]"].append(
         await create_resource(
             "/tmp/dir1/file1",
             ResourceState.deploying,
@@ -154,11 +157,14 @@ async def env_with_resources(server, client):
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=/tmp/dir1]",
+                    "std::testing::NullResource[internal,name=/tmp/dir1/file2]",
+                ],
             },
         )
     )
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file1]"].append(
         await create_resource(
             "/tmp/dir1/file1",
             ResourceState.deployed,
@@ -166,11 +172,14 @@ async def env_with_resources(server, client):
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=/tmp/dir1]",
+                    "std::testing::NullResource[internal,name=/tmp/dir1/file2]",
+                ],
             },
         )
     )
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file1]"].append(
         await create_resource(
             "/tmp/dir1/file1",
             ResourceState.undefined,
@@ -178,70 +187,77 @@ async def env_with_resources(server, client):
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=/tmp/dir1]",
+                    "std::testing::NullResource[internal,name=/tmp/dir1/file2]",
+                ],
             },
         )
     )
 
     # A resource that didn't change its attributes, but was only released with the second version and has no requirements
-    resources[env.id]["std::Directory[internal,path=/tmp/dir1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1]"].append(
         await create_resource(
             "/tmp/dir1",
             ResourceState.undefined,
             1,
             {"key2": "val2", "requires": []},
-            resource_type="std::Directory",
+            resource_type="std::testing::NullResource",
         )
     )
-    resources[env.id]["std::Directory[internal,path=/tmp/dir1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1]"].append(
         await create_resource(
-            "/tmp/dir1", ResourceState.deploying, 2, {"key2": "val2", "requires": []}, resource_type="std::Directory"
+            "/tmp/dir1",
+            ResourceState.deploying,
+            2,
+            {"key2": "val2", "requires": []},
+            resource_type="std::testing::NullResource",
         )
     )
-    resources[env.id]["std::Directory[internal,path=/tmp/dir1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1]"].append(
         await create_resource(
-            "/tmp/dir1", ResourceState.deployed, 3, {"key2": "val2", "requires": []}, resource_type="std::Directory"
+            "/tmp/dir1", ResourceState.deployed, 3, {"key2": "val2", "requires": []}, resource_type="std::testing::NullResource"
         )
     )
-    resources[env.id]["std::Directory[internal,path=/tmp/dir1]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1]"].append(
         await create_resource(
-            "/tmp/dir1", ResourceState.deployed, 4, {"key2": "val2", "requires": []}, resource_type="std::Directory"
+            "/tmp/dir1", ResourceState.deployed, 4, {"key2": "val2", "requires": []}, resource_type="std::testing::NullResource"
         )
     )
 
     # A resource that changed the attributes in the last released version,
     # so the last and the first time the attributes are the same, is the same as well;
     # And it also has a single requirement
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file2]"].append(
         await create_resource("/tmp/dir1/file2", ResourceState.undefined, 1, {"key3": "val3", "requires": []})
     )
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file2]"].append(
         await create_resource(
             "/tmp/dir1/file2",
             ResourceState.deployed,
             2,
-            {"key3": "val3", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key3": "val3", "requires": ["std::testing::NullResource[internal,name=/tmp/dir1]"]},
         )
     )
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file2]"].append(
         await create_resource(
             "/tmp/dir1/file2",
             ResourceState.deployed,
             3,
-            {"key3": "val3", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key3": "val3", "requires": ["std::testing::NullResource[internal,name=/tmp/dir1]"]},
         )
     )
-    resources[env.id]["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/dir1/file2]"].append(
         await create_resource(
             "/tmp/dir1/file2",
             ResourceState.deploying,
             4,
-            {"key3": "val3updated", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key3": "val3updated", "requires": ["std::testing::NullResource[internal,name=/tmp/dir1]"]},
         )
     )
 
     # Add an unreleased resource
-    resources[env.id]["std::File[internal,path=/etc/filexyz]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/filexyz]"].append(
         await create_resource(
             "/etc/filexyz",
             ResourceState.undefined,
@@ -249,7 +265,7 @@ async def env_with_resources(server, client):
             {"key4": "val4", "requires": []},
         )
     )
-    resources[env.id]["std::File[internal,path=/etc/never_deployed]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/never_deployed]"].append(
         await create_resource(
             "/etc/never_deployed",
             ResourceState.undefined,
@@ -257,7 +273,7 @@ async def env_with_resources(server, client):
             {"key5": "val5", "requires": []},
         )
     )
-    resources[env.id]["std::File[internal,path=/etc/never_deployed]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/never_deployed]"].append(
         await create_resource(
             "/etc/never_deployed",
             ResourceState.unavailable,
@@ -266,7 +282,7 @@ async def env_with_resources(server, client):
         )
     )
 
-    resources[env.id]["std::File[internal,path=/etc/deployed_only_with_different_hash]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/deployed_only_with_different_hash]"].append(
         await create_resource(
             "/etc/deployed_only_with_different_hash",
             ResourceState.deployed,
@@ -275,7 +291,7 @@ async def env_with_resources(server, client):
         )
     )
 
-    resources[env.id]["std::File[internal,path=/etc/deployed_only_with_different_hash]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/deployed_only_with_different_hash]"].append(
         await create_resource(
             "/etc/deployed_only_with_different_hash",
             ResourceState.undefined,
@@ -284,16 +300,16 @@ async def env_with_resources(server, client):
         )
     )
 
-    resources[env.id]["std::File[internal,path=/etc/deployed_only_in_earlier_version]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/deployed_only_in_earlier_version]"].append(
         await create_resource(
             "/etc/deployed_only_in_earlier_version",
             ResourceState.deployed,
             3,
-            {"key7": "val7", "requires": ["std::File[internal,path=/etc/requirement_in_later_version]"]},
+            {"key7": "val7", "requires": ["std::testing::NullResource[internal,name=/etc/requirement_in_later_version]"]},
         )
     )
 
-    resources[env.id]["std::File[internal,path=/etc/requirement_in_later_version]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/requirement_in_later_version]"].append(
         await create_resource(
             "/etc/requirement_in_later_version",
             ResourceState.deploying,
@@ -301,7 +317,7 @@ async def env_with_resources(server, client):
             {"key8": "val8", "requires": []},
         )
     )
-    resources[env.id]["std::File[internal,path=/etc/requirement_in_later_version]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/requirement_in_later_version]"].append(
         await create_resource(
             "/etc/requirement_in_later_version",
             ResourceState.deployed,
@@ -309,7 +325,7 @@ async def env_with_resources(server, client):
             {"key8": "val8", "requires": []},
         )
     )
-    resources[env.id]["std::File[internal,path=/etc/requirement_in_later_version]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/etc/requirement_in_later_version]"].append(
         await create_resource(
             "/etc/requirement_in_later_version",
             ResourceState.skipped,
@@ -318,15 +334,15 @@ async def env_with_resources(server, client):
         )
     )
 
-    resources[env.id]["std::File[internal,path=/tmp/orphaned]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/orphaned]"].append(
         await create_resource(
             "/tmp/orphaned",
             ResourceState.deployed,
             3,
-            {"key9": "val9", "requires": ["std::File[internal,path=/tmp/orphaned_req]"]},
+            {"key9": "val9", "requires": ["std::testing::NullResource[internal,name=/tmp/orphaned_req]"]},
         )
     )
-    resources[env.id]["std::File[internal,path=/tmp/orphaned_req]"].append(
+    resources[env.id]["std::testing::NullResource[internal,name=/tmp/orphaned_req]"].append(
         await create_resource(
             "/tmp/orphaned_req",
             ResourceState.deployed,
@@ -336,30 +352,30 @@ async def env_with_resources(server, client):
     )
 
     # Add the same resources the first one requires in another environment
-    resources[env2.id]["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources[env2.id]["std::testing::NullResource[internal,name=/tmp/dir1/file2]"].append(
         await create_resource(
             "/tmp/dir1/file2",
             ResourceState.unavailable,
             4,
-            {"key3": "val3", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
-            resource_type="std::Directory",
+            {"key3": "val3", "requires": ["std::testing::NullResource[internal,name=/tmp/dir1]"]},
+            resource_type="std::testing::NullResource",
             environment=env2.id,
         )
     )
 
-    resources[env2.id]["std::Directory[internal,path=/tmp/dir1]"].append(
+    resources[env2.id]["std::testing::NullResource[internal,name=/tmp/dir1]"].append(
         await create_resource(
             "/tmp/dir1",
             ResourceState.available,
             4,
             {"key2": "val2", "requires": []},
-            resource_type="std::Directory",
+            resource_type="std::testing::NullResource",
             environment=env2.id,
         )
     )
 
     # Add the same main resource to another environment with higher version
-    resources[env3.id]["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources[env3.id]["std::testing::NullResource[internal,name=/tmp/dir1/file1]"].append(
         await create_resource(
             "/tmp/dir1/file1",
             ResourceState.deploying,
@@ -367,20 +383,23 @@ async def env_with_resources(server, client):
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=/tmp/dir1]",
+                    "std::testing::NullResource[internal,name=/tmp/dir1/file2]",
+                ],
             },
             environment=env3.id,
         )
     )
     ids = {
-        "multiple_requires": "std::File[internal,path=/tmp/dir1/file1]",
-        "no_requires": "std::Directory[internal,path=/tmp/dir1]",
-        "single_requires": "std::File[internal,path=/tmp/dir1/file2]",
-        "unreleased": "std::File[internal,path=/etc/filexyz]",
-        "never_deployed": "std::File[internal,path=/etc/never_deployed]",
-        "deployed_only_with_different_hash": "std::File[internal,path=/etc/deployed_only_with_different_hash]",
-        "deployed_only_in_earlier_version": "std::File[internal,path=/etc/deployed_only_in_earlier_version]",
-        "orphaned_and_requires_orphaned": "std::File[internal,path=/tmp/orphaned]",
+        "multiple_requires": "std::testing::NullResource[internal,name=/tmp/dir1/file1]",
+        "no_requires": "std::testing::NullResource[internal,name=/tmp/dir1]",
+        "single_requires": "std::testing::NullResource[internal,name=/tmp/dir1/file2]",
+        "unreleased": "std::testing::NullResource[internal,name=/etc/filexyz]",
+        "never_deployed": "std::testing::NullResource[internal,name=/etc/never_deployed]",
+        "deployed_only_with_different_hash": "std::testing::NullResource[internal,name=/etc/deployed_only_with_different_hash]",
+        "deployed_only_in_earlier_version": "std::testing::NullResource[internal,name=/etc/deployed_only_in_earlier_version]",
+        "orphaned_and_requires_orphaned": "std::testing::NullResource[internal,name=/tmp/orphaned]",
     }
 
     yield env, cm_times, ids, resources
@@ -414,8 +433,8 @@ async def test_resource_details(server, client, env_with_resources):
     assert deploy_time == resources[env.id][multiple_requires][3].last_deploy.astimezone(datetime.timezone.utc)
     await assert_matching_attributes(result.result["data"], resources[env.id][multiple_requires][3])
     assert result.result["data"]["requires_status"] == {
-        "std::Directory[internal,path=/tmp/dir1]": "deployed",
-        "std::File[internal,path=/tmp/dir1/file2]": "deploying",
+        "std::testing::NullResource[internal,name=/tmp/dir1]": "deployed",
+        "std::testing::NullResource[internal,name=/tmp/dir1/file2]": "deploying",
     }
     assert result.result["data"]["status"] == "deployed"
 
@@ -440,7 +459,7 @@ async def test_resource_details(server, client, env_with_resources):
     deploy_time = parse_timestamp(result.result["data"]["last_deploy"])
     assert deploy_time == resources[env.id][single_requires][3].last_deploy.astimezone(datetime.timezone.utc)
     await assert_matching_attributes(result.result["data"], resources[env.id][single_requires][3])
-    assert result.result["data"]["requires_status"] == {"std::Directory[internal,path=/tmp/dir1]": "deployed"}
+    assert result.result["data"]["requires_status"] == {"std::testing::NullResource[internal,name=/tmp/dir1]": "deployed"}
     assert result.result["data"]["status"] == "deploying"
 
     result = await client.resource_details(env.id, "non_existing_id")
@@ -470,7 +489,7 @@ async def test_resource_details(server, client, env_with_resources):
     assert result.result["data"]["status"] == "orphaned"
     await assert_matching_attributes(result.result["data"], resources[env.id][deployed_only_in_earlier_version][0])
     assert result.result["data"]["requires_status"] == {
-        "std::File[internal,path=/etc/requirement_in_later_version]": "deployed"
+        "std::testing::NullResource[internal,name=/etc/requirement_in_later_version]": "deployed"
     }
 
     orphaned = ids["orphaned_and_requires_orphaned"]
@@ -479,4 +498,6 @@ async def test_resource_details(server, client, env_with_resources):
     assert result.result["data"]["first_generated_version"] == 3
     assert result.result["data"]["status"] == "orphaned"
     await assert_matching_attributes(result.result["data"], resources[env.id][orphaned][0])
-    assert result.result["data"]["requires_status"] == {"std::File[internal,path=/tmp/orphaned_req]": "orphaned"}
+    assert result.result["data"]["requires_status"] == {
+        "std::testing::NullResource[internal,name=/tmp/orphaned_req]": "orphaned"
+    }

--- a/tests/server/test_resource_history.py
+++ b/tests/server/test_resource_history.py
@@ -97,19 +97,19 @@ async def env_with_resources(server, client):
         return sum([len(resource_list) for resource_list in resources.values()])
 
     async def create_resource(
-        path: str,
+        name: str,
         status: ResourceState,
         version: int,
         attributes: dict[str, object],
         agent: str = "internal",
-        resource_type: str = "std::File",
+        resource_type: str = "std::testing::NullResource",
         environment: UUID = env.id,
     ):
-        key = f"{resource_type}[{agent},path={path}]"
+        key = f"{resource_type}[{agent},name={name}]"
         res = data.Resource.new(
             environment=environment,
             resource_version_id=ResourceVersionIdStr(f"{key},v={version}"),
-            attributes={**attributes, **{"path": path}, "version": version},
+            attributes={**attributes, **{"name": name}, "version": version},
             status=status,
             last_deploy=resource_deploy_times[total_number_of_resources()],
         )
@@ -137,7 +137,7 @@ async def env_with_resources(server, client):
             },
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
             "file1",
             ResourceState.deploying,
@@ -273,7 +273,7 @@ async def env_with_resources(server, client):
             "file2",
             ResourceState.deployed,
             3,
-            {"key3": "val3", "requires": ["std::testing::NullResource[internal,dir1]"]},
+            {"key3": "val3", "requires": ["std::testing::NullResource[internal,name=dir1]"]},
         )
     )
     resources["std::testing::NullResource[internal,name=file2]"].append(
@@ -510,18 +510,18 @@ async def test_history_not_continuous_versions(server, client, environment):
         cm_times.append(datetime.datetime.strptime(f"2021-07-07T11:{i}:00.0", "%Y-%m-%dT%H:%M:%S.%f"))
 
     async def create_resource(
-        path: str,
+        name: str,
         status: ResourceState,
         version: int,
         attributes: dict[str, object],
         agent: str = "internal",
-        resource_type: str = "std::File",
+        resource_type: str = "std::testing::NullResource",
     ):
-        key = f"{resource_type}[{agent},path={path}]"
+        key = f"{resource_type}[{agent},name={name}]"
         res = data.Resource.new(
             environment=environment,
             resource_version_id=ResourceVersionIdStr(f"{key},v={version}"),
-            attributes={**attributes, **{"path": path}, "version": version},
+            attributes={**attributes, **{"name": name}, "version": version},
             status=status,
             last_deploy=datetime.datetime.now(),
         )

--- a/tests/server/test_resource_history.py
+++ b/tests/server/test_resource_history.py
@@ -118,156 +118,177 @@ async def env_with_resources(server, client):
 
     # A resource with multiple resources in its requires list, and multiple versions where it was released,
     # and is also present in versions that were not released
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.undefined,
             1,
-            {"key1": "val1", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key1": "val1", "requires": ["std::testing::NullResource[internal,name=dir1]"]},
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.skipped,
             2,
             {
                 "key1": "val1",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": ["std::testing::NullResource[internal,dir1]", "std::testing::NullResource[internal,name=file2]"],
             },
         )
     )
     resources["std::File[internal,path=/tmp/dir1/file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deploying,
             3,
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deployed,
             4,
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deployed,
             5,
             {
                 "key1": "modified_value2",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deployed,
             6,
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deployed,
             7,
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deployed,
             8,
             {
                 "key1": "different_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deployed,
             9,
             {
                 "key1": "different_value_2",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )
 
     # A resource that didn't change its attributes, but was only released with the second version and has no requirements
     for i in range(1, 9):
-        resources["std::Directory[internal,path=/tmp/dir1]"].append(
+        resources["std::testing::NullResource[internal,name=dir1]"].append(
             await create_resource(
-                "/tmp/dir1",
+                "dir1",
                 ResourceState.undefined,
                 i,
                 {"key2": "val2", "requires": []},
-                resource_type="std::Directory",
+                resource_type="std::testing::NullResource",
             )
         )
 
     # A resource that changed the attributes in the last released version,
     # And it also has a single requirement
-    resources["std::File[internal,path=/tmp/dir1/file2]"].append(
-        await create_resource("/tmp/dir1/file2", ResourceState.undefined, 1, {"key3": "val3", "requires": []})
+    resources["std::testing::NullResource[internal,name=file2]"].append(
+        await create_resource("file2", ResourceState.undefined, 1, {"key3": "val3", "requires": []})
     )
-    resources["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources["std::testing::NullResource[internal,name=file2]"].append(
         await create_resource(
-            "/tmp/dir1/file2",
+            "file2",
             ResourceState.deployed,
             2,
-            {"key3": "val3", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key3": "val3", "requires": ["std::testing::NullResource[internal,name=dir1]"]},
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources["std::testing::NullResource[internal,name=file2]"].append(
         await create_resource(
-            "/tmp/dir1/file2",
+            "file2",
             ResourceState.deployed,
             3,
-            {"key3": "val3", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key3": "val3", "requires": ["std::testing::NullResource[internal,dir1]"]},
         )
     )
-    resources["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources["std::testing::NullResource[internal,name=file2]"].append(
         await create_resource(
-            "/tmp/dir1/file2",
+            "file2",
             ResourceState.deploying,
             8,
-            {"key3": "val3updated", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
+            {"key3": "val3updated", "requires": ["std::testing::NullResource[internal,name=dir1]"]},
         )
     )
 
     # Add an unreleased resource
-    resources["std::File[internal,path=/etc/filexyz]"].append(
+    resources["std::testing::NullResource[internal,name=filexyz]"].append(
         await create_resource(
-            "/etc/filexyz",
+            "filexyz",
             ResourceState.undefined,
             9,
             {"key4": "val4", "requires": []},
@@ -275,47 +296,50 @@ async def env_with_resources(server, client):
     )
 
     # Add the same resources the first one requires in another environment
-    resources["std::File[internal,path=/tmp/dir1/file2]"].append(
+    resources["std::testing::NullResource[internal,name=file2]"].append(
         await create_resource(
-            "/tmp/dir1/file2",
+            "file2",
             ResourceState.unavailable,
             8,
-            {"key3": "val3", "requires": ["std::Directory[internal,path=/tmp/dir1]"]},
-            resource_type="std::Directory",
+            {"key3": "val3", "requires": ["std::testing::NullResource[internal,name=dir1]"]},
+            resource_type="std::testing::NullResource",
             environment=env2.id,
         )
     )
 
-    resources["std::Directory[internal,path=/tmp/dir1]"].append(
+    resources["std::testing::NullResource[internal,name=dir1]"].append(
         await create_resource(
-            "/tmp/dir1",
+            "dir1",
             ResourceState.available,
             8,
             {"key2": "val2", "requires": []},
-            resource_type="std::Directory",
+            resource_type="std::testing::NullResource",
             environment=env2.id,
         )
     )
 
     # Add the same main resource to another environment with higher version
-    resources["std::File[internal,path=/tmp/dir1/file1]"].append(
+    resources["std::testing::NullResource[internal,name=file1]"].append(
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deploying,
             8,
             {
                 "key1": "modified_value",
                 "another_key": "val",
-                "requires": ["std::Directory[internal,path=/tmp/dir1]", "std::File[internal,path=/tmp/dir1/file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
             environment=env3.id,
         )
     )
     ids = {
-        "long_history": "std::File[internal,path=/tmp/dir1/file1]",
-        "single_entry": "std::Directory[internal,path=/tmp/dir1]",
-        "short_history": "std::File[internal,path=/tmp/dir1/file2]",
-        "unreleased": "std::File[internal,path=/etc/filexyz]",
+        "long_history": "std::testing::NullResource[internal,name=file1]",
+        "single_entry": "std::testing::NullResource[internal,name=dir1]",
+        "short_history": "std::testing::NullResource[internal,name=file2]",
+        "unreleased": "std::testing::NullResource[internal,name=filexyz]",
     }
 
     yield env, cm_times, ids, resources
@@ -517,7 +541,7 @@ async def test_history_not_continuous_versions(server, client, environment):
             is_suitable_for_partial_compiles=False,
         ).insert()
         await create_resource(
-            "/tmp/dir1/file1",
+            "file1",
             ResourceState.deployed,
             version,
             {
@@ -525,7 +549,7 @@ async def test_history_not_continuous_versions(server, client, environment):
             },
         )
 
-    result = await client.resource_history(environment, "std::File[internal,path=/tmp/dir1/file1]")
+    result = await client.resource_history(environment, "std::testing::NullResource[internal,name=file1]")
     assert result.code == 200
     assert len(result.result["data"]) == 1
-    assert result.result["data"][0]["attributes"] == {"key1": "val1", "path": "/tmp/dir1/file1", "version": 1}
+    assert result.result["data"][0]["attributes"] == {"key1": "val1", "name": "file1", "version": 1}

--- a/tests/server/test_resource_history.py
+++ b/tests/server/test_resource_history.py
@@ -133,7 +133,10 @@ async def env_with_resources(server, client):
             2,
             {
                 "key1": "val1",
-                "requires": ["std::testing::NullResource[internal,dir1]", "std::testing::NullResource[internal,name=file2]"],
+                "requires": [
+                    "std::testing::NullResource[internal,name=dir1]",
+                    "std::testing::NullResource[internal,name=file2]",
+                ],
             },
         )
     )

--- a/tests/server/test_resourceservice.py
+++ b/tests/server/test_resourceservice.py
@@ -80,14 +80,14 @@ async def test_events_api_endpoints_basic_case(server, client, environment, clie
     rid = r"""exec::Run[agent1,command=sh -c "git _%\/ clone \"https://codis.git\"  && chown -R centos:centos "]"""
     rid_r1_v1 = ResourceIdStr(rid)
     rvid_r1_v1 = ResourceVersionIdStr(f"{rid_r1_v1},v={version}")
-    rid_r2_v1 = ResourceIdStr("std::File[agent1,path=/etc/file2]")
+    rid_r2_v1 = ResourceIdStr("std::testing::NullResource[agent1,name=file2]")
     rvid_r2_v1 = ResourceVersionIdStr(f"{rid_r2_v1},v={version}")
-    rid_r3_v1 = ResourceIdStr("std::File[agent1,path=/etc/file3]")
+    rid_r3_v1 = ResourceIdStr("std::testing::NullResource[agent1,name=file3]")
     rvid_r3_v1 = ResourceVersionIdStr(f"{rid_r3_v1},v={version}")
     resources = [
-        {"path": "/etc/file1", "id": rvid_r1_v1, "requires": [rvid_r2_v1, rvid_r3_v1], "purged": False, "send_event": False},
-        {"path": "/etc/file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": False},
-        {"path": "/etc/file3", "id": rvid_r3_v1, "requires": [], "purged": False, "send_event": False},
+        {"name": "file1", "id": rvid_r1_v1, "requires": [rvid_r2_v1, rvid_r3_v1], "purged": False, "send_event": False},
+        {"name": "file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": False},
+        {"name": "file3", "id": rvid_r3_v1, "requires": [], "purged": False, "send_event": False},
     ]
 
     await clienthelper.put_version_simple(resources, version)
@@ -169,8 +169,8 @@ async def test_events_api_endpoints_increment(server, client, environment, clien
     """
     rid = r"""exec::Run[agent1,command=sh -c "git _%\/ clone \"https://codis.git\"  && chown -R centos:centos "]"""
     rid_r1 = ResourceIdStr(rid)
-    rid_r2 = ResourceIdStr("std::File[agent1,path=/etc/file2]")
-    rid_r3 = ResourceIdStr("std::File[agent1,path=/etc/file3]")
+    rid_r2 = ResourceIdStr("std::testing::NullResource[agent1,name=file2]")
+    rid_r3 = ResourceIdStr("std::testing::NullResource[agent1,name=file3]")
 
     async def put_version() -> tuple[ResourceVersionIdStr, ResourceVersionIdStr, ResourceVersionIdStr]:
         version = await clienthelper.get_version()
@@ -179,9 +179,9 @@ async def test_events_api_endpoints_increment(server, client, environment, clien
         rvid_r2_v1 = ResourceVersionIdStr(f"{rid_r2},v={version}")
         rvid_r3_v1 = ResourceVersionIdStr(f"{rid_r3},v={version}")
         resources = [
-            {"path": "/etc/file1", "id": rvid_r1_v1, "requires": [rvid_r2_v1, rvid_r3_v1], "purged": False, "send_event": True},
-            {"path": "/etc/file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": True},
-            {"path": "/etc/file3", "id": rvid_r3_v1, "requires": [], "purged": False, "send_event": True},
+            {"name": "file1", "id": rvid_r1_v1, "requires": [rvid_r2_v1, rvid_r3_v1], "purged": False, "send_event": True},
+            {"name": "file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": True},
+            {"name": "file3", "id": rvid_r3_v1, "requires": [], "purged": False, "send_event": True},
         ]
 
         await clienthelper.put_version_simple(resources, version)
@@ -277,11 +277,11 @@ async def test_events_api_endpoints_events_across_versions(server, client, envir
     """
     # Version 1
     version = await clienthelper.get_version()
-    rvid_r1_v1 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file1],v={version}")
-    rvid_r2_v1 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file2],v={version}")
+    rvid_r1_v1 = ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file1],v={version}")
+    rvid_r2_v1 = ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file2],v={version}")
     resources = [
-        {"path": "/etc/file1", "id": rvid_r1_v1, "requires": [rvid_r2_v1], "purged": False, "send_event": False},
-        {"path": "/etc/file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": False},
+        {"name": "file1", "id": rvid_r1_v1, "requires": [rvid_r2_v1], "purged": False, "send_event": False},
+        {"name": "file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": False},
     ]
     await clienthelper.put_version_simple(resources, version)
 
@@ -290,13 +290,13 @@ async def test_events_api_endpoints_events_across_versions(server, client, envir
 
     # Version 2
     version = await clienthelper.get_version()
-    rvid_r1_v2 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file1],v={version}")
-    rvid_r2_v2 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file2],v={version}")
-    rvid_r3_v2 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file3],v={version}")
+    rvid_r1_v2 = ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file1],v={version}")
+    rvid_r2_v2 = ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file2],v={version}")
+    rvid_r3_v2 = ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file3],v={version}")
     resources = [
-        {"path": "/etc/file1", "id": rvid_r1_v2, "requires": [rvid_r2_v2, rvid_r3_v2], "purged": False, "send_event": False},
-        {"path": "/etc/file2", "id": rvid_r2_v2, "requires": [], "purged": False, "send_event": False},
-        {"path": "/etc/file3", "id": rvid_r3_v2, "requires": [], "purged": False, "send_event": False},
+        {"name": "file1", "id": rvid_r1_v2, "requires": [rvid_r2_v2, rvid_r3_v2], "purged": False, "send_event": False},
+        {"name": "file2", "id": rvid_r2_v2, "requires": [], "purged": False, "send_event": False},
+        {"name": "file3", "id": rvid_r3_v2, "requires": [], "purged": False, "send_event": False},
     ]
     await clienthelper.put_version_simple(resources, version)
 
@@ -306,12 +306,12 @@ async def test_events_api_endpoints_events_across_versions(server, client, envir
 
     # Version 3
     version = await clienthelper.get_version()
-    rvid_r1_v3 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file1],v={version}")
-    rid_v3_v3 = ResourceIdStr("std::File[agent1,path=/etc/file3]")
+    rvid_r1_v3 = ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file1],v={version}")
+    rid_v3_v3 = ResourceIdStr("std::testing::NullResource[agent1,name=file3]")
     rvid_r3_v3 = ResourceVersionIdStr(f"{rid_v3_v3},v={version}")
     resources = [
-        {"path": "/etc/file1", "id": rvid_r1_v3, "requires": [rvid_r3_v3], "purged": False, "send_event": False},
-        {"path": "/etc/file3", "id": rvid_r3_v3, "requires": [], "purged": False, "send_event": False},
+        {"name": "file1", "id": rvid_r1_v3, "requires": [rvid_r3_v3], "purged": False, "send_event": False},
+        {"name": "file3", "id": rvid_r3_v3, "requires": [], "purged": False, "send_event": False},
     ]
     await clienthelper.put_version_simple(resources, version)
 
@@ -354,9 +354,9 @@ async def test_events_resource_without_dependencies(server, client, environment,
     """
     # Version 1
     version = await clienthelper.get_version()
-    rvid_r1_v1 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file1],v={version}")
+    rvid_r1_v1 = ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file1],v={version}")
     resources = [
-        {"path": "/etc/file1", "id": rvid_r1_v1, "requires": [], "purged": False, "send_event": False},
+        {"name": "file1", "id": rvid_r1_v1, "requires": [], "purged": False, "send_event": False},
     ]
     await clienthelper.put_version_simple(resources, version)
 
@@ -382,11 +382,13 @@ async def test_last_non_deploying_status_field_on_resource(
                             The old one (resource_action_update) or the new one (deployment_endpoint).
     """
     version = await clienthelper.get_version()
-    rvid_r1_v1 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file1],v={version}")
-    rvid_r2_v1 = ResourceVersionIdStr(f"std::File[agent1,path=/etc/file2],v={version}")
+    rid_r1 = "std::testing::NullResource[agent1,name=file1]"
+    rvid_r1_v1 = ResourceVersionIdStr(f"{rid_r1},v={version}")
+    rid_r2 = "std::testing::NullResource[agent1,name=file2]"
+    rvid_r2_v1 = ResourceVersionIdStr(f"{rid_r2},v={version}")
     resources = [
-        {"path": "/etc/file1", "id": rvid_r1_v1, "requires": [], "purged": False, "send_event": False},
-        {"path": "/etc/file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": False},
+        {"name": "file1", "id": rvid_r1_v1, "requires": [], "purged": False, "send_event": False},
+        {"name": "file2", "id": rvid_r2_v1, "requires": [], "purged": False, "send_event": False},
     ]
     await clienthelper.put_version_simple(resources, version)
 
@@ -489,10 +491,10 @@ async def test_log_deploy_start(server, client, environment, clienthelper, agent
     """
     # Version 1
     version = await clienthelper.get_version()
-    rid_r1 = ResourceIdStr("std::File[agent1,path=/etc/file1]")
+    rid_r1 = ResourceIdStr("std::testing::NullResource[agent1,name=file1]")
     rvid_r1_v1 = ResourceVersionIdStr(f"{rid_r1},v={version}")
     resources = [
-        {"path": "/etc/file1", "id": rvid_r1_v1, "requires": [], "purged": False, "send_event": False},
+        {"name": "file1", "id": rvid_r1_v1, "requires": [], "purged": False, "send_event": False},
     ]
     await clienthelper.put_version_simple(resources, version)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -50,7 +50,7 @@ async def test_agent_get_status(server, environment, agent):
 
 def test_context_changes():
     """Test registering changes in the handler context"""
-    resource = PurgeableResource(Id.parse_id("std::File[agent,path=/test],v=1"))
+    resource = PurgeableResource(Id.parse_id("std::testing::NullResource[agent,name=test],v=1"))
     ctx = HandlerContext(resource)
 
     # use attribute change attributes

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1148,11 +1148,11 @@ async def test_mark_done(init_dataclasses_and_load_schema, resource_state, versi
 
 
 async def populate_model(env_id, version):
-    def get_path(n):
+    def get_name(n):
         return "/tmp/%d" % n
 
     def get_id(n):
-        return "std::File[agent1,path=/tmp/%d],v=%s" % (n, version)
+        return "std::testing::NullResource[agent1,name=/tmp/%d],v=%s" % (n, version)
 
     def get_resource(n, depends, status=const.ResourceState.available):
         requires = [get_id(z) for z in depends]
@@ -1160,7 +1160,7 @@ async def populate_model(env_id, version):
             environment=env_id,
             resource_version_id=get_id(n),
             status=status,
-            attributes={"path": get_path(n), "purge_on_delete": False, "purged": False, "requires": requires},
+            attributes={"name": get_name(n), "purge_on_delete": False, "purged": False, "requires": requires},
         )
 
     res1 = get_resource(1, [])
@@ -1202,17 +1202,17 @@ async def test_resource_purge_on_delete(init_dataclasses_and_load_schema):
 
     res11 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
+        resource_version_id="std::testing::NullResource[agent1,name=/etc/motd],v=%s" % version,
         status=const.ResourceState.deployed,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": False},
     )
     await res11.insert()
 
     res12 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent2,path=/etc/motd],v=%s" % version,
+        resource_version_id="std::testing::NullResource[agent2,name=/etc/motd],v=%s" % version,
         status=const.ResourceState.deployed,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": True},
     )
     await res12.insert()
 
@@ -1233,9 +1233,9 @@ async def test_resource_purge_on_delete(init_dataclasses_and_load_schema):
 
         res21 = data.Resource.new(
             environment=env.id,
-            resource_version_id="std::File[agent5,path=/etc/motd],v=%s" % version,
+            resource_version_id="std::testing::NullResource[agent5,name=/etc/motd],v=%s" % version,
             status=const.ResourceState.available,
-            attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+            attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": False},
         )
         await res21.insert()
 
@@ -1255,7 +1255,7 @@ async def test_resource_purge_on_delete(init_dataclasses_and_load_schema):
 
     assert len(to_purge) == 1
     assert to_purge[0].model == 1
-    assert to_purge[0].resource_id == "std::File[agent1,path=/etc/motd]"
+    assert to_purge[0].resource_id == "std::testing::NullResource[agent1,name=/etc/motd]"
 
 
 async def test_issue_422(init_dataclasses_and_load_schema):
@@ -1281,9 +1281,9 @@ async def test_issue_422(init_dataclasses_and_load_schema):
 
     res11 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
+        resource_version_id="std::testing::NullResource[agent1,name=/etc/motd],v=%s" % version,
         status=const.ResourceState.deployed,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": False},
     )
     await res11.insert()
 
@@ -1303,9 +1303,9 @@ async def test_issue_422(init_dataclasses_and_load_schema):
 
     res21 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % version,
+        resource_version_id="std::testing::NullResource[agent1,name=/etc/motd],v=%s" % version,
         status=const.ResourceState.available,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": False},
     )
     await res21.insert()
 
@@ -1325,7 +1325,7 @@ async def test_issue_422(init_dataclasses_and_load_schema):
 
     assert len(to_purge) == 1
     assert to_purge[0].model == 1
-    assert to_purge[0].resource_id == "std::File[agent1,path=/etc/motd]"
+    assert to_purge[0].resource_id == "std::testing::NullResource[agent1,name=/etc/motd]"
 
 
 async def test_get_latest_resource(init_dataclasses_and_load_schema, postgresql_client):
@@ -1813,35 +1813,35 @@ async def test_resource_copy_last_success(init_dataclasses_and_load_schema):
 
     res1 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/file1],v=1",
+        resource_version_id="std::testing::NullResource[agent1,name=/etc/file1],v=1",
         status=const.ResourceState.deployed,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": False},
     )
     res2 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/file1],v=2",
+        resource_version_id="std::testing::NullResource[agent1,name=/etc/file1],v=2",
         status=const.ResourceState.deployed,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": False},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": False},
         last_success=marker_date,
     )
     res3 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/file1],v=3",
+        resource_version_id="std::testing::NullResource[agent1,name=/etc/file1],v=3",
         status=const.ResourceState.available,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": True},
     )
     res4 = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/file1],v=4",
+        resource_version_id="std::testing::NullResource[agent1,path=/etc/file1],v=4",
         status=const.ResourceState.available,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": True},
     )
 
     side_res = data.Resource.new(
         environment=env.id,
-        resource_version_id="std::File[agent1,path=/etc/file2],v=3",
+        resource_version_id="std::testing::NullResource[agent1,path=/etc/file2],v=3",
         status=const.ResourceState.available,
-        attributes={"path": "/etc/motd", "purge_on_delete": True, "purged": True},
+        attributes={"name": "/etc/motd", "purge_on_delete": True, "purged": True},
     )
 
     await res1.insert()

--- a/tests/test_data_concurrency.py
+++ b/tests/test_data_concurrency.py
@@ -104,7 +104,7 @@ async def test_4889_deadlock_delete_resource_action_update(
         is_suitable_for_partial_compiles=False,
     ).insert()
 
-    resource = model.ResourceVersionIdStr(f"std::File[agent1,path=/etc/file1],v={version}")
+    resource = model.ResourceVersionIdStr(f"std::testing::NullResource[agent1,name=file1],v={version}")
     await data.Resource.new(
         environment=env_id,
         status=const.ResourceState.available,
@@ -119,7 +119,7 @@ async def test_4889_deadlock_delete_resource_action_update(
         id=parameter_id,
         source=const.ParameterSource.user,
         value="val",
-        resource_id="std::File[agent1,path=/etc/file1]",
+        resource_id="std::testing::NullResource[agent1,name=file1]",
     )
     assert result.code == 200
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -27,17 +27,16 @@ from inmanta import deploy
 
 
 @pytest.mark.parametrize("default_main_file", [True, False])
-def test_deploy(snippetcompiler, tmpdir, postgres_db, default_main_file: bool):
+def test_deploy(snippetcompiler, tmpdir, postgres_db, default_main_file: bool, capsys):
     """
     Test the deploy command. The default_main_file parameter checks that the deploy command accepts
     files other than `main.cf` through its `-f` cli option.
     """
-    file_name = tmpdir.join("test_file")
     # TODO: when agentconfig deploys no longer require an agent restart, define a new agent. Currently this makes the
     # test to slow.
-    code = f"""
-        host = std::Host(name="internal", os=std::linux)
-        file = std::Symlink(host=host, source="/dev/null", target="{file_name}")
+    code = """
+        import std::testing
+        test_resource = std::testing::NullResource(name="test")
     """
 
     main_file = "main.cf" if default_main_file else "other.cf"
@@ -47,8 +46,9 @@ def test_deploy(snippetcompiler, tmpdir, postgres_db, default_main_file: bool):
     Options = collections.namedtuple("Options", ["dryrun", "dashboard", "main_file"])
     options = Options(dryrun=False, dashboard=False, main_file=main_file)
 
-    assert not file_name.exists()
+    out, err = capsys.readouterr()
 
+    assert out == ""
     run = deploy.Deploy(options, postgresport=postgres_db.port)
     try:
         if not run.setup():
@@ -57,24 +57,22 @@ def test_deploy(snippetcompiler, tmpdir, postgres_db, default_main_file: bool):
     finally:
         run.stop()
 
-    assert file_name.exists()
-
+    out, err = capsys.readouterr()
+    assert "deployed\n[1 / 1]" in out
     assert project.main_file == main_file
 
 
 @pytest.mark.slowtest
-def test_deploy_with_non_default_config(snippetcompiler, tmpdir) -> None:
+def test_deploy_with_non_default_config(snippetcompiler, tmpdir, capsys) -> None:
     """
     Ensure that configuration options set in one of the inmanta configuration
     files cannot make the `inmanta deploy` fail.
     """
-    file_name = tmpdir.join("test_file")
     snippetcompiler.setup_for_snippet(
         """
-    host = std::Host(name="internal", os=std::linux)
-    file = std::Symlink(host=host, source="/dev/null", target="%s")
+    import std::testing
+    a = std::testing::NullResource()
     """
-        % file_name
     )
 
     path_dot_inmanta_file = os.path.join(snippetcompiler.project_dir, ".inmanta")
@@ -94,9 +92,9 @@ bind-address=192.168.100.100
         """
         )
 
-    assert not file_name.exists()
-    subprocess.check_call([sys.executable, "-m", "inmanta.app", "deploy"], cwd=snippetcompiler.project_dir)
-    assert file_name.exists()
+    out = subprocess.check_output([sys.executable, "-m", "inmanta.app", "deploy"], cwd=snippetcompiler.project_dir)
+    output = out.decode("utf-8")
+    assert "deployed\n[1 / 1]" in output
 
 
 async def test_fork(server):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -61,8 +61,8 @@ def test_code_manager(tmpdir: py.path.local):
     import inmanta_plugins.single_plugin_file as single
 
     mgr = loader.CodeManager()
-    mgr.register_code("std::File", single.MyHandler)
-    mgr.register_code("std::Directory", multi.MyHandler)
+    mgr.register_code("std::testing::NullResource", single.MyHandler)
+    mgr.register_code("multiple_plugin_files::NullResourceBis", multi.MyHandler)
 
     def assert_content(source_info: SourceInfo, handler) -> str:
         filename = inspect.getsourcefile(handler)
@@ -76,11 +76,11 @@ def test_code_manager(tmpdir: py.path.local):
 
     # get types
     types = dict(mgr.get_types())
-    assert "std::File" in types
-    assert "std::Directory" in types
+    assert "std::testing::NullResource" in types
+    assert "multiple_plugin_files::NullResourceBis" in types
 
-    single_type_list: list[SourceInfo] = types["std::File"]
-    multi_type_list: list[SourceInfo] = types["std::Directory"]
+    single_type_list: list[SourceInfo] = types["std::testing::NullResource"]
+    multi_type_list: list[SourceInfo] = types["multiple_plugin_files::NullResourceBis"]
 
     assert len(single_type_list) == 1
     single_content: str = assert_content(single_type_list[0], single.MyHandler)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -346,7 +346,7 @@ end
     statements = parse_code(
         """
 implementation test for Test:
-    std::File(attr="a")
+    std::testing::NullResource(attr="a")
     var = hello::func("world")
 end
 """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -393,7 +393,7 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version,
+            "id": "std::testing::NullResource[vm1.dev.inmanta.com,name=network],v=%d" % version,
             "owner": "root",
             "path": "/etc/sysconfig/network",
             "permissions": 644,
@@ -405,7 +405,7 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
         {
             "group": "root",
             "hash": "b4350bef50c3ec3ee532d4a3f9d6daedec3d2aba",
-            "id": "std::File[vm2.dev.inmanta.com,path=/etc/motd],v=%d" % version,
+            "id": "std::testing::NullResource[vm2.dev.inmanta.com,name=motd],v=%d" % version,
             "owner": "root",
             "path": "/etc/motd",
             "permissions": 644,
@@ -417,7 +417,7 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
         {
             "group": "root",
             "hash": "3bfcdad9ab7f9d916a954f1a96b28d31d95593e4",
-            "id": "std::File[vm1.dev.inmanta.com,path=/etc/hostname],v=%d" % version,
+            "id": "std::testing::NullResource[vm1.dev.inmanta.com,name=hostname],v=%d" % version,
             "owner": "root",
             "path": "/etc/hostname",
             "permissions": 644,
@@ -430,7 +430,7 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
             "id": "std::Service[vm1.dev.inmanta.com,name=network],v=%d" % version,
             "name": "network",
             "onboot": True,
-            "requires": ["std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version],
+            "requires": ["std::testing::NullResource[vm1.dev.inmanta.com,name=network],v=%d" % version],
             "state": "running",
             "version": version,
         },
@@ -474,7 +474,7 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     now = datetime.now()
     result = await aclient.resource_action_update(
         environment_multi,
-        ["std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version],
+        ["std::testing::NullResource[vm1.dev.inmanta.com,name=network],v=%d" % version],
         action_id,
         "deploy",
         now,
@@ -494,7 +494,7 @@ async def test_get_resource_for_agent(server_multi, client_multi, environment_mu
     now = datetime.now()
     result = await aclient.resource_action_update(
         environment_multi,
-        ["std::File[vm1.dev.inmanta.com,path=/etc/hostname],v=%d" % version],
+        ["std::testing::NullResource[vm1.dev.inmanta.com,name=hostname],v=%d" % version],
         action_id,
         "deploy",
         now,
@@ -520,7 +520,7 @@ async def test_get_environment(client, clienthelper, server, environment):
                 {
                     "group": "root",
                     "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-                    "id": "std::File[vm1.dev.inmanta.com,path=/tmp/file%d],v=%d" % (j, version),
+                    "id": "std::testing::NullResource[vm1.dev.inmanta.com,name=file%d],v=%d" % (j, version),
                     "owner": "root",
                     "path": "/tmp/file%d" % j,
                     "permissions": 644,
@@ -567,7 +567,7 @@ async def test_resource_update(postgresql_client, client, clienthelper, server, 
             {
                 "group": "root",
                 "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-                "id": "std::File[vm1,path=/tmp/file%d],v=%d" % (j, version),
+                "id": "std::testing::NullResource[vm1,name=file%d],v=%d" % (j, version),
                 "owner": "root",
                 "path": "/tmp/file%d" % j,
                 "permissions": 644,
@@ -789,7 +789,7 @@ async def test_resource_action_log(server, client, environment):
         {
             "group": "root",
             "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-            "id": "std::File[vm1.dev.inmanta.com,path=/etc/sysconfig/network],v=%d" % version,
+            "id": "std::testing::NullResource[vm1.dev.inmanta.com,name=network],v=%d" % version,
             "owner": "root",
             "path": "/etc/sysconfig/network",
             "permissions": 644,
@@ -824,7 +824,7 @@ async def test_invalid_sid(server, client, environment):
     Test the server to manage the updates on a model during agent deploy
     """
     # request get_code with a compiler client that does not have a sid
-    res = await client.get_code(tid=environment, id=1, resource="std::File")
+    res = await client.get_code(tid=environment, id=1, resource="std::testing::NullResource")
     assert res.code == 400
     assert res.result["message"] == "Invalid request: this is an agent to server call, it should contain an agent session id"
 
@@ -901,7 +901,7 @@ async def test_get_resource_actions(postgresql_client, client, clienthelper, ser
             {
                 "group": "root",
                 "hash": "89bf880a0dc5ffc1156c8d958b4960971370ee6a",
-                "id": "std::File[vm1,path=/tmp/file%d],v=%d" % (j, version),
+                "id": "std::testing::NullResource[vm1,name=file%d],v=%d" % (j, version),
                 "owner": "root",
                 "path": "/tmp/file%d" % j,
                 "permissions": 644,
@@ -915,7 +915,7 @@ async def test_get_resource_actions(postgresql_client, client, clienthelper, ser
     #  adding a resource action with its change field set to "created" to test the get_resource_actions
     #  filtering on resources with changes
 
-    rvid_r1_v1 = f"std::File[agent1,path=/etc/file200],v={version}"
+    rvid_r1_v1 = f"std::testing::NullResource[agent1,name=file200],v={version}"
     resources.append(
         {
             "group": "root",
@@ -1038,7 +1038,7 @@ async def test_resource_action_pagination(postgresql_client, client, clienthelpe
         await cm.insert()
         res1 = data.Resource.new(
             environment=env.id,
-            resource_version_id="std::File[agent1,path=/etc/motd],v=%s" % str(i),
+            resource_version_id="std::testing::NullResource[agent1,name=motd],v=%s" % str(i),
             status=const.ResourceState.deployed,
             last_deploy=datetime.now() + timedelta(minutes=i),
             attributes={"attr": [{"a": 1, "b": "c"}], "path": "/etc/motd"},
@@ -1051,7 +1051,7 @@ async def test_resource_action_pagination(postgresql_client, client, clienthelpe
     resource_action = data.ResourceAction(
         environment=env.id,
         version=1,
-        resource_version_ids=[f"std::File[agent1,path=/etc/motd],v={1}"],
+        resource_version_ids=[f"std::testing::NullResource[agent1,name=motd],v={1}"],
         action_id=earliest_action_id,
         action=const.ResourceAction.deploy,
         started=motd_first_start_time - timedelta(minutes=1),
@@ -1067,7 +1067,7 @@ async def test_resource_action_pagination(postgresql_client, client, clienthelpe
         resource_action = data.ResourceAction(
             environment=env.id,
             version=i,
-            resource_version_ids=[f"std::File[agent1,path=/etc/motd],v={i}"],
+            resource_version_ids=[f"std::testing::NullResource[agent1,name=motd],v={i}"],
             action_id=action_id,
             action=const.ResourceAction.deploy,
             started=motd_first_start_time,
@@ -1080,7 +1080,7 @@ async def test_resource_action_pagination(postgresql_client, client, clienthelpe
     resource_action = data.ResourceAction(
         environment=env.id,
         version=6,
-        resource_version_ids=[f"std::File[agent1,path=/etc/motd],v={6}"],
+        resource_version_ids=[f"std::testing::NullResource[agent1,name=motd],v={6}"],
         action_id=later_action_id,
         action=const.ResourceAction.deploy,
         started=motd_first_start_time + timedelta(minutes=6),
@@ -1091,7 +1091,7 @@ async def test_resource_action_pagination(postgresql_client, client, clienthelpe
 
     result = await client.get_resource_actions(
         tid=env.id,
-        resource_type="std::File",
+        resource_type="std::testing::NullResource",
         attribute="path",
         attribute_value="/etc/motd",
         last_timestamp=motd_first_start_time + timedelta(minutes=7),
@@ -1165,9 +1165,9 @@ async def test_resource_deploy_start(server, client, environment, agent, endpoin
     await cm.insert()
 
     model_version = 1
-    rvid_r1 = "std::File[agent1,path=/etc/file1]"
-    rvid_r2 = "std::File[agent1,path=/etc/file2]"
-    rvid_r3 = "std::File[agent1,path=/etc/file3]"
+    rvid_r1 = "std::testing::NullResource[agent1,name=file1]"
+    rvid_r2 = "std::testing::NullResource[agent1,name=file2]"
+    rvid_r3 = "std::testing::NullResource[agent1,name=file3]"
     rvid_r1_v1 = f"{rvid_r1},v={model_version}"
     rvid_r2_v1 = f"{rvid_r2},v={model_version}"
     rvid_r3_v1 = f"{rvid_r3},v={model_version}"
@@ -1238,13 +1238,13 @@ async def test_resource_deploy_start_error_handling(server, client, environment,
 
     # Version part missing from resource_version_id
     result = await agent._client.resource_deploy_start(
-        tid=env_id, rvid="std::File[agent1,path=/etc/file1]", action_id=uuid.uuid4()
+        tid=env_id, rvid="std::testing::NullResource[agent1,name=file1]", action_id=uuid.uuid4()
     )
     assert result.code == 400
     assert "Invalid resource version id" in result.result["message"]
 
     # Execute resource_deploy_start call for resource that doesn't exist
-    resource_id = "std::File[agent1,path=/etc/file1],v=1"
+    resource_id = "std::testing::NullResource[agent1,name=file1],v=1"
     result = await agent._client.resource_deploy_start(tid=env_id, rvid=resource_id, action_id=uuid.uuid4())
     assert result.code == 404
     assert f"Environment {environment} doesn't contain a resource with id {resource_id}" in result.result["message"]
@@ -1268,7 +1268,7 @@ async def test_resource_deploy_start_action_id_conflict(server, client, environm
     await cm.insert()
 
     model_version = 1
-    rvid_r1_v1 = f"std::File[agent1,path=/etc/file1],v={model_version}"
+    rvid_r1_v1 = f"std::testing::NullResource[agent1,name=file1],v={model_version}"
 
     await data.Resource.new(
         environment=env_id,
@@ -1313,7 +1313,7 @@ async def test_resource_deploy_done(server, client, environment, agent, caplog, 
     )
     await cm.insert()
 
-    rvid_r1_v1 = f"std::File[agent1,path=/etc/file1],v={model_version}"
+    rvid_r1_v1 = f"std::testing::NullResource[agent1,name=file1],v={model_version}"
     await data.Resource.new(
         environment=env_id,
         status=const.ResourceState.available,
@@ -1328,7 +1328,7 @@ async def test_resource_deploy_done(server, client, environment, agent, caplog, 
         id=parameter_id,
         source=const.ParameterSource.user,
         value="val",
-        resource_id="std::File[agent1,path=/etc/file1]",
+        resource_id="std::testing::NullResource[agent1,name=file1]",
     )
     assert result.code == 200
 
@@ -1485,7 +1485,7 @@ async def test_resource_deploy_done_invalid_state(server, client, environment, a
     )
     await cm.insert()
 
-    rvid_r1_v1 = f"std::File[agent1,path=/etc/file1],v={model_version}"
+    rvid_r1_v1 = f"std::testing::NullResource[agent1,name=file1],v={model_version}"
     await data.Resource.new(
         environment=env_id,
         status=const.ResourceState.available,
@@ -1524,7 +1524,7 @@ async def test_resource_deploy_done_error_handling(server, client, environment, 
     )
     await cm.insert()
 
-    rvid_r1_v1 = f"std::File[agent1,path=/etc/file1],v={model_version}"
+    rvid_r1_v1 = f"std::testing::NullResource[agent1,name=file1],v={model_version}"
 
     # Resource doesn't exist
     result = await agent._client.resource_deploy_done(
@@ -1635,11 +1635,11 @@ async def test_cleanup_old_agents(server, client, env1_halted, env2_halted):
         is_suitable_for_partial_compiles=False,
     ).insert()
 
-    path = "/etc/file1"
-    resource_id = f"std::File[agent4,path={path}]"
+    name = "file1"
+    resource_id = f"std::testing::NullResource[agent4,name={name}]"
 
     await data.Resource.new(
-        environment=env1.id, resource_version_id=ResourceVersionIdStr(f"{resource_id},v={version}"), attributes={"path": path}
+        environment=env1.id, resource_version_id=ResourceVersionIdStr(f"{resource_id},v={version}"), attributes={"name": name}
     ).insert()
 
     # should get purged


### PR DESCRIPTION
# Description

drop all usages of deprecated std resources from core test

(https://github.com/suite/inmanta-core/issues/7356)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
