### PR TITLE
allow indexes on nullable attributes

### DIFF
--- a/changelogs/unreleased/7204-index-on-nullable.yml
+++ b/changelogs/unreleased/7204-index-on-nullable.yml
@@ -1,0 +1,8 @@
+description: Allow indexes on nullable attributes
+issue-nr: 7204
+change-type: minor
+sections:
+  feature: "Compiler: {{description}}"
+destination-branches:
+  - master
+  - iso7

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -33,9 +33,9 @@ from inmanta.ast import (
 )
 from inmanta.ast.blocks import BasicBlock
 from inmanta.ast.statements.generator import SubConstructor
-from inmanta.ast.type import Float, NamedType, Type
+from inmanta.ast.type import Float, NamedType, NullableType, Type
 from inmanta.execute.runtime import Instance, QueueScheduler, Resolver, dataflow
-from inmanta.execute.util import AnyType
+from inmanta.execute.util import AnyType, NoneValue
 
 try:
     from typing import TYPE_CHECKING
@@ -433,12 +433,24 @@ class Entity(NamedType, WithComment):
                 stmt, self.get_full_name(), "No index defined on %s for this lookup: " % self.get_full_name() + str(params)
             )
 
+        def coerce(t: Type, v: object) -> object:
+            """
+            Coerce float-typed values to float (e.g. 1 -> 1.0)
+            """
+            match t:
+                case Float():
+                    return t.cast(v)
+                case NullableType(element_type=Float() as float):
+                    return v if isinstance(v, NoneValue) else float.cast(v)
+                case _:
+                    return v
+
         key = ", ".join(
             [
                 "%s=%s"
                 % (
                     k,
-                    repr(self.get_attribute(k).type.cast(v) if isinstance(self.get_attribute(k).type, Float) else v),
+                    repr(coerce(self.get_attribute(k).type, v)),
                 )
                 for k, v in sorted(params, key=lambda x: x[0])
             ]

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -621,10 +621,10 @@ class DefineIndex(DefinitionStatement):
                 rattribute = entity_type.get_attribute(str_attribute)
                 self.anchors.append(AttributeAnchor(attribute.get_location(), rattribute))
                 assert rattribute is not None  # Make mypy happy
-                if rattribute.is_optional():
+                if rattribute.is_optional() and isinstance(rattribute, RelationAttribute):
                     raise IndexException(
                         self,
-                        f"Index can not contain optional attributes, Attribute ' {attribute}.{entity_type}' is optional",
+                        f"Index can not contain optional relations, Relation ' {attribute}.{entity_type}' is optional",
                     )
                 if rattribute.is_multi():
                     raise IndexException(

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -667,7 +667,9 @@ def test_index_on_nullable(snippetcompiler) -> None:
 
 
 def test_lookup_on_float_with_int(snippetcompiler):
-    # TODO: docstring
+    """
+    Verify that index lookups work as expected on float-type attributes, both with float and equivalent int lookups.
+    """
     snippetcompiler.setup_for_snippet(
         """
 entity A:

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -81,21 +81,6 @@ def test_issue_140_index_error(snippetcompiler):
         assert re.match(".*No index defined on std::Service for this lookup:.*", str(e))
 
 
-def test_issue_745_index_on_nullable(snippetcompiler):
-    with pytest.raises(IndexException):
-        snippetcompiler.setup_for_snippet(
-            """
-entity A:
-    string name
-    string? opt
-end
-
-index A(name,opt)
-"""
-        )
-        compiler.do_compile()
-
-
 @pytest.mark.parametrize("explicit", [True, False])
 def test_issue_745_2689_index_on_optional(snippetcompiler, explicit: bool):
     with pytest.raises(IndexException):
@@ -592,3 +577,126 @@ The constructor `A(id=1,left='LL',right='RR',other_id=3)` ({snippetcompiler.proj
 - index A(other_id) matches __config__::A (instantiated at {snippetcompiler.project_dir}/main.cf:17)
 """  # noqa: E501
     )
+
+
+def test_index_on_nullable(snippetcompiler) -> None:
+    """
+    Verify that indexes on nullable attributes are allowed and behave as expected.
+
+    Indexes on optional relations are not supported and are tested in test_issue_745_2689_index_on_optional.
+    """
+    snippetcompiler.setup_for_snippet(
+        """
+        entity A:
+            int? n = null
+        end
+        index A(n)
+
+        entity B:
+            int? m = null
+            int? n = null
+        end
+        index B(m, n)
+
+        entity C:
+            string? s = null
+        end
+        index C(s)
+
+        entity D:
+            # this may be deprecated but best to make sure it behaves consistently nonetheless
+            list? l = null
+        end
+        index D(l)
+
+        implement A using std::none
+        implement B using std::none
+        implement C using std::none
+        implement D using std::none
+
+        assert = true
+
+        a_default = A()
+        a_null = A(n=null)
+        a_zero = A(n=0)
+        a_one = A(n=1)
+
+        assert = (a_default == a_null)
+        assert = (a_default == A())
+        assert = (a_null == A(n=null))
+        assert = (a_zero == A(n=0))
+        assert = (a_one == A(n=1))
+        assert = (a_null == A[n=null])
+        assert = (a_zero == A[n=0])
+        assert = (a_one == A[n=1])
+        assert = (a_default != a_zero)
+        assert = (a_default != a_one)
+        assert = (a_zero != a_one)
+
+        # concept is trivially the same: only test that basic behavior
+        b_default = B()
+        assert = (b_default == B[m=null,n=null])
+        assert = (b_default == B(n=null))
+        assert = (b_default != B(n=0))
+
+        # guard against some plausible implementation errors, especially given that we use `repr` for index matching
+        c_null = C()
+        c_null_str = C(s="null")
+        c_None = C(s="None")
+        c_none = C(s="none")
+
+        assert = (c_null != c_null_str)
+        assert = (c_null != c_None)
+        assert = (c_null != c_none)
+        assert = (c_null == C[s=null])
+        assert = (c_null_str == C[s="null"])
+
+        d_default = D()
+        d_null = D(l=null)
+        d_empty = D(l=[])
+        d_one = D(l=[1])
+
+        assert = (d_null == d_default)
+        assert = (d_null != d_empty)
+        assert = (d_null != d_one)
+        assert = (d_null == D[l=null])
+        assert = (d_empty == D[l=[]])
+        """
+    )
+    compiler.do_compile()
+
+
+def test_lookup_on_float_with_int(snippetcompiler):
+    # TODO: docstring
+    snippetcompiler.setup_for_snippet(
+        """
+entity A:
+    float x
+end
+index A(x)
+
+entity B:
+    float? x
+end
+index B(x)
+
+implement A using std::none
+implement B using std::none
+
+assert = true
+
+a_one = A(x=1.0)
+
+assert = (a_one == A[x=1.0])
+assert = (a_one == A[x=1])
+
+b_null = B(x=null)
+b_one = B(x=1.0)
+
+assert = (b_null != b_one)
+assert = (b_null == B[x=null])
+assert = (b_one == B[x=1.0])
+assert = (b_one == B[x=1])
+        """,
+    )
+    compiler.do_compile()

--- a/tests/compiler/test_typing.py
+++ b/tests/compiler/test_typing.py
@@ -534,22 +534,6 @@ def test_float_type(snippetcompiler):
     assert Number().validate(u)
 
 
-def test_lookup_on_float_with_int(snippetcompiler):
-    snippetcompiler.setup_for_snippet(
-        """
-entity A:
-    float x
-end
-implement A using std::none
-index A(x)
-a = A(x=1.0)
-y = A[x=1]
-a = y
-        """,
-    )
-    compiler.do_compile()
-
-
 def test_print_float(snippetcompiler, capsys):
     snippetcompiler.setup_for_snippet(
         """


### PR DESCRIPTION
# Description

Allow indexes on nullable attributes

closes #7204

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
