### PR TITLE
Issue/dict path improvs

### DIFF
--- a/changelogs/unreleased/extend-dict-path-library.yml
+++ b/changelogs/unreleased/extend-dict-path-library.yml
@@ -1,0 +1,4 @@
+---
+description: Add get_paths method to dict path library.
+change-type: minor
+destination-branches: [master, iso7]

--- a/changelogs/unreleased/extend-dict-path-library.yml
+++ b/changelogs/unreleased/extend-dict-path-library.yml
@@ -1,4 +1,6 @@
 ---
-description: Add get_paths method to dict path library.
+description: Add resolve_wild_cards method to dict path library.
 change-type: minor
 destination-branches: [master, iso7]
+sections:
+  minor-improvement: Extend dict_path library, allow to resolve the wild cards of a wild dict path for a specific container.

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -228,7 +228,7 @@ class WildDictPath(abc.ABC):
     def get_paths(self, container: object) -> list["DictPath"]:
         """
         Get all the dict paths that this wild dict path contains, in the given
-        containers.  That is, the set of dict path that would resolve the same
+        container.  That is, the set of dict path that would resolve the same
         set of elements as this wild dict path, when searching in the given
         container.
 

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -540,7 +540,7 @@ class WildKeyedList(WildDictPath):
 
     def get_paths(self, container: object) -> Sequence["KeyedList"]:
         """
