### PR TITLE
Fix pkgresources import

### DIFF
--- a/changelogs/unreleased/fix-pkgresources-import.yml
+++ b/changelogs/unreleased/fix-pkgresources-import.yml
@@ -2,7 +2,7 @@ description: Fixed dropped import from pkg_resources
 change-type: patch
 sections:
   bugfix: "Addressed breaking change in setuptools (core Python library)"
-  upgrade-note: "If you had previously constrained `setuptools<71` in your `project.yml`, you may now drop the constraint"
+  upgrade-note: "If you had previously constrained `setuptools<71` in your project's `requirements.txt`, you may now drop the constraint"
 destination-branches:
   - master
   - iso7

--- a/changelogs/unreleased/fix-pkgresources-import.yml
+++ b/changelogs/unreleased/fix-pkgresources-import.yml
@@ -1,4 +1,5 @@
 description: Fixed dropped import from pkg_resources
+change-type: patch
 sections:
   bugfix: "Addressed breaking change in setuptools (core Python library)"
   upgrade-note: "If you had previously constrained `setuptools<71` in your `project.yml`, you may now drop the constraint"

--- a/changelogs/unreleased/fix-pkgresources-import.yml
+++ b/changelogs/unreleased/fix-pkgresources-import.yml
@@ -1,7 +1,7 @@
 description: Fixed dropped import from pkg_resources
 sections:
   bugfix: "Addressed breaking change in setuptools (core Python library)"
-  upgrade-note: "If you had previously constrained `setuptools<71` in your `pyproject.yml`, you may now drop the constraint"
+  upgrade-note: "If you had previously constrained `setuptools<71` in your `project.yml`, you may now drop the constraint"
 destination-branches:
   - master
   - iso7

--- a/changelogs/unreleased/fix-pkgresources-import.yml
+++ b/changelogs/unreleased/fix-pkgresources-import.yml
@@ -1,0 +1,4 @@
+description: Fixed dropped import from pkg_resources
+sections:
+  bugfix: "Addressed breaking change in setuptools (core Python library)"
+  upgrade-note: "If you had previously constrained `setuptools<71` in your `pyproject.yml`, you may now drop the constraint"

--- a/changelogs/unreleased/fix-pkgresources-import.yml
+++ b/changelogs/unreleased/fix-pkgresources-import.yml
@@ -2,3 +2,6 @@ description: Fixed dropped import from pkg_resources
 sections:
   bugfix: "Addressed breaking change in setuptools (core Python library)"
   upgrade-note: "If you had previously constrained `setuptools<71` in your `pyproject.yml`, you may now drop the constraint"
+destination-branches:
+  - master
+  - iso7

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -999,6 +999,8 @@ class ActiveEnv(PythonEnvironment):
         installed_constraints: abc.Set[OwnedRequirement] = frozenset(
             OwnedRequirement(requirement, dist_info.key)
             for dist_info in pkg_resources.working_set
+            # pypa/setuptools#4482. May be removed when we migrate away from pkg_resources
+            if not dist_info.location.endswith("setuptools/_vendor")
             for requirement in dist_info.requires()
         )
         inmanta_constraints: abc.Set[OwnedRequirement] = frozenset(
@@ -1094,6 +1096,8 @@ class ActiveEnv(PythonEnvironment):
             requirement
             for dist_info in working_set
             if in_scope.fullmatch(dist_info.key)
+            # pypa/setuptools#4482. May be removed when we migrate away from pkg_resources
+            if not dist_info.location.endswith("setuptools/_vendor")
             for requirement in dist_info.requires()
         )
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -76,12 +76,9 @@ from inmanta.module import (
     gitprovider,
 )
 from inmanta.stable_api import stable_api
+from packaging.requirements import InvalidRequirement
 from packaging.version import Version
 
-if TYPE_CHECKING:
-    from packaging.requirements import InvalidRequirement
-else:
-    from pkg_resources.extern.packaging.requirements import InvalidRequirement
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -38,7 +38,7 @@ from collections.abc import Mapping, Sequence
 from configparser import ConfigParser
 from functools import total_ordering
 from re import Pattern
-from typing import IO, TYPE_CHECKING, Any, Optional
+from typing import IO, Any, Optional
 
 import click
 import more_itertools
@@ -78,7 +78,6 @@ from inmanta.module import (
 from inmanta.stable_api import stable_api
 from packaging.requirements import InvalidRequirement
 from packaging.version import Version
-
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

Fixed import of `pkg_resources.extern`, which was dropped in the latest `setuptools` release (v71).

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] ~~Type annotations are present~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
