### PR TITLE
Issue/auth on longpoll

### DIFF
--- a/changelogs/unreleased/auth-improvements-2.yml
+++ b/changelogs/unreleased/auth-improvements-2.yml
@@ -1,0 +1,3 @@
+description: Fixed bug in authentication on return channel
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -418,6 +418,8 @@ class MethodProperties:
         if validate_sid is None:
             validate_sid = agent_server and not api
 
+        assert not (enforce_auth and server_agent), "Can not authenticate the return channel"
+
         self._path = UrlPath(path)
         self.path = path
         self._operation = operation

--- a/src/inmanta/protocol/decorators.py
+++ b/src/inmanta/protocol/decorators.py
@@ -73,6 +73,7 @@ def method(
     api_prefix: str = "api",
     envelope: bool = False,
     envelope_key: str = const.ENVELOPE_KEY,
+    enforce_auth: bool = True,
 ) -> Callable[..., Callable]:
     """
     Decorator to identify a method as a RPC call. The arguments of the decorator are used by each transport to build
@@ -100,7 +101,8 @@ def method(
     :param api_prefix: The prefix of the method: /<prefix>/v<version>/<method_name>.
     :param envelope: Put the response of the call under an envelope with key envelope_key.
     :param envelope_key: The envelope key to use.
-
+    :param enforce_auth: When set to true authentication is enforced on this endpoint. When set to false, authentication is not
+                         enforced, even if auth is enabled.
     """
 
     def wrapper(func: MethodT) -> MethodT:
@@ -121,6 +123,7 @@ def method(
             envelope,
             False,
             envelope_key,
+            enforce_auth=enforce_auth,
         )
         common.MethodProperties.register_method(properties)
         return func

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -652,7 +652,15 @@ def dryrun_update(tid: uuid.UUID, id: uuid.UUID, resource: str, changes: dict):
 # Method for requesting a dryrun from an agent
 
 
-@method(path="/agent_dryrun/<id>", operation="POST", server_agent=True, timeout=5, arg_options=AGENT_ENV_OPTS, client_types=[])
+@method(
+    path="/agent_dryrun/<id>",
+    operation="POST",
+    server_agent=True,
+    timeout=5,
+    arg_options=AGENT_ENV_OPTS,
+    client_types=[],
+    enforce_auth=False,
+)
 def do_dryrun(tid: uuid.UUID, id: uuid.UUID, agent: str, version: int):
     """
     Do a dryrun on an agent
@@ -833,6 +841,7 @@ def set_parameters(tid: uuid.UUID, parameters: list):
     arg_options=AGENT_ENV_OPTS,
     client_types=[],
     reply=False,
+    enforce_auth=False,
 )
 def get_parameter(tid: uuid.UUID, agent: str, resource: dict):
     """
