### PR TITLE
Issue/issue/remove std config file usages iso6

### DIFF
--- a/changelogs/unreleased/remove-std-ConfigFile-usages.yml
+++ b/changelogs/unreleased/remove-std-ConfigFile-usages.yml
@@ -1,0 +1,3 @@
+description: Remove remaining usages of deprecated std::ConfigFile from test cases.
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/remove-std-ConfigFile-usages.yml
+++ b/changelogs/unreleased/remove-std-ConfigFile-usages.yml
@@ -1,3 +1,3 @@
 description: Remove remaining usages of deprecated std::ConfigFile from test cases.
 change-type: patch
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]

--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -25,7 +25,9 @@ from inmanta.module import RelationPrecedenceRule
 
 def test_issue_139_scheduler(snippetcompiler):
     snippetcompiler.setup_for_snippet(
-        """import std
+        """
+import std
+import std::testing
 
 entity Host extends std::Host:
     string attr
@@ -34,7 +36,8 @@ implement Host using std::none
 
 host = Host(name="vm1", os=std::linux)
 
-f = std::ConfigFile(host=host, path="", content="{{ host.attr }}")
+f = std::testing::NullResource(name=host.name)
+
 std::Service(host=host, name="svc", state="running", onboot=true, requires=[f])
 ref = std::Service[host=host, name="svc"]
 

--- a/tests/compiler/test_iterations.py
+++ b/tests/compiler/test_iterations.py
@@ -29,6 +29,8 @@ def test_max_iterations(snippetcompiler, monkeypatch):
         snippetcompiler.setup_for_snippet(
             """
     import std
+    import std::testing
+
 
     entity Hg:
     end
@@ -45,7 +47,8 @@ def test_max_iterations(snippetcompiler, monkeypatch):
 
 
     for i in hg.hosts:
-        std::ConfigFile(host=i, path="/fx", content="")
+        std::testing::NullResource(name=i.name)
+
     end
     """
         )

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -535,14 +535,25 @@ def test_610_multi_add(snippetcompiler):
 def test_670_assign_on_relation(snippetcompiler):
     snippetcompiler.setup_for_error_re(
         """
-        h = std::Host(name="test", os=std::linux)
-        f = std::ConfigFile(host=h, path="a", content="")
+import std::testing
 
-        h.files.path = "1"
+entity File extends std::testing::NullResource:
+end
+implement File using std::none
 
+entity Host extends std::testing::NullResource:
+end
+implement Host using std::none
+
+File.host [1] -- Host.files [0:]
+
+f1 = File(name="f1")
+host = Host(name="host", files=[f1])
+
+host.files.name = "foo"
         """,
-        r"The object at h.files is not an Entity but a <class 'list'> with value \[std::ConfigFile [0-9a-fA-F]+\]"
-        r" \(reported in h.files.path = '1' \({dir}/main.cf:5\)\)",
+        r"The object at host.files is not an Entity but a <class 'list'> with value \[__config__::File [0-9a-fA-F]+\]"
+        r" \(reported in host.files.name = 'foo' \({dir}/main.cf:17\)\)",
     )
 
 

--- a/tests/compiler/test_requires.py
+++ b/tests/compiler/test_requires.py
@@ -25,6 +25,8 @@ from utils import assert_graph
 def test_abstract_requires(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
+import std::testing
+
 host = std::Host(name="host", os=std::unix)
 
 entity A:
@@ -32,15 +34,16 @@ entity A:
 end
 
 implementation a for A:
-    one = std::ConfigFile(path="{{self.name}}1", host=host, content="")
-    two = std::ConfigFile(path="{{self.name}}2", host=host, content="")
+    one = std::testing::NullResource(name="{{self.name}}1")
+    two = std::testing::NullResource(name="{{self.name}}2")
+
     two.requires = one
 end
 
 implement A using a
 
-pre = std::ConfigFile(path="host0", host=host, content="")
-post = std::ConfigFile(path="hosts4", host=host, content="")
+pre = std::testing::NullResource(name="host0")
+post = std::testing::NullResource(name="hosts4")
 
 inter = A(name = "inter")
 """
@@ -53,15 +56,15 @@ inter = A(name = "inter")
 def test_abstract_requires_3(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-host = std::Host(name="host", os=std::unix)
+import std::testing
 
 entity A:
     string name
 end
 
 implementation a for A:
-    one = std::ConfigFile(path="{{self.name}}1", host=host, content="")
-    two = std::ConfigFile(path="{{self.name}}2", host=host, content="")
+    one = std::testing::NullResource(name="{{self.name}}1")
+    two = std::testing::NullResource(name="{{self.name}}2")
     two.requires = one
     one.requires = self.requires
     two.provides = self.provides
@@ -69,8 +72,8 @@ end
 
 implement A using a
 
-pre = std::ConfigFile(path="pre", host=host, content="")
-post = std::ConfigFile(path="post", host=host, content="")
+pre = std::testing::NullResource(name="pre")
+post = std::testing::NullResource(name="post")
 
 inter = A(name = "inter")
 inter.requires = pre
@@ -82,30 +85,30 @@ post.requires = inter
     assert_graph(
         resources,
         """post: inter2
-                                  inter2: inter1
-                                  inter1: pre""",
+        inter2: inter1
+        inter1: pre""",
     )
 
 
 def test_abstract_requires_2(snippetcompiler, caplog):
     snippetcompiler.setup_for_snippet(
         """
-host = std::Host(name="host", os=std::unix)
+import std::testing
 
 entity A:
-string name
+    string name
 end
 
 implementation a for A:
-one = std::ConfigFile(path="{{self.name}}1", host=host, content="")
-two = std::ConfigFile(path="{{self.name}}2", host=host, content="")
-two.requires = one
+    one = std::testing::NullResource(name="{{self.name}}1")
+    two = std::testing::NullResource(name="{{self.name}}2")
+    two.requires = one
 end
 
 implement A using a
 
-pre = std::ConfigFile(path="host0", host=host, content="")
-post = std::ConfigFile(path="hosts4", host=host, content="")
+pre = std::testing::NullResource(name="host0")
+post = std::testing::NullResource(name="host4")
 
 inter = A(name = "inter")
 inter.requires = pre

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -352,11 +352,11 @@ async def test_compile_runner(environment_factory: EnvironmentFactory, server, c
 
     def make_main(marker_print):
         return f"""
+    import std::testing
     marker = std::get_env("{testmarker_env}","{no_marker}")
     std::print("{marker_print} {{{{marker}}}}")
 
-    host = std::Host(name="test", os=std::linux)
-    std::ConfigFile(host=host, path="/etc/motd", content="1234")
+    std::testing::NullResource(name="test")
         """
 
     env = await environment_factory.create_environment(make_main(marker_print))
@@ -469,8 +469,8 @@ async def test_server_side_compile_with_ssl_enabled(
     ensure_directory_exist(project_work_dir)
 
     main_cf = """
-host = std::Host(name="test", os=std::linux)
-std::ConfigFile(host=host, path="/tmp/test", content="1234")
+import std::testing
+std::testing::NullResource(name="test")
     """.strip()
 
     # Add .inmanta file with inverse SSL config as the server itself.
@@ -688,8 +688,10 @@ async def test_server_recompile(server, client, environment, monkeypatch):
     with open(os.path.join(project_dir, "main.cf"), "w", encoding="utf-8") as fd:
         fd.write(
             f"""
+        import std::testing
+
         host = std::Host(name="test", os=std::linux)
-        std::ConfigFile(host=host, path="/etc/motd", content="1234")
+        std::testing::NullResource(name=host.name)
         std::print(std::get_env("{key_env_var}"))
 """
         )

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -146,7 +146,7 @@ def test_module_help(inmanta_config, capsys):
 
 @pytest.mark.parametrize_any("push_method", [([]), (["-d"]), (["-d", "--full"])])
 @pytest.mark.parametrize_any("set_server", [True, False])
-@pytest.mark.parametrize_any("set_port", [False, True])
+@pytest.mark.parametrize_any("set_port", [True, False])
 async def test_export(tmpvenv_active_inherit: env.VirtualEnv, tmpdir, server, client, push_method, set_server, set_port):
     server_port = Config.get("client_rest_transport", "port")
     server_host = Config.get("client_rest_transport", "host", "localhost")
@@ -172,7 +172,6 @@ downloadpath: {libs_dir}
 repo: https://github.com/inmanta/
 """
     )
-
 
     path_main_file.write(
         """
@@ -226,7 +225,6 @@ std::testing::NullResource(name="test", agentname="agent")
     assert result.code == 200
     assert len(result.result["versions"]) == 1
 
-    breakpoint()
     details_exported_version = result.result["versions"][0]
 
     assert details_exported_version["result"] == VersionState.deploying.name

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -175,8 +175,9 @@ repo: https://github.com/inmanta/
 
     path_main_file.write(
         """
+import std::testing
 vm1=std::Host(name="non-existing-machine", os=std::linux)
-std::ConfigFile(host=vm1, path="/test", content="")
+std::testing::NullResource(name=vm1.name)
 """
     )
 
@@ -395,8 +396,9 @@ repo: https://github.com/inmanta/
 
     path_main_file.write(
         """
-vm1=std::Host(name="non-existing-machine", os=std::linux)
-std::ConfigFile(host=vm1, path="/test", content="")
+import std::testing
+
+std::testing::NullResource(name="test")
 """
     )
 

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -144,9 +144,9 @@ def test_module_help(inmanta_config, capsys):
     assert info.value.args[0].startswith("A subcommand is required.")
 
 
-@pytest.mark.parametrize_any("push_method", [([]), (["-d"]), (["-d", "--full"])])
-@pytest.mark.parametrize_any("set_server", [True, False])
-@pytest.mark.parametrize_any("set_port", [True, False])
+@pytest.mark.parametrize_any("push_method", [([])])#, (["-d"]), (["-d", "--full"])])
+@pytest.mark.parametrize_any("set_server", [True])
+@pytest.mark.parametrize_any("set_port", [False])
 async def test_export(tmpvenv_active_inherit: env.VirtualEnv, tmpdir, server, client, push_method, set_server, set_port):
     server_port = Config.get("client_rest_transport", "port")
     server_host = Config.get("client_rest_transport", "host", "localhost")

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -172,13 +172,30 @@ downloadpath: {libs_dir}
 repo: https://github.com/inmanta/
 """
     )
+    # nullres
+    # [{'date': '2024-05-17T13:16:53.396519', 'partial_base': None, 'released': True, 'deployed': True, 'result': 'success',
+    #   'version_info': {'export_metadata': {'type': 'manual', 'message': 'Manual compile on the CLI by user', 'cli-user': 'hugo',
+    #                                        'hostname': 'hugo-Latitude-5421', 'inmanta:compile:state': 'success'}}, 'total': 1,
+    #   'undeployable': [], 'skipped_for_undeployable': [], 'version': 1, 'environment': 'd95c22bb-c013-49f0-9d56-7c127e852d9d',
+    #   'is_suitable_for_partial_compiles': True, 'status': {
+    #         'fe623595-cf58-5588-bcd2-4841e70bfcb1': {'id': 'std::testing::NullResource[internal,name=non-existing-machine]',
+    #                                                  'status': 'deployed'}}, 'done': 1}]
+
+    # configfile
+    # [{'date': '2024-05-17T13:17:54.400084', 'partial_base': None, 'released': True, 'deployed': False, 'result': 'deploying',
+    #   'version_info': {'export_metadata': {'type': 'manual', 'message': 'Manual compile on the CLI by user', 'cli-user': 'hugo',
+    #                                        'hostname': 'hugo-Latitude-5421', 'inmanta:compile:state': 'success'}}, 'total': 1,
+    #   'undeployable': [], 'skipped_for_undeployable': [], 'version': 1, 'environment': '54ac4fa6-91d3-4c53-a125-e602bb62e86f',
+    #   'is_suitable_for_partial_compiles': True, 'status': {
+    #         '4dbde0ff-4b16-529d-8772-92ed1fa2c6d1': {'id': 'std::File[non-existing-machine,path=/test]',
+    #                                                  'status': 'available'}}, 'done': 0}]
 
     path_main_file.write(
         """
 import std::testing
 vm1=std::Host(name="non-existing-machine", os=std::linux)
-# std::ConfigFile(host=vm1, path="/test", content="")
-std::testing::NullResource(name=vm1.name)
+std::ConfigFile(host=vm1, path="/test", content="")
+# std::testing::NullResource(name=vm1.name)
 """
     )
 
@@ -227,6 +244,7 @@ std::testing::NullResource(name=vm1.name)
     assert result.code == 200
     assert len(result.result["versions"]) == 1
 
+    breakpoint()
     details_exported_version = result.result["versions"][0]
 
     assert details_exported_version["result"] == VersionState.deploying.name

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -173,10 +173,14 @@ repo: https://github.com/inmanta/
 """
     )
 
+    # Use non-default agent to make sure the resource can be checked in the 'deploying' state.
+    # Using the internal default agent might trigger a race condition where the 'success' state
+    # is reached because the resource actually gets deployed.
+
     path_main_file.write(
         """
 import std::testing
-std::testing::NullResource(name="test", agentname="agent")
+std::testing::NullResource(name="test", agentname="not_internal")
 """
     )
 
@@ -227,6 +231,7 @@ std::testing::NullResource(name="test", agentname="agent")
 
     details_exported_version = result.result["versions"][0]
 
+    # Check that the version started deploying thanks to auto-deploy:
     assert details_exported_version["result"] == VersionState.deploying.name
 
     shutil.rmtree(workspace)

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -144,9 +144,9 @@ def test_module_help(inmanta_config, capsys):
     assert info.value.args[0].startswith("A subcommand is required.")
 
 
-@pytest.mark.parametrize_any("push_method", [([])])#, (["-d"]), (["-d", "--full"])])
-@pytest.mark.parametrize_any("set_server", [True])
-@pytest.mark.parametrize_any("set_port", [False])
+@pytest.mark.parametrize_any("push_method", [([]), (["-d"]), (["-d", "--full"])])
+@pytest.mark.parametrize_any("set_server", [True, False])
+@pytest.mark.parametrize_any("set_port", [False, True])
 async def test_export(tmpvenv_active_inherit: env.VirtualEnv, tmpdir, server, client, push_method, set_server, set_port):
     server_port = Config.get("client_rest_transport", "port")
     server_host = Config.get("client_rest_transport", "host", "localhost")
@@ -172,30 +172,12 @@ downloadpath: {libs_dir}
 repo: https://github.com/inmanta/
 """
     )
