### PR TITLE
Fix code loading on packaged V2 modules #7849

### DIFF
--- a/changelogs/unreleased/7849-code-loading.yml
+++ b/changelogs/unreleased/7849-code-loading.yml
@@ -1,0 +1,3 @@
+description: Make sure the compiler will not load Python code code present in the `files`, `model` or `templates` directory
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -2976,18 +2976,24 @@ class Module(ModuleLike[TModuleMetadata], ABC):
         """
         Generate a list of all Python files in the given plugin directory.
         This method prioritizes .pyc files over .py files, uses caching to avoid duplicate directory walks,
-        includes namespace packages and excludes the model directory.
+        includes namespace packages and excludes the `model`, `files` and `templates` directories.
         """
         # Return cached results if this directory has been processed before
         if plugin_dir in self._dir_cache:
             return self._dir_cache[plugin_dir]
 
         files: dict[str, str] = {}
-        model_dir_path: str = os.path.join(plugin_dir, "inmanta_plugins", self.name, "model")
+        model_dir_path: str = os.path.join(plugin_dir, "model")
+        files_dir_path: str = os.path.join(plugin_dir, "files")
+        templates_dir_path: str = os.path.join(plugin_dir, "templates")
 
         for dirpath, dirnames, filenames in os.walk(plugin_dir, topdown=True):
             # Modify dirnames in-place to stop os.walk from descending into any more subdirectories of the model directory
