### PR TITLE
Improved config parser output

### DIFF
--- a/changelogs/unreleased/buildmaster_type_validation.yml
+++ b/changelogs/unreleased/buildmaster_type_validation.yml
@@ -1,0 +1,2 @@
+description: Improve output of the config parser
+destination-branches: [master, iso6, iso7]

--- a/changelogs/unreleased/buildmaster_type_validation.yml
+++ b/changelogs/unreleased/buildmaster_type_validation.yml
@@ -1,2 +1,3 @@
 description: Improve output of the config parser
 destination-branches: [master, iso6, iso7]
+change-type: patch

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -58,6 +58,7 @@ class LenientConfigParser(ConfigParser):
             raise TypeError(f"option keys must be strings, instead received {option} of type {type(option)}")
         if not isinstance(value, str):
             raise TypeError(f"option values must be strings, instead received {value} of type {type(value)}")
+        super()._validate_value_types(section=section, option=option, value=value)
 
 
 class Config:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -48,7 +48,7 @@ class LenientConfigParser(ConfigParser):
         name = _normalize_name(name)
         return super().optionxform(name)
 
-    def _validate_value_types(self, *, section="", option="", value=""):
+    def _validate_value_types(self, *, section: str = "", option: str = "", value: str = "") -> None:
         """
         Override parent class to get clear exceptions
         """
@@ -56,9 +56,8 @@ class LenientConfigParser(ConfigParser):
             raise TypeError(f"section names must be strings, instead received {section} of type {type(section)}")
         if not isinstance(option, str):
             raise TypeError(f"option keys must be strings, instead received {option} of type {type(option)}")
-        if not self._allow_no_value or value:
-            if not isinstance(value, str):
-                raise TypeError(f"option values must be strings, instead received {value} of type {type(value)}")
+        if not isinstance(value, str):
+            raise TypeError(f"option values must be strings, instead received {value} of type {type(value)}")
 
 
 class Config:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -48,6 +48,18 @@ class LenientConfigParser(ConfigParser):
         name = _normalize_name(name)
         return super().optionxform(name)
 
+    def _validate_value_types(self, *, section="", option="", value=""):
+        """
+        Override parent class to get clear exceptions
+        """
+        if not isinstance(section, str):
+            raise TypeError(f"section names must be strings, instead received {section} of type {type(section)}")
+        if not isinstance(option, str):
+            raise TypeError(f"option keys must be strings, instead received {option} of type {type(option)}")
+        if not self._allow_no_value or value:
+            if not isinstance(value, str):
+                raise TypeError(f"option values must be strings, instead received {value} of type {type(value)}")
+
 
 class Config:
     __instance: Optional[ConfigParser] = None


### PR DESCRIPTION
# Description

Override code from the python sdk

Original

```
    def _validate_value_types(self, *, section="", option="", value=""):
        """Raises a TypeError for non-string values.

        The only legal non-string value if we allow valueless
        options is None, so we need to check if the value is a
        string if:
        - we do not allow valueless options, or
        - we allow valueless options but the value is not None

        For compatibility reasons this method is not used in classic set()
        for RawConfigParsers. It is invoked in every case for mapping protocol
        access and in ConfigParser.set().
        """
        if not isinstance(section, str):
            raise TypeError("section names must be strings")
        if not isinstance(option, str):
            raise TypeError("option keys must be strings")
        if not self._allow_no_value or value:
            if not isinstance(value, str):
                raise TypeError("option values must be strings")
```

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
