### PR TITLE
Issue/7531 race condition in exporter file upload

### DIFF
--- a/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
+++ b/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
@@ -1,4 +1,6 @@
-description: Trying to upload a file that is already present in the database will now silently fail.
+description: >
+  The upload_file endpoint will now silently ignore attempts to upload a file if a file with the same
+  hash was previously uploaded.
 issue-nr: 7531
 change-type: minor
 destination-branches: [master, iso7]

--- a/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
+++ b/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
@@ -2,8 +2,8 @@ description: >
   The upload_file endpoint will now silently ignore attempts to upload a file if a file with the same
   hash was previously uploaded.
 issue-nr: 7531
-change-type: minor
-destination-branches: [master, iso7]
+change-type: patch
+destination-branches: [master, iso7, iso6]
 sections:
   bugfix: >
     Fix race condition where exporting a file might fail if a file with similar content

--- a/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
+++ b/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
@@ -6,5 +6,5 @@ change-type: patch
 destination-branches: [master, iso7, iso6]
 sections:
   bugfix: >
-    Fix race condition where exporting a file might fail if a file with similar content
+    Fix race condition where exporting a file might fail if a file with the same content
     was uploaded between the file existence check in the database and the export itself.

--- a/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
+++ b/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
@@ -1,0 +1,9 @@
+description: Trying to upload a file that is already present in the database will now silently fail.
+issue-nr: 7531
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"
+  bugfix: >
+    Fix race condition where exporting a file might fail if a file with similar content
+    was uploaded between the file existence check in the database and the export itself.

--- a/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
+++ b/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
@@ -5,7 +5,6 @@ issue-nr: 7531
 change-type: minor
 destination-branches: [master, iso7]
 sections:
-  minor-improvement: "{{description}}"
   bugfix: >
     Fix race condition where exporting a file might fail if a file with similar content
     was uploaded between the file existence check in the database and the export itself.

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -876,7 +876,7 @@ def upload_code_batched(tid: uuid.UUID, id: int, resources: dict):
     :param tid: The id of the environment to which the code belongs.
     :param id: The version number of the configuration model.
     :param resources: A dictionary where each key is a string representing a resource type.
-                  For each resource type, the value is a dictionary. This nested dictionary's keys are file names,
+                  For each resource type, the value is a dictionary. This nested dictionary's keys are file hashes,
                   and each key maps to a tuple. This tuple contains three elements: the file name, the module name,
                   and a list of requirements.
 

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -26,7 +26,7 @@ from asyncpg.exceptions import UniqueViolationError
 
 from inmanta.data import File
 from inmanta.protocol import handle, methods
-from inmanta.protocol.exceptions import BadRequest, NotFound, ServerError
+from inmanta.protocol.exceptions import BadRequest, NotFound
 from inmanta.server import SLICE_DATABASE, SLICE_FILE, SLICE_TRANSPORT, protocol
 from inmanta.server.server import Server
 from inmanta.types import Apireturn
@@ -61,7 +61,7 @@ class FileService(protocol.ServerSlice):
         try:
             await File(content_hash=file_hash, content=content).insert()
         except UniqueViolationError:
-            raise ServerError("A file with this id already exists.")
+            pass
 
     @handle(methods.stat_file, file_hash="id")
     async def stat_file(self, file_hash: str) -> Apireturn:

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -61,6 +61,7 @@ class FileService(protocol.ServerSlice):
         try:
             await File(content_hash=file_hash, content=content).insert()
         except UniqueViolationError:
+            # Silently ignore attempts to upload the same file twice
             pass
 
     @handle(methods.stat_file, file_hash="id")

--- a/tests/protocol/test_protocol.py
+++ b/tests/protocol/test_protocol.py
@@ -155,7 +155,7 @@ async def test_upload_file_twice(client):
     assert len(result.result["files"]) == 1
 
     await upload_and_stat(body, client, hash)
-    await upload_and_stat(body * 2, client, hash)
+    await upload_and_stat(body, client, hash)
 
 
 async def test_diff(client):

--- a/tests/protocol/test_protocol.py
+++ b/tests/protocol/test_protocol.py
@@ -138,7 +138,7 @@ async def test_client_files_stat(client):
 
 async def test_upload_file_twice(client):
     """
-    This test checks that attempts to re-upload the same file will be silently ignored.
+    This test checks that attempts to upload the same file twice (concurrently) don't cause an exception.
     """
 
     async def upload_and_stat(body: str, client, hash: str):
@@ -154,8 +154,7 @@ async def test_upload_file_twice(client):
     assert result.code == 200
     assert len(result.result["files"]) == 1
 
-    await upload_and_stat(body, client, hash)
-    await upload_and_stat(body, client, hash)
+    await asyncio.gather(upload_and_stat(body, client, hash), upload_and_stat(body, client, hash))
 
 
 async def test_diff(client):


### PR DESCRIPTION
# Description

- [x] Make the file upload endpoint idempotent: if the file already exists, silently ignore the request
- [x] Double check that the exporter can handle this new behavior

closes https://github.com/inmanta/inmanta-core/issues/7531

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
~~- [ ] Correct, in line with design~~
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
