### PR TITLE
Issue/736 follow up get rid of removed resource sets parameter

### DIFF
--- a/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
+++ b/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
@@ -1,0 +1,11 @@
+description: >
+  Resource sets marked for deletion should no longer be passed via the ``--delete-resource-set`` parameter of the
+  ``export`` command. These resource sets should be passed via the ``ENV_REMOVED_SET_ID`` environment variable as
+  a space-separated list. The ``--delete-resource-set`` parameter of the ``export`` command is now a flag to control
+  resource set deletion.
+issue-nr: 736
+change-type: minor
+issue-repo: lsm
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
+++ b/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
@@ -8,4 +8,4 @@ change-type: minor
 issue-repo: lsm
 destination-branches: [master, iso7]
 sections:
-  minor-improvement: "{{description}}"
+  upgrade-note: "{{description}}"

--- a/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
+++ b/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
@@ -1,8 +1,7 @@
 description: >
-  Resource sets marked for deletion should no longer be passed via the ``--delete-resource-set`` parameter of the
-  ``export`` command. These resource sets should be passed via the ``INMANTA_REMOVED_SET_ID`` environment variable as
-  a space-separated list. The ``--delete-resource-set`` parameter of the ``export`` command is now a flag to control
-  resource set deletion.
+  The ``export`` command will now look for resource sets marked for deletion in the ``INMANTA_REMOVED_RESOURCE_SET_ID``
+  environment variable (As a space-separated list of sets to remove) in addition to the ones passed via the
+  ``--delete-resource-set`` parameter.
 issue-nr: 736
 change-type: minor
 issue-repo: lsm

--- a/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
+++ b/changelogs/unreleased/736-also-enable-batched-partial-compiles-for-termination-states.yml
@@ -1,6 +1,6 @@
 description: >
   Resource sets marked for deletion should no longer be passed via the ``--delete-resource-set`` parameter of the
-  ``export`` command. These resource sets should be passed via the ``ENV_REMOVED_SET_ID`` environment variable as
+  ``export`` command. These resource sets should be passed via the ``INMANTA_REMOVED_SET_ID`` environment variable as
   a space-separated list. The ``--delete-resource-set`` parameter of the ``export`` command is now a flag to control
   resource set deletion.
 issue-nr: 736

