### PR TITLE
Issue/7641

### DIFF
--- a/changelogs/unreleased/7641-executor-reload.yml
+++ b/changelogs/unreleased/7641-executor-reload.yml
@@ -1,0 +1,5 @@
+description: Correct bug in shutdown of agent executors
+issue-nr: 7641
+change-type: patch
+destination-branches: [master]
+

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -474,6 +474,7 @@ class ExecutorManager(abc.ABC, typing.Generic[E]):
         """
         pass
 
+    @abc.abstractmethod
     async def stop_for_agent(self, agent_name: str) -> list[E]:
         """
         Indicate that all executors for this agent can be stopped.

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -474,11 +474,13 @@ class ExecutorManager(abc.ABC, typing.Generic[E]):
         """
         pass
 
-    async def stop_for_agent(self, agent_name: str) -> None:
+    async def stop_for_agent(self, agent_name: str) -> list[E]:
         """
         Indicate that all executors for this agent can be stopped.
 
         This is considered to be a hint , the manager can choose to follow or not
+
+        If executors are stopped, they are returned
         """
         pass
 

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -339,6 +339,7 @@ class MPExecutor(executor.Executor):
         self.process = process
         self.connection = connection
         self.connection.finalizers.append(self.force_stop)
+        self.closing = False
         self.closed = False
         self.owner = owner
         # Pure for debugging purpose
@@ -351,6 +352,7 @@ class MPExecutor(executor.Executor):
 
     async def stop(self) -> None:
         """Stop by shutdown"""
+        self.closing = True
         try:
             self.connection.call(StopCommand(), False)
         except inmanta.protocol.ipc_light.ConnectionLost:
@@ -378,6 +380,7 @@ class MPExecutor(executor.Executor):
         # this code can be raced from the join call and the disconnect handler
         # relying on the GIL to keep us safe
         if not self.closed:
+            self.closing = True
             self.closed = True
             self.process.close()
             self.owner._child_closed(self)
@@ -462,6 +465,8 @@ class MPManager(executor.ExecutorManager[MPExecutor]):
         self.cli_log = cli_log
         self.session_gid = session_gid
 
+        # These maps are cleaned by the close callbacks
+        # This means it can contain closing entries
         self.executor_map: dict[executor.ExecutorId, MPExecutor] = {}
         self.agent_map: dict[str, set[executor.ExecutorId]] = collections.defaultdict(set)
 
@@ -501,14 +506,23 @@ class MPManager(executor.ExecutorManager[MPExecutor]):
         blueprint = executor.ExecutorBlueprint.from_specs(code)
         executor_id = executor.ExecutorId(agent_name, agent_uri, blueprint)
         if executor_id in self.executor_map:
-            LOGGER.debug("Found existing executor for agent %s with id %s", agent_name, executor_id.identity())
-            return self.executor_map[executor_id]
+            it = self.executor_map[executor_id]
+            if not it.closing:
+                LOGGER.debug("Found existing executor for agent %s with id %s", agent_name, executor_id.identity())
+                return it
         # Acquire a lock based on the blueprint's hash
         # We don't care about URI here
         async with self._locks.get(executor_id.identity()):
             if executor_id in self.executor_map:
-                LOGGER.debug("Found existing executor for agent %s with id %s", agent_name, executor_id.identity())
-                return self.executor_map[executor_id]
+                it = self.executor_map[executor_id]
+                if not it.closing:
+                    LOGGER.debug("Found existing executor for agent %s with id %s", agent_name, executor_id.identity())
+                    return it
+                else:
+                    LOGGER.debug(
+                        "Found stale executor for agent %s with id %s, waiting for close", agent_name, executor_id.identity()
+                    )
+                    await it.join(2.0)
             my_executor = await self.create_executor(executor_id)
             self.__add_executor(executor_id, my_executor)
             if my_executor.failed_resource_sources:
@@ -609,6 +623,8 @@ class MPManager(executor.ExecutorManager[MPExecutor]):
     async def join(self, thread_pool_finalizer: list[concurrent.futures.ThreadPoolExecutor], timeout: float) -> None:
         await asyncio.gather(*(child.join(timeout) for child in self.children))
 
-    async def stop_for_agent(self, agent_name: str) -> None:
+    async def stop_for_agent(self, agent_name: str) -> list[MPExecutor]:
         children_ids = self.agent_map[agent_name]
-        await asyncio.gather(*(self.executor_map[child_id].stop() for child_id in children_ids))
+        children = [self.executor_map[child_id] for child_id in children_ids]
+        await asyncio.gather(*(child.stop() for child in children))
+        return children

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -458,9 +458,13 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
         for child in self.executors.values():
             child.stop()
 
-    async def stop_for_agent(self, agent_name: str) -> None:
+    async def stop_for_agent(self, agent_name: str) -> list[InProcessExecutor]:
         if agent_name in self.executors:
-            self.executors[agent_name].stop()
+            out = self.executors[agent_name]
+            del self.executors[agent_name]
+            out.stop()
+            return [out]
+        return []
 
     async def join(self, thread_pool_finalizer: list[ThreadPoolExecutor], timeout: float) -> None:
         for child in self.executors.values():
@@ -476,27 +480,16 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
         :param executor_id: executor identifier containing an agent name and a blueprint configuration.
         :return: An Executor instance
         """
