### PR TITLE
Killl executor processes that fail to stop

### DIFF
--- a/changelogs/unreleased/kill-executors-that-fail-to-stop.yml
+++ b/changelogs/unreleased/kill-executors-that-fail-to-stop.yml
@@ -1,0 +1,4 @@
+---
+description: Kill the executor process if it didn't stop after timeout.
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -390,6 +390,14 @@ class MPExecutor(executor.Executor):
             return
         try:
             await asyncio.get_running_loop().run_in_executor(None, functools.partial(self.process.join, timeout))
+            if self.process.exitcode is None:
+                LOGGER.warning(
+                    "Executor for agent %s with id %s didn't stop after timeout of %d seconds. Killing it.",
+                    self.executor_id.agent_name,
+                    self.executor_id.identity(),
+                    timeout,
+                )
+                self.process.kill()
             self._set_closed()
         except ValueError as e:
             if "process object is closed" in str(e):

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -398,6 +398,7 @@ class MPExecutor(executor.Executor):
                     timeout,
                 )
                 self.process.kill()
+                await asyncio.get_running_loop().run_in_executor(None, functools.partial(self.process.join, timeout))
             self._set_closed()
         except ValueError as e:
             if "process object is closed" in str(e):


### PR DESCRIPTION
# Description

Kill the executor process if it didn't stop after timeout.

This issue was detected by the following test case:

```
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ERROR at teardown of test_process_manager ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

    def finalizer() -> None:
        """Yield again, to finalize."""
    
        async def async_finalizer() -> None:
            try:
                await gen_obj.__anext__()
            except StopAsyncIteration:
                pass
            else:
                msg = "Async generator fixture didn't stop."
                msg += "Yield only once."
                raise ValueError(msg)
    
>       event_loop.run_until_complete(async_finalizer())

../../../.virtualenvs/inmanta-core/lib/python3.11/site-packages/pytest_asyncio/plugin.py:342: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib64/python3.11/asyncio/base_events.py:654: in run_until_complete
    return future.result()
../../../.virtualenvs/inmanta-core/lib/python3.11/site-packages/pytest_asyncio/plugin.py:334: in async_finalizer
    await gen_obj.__anext__()
tests/forking_agent/conftest.py:68: in mp_manager_factory
    await asyncio.gather(*(manager.join([], 10) for manager in managers))
src/inmanta/agent/forking_executor.py:632: in join
    await asyncio.gather(*(child.join(timeout) for child in self.children))
src/inmanta/agent/forking_executor.py:393: in join
    self._set_closed()
src/inmanta/agent/forking_executor.py:385: in _set_closed
    self.process.close()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Process name='agent.executor.agent1' pid=50340 parent=11369 stopped exitcode=1>

    def close(self):
        '''
        Close the Process object.
    
        This method releases resources held by the Process object.  It is
        an error to call this method if the child process is still running.
        '''
        if self._popen is not None:
            if self._popen.poll() is None:
>               raise ValueError("Cannot close a process while it is still running. "
                                 "You should first call join() or terminate().")
E               ValueError: Cannot close a process while it is still running. You should first call join() or terminate().

/usr/lib64/python3.11/multiprocessing/process.py:181: ValueError
------------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------------
agent.executor.agent1    INFO    Started with PID: 50333
inmanta.env              INFO    Initializing virtual environment at /tmp/pytest-of-arnaud/pytest-5/test_process_manager0/venvs/085250d9ab646da404327831bd82c9a0
agent.executor.agent1    INFO    Started with PID: 50335
inmanta.env              INFO    Initializing virtual environment at /tmp/pytest-of-arnaud/pytest-5/test_process_manager0/venvs/085250d9ab646da404327831bd82c9a0
inmanta.loader           INFO    Deploying code (hv=c10b5de75a793946e640bb8c9746ed5e50a71cd9, module=inmanta_plugins.test)
inmanta.loader           INFO    Loaded module inmanta_plugins.test
agent.executor.agent1    INFO    Started with PID: 50340
inmanta.env              INFO    Initializing virtual environment at /tmp/pytest-of-arnaud/pytest-5/test_process_manager0/venvs/f2a7980c118c164694986ef4e3f48f3e
inmanta.loader           INFO    Deploying code (hv=c10b5de75a793946e640bb8c9746ed5e50a71cd9, module=inmanta_plugins.test)
inmanta.loader           INFO    Loaded module inmanta_plugins.test
---------------------------------------------------------------------- Captured stdout teardown -----------------------------------------------------------------------
ipc.agent1               INFO    Stopping
ipc.agent1               INFO    Stopping
ipc.agent1               INFO    Stopping
ipc.agent1               INFO    Connection lost
ipc.agent1               INFO    Connection lost
ipc.agent1               INFO    Connection lost
agent.executor.agent1    INFO    Stopped with PID: 50333
agent.executor.agent1    INFO    Stopped with PID: 50335
agent.executor.agent1    INFO    Stopped with PID: 50340

```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
