### PR TITLE
Improve error reporting when test case times out

### DIFF
--- a/changelogs/unreleased/improve-error-reporting-testcase-timeout.yml
+++ b/changelogs/unreleased/improve-error-reporting-testcase-timeout.yml
@@ -1,0 +1,4 @@
+---
+description: Improve the error reporting when a test case times out.
+change-type: patch
+destination-branches: [master]

--- a/tests/forking_agent/test_agent_executor.py
+++ b/tests/forking_agent/test_agent_executor.py
@@ -209,6 +209,7 @@ def with_timeout(delay):
                     return await func(*args, **kwargs)
             except TimeoutError:
                 raise TimeoutError(f"Test case got interrupted, because it didn't finish in {delay} seconds.")
+
         return new_func
 
     return decorator

--- a/tests/forking_agent/test_agent_executor.py
+++ b/tests/forking_agent/test_agent_executor.py
@@ -204,9 +204,11 @@ def with_timeout(delay):
     def decorator(func):
         @functools.wraps(func)
         async def new_func(*args, **kwargs):
-            async with asyncio.timeout(delay):
-                return await func(*args, **kwargs)
-
+            try:
+                async with asyncio.timeout(delay):
+                    return await func(*args, **kwargs)
+            except TimeoutError:
+                raise TimeoutError(f"Test case got interrupted, because it didn't finish in {delay} seconds.")
         return new_func
 
     return decorator


### PR DESCRIPTION
# Description

Improve error reporting when test case times out

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
