### PR TITLE
Fix broken tests following the removal of some resources in std (>= 6…

### DIFF
--- a/tests/compiler/test_execution.py
+++ b/tests/compiler/test_execution.py
@@ -30,6 +30,28 @@ def test_issue_139_scheduler(snippetcompiler):
 import std
 import std::testing
 
+typedef service_state as string matching self == "running" or self == "stopped"
+
+entity Service:
+    string name
+    service_state state
+    bool onboot
+    bool reload=false
+    bool send_event=false
+end
+
+implement Service using serviceHost
+
+Service.host [1] -- Host.services [0:]
+
+index Service(host, name)
+
+implementation serviceHost for Service:
+    self.requires = self.host.requires
+end
+
+implement Service using serviceHost
+
 entity Host extends std::Host:
     string attr
 end
@@ -38,10 +60,8 @@ implement Host using std::none
 host = Host(name="vm1", os=std::linux)
 
 f = std::testing::NullResource(name=host.name)
-
-std::Service(host=host, name="svc", state="running", onboot=true, requires=[f])
-ref = std::Service[host=host, name="svc"]
-
+Service(host=host, name="svc", state="running", onboot=true, requires=[f])
+ref = Service[host=host, name="svc"]
 """
     )
     with pytest.raises(MultiException):

--- a/tests/compiler/test_index.py
+++ b/tests/compiler/test_index.py
@@ -72,13 +72,21 @@ def test_issue_140_index_error(snippetcompiler):
     try:
         snippetcompiler.setup_for_snippet(
             """
+        entity A:
+            string name
+        end
+
+        A.host [1] -- std::Host
+
+        index A(host, name)
+
         h = std::Host(name="test", os=std::linux)
-        test = std::Service[host=h, path="test"]"""
+        test = A[host=h, path="test"]"""
         )
         compiler.do_compile()
         raise AssertionError("Should get exception")
     except NotFoundException as e:
-        assert re.match(".*No index defined on std::Service for this lookup:.*", str(e))
+        assert re.match(".*No index defined on __config__::A for this lookup:.*", str(e))
 
 
 @pytest.mark.parametrize("explicit", [True, False])
@@ -141,9 +149,23 @@ index Test1(x,y)
 def test_index_on_subtype(snippetcompiler):
     snippetcompiler.setup_for_snippet(
         """
-        host = std::Host(name="a",os=std::linux)
-        a=std::DefaultDirectory(host=host,path="/etc")
-        b=std::DefaultDirectory(host=host,path="/etc")
+        entity A:
+            string path
+        end
+
+        A.host [1] -- std::Host.ases [0:]
+
+        index A(host, path)
+
+        entity B extends A:
+        end
+
+        implement A using std::none
+        implement B using parents
+
+        host = std::Host(name="ahost",os=std::linux)
+        a=B(host=host,path="/etc")
+        b=B(host=host,path="/etc")
     """
     )
 

--- a/tests/compiler/test_relations.py
+++ b/tests/compiler/test_relations.py
@@ -152,11 +152,18 @@ def test_issue_141(snippetcompiler):
         """
 h = std::Host(name="test", os=std::linux)
 
-entity SpecialService extends std::Service:
+entity A:
 
 end
 
-std::Host.services_list [0:] -- SpecialService.host [1]"""
+A.host [1] -- std::Host
+
+
+entity B extends A:
+
+end
+
+std::Host.services_list [0:] -- B.host [1]"""
     )
     with pytest.raises(DuplicateException):
         compiler.do_compile()


### PR DESCRIPTION
….0.0)

# Description

- Cherry-pick of a829ee7
- Change entry removed



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
