### PR TITLE
Issue/fix compatibility range display for not yet pinned modules iso6

### DIFF
--- a/changelogs/unreleased/fix-module-compatibility-range-display-for-not-pinned-case.yml
+++ b/changelogs/unreleased/fix-module-compatibility-range-display-for-not-pinned-case.yml
@@ -1,4 +1,4 @@
 description: Add default display value for modules compatibility ranges. This fixes an error in the docs build
   where the ``centered`` directive was called without arguments.
 change-type: patch
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]

--- a/changelogs/unreleased/fix-module-compatibility-range-display-for-not-pinned-case.yml
+++ b/changelogs/unreleased/fix-module-compatibility-range-display-for-not-pinned-case.yml
@@ -1,0 +1,4 @@
+description: Add default display value for modules compatibility ranges. This fixes an error in the docs build
+  where the ``centered`` directive was called without arguments.
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/docs/_templates/components_requirements.tmpl
+++ b/docs/_templates/components_requirements.tmpl
@@ -46,8 +46,15 @@
 
        {% for key, value in data["module_compatibility_ranges"]  | dictsort %}
        {% if key in list_only %}
+
+       {% if value %}
+       {% set compatible_range = value %}
+       {% else %}
+       {% set compatible_range = 'Not pinned yet' %}
+       {% endif %}
+
        * - {{ key.split("inmanta-module-")[1] }}
-         - .. centered:: {{ value }}
+         - .. centered:: {{ compatible_range }}
        {% endif %}
        {% endfor %}
 


### PR DESCRIPTION
# Description

iso6-specific PR for https://github.com/inmanta/inmanta-core/pull/7621



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
