### PR TITLE
Fix broken link

### DIFF
--- a/changelogs/unreleased/issue7557-fix-broken-link-in-docs.yml
+++ b/changelogs/unreleased/issue7557-fix-broken-link-in-docs.yml
@@ -1,0 +1,3 @@
+description: Fix broken link in docs
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1325,8 +1325,7 @@ def list_notifications(
     List the notifications in an environment.
 
     The returned notification objects may carry links to other objects, e.g. a compile report. The full list of supported links
-    can be found at
-    https://docs.inmanta.com/inmanta-service-orchestrator/latest/reference/apilinks.html#api-self-referencing-links
+    can be found :ref:`here <api_self_referencing_links>`.
 
     :param tid: The id of the environment
     :param limit: Limit the number of notifications that are returned
@@ -1610,8 +1609,8 @@ def discovered_resources_get_batch(
     Get a list of discovered resources.
 
     For resources that the orchestrator is already managing, a link to the corresponding resource is provided. The full list of
-    supported links can be found at
-    https://docs.inmanta.com/inmanta-service-orchestrator/latest/reference/apilinks.html#api-self-referencing-links
+    supported links can be found :ref:`here <api_self_referencing_links>`.
+
 
     :param tid: The id of the environment this resource belongs to
     :param limit: Limit the number of instances that are returned


### PR DESCRIPTION
# Description

Follow-up to https://github.com/inmanta/inmanta-core/pull/7648. Fixes broken links that were always pointing to latest.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

~~- [ ] Attached issue to pull request~~
- [x] Changelog entry
~~- [ ] Type annotations are present~~
~~- [ ] Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