-        def construct_or_reconstruct():
-            out = self.executors.get(agent_name)
-            if out:
-                out.stop()
-            out = InProcessExecutor(agent_name, agent_uri, self.environment, self.client, self.eventloop, self.logger)
-            self.executors[agent_name] = out
-
-
         if agent_name in self.executors:
             out = self.executors[agent_name]
-            if out.uri != agent_uri:
-                construct_or_reconstruct()
         else:
             async with self._creation_locks.get(agent_name):
                 if agent_name in self.executors:
                     out = self.executors[agent_name]
-                    if out.uri != agent_uri:
-                        construct_or_reconstruct()
                 else:
-                    construct_or_reconstruct()
-
+                    out = InProcessExecutor(agent_name, agent_uri, self.environment, self.client, self.eventloop, self.logger)
+                    self.executors[agent_name] = out
+        assert out.uri == agent_uri
         failed_resource_types: FailedResourcesSet = await self.process.ensure_code(code)
         out.failed_resource_types = failed_resource_types
 

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -64,7 +64,6 @@ from utils import (
     LogSequence,
     _wait_until_deployment_finishes,
     assert_equal_ish,
-    assert_no_warning,
     log_contains,
     log_index,
     resource_action_consistency_check,

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -139,6 +139,10 @@ def test():
     assert await simplest.connection.call(GetName()) == "agent1"
     assert await full_runner.connection.call(GetName()) == "agent2"
 
+    # Assert shutdown and back up
+    await mpmanager.stop_for_agent("agent2")
+    full_runner = await manager.get_executor("agent2", "internal:", [executor.ResourceInstallSpec("test::Test", 5, full)])
+
     await simplest.stop()
     await simplest.join(2)
     with pytest.raises(ConnectionLost):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -264,7 +264,7 @@ def assert_no_warning(caplog, loggers_to_allow: list[str] = NOISY_LOGGERS):
     Assert there are no warning, except from the list of loggers to allow
     """
     for record in caplog.records:
-        assert record.levelname != "WARNING" or (record.name in loggers_to_allow), record
+        assert record.levelname != "WARNING" or (record.name in loggers_to_allow), str(record) + record.getMessage()
 
 
 def configure(unused_tcp_port, database_name, database_port):


### PR DESCRIPTION
# Description

Fix cache invalidation in agent shutdown

# Problem

- in `_update_agent_map` we have `update_uri_agents` which are added and removed
- `remove` calls into `AgentInstance.stop`
-  calls into `executor_manager.stop_for_agent`
-  calls `self.executors[agent_name].stop()`
-  but doesn't `del self.executors[agent_name]`
closes #7641 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
