### PR TITLE
Added alterantive childwatcher

### DIFF
--- a/changelogs/unreleased/agent_executor_6_5.yml
+++ b/changelogs/unreleased/agent_executor_6_5.yml
@@ -1,0 +1,5 @@
+description: Make the server work as a child reaper
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: The server now also cleans up zombie processes, which is convenient when running in a container

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -108,7 +108,6 @@ class InmantaBootloader:
         childwatcher.attach_loop(asyncio.get_running_loop())
         asyncio.set_child_watcher(childwatcher)
 
-
         db_wait_time: int = config.db_wait_time.get()
         if db_wait_time != 0:
             # Wait for the database to be up before starting the server

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -20,6 +20,7 @@ import asyncio
 import importlib
 import logging
 import pkgutil
+from asyncio import FastChildWatcher
 from collections.abc import Generator
 from pkgutil import ModuleInfo
 from types import ModuleType
@@ -100,6 +101,14 @@ class InmantaBootloader:
             inmanta_logger_config.apply_options(inmanta_logging.Options())
 
     async def start(self) -> None:
+
+        # Use the fast child watcher
+        # It also servers as a reaper when the server is pid 1 in a container
+        childwatcher = FastChildWatcher()
+        childwatcher.attach_loop(asyncio.get_running_loop())
+        asyncio.set_child_watcher(childwatcher)
+
+
         db_wait_time: int = config.db_wait_time.get()
         if db_wait_time != 0:
             # Wait for the database to be up before starting the server


### PR DESCRIPTION
# Description

Replace standard child watcher with FastChildWatcher

This will cause it to also clean up zombie processes, but we will have to replace this in the near future, as this while subsystem is deprecated https://github.com/python/cpython/issues/94597. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
