### PR TITLE
ensure_agents: do not start new agent process if a session is active

### DIFF
--- a/changelogs/unreleased/ensure-agents-do-not-start-when-active-session.yml
+++ b/changelogs/unreleased/ensure-agents-do-not-start-when-active-session.yml
@@ -1,0 +1,6 @@
+description: "Do not start new agent process when session is active, even if non-autostarted"
+change-type: patch
+destination-branches:
+  - master
+  - iso7
+  - iso6

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -1117,7 +1117,7 @@ class AutostartedAgentManager(ServerSlice):
                 if env.halted:
                     return False
 
-                if await self._agent_manager.are_agents_active(env.id, autostart_agents):
+                if not restart and await self._agent_manager.are_agents_active(env.id, autostart_agents):
                     # do not start a new agent process if the agents are already active, regardless of whether their session
                     # is with an autostarted process or not.
                     return False

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -645,6 +645,21 @@ class AgentManager(ServerSlice, SessionListener):
             )
             await asyncio.gather(*(s.expire_and_abort(timeout=0) for s in sessions_to_expire))
 
+    async def are_agents_active(self, tid: uuid.UUID, endpoints: Iterable[str]) -> bool:
+        """
+        Return true iff all the given agents are in the up or the paused state.
+        """
+        return all(active for (_, active) in await self.get_agent_active_status(tid, endpoints))
+
+    async def get_agent_active_status(self, tid: uuid.UUID, endpoints: Iterable[str]) -> list[tuple[str, bool]]:
+        """
+        Return a list of tuples where the first element of the tuple contains the name of an endpoint
+        and the second a boolean indicating where there is an active (up or paused) agent for that endpoint.
+        """
+        all_sids_for_env = [sid for (sid, session) in self.sessions.items() if session.tid == tid]
+        all_active_endpoints_for_env = {ep for sid in all_sids_for_env for ep in self.endpoints_for_sid[sid]}
+        return [(ep, ep in all_active_endpoints_for_env) for ep in endpoints]
+
     async def expire_all_sessions_for_environment(self, env_id: uuid.UUID) -> None:
         async with self.session_lock:
             await asyncio.gather(*[s.expire_and_abort(timeout=0) for s in self.sessions.values() if s.tid == env_id])
@@ -1100,6 +1115,11 @@ class AutostartedAgentManager(ServerSlice):
                     raise Exception("Can't ensure agent: environment %s does not exist" % env.id)
                 env = refreshed_env
                 if env.halted:
+                    return False
+
+                if await self._agent_manager.are_agents_active(env.id, autostart_agents):
+                    # do not start a new agent process if the agents are already active, regardless of whether their session
+                    # is with an autostarted process or not.
                     return False
 
                 start_new_process: bool


### PR DESCRIPTION
# Description

#7612 made the autostarted agent manager take full authority over autostarted agents. However, it was decided that it should not start an autostarted agent process if a session is already active for all required agents, even if that session is not with an autostarted process.

This pull request restores that behavior. It adds back two utility methods without change that were dropped in #7612, and its associated test case. It adds a new guard in `_ensure_agents` and adds a test case (parametrization of an existing one) for the intended behavior. The new test case has been verified to fail on #7612, and to succeed on the commit that precedes it (ensuring backwards compatibility).

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