-    # nullres
-    # [{'date': '2024-05-17T13:16:53.396519', 'partial_base': None, 'released': True, 'deployed': True, 'result': 'success',
-    #   'version_info': {'export_metadata': {'type': 'manual', 'message': 'Manual compile on the CLI by user', 'cli-user': 'hugo',
-    #                                        'hostname': 'hugo-Latitude-5421', 'inmanta:compile:state': 'success'}}, 'total': 1,
-    #   'undeployable': [], 'skipped_for_undeployable': [], 'version': 1, 'environment': 'd95c22bb-c013-49f0-9d56-7c127e852d9d',
-    #   'is_suitable_for_partial_compiles': True, 'status': {
-    #         'fe623595-cf58-5588-bcd2-4841e70bfcb1': {'id': 'std::testing::NullResource[internal,name=non-existing-machine]',
-    #                                                  'status': 'deployed'}}, 'done': 1}]
 
-    # configfile
-    # [{'date': '2024-05-17T13:17:54.400084', 'partial_base': None, 'released': True, 'deployed': False, 'result': 'deploying',
-    #   'version_info': {'export_metadata': {'type': 'manual', 'message': 'Manual compile on the CLI by user', 'cli-user': 'hugo',
-    #                                        'hostname': 'hugo-Latitude-5421', 'inmanta:compile:state': 'success'}}, 'total': 1,
-    #   'undeployable': [], 'skipped_for_undeployable': [], 'version': 1, 'environment': '54ac4fa6-91d3-4c53-a125-e602bb62e86f',
-    #   'is_suitable_for_partial_compiles': True, 'status': {
-    #         '4dbde0ff-4b16-529d-8772-92ed1fa2c6d1': {'id': 'std::File[non-existing-machine,path=/test]',
-    #                                                  'status': 'available'}}, 'done': 0}]
 
     path_main_file.write(
         """
 import std::testing
-vm1=std::Host(name="non-existing-machine", os=std::linux)
-std::ConfigFile(host=vm1, path="/test", content="")
-# std::testing::NullResource(name=vm1.name)
+std::testing::NullResource(name="test", agentname="agent")
 """
     )
 

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -177,6 +177,7 @@ repo: https://github.com/inmanta/
         """
 import std::testing
 vm1=std::Host(name="non-existing-machine", os=std::linux)
+# std::ConfigFile(host=vm1, path="/test", content="")
 std::testing::NullResource(name=vm1.name)
 """
     )

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -180,7 +180,7 @@ repo: https://github.com/inmanta/
     path_main_file.write(
         """
 import std::testing
-std::testing::NullResource(name="test", agentname="not_internal")
+std::testing::NullResource(name="test", agentname="non_existing_agent")
 """
     )
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -216,8 +216,8 @@ async def test_empty_server_export(snippetcompiler, server, client, environment)
 async def test_server_export(snippetcompiler, server: Server, client, environment):
     snippetcompiler.setup_for_snippet(
         """
-            h = std::Host(name="test", os=std::linux)
-            f = std::ConfigFile(host=h, path="/etc/motd", content="test")
+            import std::testing
+            f = std::testing::NullResource(name="test")
         """
     )
     await snippetcompiler.do_export_and_deploy()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -748,8 +748,8 @@ async def test_batched_code_upload(
     """Test uploading all code definitions at once"""
     snippetcompiler.setup_for_snippet(
         """
-    h = std::Host(name="test", os=std::linux)
-    f = std::ConfigFile(host=h, path="/etc/motd", content="test", purge_on_delete=true)
+    import std::testing
+    f = std::testing::NullResource(name="test")
     """
     )
     version, _ = await snippetcompiler.do_export_and_deploy(do_raise=False)


### PR DESCRIPTION
# Description

iso6-specific PR for https://github.com/inmanta/inmanta-core/pull/7636
identical PR except for 
- the `test_server_recompile_param_fact_v2` test that is not present in iso6.
- `test_export` in tests/test_app_cli.py -> `agentname` is set


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
