### PR TITLE
Cleaner exception when influxdb connection fails

### DIFF
--- a/changelogs/unreleased/7622-cleaner-influxdb-exception.yml
+++ b/changelogs/unreleased/7622-cleaner-influxdb-exception.yml
@@ -1,0 +1,4 @@
+description: Cleaner exception when influxdb connection fails
+issue-nr: 7622
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/src/inmanta/reporter.py
+++ b/src/inmanta/reporter.py
@@ -127,7 +127,7 @@ class InfluxReporter(AsyncReporter):
             # Only set if we actually were able to get a successful response
             self._did_create_database = True
         except Exception:
-            LOGGER.warning("Cannot create database %s to %s", self.database, self.server, exc_info=True)
+            LOGGER.warning("Failed to connect or create to influx database %s to %s", self.database, self.server, exc_info=True)
 
     async def report_now(self, registry: Optional[MetricsRegistry] = None, timestamp: Optional[float] = None) -> None:
         http_client = AsyncHTTPClient()

--- a/src/inmanta/reporter.py
+++ b/src/inmanta/reporter.py
@@ -127,7 +127,9 @@ class InfluxReporter(AsyncReporter):
             # Only set if we actually were able to get a successful response
             self._did_create_database = True
         except Exception:
-            LOGGER.warning("Failed to connect or create to influx database %s to %s", self.database, self.server, exc_info=True)
+            LOGGER.warning(
+                "Failed to connect to or create the influx database %s on %s", self.database, self.server, exc_info=True
+            )
 
     async def report_now(self, registry: Optional[MetricsRegistry] = None, timestamp: Optional[float] = None) -> None:
         http_client = AsyncHTTPClient()


### PR DESCRIPTION
# Description

Changed the exception to explicitly mention influxdb so it is more clear

closes #7622 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