-            if dirpath.startswith(model_dir_path):
+            if (
+                dirpath.startswith(model_dir_path)
+                or dirpath.startswith(files_dir_path)
+                or dirpath.startswith(templates_dir_path)
+            ):
                 dirnames[:] = []
                 continue
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1761,7 +1761,7 @@ setup(name="{ModuleV2Source.get_package_name_for(self._module.name)}",
                 elif problematic_dir_name == "files":
                     bundling_description = "inmanta files for managed machines"
                 elif problematic_dir_name == "templates":
-                    bundling_description = "templates that will be used to generate configuration files"
+                    bundling_description = "inmanta templates that will be used to generate configuration files"
                 else:
                     raise RuntimeError(f"Unexpected bundling case: {problematic_dir_name}!")
 

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -1750,30 +1750,22 @@ setup(name="{ModuleV2Source.get_package_name_for(self._module.name)}",
         Copy all files that have to be packaged into the Python package of the module
         """
         python_pkg_dir: str = os.path.join(build_path, "inmanta_plugins", self._module.name)
-        model_dir: str = os.path.join(python_pkg_dir, "model")
-        files_dir: str = os.path.join(python_pkg_dir, "files")
-        templates_dir: str = os.path.join(python_pkg_dir, "templates")
-        for problematic_dir_path in [model_dir, files_dir, templates_dir]:
-            if os.path.exists(problematic_dir_path):
-                problematic_dir_name = os.path.basename(problematic_dir_path)
-                if problematic_dir_name == "model":
-                    bundling_description = "the inmanta model files"
-                elif problematic_dir_name == "files":
-                    bundling_description = "inmanta files for managed machines"
-                elif problematic_dir_name == "templates":
-                    bundling_description = "inmanta templates that will be used to generate configuration files"
-                else:
-                    raise RuntimeError(f"Unexpected bundling case: {problematic_dir_name}!")
-
+        dir_path_bundling_description_mapping = {
+            ("model", "the inmanta model files"),
+            ("files", "inmanta files for managed machines"),
+            ("templates", "inmanta templates that will be used to generate configuration files"),
+        }
+        for problematic_dir, bundling_description in dir_path_bundling_description_mapping:
+            if os.path.exists(os.path.join(python_pkg_dir, problematic_dir)):
                 raise ModuleBuildFailedError(
                     msg="There is already a `%s` directory in %s. "
                     "The `inmanta_plugins.%s.%s` package is reserved for bundling %s. "
                     "Please use a different name for this Python package."
                     % (
-                        problematic_dir_name,
+                        problematic_dir,
                         os.path.join(self._module.path, "inmanta_plugins", self._module.name),
                         self._module.name,
-                        problematic_dir_name,
+                        problematic_dir,
                         bundling_description,
                     )
                 )

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -751,18 +751,20 @@ def test_moduletool_failing(
     # set up venv
     snippetcompiler_clean.setup_for_snippet("", autostd=False)
 
+    module_template_path: pathlib.Path = pathlib.Path(modules_v2_dir) / "failingminimalv2module"
+    module_from_template(
+        str(module_template_path),
+        str(tmpdir.join("custom_mod_one")),
+        new_name="custom_mod_one",
+        new_version=version.Version("1.0.0"),
+        install=True,
+        editable=False,
+    )
+
     for problematic_folder in ["files", "model", "templates"]:
-        module_template_path: pathlib.Path = pathlib.Path(modules_v2_dir) / "failingminimalv2module"
+        (module_template_path / problematic_folder).mkdir(exist_ok=True)
         new_file = module_template_path / problematic_folder / "afile.py"
         new_file.write_text("raise RuntimeError('This file should not be loaded')")
-        module_from_template(
-            module_template_path,
-            str(tmpdir.join("custom_mod_one")),
-            new_name="custom_mod_one",
-            new_version=version.Version("1.0.0"),
-            install=True,
-            editable=False,
-        )
 
         # set up project with a v2 module
         snippetcompiler_clean.setup_for_snippet(

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -738,14 +738,12 @@ def test_implementation_import_missing_error(snippetcompiler) -> None:
 
 
 @pytest.mark.slowtest
-@pytest.mark.parametrize("problematic_folder", ["files", "model", "templates"])
 def test_moduletool_failing(
     capsys,
     tmpdir: py.path.local,
     local_module_package_index: str,
     snippetcompiler_clean,
     modules_v2_dir: str,
-    problematic_folder: str,
 ) -> None:
     """
     Verify code is not loaded when python files are stored in `files`, `model` and `template` folders of a V2 module.
@@ -753,38 +751,37 @@ def test_moduletool_failing(
     # set up venv
     snippetcompiler_clean.setup_for_snippet("", autostd=False)
 
-    module_template_path: pathlib.Path = pathlib.Path(modules_v2_dir) / "failingminimalv2module"
-    new_file = module_template_path / problematic_folder / "afile.py"
-    new_file.write_text("raise RuntimeError('This file should not be loaded')")
-    module_from_template(
-        module_template_path,
-        str(tmpdir.join("custom_mod_one")),
-        new_name="custom_mod_one",
-        new_version=version.Version("1.0.0"),
-        install=True,
-        editable=False,
-    )
+    for problematic_folder in ["files", "model", "templates"]:
+        module_template_path: pathlib.Path = pathlib.Path(modules_v2_dir) / "failingminimalv2module"
+        new_file = module_template_path / problematic_folder / "afile.py"
+        new_file.write_text("raise RuntimeError('This file should not be loaded')")
+        module_from_template(
+            module_template_path,
+            str(tmpdir.join("custom_mod_one")),
+            new_name="custom_mod_one",
+            new_version=version.Version("1.0.0"),
+            install=True,
+            editable=False,
+        )
 
-    # set up project with a v2 module
-    snippetcompiler_clean.setup_for_snippet(
-        """
-import std
-import custom_mod_one
-        """.strip(),
-        python_package_sources=[local_module_package_index],
-        project_requires=[
-            module.InmantaModuleRequirement.parse("std~=4.3.3,<4.3.4"),
-            module.InmantaModuleRequirement.parse("custom_mod_one>0"),
-        ],
-        python_requires=[
-            module.InmantaModuleRequirement.parse("custom_mod_one<999").get_python_package_requirement(),
-        ],
-        install_mode=InstallMode.release,
-        install_project=True,
-        autostd=False,
-    )
+        # set up project with a v2 module
+        snippetcompiler_clean.setup_for_snippet(
+            """
+    import std
+    import custom_mod_one
+            """.strip(),
+            python_package_sources=[local_module_package_index],
+            project_requires=[
+                module.InmantaModuleRequirement.parse("std"),
+                module.InmantaModuleRequirement.parse("custom_mod_one"),
+            ],
+            python_requires=[],
+            install_mode=InstallMode.release,
+            install_project=True,
+            autostd=False,
+        )
 
-    compiler.do_compile()
+        compiler.do_compile()
 
-    # We remove the problematic file to be sure to test the other problematic directories
-    new_file.unlink()
+        # We remove the problematic file to be sure to test the other problematic directories
+        new_file.unlink()

--- a/tests/compiler/test_basics.py
+++ b/tests/compiler/test_basics.py
@@ -754,6 +754,8 @@ def test_moduletool_failing(
     snippetcompiler_clean.setup_for_snippet("", autostd=False)
 
     module_template_path: pathlib.Path = pathlib.Path(modules_v2_dir) / "failingminimalv2module"
+    new_file = module_template_path / problematic_folder / "afile.py"
+    new_file.write_text("raise RuntimeError('This file should not be loaded')")
     module_from_template(
         module_template_path,
         str(tmpdir.join("custom_mod_one")),
@@ -784,4 +786,5 @@ import custom_mod_one
 
     compiler.do_compile()
 
-    (module_template_path / problematic_folder / "afile.py").unlink()
+    # We remove the problematic file to be sure to test the other problematic directories
+    new_file.unlink()

--- a/tests/data/modules_v2/failingminimalv2module/MANIFEST.in
+++ b/tests/data/modules_v2/failingminimalv2module/MANIFEST.in
@@ -1,0 +1,4 @@
+include inmanta_plugins/failingminimalv2module/setup.cfg
+recursive-include inmanta_plugins/failingminimalv2module/model *.cf
+graft inmanta_plugins/failingminimalv2module/files
+graft inmanta_plugins/failingminimalv2module/templates

--- a/tests/data/modules_v2/failingminimalv2module/inmanta_plugins/anothermod/__init__.py
+++ b/tests/data/modules_v2/failingminimalv2module/inmanta_plugins/anothermod/__init__.py
@@ -1,0 +1,10 @@
+from inmanta.plugins import plugin
+
+
+@plugin("flag_plugin")
+def flag_plugin(message: "string"):
+    print(message)
+
+
+def triple_string(message: str) -> str:
+    return message * 3

--- a/tests/data/modules_v2/failingminimalv2module/model/_init.cf
+++ b/tests/data/modules_v2/failingminimalv2module/model/_init.cf
@@ -1,0 +1,1 @@
+std::print("Hello world")

--- a/tests/data/modules_v2/failingminimalv2module/pyproject.toml
+++ b/tests/data/modules_v2/failingminimalv2module/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/data/modules_v2/failingminimalv2module/setup.cfg
+++ b/tests/data/modules_v2/failingminimalv2module/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = inmanta-module-failingminimalv2module
+version = 1.2.3
+description = A minimal v2 module
+license = Apache 2.0
+author = Inmanta <code@inmanta.com>
+
+[options]
+zip_safe=False
+include_package_data=True
+packages=find_namespace:

--- a/tests/moduletool/test_build.py
+++ b/tests/moduletool/test_build.py
@@ -248,7 +248,7 @@ def test_build_with_existing_model_directory(tmpdir, modules_v2_dir: str):
     for problematic_dir, bundling_description in dir_path_bundling_description_mapping:
         problematic_dir_path = os.path.join(python_pkg_dir, problematic_dir)
         os.makedirs(problematic_dir_path)
-        assert os.path.exists(problematic_dir_path)  # Ensure the model directory exists
+        assert os.path.exists(problematic_dir_path)  # Ensure the directory exists to crash the builder
 
         with pytest.raises(
             Exception,
@@ -259,7 +259,7 @@ def test_build_with_existing_model_directory(tmpdir, modules_v2_dir: str):
             V2ModuleBuilder(module_copy_dir).build(os.path.join(module_copy_dir, "dist"))
 
         os.removedirs(problematic_dir_path)
-        assert not os.path.exists(problematic_dir_path)  # Ensure the model directory doesn't exist
+        assert not os.path.exists(problematic_dir_path)  # Ensure the directory doesn't exist
 
 
 def test_create_dev_build_of_v2_module(tmpdir, modules_v2_dir: str) -> None:

--- a/tests/moduletool/test_build.py
+++ b/tests/moduletool/test_build.py
@@ -238,21 +238,17 @@ def test_build_with_existing_model_directory(tmpdir, modules_v2_dir: str):
     shutil.copytree(module_dir, module_copy_dir)
     assert os.path.isdir(module_copy_dir)
 
+    dir_path_bundling_description_mapping = {
+        ("model", "the inmanta model files"),
+        ("files", "inmanta files for managed machines"),
+        ("templates", "inmanta templates that will be used to generate configuration files"),
+    }
     # Simulate the existence of a model directory in inmanta_plugins/<module_name>/
     python_pkg_dir = os.path.join(module_copy_dir, "inmanta_plugins", module_name)
-    for problematic_dir in ["files", "model", "templates"]:
+    for problematic_dir, bundling_description in dir_path_bundling_description_mapping:
         problematic_dir_path = os.path.join(python_pkg_dir, problematic_dir)
         os.makedirs(problematic_dir_path)
         assert os.path.exists(problematic_dir_path)  # Ensure the model directory exists
-
-        if problematic_dir == "model":
-            bundling_description = "the inmanta model files"
-        elif problematic_dir == "files":
-            bundling_description = "inmanta files for managed machines"
-        elif problematic_dir == "templates":
-            bundling_description = "inmanta templates that will be used to generate configuration files"
-        else:
-            raise RuntimeError(f"Unexpected bundling case: {problematic_dir}!")
 
         with pytest.raises(
             Exception,
@@ -263,6 +259,7 @@ def test_build_with_existing_model_directory(tmpdir, modules_v2_dir: str):
             V2ModuleBuilder(module_copy_dir).build(os.path.join(module_copy_dir, "dist"))
 
         os.removedirs(problematic_dir_path)
+        assert not os.path.exists(problematic_dir_path)  # Ensure the model directory doesn't exist
 
 
 def test_create_dev_build_of_v2_module(tmpdir, modules_v2_dir: str) -> None:

--- a/tests/moduletool/test_build.py
+++ b/tests/moduletool/test_build.py
@@ -250,7 +250,7 @@ def test_build_with_existing_model_directory(tmpdir, modules_v2_dir: str):
         elif problematic_dir == "files":
             bundling_description = "inmanta files for managed machines"
         elif problematic_dir == "templates":
-            bundling_description = "templates that will be used to generate configuration files"
+            bundling_description = "inmanta templates that will be used to generate configuration files"
         else:
             raise RuntimeError(f"Unexpected bundling case: {problematic_dir}!")
 


### PR DESCRIPTION
# Description

The compiler was loading any python file in the `files`, `model` and `templates` directory. This is no longer the case

closes https://github.com/inmanta/inmanta-core/issues/7849

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
