### PR TITLE
Issue/7531 race condition in exporter file upload iso6

### DIFF
--- a/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
+++ b/changelogs/unreleased/7531-race-condition-in-exporter-file-upload.yml
@@ -1,0 +1,10 @@
+description: >
+  The upload_file endpoint will now silently ignore attempts to upload a file if a file with the same
+  hash was previously uploaded.
+issue-nr: 7531
+change-type: patch
+destination-branches: [iso6]
+sections:
+  bugfix: >
+    Fix race condition where exporting a file might fail if a file with the same content
+    was uploaded between the file existence check in the database and the export itself.

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -865,7 +865,7 @@ def upload_code_batched(tid: uuid.UUID, id: int, resources: dict):
     :param tid: The id of the environment to which the code belongs.
     :param id: The version number of the configuration model.
     :param resources: A dictionary where each key is a string representing a resource type.
-                  For each resource type, the value is a dictionary. This nested dictionary's keys are file names,
+                  For each resource type, the value is a dictionary. This nested dictionary's keys are file hashes,
                   and each key maps to a tuple. This tuple contains three elements: the file name, the module name,
                   and a list of requirements.
 

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -61,6 +61,7 @@ class FileService(protocol.ServerSlice):
         file_name = os.path.join(self.server_slice._server_storage["files"], file_hash)
 
         if os.path.exists(file_name):
+            # Silently ignore attempts to upload the same file twice
             return
 
         if hash_file(content) != file_hash:

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -60,11 +60,11 @@ class FileService(protocol.ServerSlice):
     def upload_file_internal(self, file_hash: str, content: bytes) -> None:
         file_name = os.path.join(self.server_slice._server_storage["files"], file_hash)
 
-        if hash_file(content) != file_hash:
-            raise BadRequest("The hash does not match the content")
-
         if os.path.exists(file_name):
             return
+
+        if hash_file(content) != file_hash:
+            raise BadRequest("The hash does not match the content")
 
         with open(file_name, "wb+") as fd:
             fd.write(content)

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -60,9 +60,6 @@ class FileService(protocol.ServerSlice):
     def upload_file_internal(self, file_hash: str, content: bytes) -> None:
         file_name = os.path.join(self.server_slice._server_storage["files"], file_hash)
 
-        if os.path.exists(file_name):
-            raise ServerError("A file with this id already exists.")
-
         if hash_file(content) != file_hash:
             raise BadRequest("The hash does not match the content")
 

--- a/src/inmanta/server/services/fileservice.py
+++ b/src/inmanta/server/services/fileservice.py
@@ -63,6 +63,9 @@ class FileService(protocol.ServerSlice):
         if hash_file(content) != file_hash:
             raise BadRequest("The hash does not match the content")
 
+        if os.path.exists(file_name):
+            return
+
         with open(file_name, "wb+") as fd:
             fd.write(content)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -228,7 +228,7 @@ async def test_client_files_corrupt(client):
     assert result.code == 500
 
     result = await client.upload_file(id=hash, content=body)
-    assert result.code == 500
+    assert result.code == 200
 
     opt.server_delete_currupt_files.set("true")
     result = await client.get_file(id=hash)


### PR DESCRIPTION
# Description

iso6 PR for https://github.com/inmanta/inmanta-core/pull/7707

conflict was in the src/inmanta/server/services/fileservice.py file because files are not stored in the db for iso6


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
