### PR TITLE
Issue/7777 prevent fact refresh on resources that are undeployable

### DIFF
--- a/changelogs/unreleased/7777-prevent-fact-refresh-on-undeployable-resources.yml
+++ b/changelogs/unreleased/7777-prevent-fact-refresh-on-undeployable-resources.yml
@@ -1,0 +1,6 @@
+description: Don't push fact refresh requests to the agent for undeployable resources.
+issue-nr: 7777
+change-type: patch
+destination-branches: [master, iso7, iso6]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -404,8 +404,8 @@ class InProcessExecutor(executor.Executor, executor.AgentInstance):
                         messages=ctx.logs,
                     )
 
-                except Exception:
-                    self.logger.exception("Unable to retrieve fact")
+                except Exception as e:
+                    self.logger.exception("Unable to retrieve fact for res %s exc %e" % resource, e)
 
         except Exception:
             self.logger.exception("Unable to find a handler for %s", resource.id)

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -404,8 +404,8 @@ class InProcessExecutor(executor.Executor, executor.AgentInstance):
                         messages=ctx.logs,
                     )
 
-                except Exception as e:
-                    self.logger.exception("Unable to retrieve fact for res %s exc %e" % resource, e)
+                except Exception:
+                    self.logger.exception("Unable to retrieve fact")
 
         except Exception:
             self.logger.exception("Unable to find a handler for %s", resource.id)

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -858,7 +858,7 @@ class AgentManager(ServerSlice, SessionListener):
                     "Ignore fact request for %s, resource is in an undeployable state.",
                     resource_id,
                 )
-                return 404, {"message": "The resource is in an undeployable state."}
+                return 503, {"message": "The resource is in an undeployable state."}
 
             rid: Id = Id.parse_id(res.resource_version_id)
             version: int = rid.version

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -37,7 +37,7 @@ from inmanta import config as global_config
 from inmanta import const, data
 from inmanta.agent import config as agent_cfg
 from inmanta.config import Config
-from inmanta.const import AgentAction, AgentStatus, UNDEPLOYABLE_NAMES
+from inmanta.const import UNDEPLOYABLE_NAMES, AgentAction, AgentStatus
 from inmanta.data import APILIMIT, InvalidSort, model
 from inmanta.data.model import ResourceIdStr
 from inmanta.protocol import encode_token, handle, methods, methods_v2

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -37,7 +37,7 @@ from inmanta import config as global_config
 from inmanta import const, data
 from inmanta.agent import config as agent_cfg
 from inmanta.config import Config
-from inmanta.const import AgentAction, AgentStatus
+from inmanta.const import AgentAction, AgentStatus, UNDEPLOYABLE_NAMES
 from inmanta.data import APILIMIT, InvalidSort, model
 from inmanta.data.model import ResourceIdStr
 from inmanta.protocol import encode_token, handle, methods, methods_v2
@@ -852,6 +852,13 @@ class AgentManager(ServerSlice, SessionListener):
 
             if res is None:
                 return 404, {"message": "The resource has no recent version."}
+
+            if res.status in UNDEPLOYABLE_NAMES:
+                LOGGER.debug(
+                    "Ignore fact request for %s, resource is in an undeployable state.",
+                    resource_id,
+                )
+                return 404, {"message": "The resource is in an undeployable state."}
 
             rid: Id = Id.parse_id(res.resource_version_id)
             version: int = rid.version

--- a/tests/agent_server/test_facts.py
+++ b/tests/agent_server/test_facts.py
@@ -23,7 +23,7 @@ import uuid
 from inmanta import const, data, resources
 from inmanta.server import SLICE_AGENT_MANAGER
 from inmanta.util import get_compiler_version
-from utils import LogSequence, _wait_until_deployment_finishes, no_error_in_logs, retry_limited, wait_until_logs_are_available
+from utils import _wait_until_deployment_finishes, no_error_in_logs, retry_limited, wait_until_logs_are_available
 
 
 async def test_get_facts(resource_container, client, clienthelper, environment, agent, caplog):
@@ -276,7 +276,6 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
     await get_fact("test::Fact[agent1,key=key3]")  # not present -> present
     await get_fact("test::Fact[agent1,key=key4]", 404)  # unknown
     await get_fact("test::Fact[agent1,key=key5]", 404)  # broken
-
 
 
 async def test_purged_resources(resource_container, client, clienthelper, server, environment, agent, no_agent_backoff):

--- a/tests/agent_server/test_facts.py
+++ b/tests/agent_server/test_facts.py
@@ -255,11 +255,11 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
     )
     assert result.code == 200
 
