### PR TITLE
[FIX] remove usages of std::ConfigFile

### DIFF
--- a/changelogs/unreleased/remove-std-ConfigFile-usages.yml
+++ b/changelogs/unreleased/remove-std-ConfigFile-usages.yml
@@ -1,0 +1,3 @@
+description: Remove remaining usages of deprecated std::ConfigFile from test cases.
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -26,7 +26,9 @@ from inmanta.module import RelationPrecedenceRule
 
 def test_issue_139_scheduler(snippetcompiler):
     snippetcompiler.setup_for_snippet(
-        """import std
+        """
+import std
+import std::testing
 
 entity Host extends std::Host:
     string attr
@@ -35,7 +37,8 @@ implement Host using std::none
 
 host = Host(name="vm1", os=std::linux)
 
-f = std::ConfigFile(host=host, path="", content="{{ host.attr }}")
+f = std::testing::NullResource(name=host.name)
+
 std::Service(host=host, name="svc", state="running", onboot=true, requires=[f])
 ref = std::Service[host=host, name="svc"]
 

--- a/tests/compiler/test_iterations.py
+++ b/tests/compiler/test_iterations.py
@@ -29,6 +29,8 @@ def test_max_iterations(snippetcompiler, monkeypatch):
         snippetcompiler.setup_for_snippet(
             """
     import std
+    import std::testing
+
 
     entity Hg:
     end
@@ -45,7 +47,8 @@ def test_max_iterations(snippetcompiler, monkeypatch):
 
 
     for i in hg.hosts:
-        std::ConfigFile(host=i, path="/fx", content="")
+        std::testing::NullResource(name=i.name)
+
     end
     """
         )

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -536,14 +536,25 @@ def test_610_multi_add(snippetcompiler):
 def test_670_assign_on_relation(snippetcompiler):
     snippetcompiler.setup_for_error_re(
         """
-        h = std::Host(name="test", os=std::linux)
-        f = std::ConfigFile(host=h, path="a", content="")
+import std::testing
 
-        h.files.path = "1"
+entity File extends std::testing::NullResource:
+end
+implement File using std::none
 
+entity Host extends std::testing::NullResource:
+end
+implement Host using std::none
+
+File.host [1] -- Host.files [0:]
+
+f1 = File(name="f1")
+host = Host(name="host", files=[f1])
+
+host.files.name = "foo"
         """,
-        r"The object at h.files is not an Entity but a <class 'list'> with value \[std::ConfigFile [0-9a-fA-F]+\]"
-        r" \(reported in h.files.path = '1' \({dir}/main.cf:5\)\)",
+        r"The object at host.files is not an Entity but a <class 'list'> with value \[__config__::File [0-9a-fA-F]+\]"
+        r" \(reported in host.files.name = 'foo' \({dir}/main.cf:17\)\)",
     )
 
 

--- a/tests/compiler/test_requires.py
+++ b/tests/compiler/test_requires.py
@@ -72,8 +72,8 @@ end
 
 implement A using a
 
-pre =  std::testing::NullResource(name="pre")
-post =  std::testing::NullResource(name="post")
+pre = std::testing::NullResource(name="pre")
+post = std::testing::NullResource(name="post")
 
 inter = A(name = "inter")
 inter.requires = pre

--- a/tests/compiler/test_requires.py
+++ b/tests/compiler/test_requires.py
@@ -25,6 +25,8 @@ from utils import assert_graph
 def test_abstract_requires(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
+import std::testing
+
 host = std::Host(name="host", os=std::unix)
 
 entity A:
@@ -32,15 +34,16 @@ entity A:
 end
 
 implementation a for A:
-    one = std::ConfigFile(path="{{self.name}}1", host=host, content="")
-    two = std::ConfigFile(path="{{self.name}}2", host=host, content="")
+    one = std::testing::NullResource(name="{{self.name}}1")
+    two = std::testing::NullResource(name="{{self.name}}2")
+
     two.requires = one
 end
 
 implement A using a
 
-pre = std::ConfigFile(path="host0", host=host, content="")
-post = std::ConfigFile(path="hosts4", host=host, content="")
+pre = std::testing::NullResource(name="host0")
+post = std::testing::NullResource(name="hosts4")
 
 inter = A(name = "inter")
 """
@@ -53,15 +56,15 @@ inter = A(name = "inter")
 def test_abstract_requires_3(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-host = std::Host(name="host", os=std::unix)
+import std::testing
 
 entity A:
     string name
 end
 
 implementation a for A:
-    one = std::ConfigFile(path="{{self.name}}1", host=host, content="")
-    two = std::ConfigFile(path="{{self.name}}2", host=host, content="")
+    one = std::testing::NullResource(name="{{self.name}}1")
+    two = std::testing::NullResource(name="{{self.name}}2")
     two.requires = one
     one.requires = self.requires
     two.provides = self.provides
@@ -69,8 +72,8 @@ end
 
 implement A using a
 
-pre = std::ConfigFile(path="pre", host=host, content="")
-post = std::ConfigFile(path="post", host=host, content="")
+pre =  std::testing::NullResource(name="pre")
+post =  std::testing::NullResource(name="post")
 
 inter = A(name = "inter")
 inter.requires = pre
@@ -82,30 +85,30 @@ post.requires = inter
     assert_graph(
         resources,
         """post: inter2
-                                  inter2: inter1
-                                  inter1: pre""",
+        inter2: inter1
+        inter1: pre""",
     )
 
 
 def test_abstract_requires_2(snippetcompiler, caplog):
     snippetcompiler.setup_for_snippet(
         """
-host = std::Host(name="host", os=std::unix)
+import std::testing
 
 entity A:
-string name
+    string name
 end
 
 implementation a for A:
-one = std::ConfigFile(path="{{self.name}}1", host=host, content="")
-two = std::ConfigFile(path="{{self.name}}2", host=host, content="")
-two.requires = one
+    one = std::testing::NullResource(name="{{self.name}}1")
+    two = std::testing::NullResource(name="{{self.name}}2")
+    two.requires = one
 end
 
 implement A using a
 
-pre = std::ConfigFile(path="host0", host=host, content="")
-post = std::ConfigFile(path="hosts4", host=host, content="")
+pre = std::testing::NullResource(name="host0")
+post = std::testing::NullResource(name="host4")
 
 inter = A(name = "inter")
 inter.requires = pre

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -410,11 +410,11 @@ async def test_compile_runner(environment_factory: EnvironmentFactory, server, c
 
     def make_main(marker_print):
         return f"""
+    import std::testing
     marker = std::get_env("{testmarker_env}","{no_marker}")
     std::print("{marker_print} {{{{marker}}}}")
 
-    host = std::Host(name="test", os=std::linux)
-    std::ConfigFile(host=host, path="/etc/motd", content="1234")
+    std::testing::NullResource(name="test")
         """
 
     env = await environment_factory.create_environment(make_main(marker_print))
@@ -527,8 +527,8 @@ async def test_server_side_compile_with_ssl_enabled(
     ensure_directory_exist(project_work_dir)
 
     main_cf = """
-host = std::Host(name="test", os=std::linux)
-std::ConfigFile(host=host, path="/tmp/test", content="1234")
+import std::testing
+std::testing::NullResource(name="test")
     """.strip()
 
     # Add .inmanta file with inverse SSL config as the server itself.
@@ -744,8 +744,10 @@ async def test_server_recompile(server, client, environment, monkeypatch):
     with open(os.path.join(project_dir, "main.cf"), "w", encoding="utf-8") as fd:
         fd.write(
             f"""
+        import std::testing
+
         host = std::Host(name="test", os=std::linux)
-        std::ConfigFile(host=host, path="/etc/motd", content="1234")
+        std::testing::NullResource(name=host.name)
         std::print(std::get_env("{key_env_var}"))
 """
         )
@@ -870,8 +872,8 @@ async def test_server_recompile_param_fact_v2(server, client, environment):
     with open(os.path.join(project_dir, "main.cf"), "w", encoding="utf-8") as fd:
         fd.write(
             """
-    host = std::Host(name="test", os=std::linux)
-        std::ConfigFile(host=host, path="/etc/motd", content="1234")
+import std::testing
+std::testing::NullResource(name='test')
 """
         )
 

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -175,8 +175,9 @@ repo: https://github.com/inmanta/
 
     path_main_file.write(
         """
+import std::testing
 vm1=std::Host(name="non-existing-machine", os=std::linux)
-std::ConfigFile(host=vm1, path="/test", content="")
+std::testing::NullResource(name=vm1.name)
 """
     )
 
@@ -395,8 +396,9 @@ repo: https://github.com/inmanta/
 
     path_main_file.write(
         """
-vm1=std::Host(name="non-existing-machine", os=std::linux)
-std::ConfigFile(host=vm1, path="/test", content="")
+import std::testing
+
+std::testing::NullResource(name="test")
 """
     )
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -223,8 +223,8 @@ async def test_empty_server_export(snippetcompiler, server, client, environment)
 async def test_server_export(snippetcompiler, server: Server, client, environment):
     snippetcompiler.setup_for_snippet(
         """
-            h = std::Host(name="test", os=std::linux)
-            f = std::ConfigFile(host=h, path="/etc/motd", content="test")
+            import std::testing
+            f = std::testing::NullResource(name="test")
         """
     )
     await snippetcompiler.do_export_and_deploy()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -790,8 +790,8 @@ async def test_batched_code_upload(
     """Test uploading all code definitions at once"""
     snippetcompiler.setup_for_snippet(
         """
-    h = std::Host(name="test", os=std::linux)
-    f = std::ConfigFile(host=h, path="/etc/motd", content="test", purge_on_delete=true)
+    import std::testing
+    f = std::testing::NullResource(name="test")
     """
     )
     version, _ = await snippetcompiler.do_export_and_deploy(do_raise=False)


### PR DESCRIPTION
# Description

Will looking into flakiness of test `test_server_recompile` I noticed it was still using `std::File`:

```
exporter       DEBUG     std::File[test,path=/etc/motd],v=1 not in any resource set`
```

This PR removes uses of `std::ConfigFile`



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
