### PR TITLE
Issue/dict path resolve wild cards backward compat

### DIFF
--- a/changelogs/unreleased/extend-dict-path-library-fix.yml
+++ b/changelogs/unreleased/extend-dict-path-library-fix.yml
@@ -1,0 +1,4 @@
+---
+description: Fix addition of resolve_wild_cards method to dict path library.
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/util/dict_path.py
+++ b/src/inmanta/util/dict_path.py
@@ -224,7 +224,6 @@ class WildDictPath(abc.ABC):
         :param container: the container to search in
         """
 
-    @abc.abstractmethod
     def resolve_wild_cards(self: TWDP, container: object) -> Sequence[TWDP]:
         """
         Resolve all the wild cards contained in this wild dict path, based on the
@@ -241,6 +240,10 @@ class WildDictPath(abc.ABC):
 
         :param container: the container to search in
         """
+        raise NotImplementedError(
+            "There is no default behavior for resolve_wild_cards on the base class WildDictCard, "
+            "it should be implemented in the sub classes."
+        )
 
     @abc.abstractmethod
     def to_str(self) -> str:


### PR DESCRIPTION
# Description

Fix backward compatibility issue with new `resolve_wild_cards` functionality of dict_path.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