-    await get_fact("test::Fact[agent1,key=key1]", 404)  # undeployable
+    await get_fact("test::Fact[agent1,key=key1]", 503)  # undeployable
     await get_fact("test::Fact[agent1,key=key2]")  # normal
     await get_fact("test::Fact[agent1,key=key3]", 503)  # not present
-    await get_fact("test::Fact[agent1,key=key4]", 404)  # unknown
-    await get_fact("test::Fact[agent1,key=key5]", 404)  # broken
+    await get_fact("test::Fact[agent1,key=key4]", 503)  # unknown
+    await get_fact("test::Fact[agent1,key=key5]", 503)  # broken
     f6 = await get_fact("test::Fact[agent1,key=key6]")  # normal
     f7 = await get_fact("test::Fact[agent1,key=key7]")  # normal
 
@@ -271,11 +271,11 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
 
     await _wait_until_deployment_finishes(client, environment, version)
 
-    await get_fact("test::Fact[agent1,key=key1]", 404)  # undeployable
+    await get_fact("test::Fact[agent1,key=key1]", 503)  # undeployable
     await get_fact("test::Fact[agent1,key=key2]")  # normal
     await get_fact("test::Fact[agent1,key=key3]")  # not present -> present
-    await get_fact("test::Fact[agent1,key=key4]", 404)  # unknown
-    await get_fact("test::Fact[agent1,key=key5]", 404)  # broken
+    await get_fact("test::Fact[agent1,key=key4]", 503)  # unknown
+    await get_fact("test::Fact[agent1,key=key5]", 503)  # broken
 
 
 async def test_purged_resources(resource_container, client, clienthelper, server, environment, agent, no_agent_backoff):

--- a/tests/agent_server/test_facts.py
+++ b/tests/agent_server/test_facts.py
@@ -226,8 +226,8 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
     ]
 
     resource_states = {
-        "test::Fact[agent1,key=key4],v=%d" % version: const.ResourceState.undefined,
-        "test::Fact[agent1,key=key5],v=%d" % version: const.ResourceState.undefined,
+        "test::Fact[agent1,key=key4]": const.ResourceState.undefined,
+        "test::Fact[agent1,key=key5]": const.ResourceState.undefined,
     }
 
     async def get_fact(rid, result_code=200, limit=10, lower_limit=2):
@@ -257,8 +257,8 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
     await get_fact("test::Fact[agent1,key=key1]")  # undeployable
     await get_fact("test::Fact[agent1,key=key2]")  # normal
     await get_fact("test::Fact[agent1,key=key3]", 503)  # not present
-    await get_fact("test::Fact[agent1,key=key4]")  # unknown
-    await get_fact("test::Fact[agent1,key=key5]", 503)  # broken
+    await get_fact("test::Fact[agent1,key=key4]", 404)  # unknown
+    await get_fact("test::Fact[agent1,key=key5]", 404)  # broken
     f6 = await get_fact("test::Fact[agent1,key=key6]")  # normal
     f7 = await get_fact("test::Fact[agent1,key=key7]")  # normal
 
@@ -270,11 +270,11 @@ async def test_get_facts_extended(server, client, agent, clienthelper, resource_
 
     await _wait_until_deployment_finishes(client, environment, version)
 
-    await get_fact("test::Fact[agent1,key=key1]")  # undeployable
+    await get_fact("test::Fact[agent1,key=key1]", )  # undeployable
     await get_fact("test::Fact[agent1,key=key2]")  # normal
     await get_fact("test::Fact[agent1,key=key3]")  # not present -> present
-    await get_fact("test::Fact[agent1,key=key4]")  # unknown
-    await get_fact("test::Fact[agent1,key=key5]", 503)  # broken
+    await get_fact("test::Fact[agent1,key=key4]", 404)  # unknown
+    await get_fact("test::Fact[agent1,key=key5]", 404)  # broken
 
     await agent.stop()
 

--- a/tests/agent_server/test_resource_sets.py
+++ b/tests/agent_server/test_resource_sets.py
@@ -1591,7 +1591,7 @@ async def test_put_partial_with_unknowns(server, client, environment, clienthelp
 
     def assert_unknown(uk: data.UnknownParameter, expected_name: str, expected_resource_id: ResourceIdStr) -> None:
         """
-        Verify that the given UnknownParameter matches has the expected content.
+        Verify that the given UnknownParameter matches the expected content.
         """
         assert uk.name == expected_name
         assert uk.environment == uuid.UUID(environment)


### PR DESCRIPTION
# Description

closes https://github.com/inmanta/inmanta-core/issues/7777

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