-        Get one KeyedList by set of of matching key value pairs that can be found
+        Get one KeyedList by set of matching key value pairs that can be found
         in the given container at the relation specified in this object.
 
         ..code-block:: python

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -755,7 +755,7 @@ class WildComposedPath(WildDictPath):
             return [WildComposedPath(path=[path]) for path in self.expanded_path[0].resolve_wild_cards(container)]
 
         return [
-            path + next_part
+            WildComposedPath(path=[path, *next_part.get_path_sections()])
             for path in self.expanded_path[0].resolve_wild_cards(container)
             for elem in path.get_elements(container)
             for next_part in WildComposedPath(path=self.expanded_path[1:]).resolve_wild_cards(elem)

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -225,7 +225,7 @@ class WildDictPath(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_paths(self, container: object) -> list["DictPath"]:
+    def get_paths(self, container: object) -> Sequence["DictPath"]:
         """
         Get all the dict paths that this wild dict path contains, in the given
         container.  That is, the set of dict path that would resolve the same
@@ -324,7 +324,7 @@ class WildInDict(WildDictPath):
         else:
             raise ContainerStructureException(f"{container} is not a Dict")
 
-    def get_paths(self, container: object) -> list["InDict"]:
+    def get_paths(self, container: object) -> Sequence["InDict"]:
         """
         Get one InDict by key matching the wild key of this object.
 
@@ -538,7 +538,7 @@ class WildKeyedList(WildDictPath):
             and all(any(key.matches(k) and value.matches(v) for k, v in dct.items()) for key, value in self.key_value_pairs)
         ]
 
-    def get_paths(self, container: object) -> list["KeyedList"]:
+    def get_paths(self, container: object) -> Sequence["KeyedList"]:
         """
         Get one KeyedList by set of of matching key value pairs that can be found
         in the given container at the relation specified in this object.
@@ -635,7 +635,7 @@ class WildKeyedList(WildDictPath):
             return []
 
         # Save here all the KeyedList that can be constructed
-        matches = []
+        matches: list[KeyedList] = []
 
         # Check each of the inner values, and emit as many paths for it
         # as can be created to match it (within the constraints of this path
@@ -775,7 +775,7 @@ class WildComposedPath(WildDictPath):
 
         return containers
 
-    def get_paths(self, container: object) -> list["ComposedPath"]:
+    def get_paths(self, container: object) -> Sequence["ComposedPath"]:
         if container is None:
             raise IndexError("Can not get anything from None")
 
@@ -786,10 +786,10 @@ class WildComposedPath(WildDictPath):
         if len(self.expanded_path) == 1:
             # The path is equivalent to its unique element, but we have to wrap
             # each of the possible path into a ComposedPath object to be consistent
-            return [ComposedPath(path) for path in self.expanded_path[0].get_paths(container)]
+            return [ComposedPath(path=[path]) for path in self.expanded_path[0].get_paths(container)]
 
         return [
-            path + next_part
+            ComposedPath(path=[path, next_part])
             for path in self.expanded_path[0].get_paths(container)
             for next_part in WildComposedPath(path=self.expanded_path[1:]).get_paths(path.get_element(container))
         ]
@@ -821,7 +821,7 @@ class WildNullPath(WildDictPath):
         else:
             raise ContainerStructureException(f"{container} is not a Dict")
 
-    def get_paths(self, container: object) -> list["NullPath"]:
+    def get_paths(self, container: object) -> Sequence["NullPath"]:
         if self._validate_container(container):
             return [NullPath()]
         else:

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -550,6 +550,11 @@ class WildKeyedList(WildDictPath):
         Get one WildKeyedList by set of matching key value pairs that can be found
         in the given container at the relation specified in this object.
 
+        As of now, this method can not be called on dict path expressions using a wild card
+        in the key of any key-value pair.  This is because the behavior for such type of path
+        is undefined.  It might get defined later on, once we get a use case for them.
+        If the method is called on such a path, a NotImplementedError is raised.
+
         ..code-block:: python
 
             assert WildKeyedList("relation","key_attribute","*").resolve_wild_cards(

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -20,7 +20,7 @@ import abc
 import logging
 import re
 from collections.abc import Sequence
-from typing import Optional, TypeGuard, TypeVar, Union, overload
+from typing import Iterator, Optional, TypeGuard, TypeVar, Union, overload
 
 from inmanta.stable_api import stable_api
 
@@ -516,8 +516,39 @@ class WildKeyedList(WildDictPath):
         except KeyError:
             return []
 
+        def emit_all_paths(pairs: list[list[tuple[str, str]]]) -> Iterator[tuple[str, str]]:
+            # TODO is this all really required? Is there a use case?
+            counters = [0 for _ in range(len(pairs))]
+            selected = []
+            while True:
+                if len(selected) == len(pairs):
+                    # We have selected a full set of pairs, we can emit it
+                    # and reset the selection
+                    counters[-1] += 1
+                    yield selected
+                    selected = []
+
+                pair = len(selected)
+                pos = counters[pair]
+                if pos >= len(pairs[pair]):
+                    # We reached the end of this list of pairs
+                    # Reset its counter and increase the root one
+                    counters[pair] = 0
+                    if pair == 0:
+                        break
+                    else:
+                        selected.pop()
+                        counters[pair - 1] += 1
+                else:
+                    # Add this item of the pair in the selection
+                    selected.append(pairs[pair][pos])
+
         # Save here all the KeyedList that can be constructed
         matches = []
+
+        # Check each of the inner values, and emit as many paths for it
+        # as can be created to match it (within the constraints of this path
+        # filters)
         for dct in self._validate_inner_container(inner):
             if not isinstance(dct, dict):
                 # Can't be a match, it is not even a dict
@@ -525,19 +556,25 @@ class WildKeyedList(WildDictPath):
 
             # Save here all the key-value pairs that will compose our
             # KeyedList dict path
-            pairs = []
-            for key, value in self.key_value_pairs:
+            pairs: list[list[tuple[str, str]]] = [[] for _ in range(len(self.key_value_pairs))]
+
+            for i, (key, value) in enumerate(self.key_value_pairs):
                 for k, v in dct.items():
                     if key.matches(k) and value.matches(v):
-                        pairs.append((str(k), str(v)))
-                        break
-                else:
-                    # Didn't find any key-value pair to be matching our filter
+                        pairs[i].append((str(k), str(v)))
+                if not pairs[i]:
+                    # This key-value filter pair didn't match any of the dict entries
                     break
             else:
-                # All filters have been matched
-                assert len(pairs) == len(self.key_value_pairs), "All matched pairs should correspond to a filter"
-                matches.append(KeyedList(self.relation.value, pairs))
+                # All filters have been matched at least once, emit one set of key value pair
+                # for each possibility that was matched
+                matches.extend(
+                    KeyedList(
+                        self.relation.value,
+                        path,
+                    )
+                    for path in emit_all_paths(pairs)
+                )
 
         return matches
 

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -835,6 +835,12 @@ class DictPath(WildDictPath):
         :raises KeyError: if the element is not found or if more than one occurrence was found.
         """
 
+    def get_elements(self, container: object) -> list[object]:
+        try:
+            return [self.get_element(container, False)]
+        except LookupError:
+            return []
+
     @abc.abstractmethod
     def set_element(self, container: object, value: object, construct: bool = True) -> None:
         """

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -647,27 +647,19 @@ class WildKeyedList(WildDictPath):
 
             # Save here all the key-value pairs that will compose our
             # KeyedList dict path
-            pairs: list[list[tuple[str, str]]] = [[] for _ in range(len(self.key_value_pairs))]
+            pairs = [
+                [(str(k), str(v)) for k, v in dct.items() if key.matches(k) and value.matches(v)]
+                for key, value in self.key_value_pairs
+            ]
 
-            for i, (key, value) in enumerate(self.key_value_pairs):
-                for k, v in dct.items():
-                    if key.matches(k) and value.matches(v):
-                        # Get all the key-value pairs from the dict which match
-                        # this filter key-value pair
-                        pairs[i].append((str(k), str(v)))
-                if not pairs[i]:
-                    # This key-value filter pair didn't match any of the dict entries
-                    break
-            else:
-                # All filters have been matched at least once, emit one set of key value pair
-                # for each possibility that was matched
-                matches.extend(
-                    KeyedList(
-                        self.relation.value,
-                        path,
-                    )
-                    for path in itertools.product(*pairs)
+            # Emit one KeyedList for each combination of matched key-value pairs
+            matches.extend(
+                KeyedList(
+                    self.relation.value,
+                    path,
                 )
+                for path in itertools.product(*pairs)
+            )
 
         return matches
 

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -326,7 +326,7 @@ class WildInDict(WildDictPath):
     def get_paths(self, container: object) -> list["InDict"]:
         if self._validate_container(container):
             try:
-                return [InDict(key) for key in container if self.key.matches(key)]
+                return [InDict(str(key)) for key in container if self.key.matches(key)]
             except KeyError:
                 return []
         else:
@@ -529,7 +529,7 @@ class WildKeyedList(WildDictPath):
             for key, value in self.key_value_pairs:
                 for k, v in dct.items():
                     if key.matches(k) and value.matches(v):
-                        pairs.append((k, v))
+                        pairs.append((str(k), str(v)))
                         break
                 else:
                     # Didn't find any key-value pair to be matching our filter

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -21,7 +21,7 @@ import itertools
 import logging
 import re
 from collections.abc import Sequence
-from typing import Iterator, Optional, TypeGuard, TypeVar, Union, overload
+from typing import Optional, TypeGuard, TypeVar, Union, overload
 
 from inmanta.stable_api import stable_api
 

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -236,6 +236,9 @@ class WildDictPath(abc.ABC):
         for the given container, should be equal to the set of all elements matched by
         this wild dict path expression for the given container.
 
+        This method may return a NotImplementedError if the path upon which it is called
+        isn't supported by the method.
+
         :param container: the container to search in
         """
 
@@ -588,50 +591,17 @@ class WildKeyedList(WildDictPath):
                 WildKeyedList("relation", [("key_attribute","key_value"), ("other_attribute", "other_value")]),
             ]
 
