### PR TITLE
Setuptools constrain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
   ignore:
+    - dependency-name: "setuptools"
+      update-types: ["version-update:semver-major"]
     - dependency-name: "pytest-inmanta-extensions"
       versions: [">=0.0.1"]
     - dependency-name: "pydantic"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
     # Allow both direct and indirect updates for all packages
     - dependency-type: "all"
   ignore:
+    # #6668
     - dependency-name: "setuptools"
       update-types: ["version-update:semver-major"]
     - dependency-name: "pytest-inmanta-extensions"

--- a/changelogs/unreleased/fix-pkgresources-import-2.yml
+++ b/changelogs/unreleased/fix-pkgresources-import-2.yml
@@ -1,0 +1,6 @@
+description: Added upper bound to setuptools dependency
+change-type: patch
+# changelog messages were already merged in previous PR
+destination-branches:
+  - master
+  - iso7

--- a/changelogs/unreleased/fix-pkgresources-import.yml
+++ b/changelogs/unreleased/fix-pkgresources-import.yml
@@ -1,8 +1,0 @@
-description: Fixed dropped import from pkg_resources
-change-type: patch
-sections:
-  bugfix: "Addressed breaking change in setuptools (core Python library)"
-  upgrade-note: "If you had previously constrained `setuptools<71` in your project's `requirements.txt`, you may now drop the constraint"
-destination-branches:
-  - master
-  - iso7

--- a/changelogs/unreleased/fix-pkgresources-import.yml
+++ b/changelogs/unreleased/fix-pkgresources-import.yml
@@ -1,0 +1,8 @@
+description: Fixed dropped import from pkg_resources
+change-type: patch
+sections:
+  bugfix: "Addressed breaking change in setuptools (core Python library)"
+  upgrade-note: "If you had previously constrained `setuptools<71` in your project's `requirements.txt`, you may now drop the constraint"
+destination-branches:
+  - master
+  - iso7

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ PyJWT==2.8.0
 pynacl==1.5.0
 python-dateutil==2.9.0.post0
 pyyaml==6.0.1
-setuptools==71.0.2
+setuptools==69.5.1
 texttable==1.7.0
 tornado==6.4.1
 toml==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requires = [
     "pynacl~=1.5",
     "python-dateutil~=2.0",
     "pyyaml~=6.0",
-    "setuptools",
+    "setuptools<70",
     "texttable~=1.0",
     "tornado~=6.0",
     # lower bound because of ilevkivskyi/typing_inspect#100

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -999,8 +999,6 @@ class ActiveEnv(PythonEnvironment):
         installed_constraints: abc.Set[OwnedRequirement] = frozenset(
             OwnedRequirement(requirement, dist_info.key)
             for dist_info in pkg_resources.working_set
-            # pypa/setuptools#4482. May be removed when we migrate away from pkg_resources
-            if not dist_info.location.endswith("setuptools/_vendor")
             for requirement in dist_info.requires()
         )
         inmanta_constraints: abc.Set[OwnedRequirement] = frozenset(
@@ -1096,8 +1094,6 @@ class ActiveEnv(PythonEnvironment):
             requirement
             for dist_info in working_set
             if in_scope.fullmatch(dist_info.key)
-            # pypa/setuptools#4482. May be removed when we migrate away from pkg_resources
-            if not dist_info.location.endswith("setuptools/_vendor")
             for requirement in dist_info.requires()
         )
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -38,7 +38,7 @@ from collections.abc import Mapping, Sequence
 from configparser import ConfigParser
 from functools import total_ordering
 from re import Pattern
-from typing import IO, Any, Optional
+from typing import IO, TYPE_CHECKING, Any, Optional
 
 import click
 import more_itertools
@@ -76,8 +76,12 @@ from inmanta.module import (
     gitprovider,
 )
 from inmanta.stable_api import stable_api
-from packaging.requirements import InvalidRequirement
 from packaging.version import Version
+
+if TYPE_CHECKING:
+    from packaging.requirements import InvalidRequirement
+else:
+    from pkg_resources.extern.packaging.requirements import InvalidRequirement
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

- Reverted previous fix
- Added upper bound to setuptools dependency. I went for `<70` rather than `<71` because the identity of the `InvalidRequirement` exception changed between 69 and 70. This is not as breaking as the issue we were observing with 71, but it might result in some less helpful error messages. 
- Follow-up ticket #6668 scheduled for next product release. We will be able to start tracking the latest release for the upper bound at that point.
- I'll apply the same fix to iso6


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
