### PR TITLE
Interrupt timer on shutdown

### DIFF
--- a/changelogs/unreleased/agent_executor_7_4.yml
+++ b/changelogs/unreleased/agent_executor_7_4.yml
@@ -1,0 +1,3 @@
+description: Interrupt sleep for shutdown
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -50,7 +50,7 @@ import abc
 import asyncio
 import datetime
 import logging
-from asyncio import FIRST_COMPLETED, CancelledError, Event, Task
+from asyncio import CancelledError, Task
 from typing import Any, Callable, Coroutine, Generic, Optional, TypeVar
 
 import inmanta.util

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -317,7 +317,7 @@ class TimeBasedPoolManager(PoolManager[TPoolID, TIntPoolID, TPoolMember]):
         self.retention_time: int = retention_time
         # We keep track of the sleep function to be able to cancel it on shutdown
         # Without risking interrupting the cleanup itself
-        self.shutdown_sleep: Optional[Task] = None
+        self.shutdown_sleep: Optional[Task[None]] = None
 
     async def start(self) -> None:
         """

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -348,7 +348,11 @@ class TimeBasedPoolManager(PoolManager[TPoolID, TIntPoolID, TPoolMember]):
         """
         try:
             while self.running:
-                sleep_interval = await self.cleanup_inactive_pool_members()
+                try:
+                    sleep_interval = await self.cleanup_inactive_pool_members()
+                except Exception:
+                    # This should not happen, as the cleanup_inactive_pool_members should handle all exceptions
+                    logging.exception("Unexpected error while cleaning up pool members")
                 if self.running:
                     LOGGER.log(LOG_LEVEL_TRACE, "Manager will clean in %.2f seconds", sleep_interval)
                     # Allow wait to be cancelled on shutdown


### PR DESCRIPTION
# Description

In order to prevent races, we interrupt the sleep timer.

I don't like this solution at all. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
