### PR TITLE
Issue/1667 dont run background tasks during migration tests iso6

### DIFF
--- a/changelogs/unreleased/1667-dont-run-background-tasks-during-migration-tests.yml
+++ b/changelogs/unreleased/1667-dont-run-background-tasks-during-migration-tests.yml
@@ -1,0 +1,6 @@
+---
+description: Disable background tasks during migration tests.
+issue-nr: 1667
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [master, iso7, iso6]

--- a/changelogs/unreleased/1667-dont-run-background-tasks-during-migration-tests.yml
+++ b/changelogs/unreleased/1667-dont-run-background-tasks-during-migration-tests.yml
@@ -3,4 +3,4 @@ description: Disable background tasks during migration tests.
 issue-nr: 1667
 issue-repo: inmanta-lsm
 change-type: patch
-destination-branches: [master, iso7, iso6]
+destination-branches: [iso6]

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -47,9 +47,6 @@ from inmanta.server import SLICE_DATABASE, SLICE_ENVIRONMENT_METRICS, SLICE_TRAN
 LOGGER = logging.getLogger(__name__)
 
 COLLECTION_INTERVAL_IN_SEC = 60
-# This variable can be updated by the test suite to disable all actions done by the server on the metric-related database
-# tables.
-DISABLE_ENV_METRICS_SERVICE = False
 
 # The category fields needs a default value in the DB as it is part of the PRIMARY KEY and can therefore not be NULL.
 DEFAULT_CATEGORY = "__None__"
@@ -195,12 +192,11 @@ class EnvironmentMetricsService(protocol.ServerSlice):
         self.register_metric_collector(CompileWaitingTimeMetricsCollector())
         self.register_metric_collector(AgentCountMetricsCollector())
         self.register_metric_collector(CompileTimeMetricsCollector())
-        if not DISABLE_ENV_METRICS_SERVICE:
-            self.schedule(
-                self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
-            )
-            # Cleanup metrics once per hour
-            self.schedule(self._cleanup_old_metrics, interval=3600, initial_delay=0, cancel_on_stop=True)
+        self.schedule(
+            self.flush_metrics, COLLECTION_INTERVAL_IN_SEC, initial_delay=COLLECTION_INTERVAL_IN_SEC, cancel_on_stop=True
+        )
+        # Cleanup metrics once per hour
+        self.schedule(self._cleanup_old_metrics, interval=3600, initial_delay=0, cancel_on_stop=True)
 
     async def _cleanup_old_metrics(self) -> None:
         """

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -28,7 +28,6 @@ import pytest
 
 from inmanta import const, data
 from inmanta.server import SLICE_ENVIRONMENT_METRICS, protocol
-from inmanta.server.services import environment_metrics_service
 from inmanta.server.services.environment_metrics_service import (
     DEFAULT_CATEGORY,
     AgentCountMetricsCollector,
@@ -54,15 +53,12 @@ async def env_metrics_service(server_config, init_dataclasses_and_load_schema) -
 
 
 @pytest.fixture
-def server_pre_start(server_config):
+def server_pre_start(disable_background_jobs, server_config):
     """
-    This fixture is called before the server starts to disable all actions done
-    by the EnvironmentMetricsService on the metrics-related database tables.
+    This fixture is called before the server starts and will disable background jobs
+    that might interfere with the testing by calling into the disable_background_jobs
+    fixture.
     """
-    old_disable_env_metrics_service = environment_metrics_service.DISABLE_ENV_METRICS_SERVICE
-    environment_metrics_service.DISABLE_ENV_METRICS_SERVICE = True
-    yield
-    environment_metrics_service.DISABLE_ENV_METRICS_SERVICE = old_disable_env_metrics_service
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

iso6 PR for https://github.com/inmanta/inmanta-core/pull/7678

Conflict was on conftest.py having one import too many