-            assert WildKeyedList("relation",[("*","other_value")]).resolve_wild_cards(
-                {
-                    "relation":[
-                        {
-                            "key_attribute":"key_value",
-                            "other_attribute":"other_value",
-                        },
-                        {
-                            "key_attribute":"other_value",
-                        },
-                        {
-                            "other_key_attribute":"other_value",
-                        },
-                    [
-                }
-            ) == [
-                WildKeyedList("relation", [("other_attribute","other_value")]),
-                WildKeyedList("relation", [("key_attribute","other_value")]),
-                WildKeyedList("relation", [("other_key_attribute","other_value")]),
-            ]
-
-            assert WildKeyedList("relation",[("*","*")]).resolve_wild_cards(
-                {
-                    "relation":[
-                        {
-                            "key_attribute":"key_value",
-                            "other_attribute":"other_value",
-                        },
-                        {
-                            "key_attribute":"other_value",
-                        },
-                        {
-                            "other_key_attribute":"other_value",
-                        },
-                    [
-                }
-            ) == [
-                WildKeyedList("relation", [("key_attribute","key_value")]),
-                WildKeyedList("relation", [("other_attribute","other_value")]),
-                WildKeyedList("relation", [("key_attribute","other_value")]),
-                WildKeyedList("relation", [("other_key_attribute","other_value")]),
-            ]
-
         """
+        # Check if we have a wild card for any of the keys, if we do, raise a NotImplementedError
+        # as we didn't define an expected behavior for it yet
+        for key, _ in self.key_value_pairs:
+            if key == WildCardValue():
+                raise NotImplementedError(
+                    "Can not call resolve_wild_cards on this path because it uses "
+                    f"wild cards (`*`) for some of its keys: `{self}`.  The desired "
+                    "behavior of resolve_wild_cards for this type of path is currently undefined."
+                )
+
         outer = self._validate_outer_container(container)
         try:
             inner = outer[self.relation.value]

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -465,6 +465,28 @@ def test_dict_path_get_elements(
 
 
 @pytest.mark.parametrize(
+    ("wild_path", "dict_paths"),
+    [
+        (".", ["."]),
+        (".*", list(str(InDict(str(k))) for k in WILD_PATH_TEST_CONTAINER.keys())),
+        ("mylist[k1=*][k2=*]", ["mylist[k1=0][k2=0]", "mylist[k1=0][k2=1]", "mylist[k1=1][k2=0]"]),
+        (
+            "mylist[k1=*][k2=*].nested.value",
+            ["mylist[k1=0][k2=0].nested.value", "mylist[k1=0][k2=1].nested.value", "mylist[k1=1][k2=0].nested.value"],
+        ),
+    ],
+)
+def test_dict_path_get_paths(
+    wild_path: str,
+    dict_paths: list[str],
+) -> None:
+    """ """
+    container_copy: object = copy.deepcopy(WILD_PATH_TEST_CONTAINER)
+    all_paths = to_wild_path(wild_path).get_paths(container_copy)
+    assert {str(p) for p in all_paths} == set(dict_paths)
+
+
+@pytest.mark.parametrize(
     "container, dict_path, result",
     [
         (None, "three", {**WILD_PATH_TEST_CONTAINER, "three": {}}),

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -482,11 +482,31 @@ def test_dict_path_get_elements(
             [
                 "mylist[k1=0]",
                 "mylist[k2=0]",
-                "mylist[k1=1]",
-                "mylist[k2=1]",
                 "mylist[nested={'value': 10}]",
+                "mylist[k1=1]",
+                "mylist[k2=0]",
                 "mylist[nested={'value': 20}]",
+                "mylist[k1=0]",
+                "mylist[k2=1]",
                 "mylist[nested={'value': 30}]",
+            ],
+        ),
+        (
+            "mylist[*=*].k1",
+            [
+                "mylist[k1=0].k1",
+                "mylist[k1=0].k1",
+                "mylist[k2=0].k1",
+                "mylist[k2=0].k1",
+                "mylist[nested={'value': 10}].k1",
+                "mylist[k1=1].k1",
+                "mylist[k2=0].k1",
+                "mylist[k2=0].k1",
+                "mylist[nested={'value': 20}].k1",
+                "mylist[k1=0].k1",
+                "mylist[k1=0].k1",
+                "mylist[k2=1].k1",
+                "mylist[nested={'value': 30}].k1",
             ],
         ),
         # A normal dict path should give a copy of itself
@@ -522,10 +542,10 @@ def test_dict_path_get_paths(
 
     # Compile the wild path
     path = to_wild_path(wild_path)
-    all_paths = path.get_paths(container_copy)
+    all_paths = path.resolve_wild_cards(container_copy)
 
     # Assert that all the paths which are resolved match what is expected
-    assert {str(p) for p in all_paths} == set(dict_paths)
+    assert sorted(str(p) for p in all_paths) == sorted(dict_paths)
 
     # Assert that all the elements we get with the wild path, we also
     # get with the combination of all the resolved paths

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -477,6 +477,18 @@ def test_dict_path_get_elements(
             "mylist[k1=*][k2=*].nested.value",
             ["mylist[k1=0][k2=0].nested.value", "mylist[k1=0][k2=1].nested.value", "mylist[k1=1][k2=0].nested.value"],
         ),
+        (
+            "mylist[*=*]",
+            [
+                "mylist[k1=0]",
+                "mylist[k2=0]",
+                "mylist[k1=1]",
+                "mylist[k2=1]",
+                "mylist[nested={'value': 10}]",
+                "mylist[nested={'value': 20}]",
+                "mylist[nested={'value': 30}]",
+            ],
+        ),
         # A normal dict path should give a copy of itself
         ("mylist[k1=0][k2=0].nested.value", ["mylist[k1=0][k2=0].nested.value"]),
         # Combine wild keyed list and wild in dict
@@ -518,7 +530,7 @@ def test_dict_path_get_paths(
     # Assert that all the elements we get with the wild path, we also
     # get with the combination of all the resolved paths
     assert {id(elem) for elem in path.get_elements(container_copy)} == {
-        id(path.get_element(container_copy)) for path in all_paths
+        id(elem) for path in all_paths for elem in path.get_elements(container_copy)
     }
 
 

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -498,6 +498,12 @@ def test_dict_path_get_elements(
             [],
             NotImplementedError,
         ),
+        # A path which doesn't match the dict should not emit any path
+        (
+            "my_list[k1=0][k2=0].test",
+            [],
+            None,
+        ),
     ],
 )
 def test_dict_path_get_paths(


### PR DESCRIPTION
# Description

Add one more functionality to the dict path library: the possibility to emit all the dict path expression that would match one of the elements matched by a wild dict path for a given container. (see test and docstrings for example)

**Context**: When unwrapping an lsm service, in an update state, we often want to check which embedded entities have been created, updated, or removed.  For each service we always need to implement this logic custom, which can be tedious if the embedded entity we care about is deep in the service attributes tree.  One thing that would make it a lot easier was the possibility to say "for all the elements matching this [wild] dict path, tell me which ones have been added, updated, removed".  But this is also very inconvenient to calculate because the notion of identity of each layer of embedded entity needs to be extracted from the dict path, which is not really what the library is meant to be used for.  This new feature allows an easier approach: resolving all the paths that point to embedded entities in the previous set of attributes and in the current one, and just making the diff on the list of dict paths.

```python
@inmanta.plugins.plugin()
def get_removed_entities(service: "lsm::ServiceEntity", wild_path: "string") -> "dict[]":
    previous_attributes = ...
    current_attributes = ...
    
    parsed_wild_path = dict_path.to_wild_path(wild_path)
    removed_entitites = (
        {str(p) for p in parsed_wild_path.resolve_wild_cards(previous_attributes)}
        - {str(p) for p in parsed_wild_path.resolve_wild_cards(current_attributes)}
    )

    return [
        dict_path.to_path(path).get_element(previous_attributes)
        for path in removed_entities
    ]
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