--- a/changelogs/unreleased/736-follow-up-get-rid-of-removed_resource_sets-parameter.yml
+++ b/changelogs/unreleased/736-follow-up-get-rid-of-removed_resource_sets-parameter.yml
@@ -1,0 +1,3 @@
+description: Remove the ``removed_resource_sets`` deprecated parameter from the compilerservice's request_recompile method.
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -451,7 +451,7 @@ def export_parser_config(parser: argparse.ArgumentParser, parent_parsers: abc.Se
     parser.add_argument(
         "--delete-resource-set",
         dest="delete_resource_set",
-        help="Remove resource set(s) passed in the ENV_REMOVED_SET_ID env variable as part of a partial compile. "
+        help="Remove resource set(s) passed in the INMANTA_REMOVED_SET_ID env variable as part of a partial compile. "
         "This option should always be used together with the --partial option",
         action="store_true",
         default=False,
@@ -476,13 +476,13 @@ def export(options: argparse.Namespace) -> None:
             )
         resource_sets_to_remove: list[str] = []
         if options.delete_resource_set is True:
-            if "ENV_REMOVED_SET_ID" not in os.environ or not (removed_sets := os.environ["ENV_REMOVED_SET_ID"]):
+            if "INMANTA_REMOVED_SET_ID" not in os.environ or not (removed_sets := os.environ["INMANTA_REMOVED_SET_ID"]):
                 raise CLIException(
                     "The --delete-resource-set cli option is set but no resource set was passed via "
-                    "the ENV_REMOVED_SET_ID env variable.",
+                    "the INMANTA_REMOVED_SET_ID env variable.",
                     exitcode=1,
                 )
-            resource_sets_to_remove = removed_sets.split(" ")
+            resource_sets_to_remove = removed_sets.split()
 
         if options.environment is not None:
             Config.set("config", "environment", options.environment)

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -476,7 +476,7 @@ def export(options: argparse.Namespace) -> None:
         if "INMANTA_REMOVED_SET_ID" in os.environ:
             removed_sets = set(os.environ["INMANTA_REMOVED_SET_ID"].split())
 
-        resource_sets_to_remove.update(removed_sets)
+            resource_sets_to_remove.update(removed_sets)
 
         if not options.partial_compile and resource_sets_to_remove:
             raise CLIException(

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -479,7 +479,8 @@ def export(options: argparse.Namespace) -> None:
             if "ENV_REMOVED_SET_ID" not in os.environ or not (removed_sets := os.environ["ENV_REMOVED_SET_ID"]):
                 raise CLIException(
                     "The --delete-resource-set cli option is set but no resource set was passed via "
-                    "the ENV_REMOVED_SET_ID env variable."
+                    "the ENV_REMOVED_SET_ID env variable.",
+                    exitcode=1,
                 )
             resource_sets_to_remove = removed_sets.split(" ")
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -473,8 +473,8 @@ def export(options: argparse.Namespace) -> None:
     with logger_mode_manager.run_in_logger_mode(LoggerMode.COMPILER):
         resource_sets_to_remove: set[str] = set(options.delete_resource_set) if options.delete_resource_set else set()
 
-        if "INMANTA_REMOVED_SET_ID" in os.environ:
-            removed_sets = set(os.environ["INMANTA_REMOVED_SET_ID"].split())
+        if const.INMANTA_REMOVED_SET_ID in os.environ:
+            removed_sets = set(os.environ[const.INMANTA_REMOVED_SET_ID].split())
 
             resource_sets_to_remove.update(removed_sets)
 

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -343,4 +343,4 @@ MODULE_PKG_NAME_PREFIX = "inmanta-module-"
 
 # Resource sets marked for deletion during a partial export can be passed via this env
 # variable as a space separated list of set ids.
-INMANTA_REMOVED_SET_ID = "INMANTA_REMOVED_SET_ID"
+INMANTA_REMOVED_SET_ID = "INMANTA_REMOVED_RESOURCE_SET_ID"

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -340,3 +340,7 @@ MODULE_CHANGELOG_FILE = "CHANGELOG.md"
 DATETIME_MIN_UTC = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
 
 MODULE_PKG_NAME_PREFIX = "inmanta-module-"
+
+# Resource sets marked for deletion during a partial export can be passed via this env
+# variable as a space separated list of set ids.
+INMANTA_REMOVED_SET_ID = "INMANTA_REMOVED_SET_ID"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3634,7 +3634,7 @@ class Compile(BaseDocument):
     compile_data: Optional[JsonType] = None
 
     partial: bool = False
-    removed_resource_sets: list[str] = []
+    removed_resource_sets: list[str] = []  # Deprecate but keep for backward compat?
 
     exporter_plugin: Optional[str] = None
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3634,7 +3634,7 @@ class Compile(BaseDocument):
     compile_data: Optional[JsonType] = None
 
     partial: bool = False
-    removed_resource_sets: list[str] = []  # Deprecate but keep for backward compat?
+    removed_resource_sets: list[str] = []
 
     exporter_plugin: Optional[str] = None
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3583,7 +3583,7 @@ class Compile(BaseDocument):
     :param requested: Time the compile was requested
     :param started: Time the compile started
     :param completed: Time to compile was completed
-    :param do_export: should this compiler perform an export
+    :param do_export: should this compile perform an export
     :param force_update: should this compile definitely update
     :param metadata: exporter metadata to be passed to the compiler
     :param requested_environment_variables: environment variables requested to be passed to the compiler

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -646,8 +646,8 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
                                   `CompileService.notify_compile_request_committed()` right after the transaction commits.
         :param soft_delete: Silently ignore deletion of resource sets passed in the env_vars or mergeable_env_vars if
             they contain resources that are being exported.
-        :param mergeable_env_vars: a set of env vars that can be compacted over multiple compiles when batched partial compiles
-            are enabled. If multiple values are compacted, they will be joined using spaces
+        :param mergeable_env_vars: a set of env vars that can be compacted over multiple compiles.
+            If multiple values are compacted, they will be joined using spaces.
         :return: the compile id of the requested compile and any warnings produced during the request
         """
         if in_db_transaction and not connection:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -731,7 +731,13 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         _compile_merge_key(c1) == _compile_merge_key(c2).
         """
         return c.to_dto().model_dump_json(
-            include={"environment" "started" "do_export" "requested_environment_variables" "partial"},
+            include={
+                "environment",
+                "started",
+                "do_export",
+                "requested_environment_variables",
+                "partial",
+            },
         )
 
     async def _process_next_compile_in_queue(

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -623,7 +623,6 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         metadata: Optional[JsonType] = None,
         env_vars: Optional[Mapping[str, str]] = None,
         partial: bool = False,
-        removed_resource_sets: Optional[list[str]] = None,
         exporter_plugin: Optional[str] = None,
         notify_failed_compile: Optional[bool] = None,
         failed_compile_message: Optional[str] = None,
@@ -649,8 +648,6 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
             they contain resources that are being exported.
         :param mergeable_env_vars: a set of env vars that can be compacted over multiple compiles.
             If multiple values are compacted, they will be joined using spaces.
-        :param removed_resource_sets: [DEPRECATED] Resource sets marked for removal should be passed by setting the
-            INMANTA_REMOVED_RESOURCE_SET_ID environment variable in the env_vars or the mergeable_env_vars parameter.
         :return: the compile id of the requested compile and any warnings produced during the request
         """
         if in_db_transaction and not connection:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -623,6 +623,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         metadata: Optional[JsonType] = None,
         env_vars: Optional[Mapping[str, str]] = None,
         partial: bool = False,
+        removed_resource_sets: Optional[list[str]] = None,
         exporter_plugin: Optional[str] = None,
         notify_failed_compile: Optional[bool] = None,
         failed_compile_message: Optional[str] = None,
@@ -648,6 +649,8 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
             they contain resources that are being exported.
         :param mergeable_env_vars: a set of env vars that can be compacted over multiple compiles.
             If multiple values are compacted, they will be joined using spaces.
+        :param removed_resource_sets: [DEPRECATED] Resource sets marked for removal should be passed by setting the
+            INMANTA_REMOVED_RESOURCE_SET_ID environment variable in the env_vars or the mergeable_env_vars parameter.
         :return: the compile id of the requested compile and any warnings produced during the request
         """
         if in_db_transaction and not connection:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -736,12 +736,12 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         """
         return c.to_dto().model_dump_json(
             include={
-                "environment",
-                "started",
-                "do_export",
-                "requested_environment_variables",
-                "partial",
-                "removed_resource_sets",
+                "environment",                      # -> env for this compile
+                "started",                          # -> None before it is actually started, then set in the _run method
+                "do_export",                        # -> exporting compile
+                "requested_environment_variables",  # ->
+                "partial",                          # -> partial compile
+                "removed_resource_sets",            # ->
             },
         )
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -731,14 +731,7 @@ class CompilerService(ServerSlice, environmentservice.EnvironmentListener):
         _compile_merge_key(c1) == _compile_merge_key(c2).
         """
         return c.to_dto().model_dump_json(
-            include={
-                "environment",  # -> env for this compile
-                "started",  # -> None before it is actually started, then set in the _run method
-                "do_export",  # -> exporting compile
-                "requested_environment_variables",  # ->
-                "partial",  # -> partial compile
-                # "removed_resource_sets",          # -> removed resource sets
-            },
+            include={"environment" "started" "do_export" "requested_environment_variables" "partial"},
         )
 
     async def _process_next_compile_in_queue(

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -690,13 +690,26 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         report = [x for x in reports if x["name"] == "Recompiling configuration model"][0]
         return expected in report["command"]
 
+    def set_removal_was_requested(report: dict, removed_sets: Optional[set[str]]=None) -> bool:
+        """
+        Returns True if a resource set removal was requested for a given compile report.
+        In addition, if the removed_sets param is set, the removal of these specific sets is checked.
+
+        :param report: Compile report for which to check if a resource set removal was requested
+        """
+        if not removed_sets:
+            return "ENV_REMOVED_SET_ID" in report["requested_environment_variables"]
+
+        assert "ENV_REMOVED_SET_ID" in report["requested_environment_variables"]
+        return set(report["requested_environment_variables"]["ENV_REMOVED_SET_ID"].split(' ')) == removed_sets
+
     # Do a compile
     compile_id, _ = await compilerslice.request_recompile(env, force_update=False, do_export=False, remote_id=remote_id1)
 
     await retry_limited(wait_for_report, 10)
     report = await client.get_report(compile_id)
     assert not verify_command_report(report, "--partial")
-    assert not verify_command_report(report, "--removed_resource_sets")
+    assert not set_removal_was_requested(report.result["report"])
 
     # Do a partial compile
     compile_id, _ = await compilerslice.request_recompile(
@@ -706,7 +719,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
     await retry_limited(wait_for_report, 10)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial")
-    assert not verify_command_report(report, "--removed_resource_sets")
+    assert not set_removal_was_requested(report.result["report"])
 
     # Do a partial compile with removed resource_sets
     compile_id, _ = await compilerslice.request_recompile(
@@ -715,7 +728,8 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
 
     await retry_limited(wait_for_report, 10)
     report = await client.get_report(compile_id)
-    assert verify_command_report(report, "--partial --delete-resource-set a --delete-resource-set b --delete-resource-set c")
+    assert verify_command_report(report, "--partial")
+    assert set_removal_was_requested(report.result["report"], {"a","b","c"})
 
 
 @pytest.mark.slowtest

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -710,7 +710,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
 
     # Do a partial compile with removed resource_sets
     compile_id, _ = await compilerslice.request_recompile(
-        env, force_update=False, do_export=False, remote_id=remote_id1, partial=True#, removed_resource_sets=["a", "b", "c"]
+        env, force_update=False, do_export=False, remote_id=remote_id1, partial=True, env_vars={"ENV_REMOVED_SET_ID": "a b c"}
     )
 
     await retry_limited(wait_for_report, 10)

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -690,7 +690,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         report = [x for x in reports if x["name"] == "Recompiling configuration model"][0]
         return expected in report["command"]
 
-    def set_removal_was_requested(report: dict, removed_sets: Optional[set[str]]=None) -> bool:
+    def set_removal_was_requested(report: dict, removed_sets: Optional[set[str]] = None) -> bool:
         """
         Returns True if a resource set removal was requested for a given compile report.
         In addition, if the removed_sets param is set, the removal of these specific sets is checked.
@@ -701,7 +701,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
             return "ENV_REMOVED_SET_ID" in report["requested_environment_variables"]
 
         assert "ENV_REMOVED_SET_ID" in report["requested_environment_variables"]
-        return set(report["requested_environment_variables"]["ENV_REMOVED_SET_ID"].split(' ')) == removed_sets
+        return set(report["requested_environment_variables"]["ENV_REMOVED_SET_ID"].split(" ")) == removed_sets
 
     # Do a compile
     compile_id, _ = await compilerslice.request_recompile(env, force_update=False, do_export=False, remote_id=remote_id1)
@@ -729,7 +729,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
     await retry_limited(wait_for_report, 10)
     report = await client.get_report(compile_id)
     assert verify_command_report(report, "--partial")
-    assert set_removal_was_requested(report.result["report"], {"a","b","c"})
+    assert set_removal_was_requested(report.result["report"], {"a", "b", "c"})
 
 
 @pytest.mark.slowtest

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -698,10 +698,10 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         :param report: Compile report for which to check if a resource set removal was requested
         """
         if not removed_sets:
-            return "ENV_REMOVED_SET_ID" in report["requested_environment_variables"]
+            return "INMANTA_REMOVED_SET_ID" in report["requested_environment_variables"]
 
-        assert "ENV_REMOVED_SET_ID" in report["requested_environment_variables"]
-        return set(report["requested_environment_variables"]["ENV_REMOVED_SET_ID"].split(" ")) == removed_sets
+        assert "INMANTA_REMOVED_SET_ID" in report["requested_environment_variables"]
+        return set(report["requested_environment_variables"]["INMANTA_REMOVED_SET_ID"].split()) == removed_sets
 
     # Do a compile
     compile_id, _ = await compilerslice.request_recompile(env, force_update=False, do_export=False, remote_id=remote_id1)
@@ -723,7 +723,12 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
 
     # Do a partial compile with removed resource_sets
     compile_id, _ = await compilerslice.request_recompile(
-        env, force_update=False, do_export=False, remote_id=remote_id1, partial=True, env_vars={"ENV_REMOVED_SET_ID": "a b c"}
+        env,
+        force_update=False,
+        do_export=False,
+        remote_id=remote_id1,
+        partial=True,
+        env_vars={"INMANTA_REMOVED_SET_ID": "a b c"},
     )
 
     await retry_limited(wait_for_report, 10)

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -39,7 +39,7 @@ import inmanta.ast.export as ast_export
 import inmanta.data.model as model
 import utils
 from inmanta import config, data
-from inmanta.const import ParameterSource
+from inmanta.const import INMANTA_REMOVED_SET_ID, ParameterSource
 from inmanta.data import APILIMIT, Compile, Report
 from inmanta.data.model import PipConfig
 from inmanta.env import PythonEnvironment
@@ -698,10 +698,10 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         :param report: Compile report for which to check if a resource set removal was requested
         """
         if not removed_sets:
-            return "INMANTA_REMOVED_SET_ID" in report["requested_environment_variables"]
+            return INMANTA_REMOVED_SET_ID in report["requested_environment_variables"]
 
-        assert "INMANTA_REMOVED_SET_ID" in report["requested_environment_variables"]
-        return set(report["requested_environment_variables"]["INMANTA_REMOVED_SET_ID"].split()) == removed_sets
+        assert INMANTA_REMOVED_SET_ID in report["requested_environment_variables"]
+        return set(report["requested_environment_variables"][INMANTA_REMOVED_SET_ID].split()) == removed_sets
 
     # Do a compile
     compile_id, _ = await compilerslice.request_recompile(env, force_update=False, do_export=False, remote_id=remote_id1)
@@ -728,7 +728,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
         do_export=False,
         remote_id=remote_id1,
         partial=True,
-        env_vars={"INMANTA_REMOVED_SET_ID": "a b c"},
+        env_vars={INMANTA_REMOVED_SET_ID: "a b c"},
     )
 
     await retry_limited(wait_for_report, 10)

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -710,7 +710,7 @@ async def test_server_partial_compile(server, client, environment, monkeypatch):
 
     # Do a partial compile with removed resource_sets
     compile_id, _ = await compilerslice.request_recompile(
-        env, force_update=False, do_export=False, remote_id=remote_id1, partial=True, removed_resource_sets=["a", "b", "c"]
+        env, force_update=False, do_export=False, remote_id=remote_id1, partial=True#, removed_resource_sets=["a", "b", "c"]
     )
 
     await retry_limited(wait_for_report, 10)
@@ -1073,7 +1073,6 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     remote_id6 = uuid.uuid4()
     compile_id6, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=True, remote_id=remote_id6)
 
-
     # Queue = [
     #   remote_id1 (Running),
     #   remote_id2 (Waiting), <----------+
@@ -1082,7 +1081,6 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     #   remote_id5 (Waiting), <----+
     #   remote_id6 (Waiting), <----+-- same _compile_merge_key
     # ]
-
 
     # request with partial, will not be merged
     remote_id7 = uuid.uuid4()

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -441,7 +441,7 @@ async def test_export_invalid_argument_combination() -> None:
     Ensure that the `inmanta export` command exits with an error when the --delete-resource-set option is
     provided without the --partial option being provided.
     """
-    args = [sys.executable, "-m", "inmanta.app", "export", "--delete-resource-set", "test"]
+    args = [sys.executable, "-m", "inmanta.app", "export", "--delete-resource-set"]
     process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
         (stdout, stderr) = await asyncio.wait_for(process.communicate(), timeout=5)
@@ -452,6 +452,21 @@ async def test_export_invalid_argument_combination() -> None:
 
     assert process.returncode == 1
     assert "The --delete-resource-set option should always be used together with the --partial option" in stderr.decode("utf-8")
+
+    args = [sys.executable, "-m", "inmanta.app", "export", "--partial", "--delete-resource-set"]
+    process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        (stdout, stderr) = await asyncio.wait_for(process.communicate(), timeout=5)
+    except asyncio.TimeoutError as e:
+        process.kill()
+        await process.communicate()
+        raise e
+
+    assert process.returncode == 1
+    assert (
+        "The --delete-resource-set cli option is set but no resource set "
+        "was passed via the INMANTA_REMOVED_SET_ID env variable." in stderr.decode("utf-8")
+    )
 
 
 @pytest.mark.parametrize("set_keep_logger_names_option", [True, False])

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -461,7 +461,7 @@ async def test_export_invalid_argument_combination() -> None:
     assert missing_partial_flag in stderr.decode("utf-8")
 
     args = [sys.executable, "-m", "inmanta.app", "export"]
-    env = os.environ.update({INMANTA_REMOVED_SET_ID: "a b c"})
+    env = {INMANTA_REMOVED_SET_ID: "a b c"}
     process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     try:
         (stdout, stderr) = await asyncio.wait_for(process.communicate(), timeout=5)

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -474,7 +474,7 @@ async def test_export_invalid_argument_combination() -> None:
     assert missing_partial_flag in stderr.decode("utf-8")
 
 
-@pytest.mark.parametrize("set_keep_logger_names_option", [True])
+@pytest.mark.parametrize("set_keep_logger_names_option", [True, False])
 async def test_logger_name_in_compiler_exporter_output(
     server,
     environment: str,
@@ -584,7 +584,7 @@ async def test_logger_name_in_compiler_exporter_output(
         *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, cwd=tmpdir
     )
     try:
-        (stdout, stderr) = await asyncio.wait_for(process.communicate(), timeout=30)
+        (stdout, _) = await asyncio.wait_for(process.communicate(), timeout=30)
     except asyncio.TimeoutError as e:
         process.kill()
         await process.communicate()

--- a/tests/test_app_cli.py
+++ b/tests/test_app_cli.py
@@ -32,7 +32,7 @@ from inmanta.app import cmd_parser
 from inmanta.command import ShowUsageException
 from inmanta.compiler.config import feature_compiler_cache
 from inmanta.config import Config
-from inmanta.const import VersionState
+from inmanta.const import INMANTA_REMOVED_SET_ID, VersionState
 from utils import v1_module_from_template
 
 
@@ -461,7 +461,7 @@ async def test_export_invalid_argument_combination() -> None:
     assert missing_partial_flag in stderr.decode("utf-8")
 
     args = [sys.executable, "-m", "inmanta.app", "export"]
-    env = os.environ.update({"INMANTA_REMOVED_SET_ID": "a b c"})
+    env = os.environ.update({INMANTA_REMOVED_SET_ID: "a b c"})
     process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     try:
         (stdout, stderr) = await asyncio.wait_for(process.communicate(), timeout=5)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -36,9 +36,9 @@ from utils import LogSequence
 
 async def assert_resource_set_assignment(environment, assignment: dict[str, Optional[str]]) -> None:
     """
-    Verify whether the resources on the server are assignment to the resource sets given via the assignment argument.
+    Verify whether the resources on the server are assigned to the resource sets given via the assignment argument.
 
-    :param environment
+    :param environment: environment uuid
     :param assignment: Map the value of name attribute of resource Res to the resource set that resource is expected to
                        belong to.
     """


### PR DESCRIPTION
# Description

Follow up PR to https://github.com/inmanta/inmanta-core/pull/7717 that removes the `removed_resource_sets` parameter



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