@@ -984,7 +993,7 @@ def list_agents(tid: uuid.UUID, start: Optional[str] = None, end: Optional[str] 
 # Reporting by the agent to the server
 
 
-@method(path="/status", operation="GET", server_agent=True, timeout=5, client_types=[])
+@method(path="/status", operation="GET", server_agent=True, enforce_auth=False, timeout=5, client_types=[])
 def get_status():
     """
     A call from the server to the agent to report its status to the server
@@ -996,7 +1005,7 @@ def get_status():
 # Methods to allow the server to set the agents state
 
 
-@method(path="/agentstate", operation="POST", server_agent=True, timeout=5, client_types=[])
+@method(path="/agentstate", operation="POST", server_agent=True, enforce_auth=False, timeout=5, client_types=[])
 def set_state(agent: str, enabled: bool):
     """
     Set the state of the agent.
@@ -1006,7 +1015,15 @@ def set_state(agent: str, enabled: bool):
     """
 
 
-@method(path="/agentstate/<id>", operation="POST", server_agent=True, timeout=5, arg_options=AGENT_ENV_OPTS, client_types=[])
+@method(
+    path="/agentstate/<id>",
+    operation="POST",
+    server_agent=True,
+    enforce_auth=False,
+    timeout=5,
+    arg_options=AGENT_ENV_OPTS,
+    client_types=[],
+)
 def trigger(tid: uuid.UUID, id: str, incremental_deploy: bool):
     """
     Request an agent to reload resources
@@ -1021,7 +1038,14 @@ def trigger(tid: uuid.UUID, id: str, incremental_deploy: bool):
 
 
 @method(
-    path="/event/<id>", operation="PUT", server_agent=True, timeout=5, arg_options=AGENT_ENV_OPTS, client_types=[], reply=False
+    path="/event/<id>",
+    operation="PUT",
+    server_agent=True,
+    enforce_auth=False,
+    timeout=5,
+    arg_options=AGENT_ENV_OPTS,
+    client_types=[],
+    reply=False,
 )
 def resource_event(
     tid: uuid.UUID, id: str, resource: str, send_events: bool, state: const.ResourceState, change: const.Change, changes={}

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -485,7 +485,9 @@ def get_agent_process_details(tid: uuid.UUID, id: uuid.UUID, report: bool = Fals
     """
 
 
-@typedmethod(path="/agentmap", api=False, server_agent=True, operation="POST", client_types=[], api_version=2)
+@typedmethod(
+    path="/agentmap", api=False, server_agent=True, enforce_auth=False, operation="POST", client_types=[], api_version=2
+)
 def update_agent_map(agent_map: dict[str, str]) -> None:
     """
     Notify an agent about the fact that the autostart_agent_map has been updated.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -884,7 +884,7 @@ async def server_multi(
             logger.exception("Timeout during stop of the server in teardown")
 
 
-def configure_auth(auth:bool, ca: bool, ssl: bool) -> None:
+def configure_auth(auth: bool, ca: bool, ssl: bool) -> None:
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
     if auth:
         config.Config.set("server", "auth", "true")

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -26,6 +26,7 @@ from pytest import fixture
 from tornado.gen import sleep
 
 from conftest import configure_auth
+
 # Methods need to be defined before the Client class is loaded by Python
 from inmanta import protocol  # NOQA
 from inmanta import data
@@ -43,12 +44,12 @@ def get_status_x(tid: uuid.UUID):
     pass
 
 
-@method(path="/status/<id>", operation="GET", server_agent=True, timeout=10)
+@method(path="/status/<id>", operation="GET", server_agent=True, enforce_auth=False, timeout=10)
 def get_agent_status_x(id: str):
     pass
 
 
-@method(path="/notify/<id>", operation="GET", server_agent=True, timeout=10, reply=False)
+@method(path="/notify/<id>", operation="GET", server_agent=True, enforce_auth=False, timeout=10, reply=False)
 def get_agent_push(id: str):
     pass
 
@@ -127,6 +128,7 @@ async def assert_agent_counter(agent: Agent, reconnect: int, disconnected: int) 
 
 
 async def test_2way_protocol(inmanta_config, server_config, no_tid_check, postgres_db, database_name):
+    # Authentication complicates this even further
     configure_auth(True, False, False)
     rs = Server()
     server = SessionSpy()

--- a/tests/test_2way_protocol.py
+++ b/tests/test_2way_protocol.py
@@ -25,6 +25,7 @@ import pytest
 from pytest import fixture
 from tornado.gen import sleep
 
+from conftest import configure_auth
 # Methods need to be defined before the Client class is loaded by Python
 from inmanta import protocol  # NOQA
 from inmanta import data
@@ -125,9 +126,8 @@ async def assert_agent_counter(agent: Agent, reconnect: int, disconnected: int) 
     await retry_limited(is_same, 10)
 
 
-async def test_2way_protocol(unused_tcp_port, no_tid_check, postgres_db, database_name):
-    configure(unused_tcp_port, database_name, postgres_db.port)
-
+async def test_2way_protocol(inmanta_config, server_config, no_tid_check, postgres_db, database_name):
+    configure_auth(True, False, False)
     rs = Server()
     server = SessionSpy()
     rs.get_slice(SLICE_SESSION_MANAGER).add_listener(server)


### PR DESCRIPTION
# Description

Fix longpoll issue introduced by https://github.com/inmanta/inmanta-core/pull/7627

1. #7627 centralized the auth code into `execute_call`
2. however,  `execute_call` is not only used on the server: the agent uses it to dispatch methods it received via the heartbeat. 
3. They have no authentication token, so now they fail.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
