### PR TITLE
Added improved waiting for agent shutdown

### DIFF
--- a/changelogs/unreleased/agent_executor_7_7.yml
+++ b/changelogs/unreleased/agent_executor_7_7.yml
@@ -1,0 +1,4 @@
+description: Race in testcase
+change-type: patch
+destination-branches: [master]
+

--- a/tests/forking_agent/test_agent_executor.py
+++ b/tests/forking_agent/test_agent_executor.py
@@ -425,8 +425,8 @@ def test():
     assert len(venvs) == 1, "Only one Virtual Environment should exist!"  # Only nr 3
 
     # Let's stop the other agent and pretend that the venv is outdated
-    await executor_manager.stop_for_agent("agent3")
-    executors = await asyncio.gather(*(e.join() for e in executors))
+    executors = await executor_manager.stop_for_agent("agent3")
+    await asyncio.gather(*(e.join() for e in executors))
     await retry_limited(wait_for_agent_stop_running, executor=executor_3, timeout=10)
     # This part of the test is a bit subtle because we rely on the fact that there is no context switching between the
     # modification override of the inmanta file and the retrieval of the last modification of the file

--- a/tests/forking_agent/test_agent_executor.py
+++ b/tests/forking_agent/test_agent_executor.py
@@ -411,20 +411,22 @@ def test():
     logger.debug("cleanup_virtual_environments ended")
 
     venvs = [str(e) for e in venv_dir.iterdir()]
-    assert len(venvs) == 2, "Only two Virtual Environment should exist!"
+    assert len(venvs) == 2, "Only two Virtual Environment should exist!"  # Venv one is gone
     assert [executor_2.process.executor_virtual_env.env_path, executor_3.process.executor_virtual_env.env_path] == venvs
 
     # Let's stop the other agent and pretend that the venv is broken
-    await executor_manager.stop_for_agent("agent2")
+    executors = await executor_manager.stop_for_agent("agent2")
+    await asyncio.gather(*(e.join() for e in executors))
     await retry_limited(wait_for_agent_stop_running, executor=executor_2, timeout=10)
     executor_2_venv_status_file.unlink()
 
     await environment_manager.cleanup_inactive_pool_members()
     venvs = [str(e) for e in venv_dir.iterdir()]
-    assert len(venvs) == 1, "Only one Virtual Environment should exist!"
+    assert len(venvs) == 1, "Only one Virtual Environment should exist!" # Only nr 3
 
     # Let's stop the other agent and pretend that the venv is outdated
     await executor_manager.stop_for_agent("agent3")
+    executors = await asyncio.gather(*(e.join() for e in executors))
     await retry_limited(wait_for_agent_stop_running, executor=executor_3, timeout=10)
     # This part of the test is a bit subtle because we rely on the fact that there is no context switching between the
     # modification override of the inmanta file and the retrieval of the last modification of the file

--- a/tests/forking_agent/test_agent_executor.py
+++ b/tests/forking_agent/test_agent_executor.py
@@ -422,7 +422,7 @@ def test():
 
     await environment_manager.cleanup_inactive_pool_members()
     venvs = [str(e) for e in venv_dir.iterdir()]
-    assert len(venvs) == 1, "Only one Virtual Environment should exist!" # Only nr 3
+    assert len(venvs) == 1, "Only one Virtual Environment should exist!"  # Only nr 3
 
     # Let's stop the other agent and pretend that the venv is outdated
     await executor_manager.stop_for_agent("agent3")


### PR DESCRIPTION
# Description

buildmaster
Fix race on agent shutdown

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
