### PR TITLE
Remove dump plugin

### DIFF
--- a/changelogs/unreleased/remove-dump.yml
+++ b/changelogs/unreleased/remove-dump.yml
@@ -1,0 +1,3 @@
+description: Remove the broken dump export plugin
+change-type: major
+destination-branches: [master]

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -19,7 +19,6 @@
 import argparse
 import base64
 import logging
-import os
 import time
 import uuid
 from collections.abc import Sequence
@@ -36,7 +35,6 @@ from inmanta.const import ResourceState
 from inmanta.data.model import PipConfig, ResourceVersionIdStr
 from inmanta.execute.proxy import DynamicProxy, UnknownException
 from inmanta.execute.runtime import Instance
-from inmanta.execute.util import Unknown
 from inmanta.module import Project
 from inmanta.protocol import Result
 from inmanta.resources import Id, IgnoreResourceException, Resource, resource, to_id
@@ -695,29 +693,3 @@ class export:  # noqa: N801
         """
         Exporter.add(self.name, self.types, function)
         return function
-
-
-@export("dump", "std::File", "std::Service", "std::Package")
-def export_dumpfiles(exporter: Exporter, types: ProxiedType) -> None:
-    prefix = "dump"
-
-    if not os.path.exists(prefix):
-        os.mkdir(prefix)
-
-    for file in types["std::File"]:
-        path = os.path.join(prefix, file.host.name + file.path.replace("/", "+"))  # type: ignore
-        with open(path, "w+", encoding="utf-8") as fd:
-            if isinstance(file.content, Unknown):  # type: ignore
-                fd.write("UNKNOWN -> error")
-            else:
-                fd.write(file.content)  # type: ignore
-
-    path = os.path.join(prefix, "services")
-    with open(path, "w+", encoding="utf-8") as fd:
-        for svc in types["std::Service"]:
-            fd.write(f"{svc.host.name} -> {svc.name}\n")  # type: ignore
-
-    path = os.path.join(prefix, "packages")
-    with open(path, "w+", encoding="utf-8") as fd:
-        for pkg in types["std::Package"]:
-            fd.write(f"{pkg.host.name} -> {pkg.name}\n")  # type: ignore


### PR DESCRIPTION
# Description

Remove dump plugin that was mostly broken due to #6693 and now entirely useless because it only works on resources that no longer exist.

Closes #6693 
