### PR TITLE
Make ipc light handle unpicklable exceptions

### DIFF
--- a/changelogs/unreleased/agent_executor_6_3.yml
+++ b/changelogs/unreleased/agent_executor_6_3.yml
@@ -1,0 +1,3 @@
+description: Make IPC exception handling resilient to unpicklable objects
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/protocol/ipc_light.py
+++ b/src/inmanta/protocol/ipc_light.py
@@ -159,7 +159,7 @@ class IPCFrameProtocol(Protocol):
         try:
             self.frame_received(frame)
         except Exception:
-            # Failed to unpickle, drop connection
+            # Failed to unpickle, drop frame
             self.logger.exception("Unexpected exception while handling frame %s", self.name)
 
     def send_frame(self, frame: IPCFrame) -> None:

--- a/tests/protocol/test_ipc.py
+++ b/tests/protocol/test_ipc.py
@@ -95,6 +95,7 @@ class UnPicleableError(inmanta.protocol.ipc_light.IPCMethod[None, None]):
         b.close()
         raise Exception(a)
 
+
 async def test_normal_flow(request):
     loop = asyncio.get_running_loop()
     parent_conn, child_conn = socket.socketpair()

--- a/tests/protocol/test_ipc.py
+++ b/tests/protocol/test_ipc.py
@@ -88,7 +88,7 @@ class Echo(inmanta.protocol.ipc_light.IPCMethod[list[int], None]):
         return self.args
 
 
-class UnPicleableError(inmanta.protocol.ipc_light.IPCMethod[None, None]):
+class UnPicklableError(inmanta.protocol.ipc_light.IPCMethod[None, None]):
     async def call(self, ctx: None) -> None:
         a, b = socketpair()
         a.close()
@@ -116,7 +116,7 @@ async def test_normal_flow(request):
         await client_protocol.call(Error())
 
     with pytest.raises(Exception, match=re.escape("<socket.socket [closed]")):
-        await client_protocol.call(UnPicleableError())
+        await client_protocol.call(UnPicklableError())
 
     args = [1, 2, 3, 4]
     result = await client_protocol.call(Echo(args))


### PR DESCRIPTION
# Description

Make IPC transport exceptions that are not pickleable

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
