### PR TITLE
Issue/executor log cleanup

### DIFF
--- a/changelogs/unreleased/agent_executor_7_3.yml
+++ b/changelogs/unreleased/agent_executor_7_3.yml
@@ -1,0 +1,3 @@
+description: Improve logging on the executor
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -245,7 +245,7 @@ class PoolManager(abc.ABC, Generic[TPoolID, TIntPoolID, TPoolMember]):
         """
         Returns a valid pool member for the given id
         """
-        LOGGER.debug("%s: requesting %s", self.my_name(), self.render_id(member_id))
+        LOGGER.log(LOG_LEVEL_TRACE, "%s: requesting %s", self.my_name(), self.render_id(member_id))
         internal_id = self._id_to_internal(member_id)
         # Acquire a lock based on the executor's pool id
         async with self._locks.get(self.get_lock_name_for(internal_id)):
@@ -258,7 +258,9 @@ class PoolManager(abc.ABC, Generic[TPoolID, TIntPoolID, TPoolMember]):
                 else:
                     await self.pre_replace(it)
             LOGGER.debug("%s: creating %s", self.my_name(), self.render_id(member_id))
-            return await self._create_or_replace(member_id, internal_id)
+            out = await self._create_or_replace(member_id, internal_id)
+            LOGGER.debug("%s: created %s", self.my_name(), self.render_id(member_id))
+            return out
 
     async def _create_or_replace(self, member_id: TPoolID, interal_id: TIntPoolID) -> TPoolMember:
         """

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -267,7 +267,7 @@ async def test_executor_server_dirty_shutdown(mpmanager: MPManager, caplog):
     print("Child there")
 
     process_name = psutil.Process(pid=child1.process.process.pid).name()
-    assert process_name == f"inmanta: executor {blueprint.blueprint_hash()} - connected"
+    assert process_name == f"inmanta: executor process {blueprint.blueprint_hash()} - connected"
 
     await asyncio.get_running_loop().run_in_executor(None, child1.process.process.kill)
     print("Kill sent")


### PR DESCRIPTION
# Description

Final log cleanup, based on working with systemtenant

closes #7692 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
