### PR TITLE
Issue/update metrics default

### DIFF
--- a/changelogs/unreleased/7676-metrics-retention.yml
+++ b/changelogs/unreleased/7676-metrics-retention.yml
@@ -1,6 +1,6 @@
 description: Reduce metrics retention time to two weeks
 issue-nr: 7676
-change-type: minor
+change-type: patch
 destination-branches: [master, iso7, iso6]
 sections:
   upgrade-note: "The default retention time of the internal metrics store ('environment_metrics_retention') is reduced from one year to two weeks"

--- a/changelogs/unreleased/7676-metrics-retention.yml
+++ b/changelogs/unreleased/7676-metrics-retention.yml
@@ -1,6 +1,6 @@
 description: Reduce metrics retention time to two weeks
 issue-nr: 7676
 change-type: minor
-destination-branches: [master, iso7]
+destination-branches: [master, iso7, iso6]
 sections:
   upgrade-note: "The default retention time of the internal metrics store ('environment_metrics_retention') is reduce from one year to two weeks"

--- a/changelogs/unreleased/7676-metrics-retention.yml
+++ b/changelogs/unreleased/7676-metrics-retention.yml
@@ -3,4 +3,4 @@ issue-nr: 7676
 change-type: minor
 destination-branches: [master, iso7, iso6]
 sections:
-  upgrade-note: "The default retention time of the internal metrics store ('environment_metrics_retention') is reduce from one year to two weeks"
+  upgrade-note: "The default retention time of the internal metrics store ('environment_metrics_retention') is reduced from one year to two weeks"

--- a/changelogs/unreleased/7676-metrics-retention.yml
+++ b/changelogs/unreleased/7676-metrics-retention.yml
@@ -1,0 +1,6 @@
+description: Reduce metrics retention time to two weeks
+issue-nr: 7676
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  upgrade-note: "The default retention time of the internal metrics store ('environment_metrics_retention') is reduce from one year to two weeks"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2641,9 +2641,9 @@ class Environment(BaseDocument):
         ENVIRONMENT_METRICS_RETENTION: Setting(
             name=ENVIRONMENT_METRICS_RETENTION,
             typ="int",
-            default=8760,
+            default=336,
             doc="The number of hours that environment metrics have to be retained before they are cleaned up. "
-            "Default=8760 hours (1 year). Set to 0 to disable automatic cleanups.",
+            "Default=336 hours (2 weeks). Set to 0 to disable automatic cleanups.",
             validator=convert_int,
         ),
     }

--- a/tests/agent_server/test_server_agent.py
+++ b/tests/agent_server/test_server_agent.py
@@ -1559,7 +1559,7 @@ async def test_autostart_mapping_overrides_config(server, client, environment, a
 
 
 async def test_autostart_mapping_update_uri(
-    server, client, clienthelper, environment, async_finalizer, resource_container, caplog
+    server, client, clienthelper, environment, async_finalizer, resource_container, caplog, no_agent_backoff
 ):
     caplog.set_level(logging.INFO)
     agent_config.use_autostart_agent_map.set("true")


### PR DESCRIPTION
# Description

Reduce the metrics retention of our internal database.
The orchestrator dashboard only shows one week of data. 
We have other dashboards on top of this, but this data is not commonly used.

closes #7676 

documented in https://github.com/inmanta/designs/pull/138

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
