### PR TITLE
fix for newly started agents

### DIFF
--- a/changelogs/unreleased/7831-agent-start-race.yml
+++ b/changelogs/unreleased/7831-agent-start-race.yml
@@ -1,0 +1,6 @@
+description: Fixed race condition where newly started agent may take 22 seconds to respond
+issue-nr: 7831
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -167,6 +167,7 @@ class SessionEndpoint(Endpoint, CallTarget):
         self.running: bool = True
         self.server_timeout = timeout
         self.reconnect_delay = reconnect_delay
+        self.dispatch_delay = 0.01  # keep at least 10 ms between dispatches
         self.add_call_target(self)
 
         self._client = SessionClient(self.name, self.sessionid, timeout=self.server_timeout)
@@ -251,6 +252,10 @@ class SessionEndpoint(Endpoint, CallTarget):
 
                             for method_call in method_calls:
                                 self.add_background_task(self.dispatch_method(transport, method_call))
+                    # Always wait a bit between calls
+                    # reduces chance of missed agent map updates: https://github.com/inmanta/inmanta-core/issues/7831
+                    # encourage call batching
+                    await asyncio.sleep(self.dispatch_delay)
                 else:
                     LOGGER.warning(
                         "Heartbeat failed with status %d and message: %s, going to sleep for %d s",


### PR DESCRIPTION
# Description

Fix for race in the agent 

closes #7831 

This is not a fix in the strict sense, it merely reduce the chance of losing the race under all normal conditions

Under extreme load, the issue may still arise. 

Tested and it works.

*I could not think of a good way to test this, as it is quite delicate.  I'm open to suggestions *

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature) -> very difficult
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
