### PR TITLE
Issue/fix compatibility range display for not yet pinned modules

### DIFF
--- a/changelogs/unreleased/fix-module-compatibility-range-display-for-not-pinned-case.yml
+++ b/changelogs/unreleased/fix-module-compatibility-range-display-for-not-pinned-case.yml
@@ -1,0 +1,4 @@
+description: Add default display value for modules compatibility ranges. This fixes an error in the docs build
+  where the ``centered`` directive was called without arguments.
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/docs/_templates/components_requirements.tmpl
+++ b/docs/_templates/components_requirements.tmpl
@@ -46,6 +46,12 @@
 
        {% for key, value in data["module_compatibility_ranges"]  | dictsort %}
        {% if key in list_only %}
+
+       {% if value %}
+       {% set compatible_range = value %}
+       {% else %}
+       {% set compatible_range = 'Not pinned yet' %}
+
        * - {{ key.split("inmanta-module-")[1] }}
          - .. centered:: {{ value }}
        {% endif %}

--- a/docs/_templates/components_requirements.tmpl
+++ b/docs/_templates/components_requirements.tmpl
@@ -51,9 +51,10 @@
        {% set compatible_range = value %}
        {% else %}
        {% set compatible_range = 'Not pinned yet' %}
+       {% endif %}
 
        * - {{ key.split("inmanta-module-")[1] }}
-         - .. centered:: {{ value }}
+         - .. centered:: {{ compatible_range }}
        {% endif %}
        {% endfor %}
 

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -556,11 +556,13 @@ class Id:
         """
         String representation for this resource id with the following format:
             <type>[<agent>,<attribute>=<value>]
+
             - type: The resource type, as defined in the configuration model.
                 For example :inmanta:entity:`std::testing::NullResource`.
             - agent: The agent responsible for this resource.
             - attribute: The key attribute that uniquely identifies this resource on the agent
             - value: The corresponding value for this key attribute.
+
         :return: Returns a :py:class:`inmanta.data.model.ResourceIdStr`
         """
         return cast(


### PR DESCRIPTION
# Description

Follow-up to https://github.com/inmanta/irt/pull/2028 
In this PR:
- fix a doc build indentation error error in `resource_str` docstring
- fix a doc build error in the case where the module compatibility range is not yet pinned (this bug was happening on master dev doc builds)


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
