### PR TITLE
Fix bug where caplog handlers were removed by clean_reset fixture

### DIFF
--- a/changelogs/unreleased/fix-removal-caplog-handlers.yml
+++ b/changelogs/unreleased/fix-removal-caplog-handlers.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix issue where the caplog handlers were removed by the `clean_reset` fixture."
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -575,11 +575,15 @@ class InmantaLoggerConfig:
 
     @classmethod
     @stable_api
-    def clean_instance(cls) -> None:
+    def clean_instance(cls, root_handlers_to_remove: Optional[abc.Sequence[logging.Handler]] = None) -> None:
         """
-        This method should be used to clean up an instance of this class
+        This method should be used to clean up an instance of this class.
+
+        By default, this method removes and closes all root handlers from the logging framework. If the
+        root_handlers_to_remove argument is not None, only the provided root handlers will be removed and closed.
         """
-        for handler in logging.root.handlers:
+        to_remove = root_handlers_to_remove if root_handlers_to_remove is not None else logging.root.handlers
+        for handler in to_remove:
             # File-based handlers automatically re-open after close() if log records are written to them.
             # As such, we explicitly remove the handler from the root logger here.
             logging.root.removeHandler(handler)

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -563,8 +563,8 @@ class InmantaLoggerConfig:
         :param stream: The stream to send log messages to. Default is standard output (sys.stdout)
         """
         if cls._instance:
-            if len(cls._instance._handlers) != 1:
-                raise Exception("More than one root handler configured.")
+            if not cls._instance._handlers:
+                raise Exception("No handlers found.")
             if not isinstance(cls._instance._handlers[0], logging.StreamHandler):
                 raise Exception("Instance already exists with a different handler")
             elif isinstance(cls._instance._handlers[0], logging.StreamHandler) and cls._instance._handlers[0].stream != stream:
@@ -710,7 +710,8 @@ class InmantaLoggerConfig:
 
         :return: The logging handler
         """
-        assert len(self._handlers) == 1, "This could happen if this method is used in combination with the caplog fixture."
+        if not self._handlers:
+            raise Exception("No handlers found.")
         return self._handlers[0]
 
     @stable_api

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import warnings
 
 from tornado.httpclient import AsyncHTTPClient
 
+import _pytest.logging
 import toml
 from inmanta import logging as inmanta_logging
 from inmanta.logging import InmantaLoggerConfig
@@ -582,7 +583,7 @@ def reset_all_objects():
     V2ModuleBuilder.DISABLE_DEFAULT_ISOLATED_ENV_CACHED = False
     compiler.Finalizers.reset_finalizers()
     auth.AuthJWTConfig.reset()
-    InmantaLoggerConfig.clean_instance()
+    InmantaLoggerConfig.clean_instance(root_handlers_to_remove=[h for h in logging.root.handlers if not is_caplog_handler(h)])
     AsyncHTTPClient.configure(None)
 
 
@@ -1838,21 +1839,35 @@ async def set_running_tests():
     inmanta.RUNNING_TESTS = True
 
 
+def is_caplog_handler(handler: logging.Handler) -> bool:
+    return isinstance(
+        handler,
+        (
+            _pytest.logging._FileHandler,
+            _pytest.logging._LiveLoggingStreamHandler,
+            _pytest.logging._LiveLoggingNullHandler,
+            _pytest.logging.LogCaptureHandler,
+        ),
+    )
+
+
 @pytest.fixture(scope="function", autouse=True)
-async def dont_override_root_logger(request, monkeypatch):
+async def dont_remove_caplog_handlers(request, monkeypatch):
     """
-    Make sure the inmanta.logging.FullLoggingConfig._to_dict_config() method doesn't override the root logger
-    when the caplog fixture is used, because caplog captures log messages by attaching a handler to the root logger.
+    Caplog captures log messages by attaching handlers to the root logger. This fixture makes sure the
+    inmanta.logging.FullLoggingConfig.apply_config() method doesn't remove any handlers that were added by the caplog fixture.
     """
-    original_to_dict_config_method = inmanta_logging.FullLoggingConfig._to_dict_config
+    original_apply_config = inmanta_logging.FullLoggingConfig.apply_config
 
-    def _to_dict_config_patched(self) -> dict[str, object]:
-        dict_config = original_to_dict_config_method(self)
-        dict_config.pop("root", None)
-        return dict_config
+    def patched_apply_config(self) -> None:
+        caplog_handlers = [h for h in logging.root.handlers if is_caplog_handler(h)]
+        original_apply_config(self)
+        # Re-add caplog handlers that were removed by the call to apply_config()
+        for current_handler in caplog_handlers:
+            if current_handler not in logging.root.handlers:
+                logging.root.addHandler(current_handler)
 
-    if "caplog" in request.fixturenames:
-        monkeypatch.setattr(inmanta_logging.FullLoggingConfig, "_to_dict_config", _to_dict_config_patched)
+    monkeypatch.setattr(inmanta_logging.FullLoggingConfig, "apply_config", patched_apply_config)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -185,10 +185,9 @@ async def test_startup_failure(async_finalizer, server_config):
 
 
 def test_load_and_filter(caplog):
-    caplog.set_level(logging.INFO)
-
     with splice_extension_in("test_module_path"):
         ibl = InmantaBootloader(configure_logging=True)
+        caplog.set_level(logging.INFO)
 
         plugin_pkgs = ibl._discover_plugin_packages()
         assert "inmanta_ext.core" in plugin_pkgs

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -913,8 +913,8 @@ async def test_get_param(server, client, environment, tz_aware_timestamp: bool):
 
 
 async def test_server_logs_address(server_config, caplog, async_finalizer):
+    ibl = InmantaBootloader(configure_logging=True)
     with caplog.at_level(logging.INFO):
-        ibl = InmantaBootloader(configure_logging=True)
         async_finalizer.add(partial(ibl.stop, timeout=15))
         await ibl.start()
 
@@ -965,9 +965,9 @@ async def test_bootloader_db_wait(monkeypatch, tmpdir, caplog, db_wait_time: str
 
     monkeypatch.setattr("inmanta.server.protocol.Server.start", mock_start)
     monkeypatch.setattr("asyncpg.connect", mock_asyncpg_connect)
+    ibl: InmantaBootloader = InmantaBootloader(configure_logging=True)
     caplog.set_level(logging.INFO)
     caplog.clear()
-    ibl: InmantaBootloader = InmantaBootloader(configure_logging=True)
     start_task: asyncio.Task = asyncio.create_task(ibl.start())
     await start_task
 
@@ -985,14 +985,14 @@ async def test_bootloader_db_wait(monkeypatch, tmpdir, caplog, db_wait_time: str
 
 
 @pytest.mark.parametrize("db_wait_time", ["2", "0"])
-async def test_bootlader_connect_running_db(server_config, postgres_db, caplog, db_wait_time: str):
+async def test_bootloader_connect_running_db(server_config, postgres_db, caplog, db_wait_time: str):
     """
     Tests that the bootloader can connect to a database and can start for both wait_up values
     """
     config.Config.set("database", "wait_time", db_wait_time)
-    caplog.set_level(logging.INFO)
-    caplog.clear()
     ibl: InmantaBootloader = InmantaBootloader(configure_logging=True)
+    caplog.clear()
+    caplog.set_level(logging.INFO)
     await ibl.start()
     await ibl.stop(timeout=15)
 


### PR DESCRIPTION
# Description

Fix issue where the caplog handlers were removed by the `clean_reset` fixture.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
