### PR TITLE
Issue/8052 agent cache follow up improve naming

### DIFF
--- a/changelogs/unreleased/8052-agent-cache-improve-naming.yml
+++ b/changelogs/unreleased/8052-agent-cache-improve-naming.yml
@@ -1,3 +1,7 @@
-description: "Clarify user facing interface."
+description: >
+  The retention policy of items in the agent cache can be set via
+  the `evict_after_creation` and `evict_after_creation` parameters.
 change-type: patch
 destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/8052-agent-cache-improve-naming.yml
+++ b/changelogs/unreleased/8052-agent-cache-improve-naming.yml
@@ -1,0 +1,3 @@
+description: "Clarify user facing interface."
+change-type: patch
+destination-branches: [master]

--- a/changelogs/unreleased/8052-agent-cache-improve-naming.yml
+++ b/changelogs/unreleased/8052-agent-cache-improve-naming.yml
@@ -5,3 +5,10 @@ change-type: minor
 destination-branches: [master]
 sections:
   minor-improvement: "{{description}}"
+  update-note: >
+    Agent cache retention policy parameter `timeout` is now an alias for
+    the `evict_after_creation` parameter.
+  deprecation-note: >
+    Agent cache retention policy parameters `for_version` and `timeout` are deprecated.
+    The `evict_after_creation` and `evict_after_last_access` parameters should be
+    used instead.

--- a/changelogs/unreleased/8052-agent-cache-improve-naming.yml
+++ b/changelogs/unreleased/8052-agent-cache-improve-naming.yml
@@ -5,7 +5,7 @@ change-type: minor
 destination-branches: [master]
 sections:
   minor-improvement: "{{description}}"
-  update-note: >
+  upgrade-note: >
     Agent cache retention policy parameter `timeout` is now an alias for
     the `evict_after_creation` parameter.
   deprecation-note: >

--- a/changelogs/unreleased/8052-agent-cache-improve-naming.yml
+++ b/changelogs/unreleased/8052-agent-cache-improve-naming.yml
@@ -1,7 +1,7 @@
 description: >
   The retention policy of items in the agent cache can be set via
-  the `evict_after_creation` and `evict_after_creation` parameters.
-change-type: patch
+  the `evict_after_creation` and `evict_after_last_access` parameters.
+change-type: minor
 destination-branches: [master]
 sections:
   minor-improvement: "{{description}}"

--- a/docs/model_developers/handlers.rst
+++ b/docs/model_developers/handlers.rst
@@ -236,12 +236,13 @@ second time with the same arguments, it will not be executed again, but the cach
 returned instead. To exclude specific arguments from the cache key, use the ``ignore`` parameter.
 
 Cache entries will be dropped from the cache when they become stale. Use the following parameters to control when an entry is considered stale:
-  * Setting ``evict_after_creation=True`` will mark entries as stale after a timeout controlled by the ``timeout`` parameter (5000s by default).
-  * Setting ``refresh_after_access=True`` will reset the expiry time of entries to 60s anytime they're used.
+  * ``evict_after_creation``: mark entries as stale after this amount of time (in seconds) has elapsed since they entered the cache (5000s by default).
+  * ``evict_after_last_access``: mark entries as stale after this amount of time (in seconds) has elapsed since they were last accessed (60 by default).
+
 
 .. note::
 
-    If both ``evict_after_creation=True`` and ``refresh_after_access=True`` are set,
+    If both ``evict_after_creation=True`` and ``evict_after_last_access=True`` are set,
     the entry will become stale when the shortest of the two timers is up.
 
 
@@ -249,12 +250,12 @@ For example, to cache the connection to a specific device for 120 seconds:
 
 .. code-block:: python
 
-    @cache(timeout=120, ignore=["ctx"], evict_after_creation=True)
+    @cache(ignore=["ctx"], evict_after_creation=120)
     def get_client_connection(self, ctx, device_id):
        # ...
        return connection
 
-Setting ``refresh_after_access=True`` (or omitting the parameter) will reset the lifetime
+Setting ``evict_after_last_access=60`` (or omitting the parameter) will reset the lifetime
 of the cached connection to 60s everytime it is read from the cache.
 
 .. code-block:: python
@@ -271,7 +272,7 @@ from the cache. It gets the cached item as argument.
 
 .. code-block:: python
 
-    @cache(timeout=120, ignore=["ctx"], refresh_after_access=True,
+    @cache(ignore=["ctx"], evict_after_last_access=60,
        call_on_delete=lambda connection:connection.close())
     def get_client_connection(self, ctx, device_id, version):
        # ...

--- a/docs/model_developers/handlers.rst
+++ b/docs/model_developers/handlers.rst
@@ -235,8 +235,8 @@ the method will form the cache key, the return value will be cached. When the me
 second time with the same arguments, it will not be executed again, but the cached result is
 returned instead. To exclude specific arguments from the cache key, use the ``ignore`` parameter.
 
-Cache entries will be dropped from the cache when they become stale. Use the following parameters to control when an entry is considered stale:
-  * ``evict_after_creation``: mark entries as stale after this amount of time (in seconds) has elapsed since they entered the cache (5000s by default).
+Cache entries will be dropped from the cache when they become stale. Use the following parameters to set the retention policy:
+  * ``evict_after_creation``: mark entries as stale after this amount of time (in seconds) has elapsed since they entered the cache.
   * ``evict_after_last_access``: mark entries as stale after this amount of time (in seconds) has elapsed since they were last accessed (60 by default).
 
 
@@ -255,8 +255,8 @@ For example, to cache the connection to a specific device for 120 seconds:
        # ...
        return connection
 
-Setting ``evict_after_last_access=60`` (or omitting the parameter) will reset the lifetime
-of the cached connection to 60s everytime it is read from the cache.
+Setting ``evict_after_last_access=60`` (or omitting the parameter) will evict
+the connection from the cache 60s after it was last read from the cache.
 
 .. code-block:: python
 

--- a/docs/model_developers/handlers.rst
+++ b/docs/model_developers/handlers.rst
@@ -50,6 +50,7 @@ entity it is serializing.
 
     from inmanta.resources import resource, Resource
 
+
     @resource("std::File", agent="host.name", id_attribute="path")
     class File(Resource):
         fields = ("path", "owner", "hash", "group", "permissions", "purged", "reload")
@@ -63,6 +64,7 @@ entity it is serializing.
         @staticmethod
         def get_permissions(_, obj):
             return int(x.mode)
+
 
 
 Classes decorated with :func:`@resource<inmanta.resources.resource>` do not have to inherit directly from
@@ -132,14 +134,18 @@ method during resource deployment (in ``read_resource`` and/or ``create_resource
 
     @provider("openstack::FloatingIP", name="openstack")
     class FloatingIPHandler(OpenStackHandler):
-        def read_resource(self, ctx: handler.HandlerContext, resource: FloatingIP) -> None:
-            ...
+        def read_resource(
+            self, ctx: handler.HandlerContext, resource: FloatingIP
+        ) -> None: ...
 
-        def create_resource(self, ctx: handler.HandlerContext, resource: FloatingIP) -> None:
+        def create_resource(
+            self, ctx: handler.HandlerContext, resource: FloatingIP
+        ) -> None:
             ...
             # Setting fact manually
             for key, value in ...:
                 ctx.set_fact(fact_id=key, value=value, expires=True)
+
 
 
 By default, facts expire when they have not been refreshed or updated for a certain time, controlled by the
@@ -171,6 +177,7 @@ handler's :meth:`~inmanta.agent.handler.CRUDHandler.facts` method. e.g.:
             fip = self._neutron.list_floatingips(port_id=port_id)["floatingips"]
             if len(fip) > 0:
                 ctx.set_fact("ip_address", fip[0]["floating_ip_address"])
+
 
 
 .. warning::
@@ -252,8 +259,9 @@ For example, to cache the connection to a specific device for 120 seconds:
 
     @cache(ignore=["ctx"], evict_after_creation=120)
     def get_client_connection(self, ctx, device_id):
-       # ...
-       return connection
+        # ...
+        return connection
+
 
 Setting ``evict_after_last_access=60`` (or omitting the parameter) will evict
 the connection from the cache 60s after it was last read from the cache.
@@ -262,8 +270,8 @@ the connection from the cache 60s after it was last read from the cache.
 
     @cache(ignore=["ctx"])
     def get_client_connection(self, ctx, device_id, version):
-       # ...
-       return connection
+        # ...
+        return connection
 
 To also ensure the connection is properly closed, an ``on_delete`` function can be passed
 via the ``call_on_delete`` parameter. This function is called when the cache entry is removed
@@ -272,8 +280,11 @@ from the cache. It gets the cached item as argument.
 
 .. code-block:: python
 
-    @cache(ignore=["ctx"], evict_after_last_access=60,
-       call_on_delete=lambda connection:connection.close())
+    @cache(
+        ignore=["ctx"],
+        evict_after_last_access=60,
+        call_on_delete=lambda connection: connection.close(),
+    )
     def get_client_connection(self, ctx, device_id, version):
-       # ...
-       return connection
+        # ...
+        return connection

--- a/docs/model_developers/handlers.rst
+++ b/docs/model_developers/handlers.rst
@@ -233,19 +233,16 @@ method annotated with this annotation will be cached, similar to the way
 `lru_cache <https://docs.python.org/3/library/functools.html#functools.lru_cache>`_ works. The arguments to
 the method will form the cache key, the return value will be cached. When the method is called a
 second time with the same arguments, it will not be executed again, but the cached result is
-returned instead. To exclude specific arguments from the cache key, use the `ignore` parameter.
+returned instead. To exclude specific arguments from the cache key, use the ``ignore`` parameter.
 
-Cache entries will be dropped from the cache when they become stale. Use the following
-parameters to control when an entry is considered stale:
+Cache entries will be dropped from the cache when they become stale. Use the following parameters to control when an entry is considered stale:
+  * Setting ``evict_after_creation=True`` will mark entries as stale after a timeout controlled by the ``timeout`` parameter (5000s by default).
+  * Setting ``refresh_after_access=True`` will reset the expiry time of entries to 60s anytime they're used.
 
-  - Setting ``evict_after_creation=True``will mark entries as stale after a timeout
-    controlled by the ``timeout`` parameter (5000s by default).
+.. note::
 
-  - Setting``refresh_after_access=True`` will reset the expiry time of entries to
-    60s anytime they're used.
-
-
-  - If both are set, the entry will become stale when the shortest of the two timers is up.
+    If both ``evict_after_creation=True`` and ``refresh_after_access=True`` are set,
+    the entry will become stale when the shortest of the two timers is up.
 
 
 For example, to cache the connection to a specific device for 120 seconds:

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -232,8 +232,8 @@ class AgentCache:
         resource: Optional[Resource] = None,
         timeout: int = 5000,
         call_on_delete: Optional[Callable[[Any], None]] = None,
-        evict_after_last_access: bool=True,
-        evict_after_creation: bool=False,
+        evict_after_last_access: bool = True,
+        evict_after_creation: bool = False,
     ) -> None:
         """
         add a value to the cache with the given key
@@ -257,7 +257,7 @@ class AgentCache:
                 value,
                 call_on_delete,
                 evict_after_last_access=evict_after_last_access,
-                evict_after_creation=evict_after_creation
+                evict_after_creation=evict_after_creation,
             )
         )
 
@@ -277,8 +277,8 @@ class AgentCache:
         self,
         key: str,
         function: Callable[..., Any],
-        evict_after_last_access: bool=True,
-        evict_after_creation: bool=False,
+        evict_after_last_access: bool = True,
+        evict_after_creation: bool = False,
         timeout: int = 5000,
         ignore: set[str] = set(),
         cache_none: bool = True,
@@ -323,7 +323,13 @@ class AgentCache:
                     value = function(**kwargs)
                     if cache_none or value is not None:
                         self.cache_value(
-                            key, value, timeout=timeout, call_on_delete=call_on_delete, evict_after_last_access=evict_after_last_access, evict_after_creation=evict_after_creation,**args
+                            key,
+                            value,
+                            timeout=timeout,
+                            call_on_delete=call_on_delete,
+                            evict_after_last_access=evict_after_last_access,
+                            evict_after_creation=evict_after_creation,
+                            **args,
                         )
             with self.addLock:
                 del self.addLocks[key]

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -59,13 +59,13 @@ class CacheItem:
 
         now = time.time()
         self.expiry_time: float = sys.float_info.max
-        self.hard_expiry: float = sys.float_info.max
+        self.after_creation_expiry_time: float = sys.float_info.max
 
         if evict_after_last_access > 0:
             self.expiry_time = now + evict_after_last_access
         if evict_after_creation > 0:
-            self.hard_expiry = now + evict_after_creation
-            self.expiry_time = min(self.expiry_time, self.hard_expiry)
+            self.after_creation_expiry_time = now + evict_after_creation
+            self.expiry_time = min(self.expiry_time, self.after_creation_expiry_time)
 
         # Make sure finalizers are only called once
         self.finalizer_lock = Lock()
@@ -94,7 +94,7 @@ class CacheItem:
         if self.refresh_after_access <= 0:
             # Refreshing on access is disabled on the CacheItem.
             return
-        self.expiry_time = min(now + self.refresh_after_access, self.hard_expiry)
+        self.expiry_time = min(now + self.refresh_after_access, self.after_creation_expiry_time)
 
 
 @stable_api

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -47,10 +47,10 @@ class CacheItem:
         :param value: The value being cached associated to the key.
         :param call_on_delete: Optional finalizer to call when the cache item is deleted. This is
             a callable expecting the cached value as an argument.
-        :param evict_after_creation: This cache item will be considered stale this number of seconds after
-            entering the cache.
         :param evict_after_last_access: This cache item will be considered stale this number of seconds after
             it was last accessed.
+        :param evict_after_creation: This cache item will be considered stale this number of seconds after
+            entering the cache.
         """
         self.key = key
         self.value = value
@@ -252,12 +252,12 @@ class AgentCache:
 
         :param key: Key for this item
         :param value: The value to cache
-        :param resource: The resource associated with this entry
-        :param call_on_delete: A callback function that is called when the value is removed from the cache.
-        :param evict_after_creation: This cache item will be considered stale this number of seconds after
-            entering the cache.
         :param evict_after_last_access: This cache item will be considered stale this number of seconds after
             it was last accessed.
+        :param evict_after_creation: This cache item will be considered stale this number of seconds after
+            entering the cache.
+        :param resource: The resource associated with this entry
+        :param call_on_delete: A callback function that is called when the value is removed from the cache.
         """
         self._cache(
             CacheItem(
@@ -300,10 +300,10 @@ class AgentCache:
 
         all kwargs are prepended to the key
 
-        :param evict_after_creation: This cache item will be considered stale this number of seconds after
-            entering the cache.
         :param evict_after_last_access: This cache item will be considered stale this number of seconds after
             it was last accessed.
+        :param evict_after_creation: This cache item will be considered stale this number of seconds after
+            entering the cache.
 
         """
         acceptable = {"resource"}
@@ -353,6 +353,7 @@ class AgentCache:
     ) -> None:
         """
         When done using the cache, reset the expiry time
-        of all cache items without a hard timeout.
+        of all cache items that should be refreshed after
+        access.
         """
         self.touch_used_cache_items()

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -40,7 +40,7 @@ class CacheItem:
         timeout: float,
         value: Any,
         call_on_delete: Optional[Callable[[Any], None]],
-        evict_after_last_access: bool = True,
+        refresh_after_access: bool = True,
         evict_after_creation: bool = False,
     ) -> None:
         """
@@ -49,19 +49,19 @@ class CacheItem:
         :param value: The value being cached associated to the key.
         :param call_on_delete: Optional finalizer to call when the cache item is deleted. This is
             a callable expecting the cached value as an argument.
-        :param evict_after_last_access: When True, this cache item will stay in the cache for 60s after its last use.
+        :param refresh_after_access: When True, this cache item will stay in the cache for 60s after its last use.
         :param evict_after_creation: When True, this cache item will be evicted from the cache <timeout> seconds after
             entering the cache.
         """
         self.key = key
         self.value = value
         self.call_on_delete = call_on_delete
-        self.evict_after_last_access = evict_after_last_access
+        self.refresh_after_access = refresh_after_access
 
         now = time.time()
         self.expiry_time: float = sys.maxsize
 
-        if evict_after_last_access:
+        if refresh_after_access:
             self.expiry_time = now + 60
         if evict_after_creation:
             self.expiry_time = min(self.expiry_time, now + timeout)
@@ -93,7 +93,7 @@ class AgentCache:
     item last access timestamp. If both are set, the shortest duration of the
     two will trigger the item to become stale.
 
-    1. evict_after_last_access
+    1. refresh_after_access
 
         These items are expected to be reused across multiple
         model versions. Their expiry time is reset to 60s any
@@ -133,7 +133,7 @@ class AgentCache:
         self._agent_instance = agent_instance
 
         # This set holds cache items used during a resource action whose
-        # expiry time should be refreshed i.e. evict_after_last_access=True
+        # expiry time should be refreshed i.e. refresh_after_access=True
         self.used_items_to_refresh: set[CacheItem] = set()
 
     def touch_used_cache_items(self) -> None:
@@ -196,7 +196,7 @@ class AgentCache:
         """
         item = self.cache[key]
 
-        if item.evict_after_last_access:
+        if item.refresh_after_access:
             self.used_items_to_refresh.add(item)
 
         return item
@@ -209,7 +209,7 @@ class AgentCache:
 
         heapq.heappush(self.timer_queue, item)
 
-        if item.evict_after_last_access:
+        if item.refresh_after_access:
             self.used_items_to_refresh.add(item)
 
         if item.expiry_time < self.next_action:
@@ -228,7 +228,7 @@ class AgentCache:
         resource: Optional[Resource] = None,
         timeout: int = 5000,
         call_on_delete: Optional[Callable[[Any], None]] = None,
-        evict_after_last_access: bool = True,
+        refresh_after_access: bool = True,
         evict_after_creation: bool = False,
     ) -> None:
         """
@@ -242,7 +242,7 @@ class AgentCache:
         :param timeout: Used in combination with evict_after_creation=True, ignored otherwise. The cached value will
             be considered stale <timeout> seconds after entering the cache.
         :param call_on_delete: A callback function that is called when the value is removed from the cache.
-        :param evict_after_last_access: Expire this cache item 60 seconds after its last usage. Each time this entry
+        :param refresh_after_access: Expire this cache item 60 seconds after its last usage. Each time this entry
             is read from the cache, this expiry timer will be reset to 60 seconds.
         :param evict_after_creation: Expire this cache item <timeout> seconds after its creation.
         """
@@ -252,7 +252,7 @@ class AgentCache:
                 timeout,
                 value,
                 call_on_delete,
-                evict_after_last_access=evict_after_last_access,
+                refresh_after_access=refresh_after_access,
                 evict_after_creation=evict_after_creation,
             )
         )
@@ -273,7 +273,7 @@ class AgentCache:
         self,
         key: str,
         function: Callable[..., Any],
-        evict_after_last_access: bool = True,
+        refresh_after_access: bool = True,
         evict_after_creation: bool = False,
         timeout: int = 5000,
         ignore: set[str] = set(),
@@ -293,7 +293,7 @@ class AgentCache:
           The cached entry will be evicted from the cache after this period of time.
         :param evict_after_creation: the cached value is not tied to any model version. It is
               considered stale after <timeout> seconds have elapsed since it entered the cache.
-        :param evict_after_last_access: the cached value is expected to be reused across multiple versions.
+        :param refresh_after_access: the cached value is expected to be reused across multiple versions.
               It is considered stale if no agent used this entry in the last 60s.
 
         """
@@ -322,7 +322,7 @@ class AgentCache:
                             value=value,
                             timeout=timeout,
                             call_on_delete=call_on_delete,
-                            evict_after_last_access=evict_after_last_access,
+                            refresh_after_access=refresh_after_access,
                             evict_after_creation=evict_after_creation,
                             **args,
                         )

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -49,7 +49,7 @@ class CacheItem:
         :param value: The value being cached associated to the key.
         :param call_on_delete: Optional finalizer to call when the cache item is deleted. This is
             a callable expecting the cached value as an argument.
-        :param evict_after_last_access: When True, this cache item will linger in the cache for 60s after its last use.
+        :param evict_after_last_access: When True, this cache item will stay in the cache for 60s after its last use.
         :param evict_after_creation: When True, this cache item will be evicted from the cache <timeout> seconds after
             entering the cache.
         """
@@ -120,10 +120,6 @@ class AgentCache:
         """
         # The cache itself
         self.cache: dict[str, CacheItem] = {}
-
-        # Lingering items will remain in the cache for this
-        # many seconds after they were last used.
-        self.item_lingering_time: float = 60
 
         # Time-based eviction mechanism
         # Keep track of when is the next earliest cache item expiry time.
@@ -295,7 +291,6 @@ class AgentCache:
 
         :param timeout: Use in combination with evict_after_creation=True to set a "hard" expiry timeout (in seconds).
           The cached entry will be evicted from the cache after this period of time.
-
         :param evict_after_creation: the cached value is not tied to any model version. It is
               considered stale after <timeout> seconds have elapsed since it entered the cache.
         :param evict_after_last_access: the cached value is expected to be reused across multiple versions.
@@ -323,8 +318,8 @@ class AgentCache:
                     value = function(**kwargs)
                     if cache_none or value is not None:
                         self.cache_value(
-                            key,
-                            value,
+                            key=key,
+                            value=value,
                             timeout=timeout,
                             call_on_delete=call_on_delete,
                             evict_after_last_access=evict_after_last_access,

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -59,7 +59,7 @@ class CacheItem:
         self.evict_after_last_access = evict_after_last_access
 
         now = time.time()
-        self.expiry_time = sys.maxsize
+        self.expiry_time: float = sys.maxsize
 
         if evict_after_last_access:
             self.expiry_time = now + 60

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -83,8 +83,8 @@ class CacheItem:
 
     def refresh(self, now: float) -> None:
         """
-        Refresh this cache item. Resets the expiry time for items
-        evicted a certain time after their last access.
+        Refresh this cache item. Resets the expiry time for items marked
+        for eviction a certain time after their last access.
 
         :parameter now: Baseline 'now' time.
         """
@@ -149,7 +149,8 @@ class AgentCache:
 
     def touch_used_cache_items(self) -> None:
         """
-        Extend the expiry time of items in the used_items_to_refresh by 60s
+        Extend the expiry time of items in the used_items_to_refresh by their
+        respective grace period.
         """
         now = time.time()
         for item in self.used_items_to_refresh:

--- a/src/inmanta/agent/cache.py
+++ b/src/inmanta/agent/cache.py
@@ -110,13 +110,14 @@ class AgentCache:
     1. evict_after_last_access
 
         These items are expected to be reused across multiple
-        model versions. Their expiry time is reset to 60s any
-        time they're accessed.
+        model versions. Their expiry time is reset to the value
+        set by the `evict_after_last_access` parameter of the
+        `@cache` decorator any time they're accessed.
 
     2. evict_after_creation
 
         These items have a fixed lifetime. Their expiry time
-        is set by the timeout parameter of the @cache decorator.
+        is set by the `evict_after_creation` parameter of the `@cache` decorator.
 
     To enforce consistency, this cache should be used as a context manager
     by the agent when performing a resource action (deploy / repair / fact retrieval / dry run).

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -125,7 +125,7 @@ def cache(
     If an argument named resource is present,
     it is assumed to be a resource and its ID is used, without the version information
 
-    :param timeout: Hard timeout for non-lingering cache item i.e. when `evict_after_creation=True`.
+    :param timeout: Hard timeout for cache items when `evict_after_creation=True`.
         Ignored otherwise.
 
 

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -105,7 +105,8 @@ def cache(
     func: Optional[T_FUNC] = None,
     ignore: list[str] = [],
     timeout: int = 5000,
-    for_version: bool = True,
+    # deprecated parameter kept for backwards compatibility: if set, overrides evict_after_creation/evict_after_last_access
+    for_version: Optional[bool] = None,
     cache_none: bool = True,
     # deprecated parameter kept for backwards compatibility: if set, overrides cache_none
     cacheNone: Optional[bool] = None,  # noqa: N803
@@ -149,16 +150,22 @@ def cache(
             def bound(**kwds: object) -> object:
                 return f(self, **kwds)
 
+            # if for_version is not None:
+            #     if for_version:
+            #         evict_after_last_access=True
+            #     else:
+            #         evict_after_creation=True
+
             return self.cache.get_or_else(
-                f.__name__,
-                bound,
-                evict_after_creation,
-                evict_after_last_access,
-                timeout,
-                myignore,
-                cacheNone if cacheNone is not None else cache_none,
-                **kwds,
+                key=f.__name__,
+                function=bound,
+                evict_after_last_access=evict_after_last_access,
+                evict_after_creation=evict_after_creation,
+                timeout=timeout,
+                ignore=myignore,
+                cache_none=cacheNone if cacheNone is not None else cache_none,
                 call_on_delete=call_on_delete,
+                **kwds,
             )
 
         # Too much magic to type statically

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -110,6 +110,8 @@ def cache(
     # deprecated parameter kept for backwards compatibility: if set, overrides cache_none
     cacheNone: Optional[bool] = None,  # noqa: N803
     call_on_delete: Optional[Callable[[Any], None]] = None,
+    evict_after_creation: Optional[bool]=None,
+    evict_after_last_access: Optional[bool]=None,
 ) -> Union[T_FUNC, Callable[[T_FUNC], T_FUNC]]:
     """
     decorator for methods in resource handlers to provide caching
@@ -123,11 +125,13 @@ def cache(
     If an argument named resource is present,
     it is assumed to be a resource and its ID is used, without the version information
 
-    :param timeout: Hard timeout for non-lingering cache item i.e. when `for_version=False`.
+    :param timeout: Hard timeout for non-lingering cache item i.e. when `evict_after_creation=True`.
         Ignored otherwise.
-    :param for_version: When True, this cache item will linger in the cache for 60s after its last use.
-        When False, this cache item will be evicted from the cache <timeout> seconds after
+
+
+    :param evict_after_creation: When True, this cache item will be evicted from the cache <timeout> seconds after
         entering the cache.
+    :param evict_after_last_access: When True, this cache item will linger in the cache for 60s after its last use.
     :param ignore: a list of argument names that should not be part of the cache key
     :param cache_none: allow the caching of None values
     :param call_on_delete: A callback function that is called when the value is removed from the cache,
@@ -148,7 +152,8 @@ def cache(
             return self.cache.get_or_else(
                 f.__name__,
                 bound,
-                for_version,
+                evict_after_creation,
+                evict_after_last_access,
                 timeout,
                 myignore,
                 cacheNone if cacheNone is not None else cache_none,

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -105,14 +105,14 @@ def cache(
     func: Optional[T_FUNC] = None,
     ignore: list[str] = [],
     timeout: int = 5000,
-    # deprecated parameter kept for backwards compatibility: if set, overrides evict_after_creation/evict_after_last_access
+    # deprecated parameter kept for backwards compatibility: if set, overrides evict_after_creation/refresh_after_access
     for_version: Optional[bool] = None,
     cache_none: bool = True,
     # deprecated parameter kept for backwards compatibility: if set, overrides cache_none
     cacheNone: Optional[bool] = None,  # noqa: N803
     call_on_delete: Optional[Callable[[Any], None]] = None,
     evict_after_creation: Optional[bool] = None,
-    evict_after_last_access: Optional[bool] = None,
+    refresh_after_access: Optional[bool] = None,
 ) -> Union[T_FUNC, Callable[[T_FUNC], T_FUNC]]:
     """
     decorator for methods in resource handlers to provide caching
@@ -132,7 +132,7 @@ def cache(
 
     :param evict_after_creation: When True, this cache item will be evicted from the cache <timeout> seconds after
         entering the cache.
-    :param evict_after_last_access: When True, this cache item will stay in the cache for 60s after its last use.
+    :param refresh_after_access: When True, this cache item will stay in the cache for 60s after its last use.
 
     :param ignore: a list of argument names that should not be part of the cache key
     :param cache_none: allow the caching of None values
@@ -151,50 +151,50 @@ def cache(
             def bound(**kwds: object) -> object:
                 return f(self, **kwds)
 
-            _evict_after_last_access: bool
+            _refresh_after_access: bool
             _evict_after_creation: bool
 
-            # Legacy parameter is passed, it overrides evict_after_last_access and evict_after_creation
+            # Legacy parameter is passed, it overrides refresh_after_access and evict_after_creation
             if for_version is not None:
-                _evict_after_last_access = for_version
+                _refresh_after_access = for_version
                 _evict_after_creation = not for_version
             else:
                 # "New" parameters are used: validate that both are not set to False
                 # and set sensible default values if need be. The following table
-                # shows the expected value for the pair (evict_after_last_access, evict_after_creation)
+                # shows the expected value for the pair (refresh_after_access, evict_after_creation)
                 # depending on their respective input value. `W` means an exception should be raised
 
                 #                                                evict_after_creation
                 #                                        None         True            False
                 #                             None        TF           FT              TF
                 #
-                # evict_after_last_access     True        TF           TT              TF
+                # refresh_after_access     True        TF           TT              TF
                 #
                 #                             False       W            FT              W
                 #
 
-                if evict_after_last_access is None:
+                if refresh_after_access is None:
                     if evict_after_creation is None:
-                        _evict_after_last_access = True
+                        _refresh_after_access = True
                         _evict_after_creation = False
                     else:
-                        _evict_after_last_access = not evict_after_creation
+                        _refresh_after_access = not evict_after_creation
                         _evict_after_creation = evict_after_creation
                 else:
-                    if not evict_after_last_access:
+                    if not refresh_after_access:
                         if not evict_after_creation:
                             raise ValueError(
                                 f"Invalid parameters for cache decorator for function {f.__name__}. "
-                                "At least one of evict_after_last_access and evict_after_creation "
+                                "At least one of refresh_after_access and evict_after_creation "
                                 "should be True."
                             )
-                    _evict_after_last_access = bool(evict_after_last_access)
+                    _refresh_after_access = bool(refresh_after_access)
                     _evict_after_creation = bool(evict_after_creation)
 
             return self.cache.get_or_else(
                 key=f.__name__,
                 function=bound,
-                evict_after_last_access=_evict_after_last_access,
+                refresh_after_access=_refresh_after_access,
                 evict_after_creation=_evict_after_creation,
                 timeout=timeout,
                 ignore=myignore,

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -160,18 +160,25 @@ def cache(
             if timeout and timeout > 0:
                 _evict_after_creation = timeout
 
-            # Legacy `for_version` parameter is passed, it overrides evict_after_last_access and evict_after_creation
+            # Legacy `for_version` parameter is used, compute
+            # evict_after_last_access and evict_after_creation
             if for_version is not None:
                 if for_version:
+                    _evict_after_creation = 0
+
                     if evict_after_last_access > 0:
                         _evict_after_last_access = evict_after_last_access
                     else:
                         _evict_after_last_access = 60
                 else:
+                    _evict_after_last_access = 0
+
+                    # Successive overrides with a 5000s default
                     _evict_after_creation = 5000
+                    if evict_after_creation > 0:
+                        _evict_after_creation = evict_after_creation
                     if timeout and timeout > 0:
                         _evict_after_creation = timeout
-                    _evict_after_last_access = 0
             else:
                 # If both params are unset/negative, keep entries alive
                 # in the cache for 60s after their last usage.

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -174,10 +174,9 @@ def cache(
 
                     if evict_after_creation > 0 and timeout and timeout > 0:
                         LOGGER.warning(
-                            msg =
-                                "Both the `evict_after_creation` and the deprecated `timeout` parameter are set "
-                                "for cached method %s. Cached entries will be kept in the cache for %.2fs "
-                                "after entering it."% (f.__name__, evict_after_creation)
+                            msg="Both the `evict_after_creation` and the deprecated `timeout` parameter are set "
+                            "for cached method %s. Cached entries will be kept in the cache for %.2fs "
+                            "after entering it." % (f.__name__, evict_after_creation)
                         )
             else:
                 _evict_after_last_access = evict_after_last_access

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -127,15 +127,14 @@ def cache(
     If an argument named resource is present,
     it is assumed to be a resource and its ID is used, without the version information
 
-    :param evict_after_creation: This cache item will be considered stale this number of seconds after
-        entering the cache.
-    :param evict_after_last_access: This cache item will be considered stale this number of seconds after
-        it was last accessed.
-
     :param ignore: a list of argument names that should not be part of the cache key
     :param cache_none: allow the caching of None values
     :param call_on_delete: A callback function that is called when the value is removed from the cache,
             with the value as argument.
+    :param evict_after_creation: This cache item will be considered stale this number of seconds after
+        entering the cache.
+    :param evict_after_last_access: This cache item will be considered stale this number of seconds after
+        it was last accessed.
     """
 
     def actual(f: Callable[..., object]) -> T_FUNC:
@@ -174,9 +173,11 @@ def cache(
 
                     if evict_after_creation > 0 and timeout and timeout > 0:
                         LOGGER.warning(
-                            msg="Both the `evict_after_creation` and the deprecated `timeout` parameter are set "
+                            "Both the `evict_after_creation` and the deprecated `timeout` parameter are set "
                             "for cached method %s. Cached entries will be kept in the cache for %.2fs "
-                            "after entering it." % (f.__name__, evict_after_creation)
+                            "after entering it.",
+                            f.__name__,
+                            _evict_after_creation,
                         )
             else:
                 _evict_after_last_access = evict_after_last_access

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -168,7 +168,7 @@ def cache(
                 #                                        None         True            False
                 #                             None        TF           FT              TF
                 #
-                # refresh_after_access     True        TF           TT              TF
+                # refresh_after_access        True        TF           TT              TF
                 #
                 #                             False       W            FT              W
                 #

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -179,10 +179,16 @@ def cache(
                         _evict_after_creation = evict_after_creation
                     if timeout and timeout > 0:
                         _evict_after_creation = timeout
+
+                    LOGGER.warning(
+                        "Both the `evict_after_creation` and the `timeout` parameter are set "
+                        f"for cached method {f.__name__}. `evict_after_creation` will be "
+                        "overridden."
+                    )
             else:
                 # If both params are unset/negative, keep entries alive
                 # in the cache for 60s after their last usage.
-                if evict_after_creation <= 0 and evict_after_last_access <= 0:
+                if _evict_after_creation <= 0 and _evict_after_last_access <= 0:
                     _evict_after_last_access = 60
 
             return self.cache.get_or_else(

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -132,17 +132,7 @@ def cache(
 
     :param evict_after_creation: When True, this cache item will be evicted from the cache <timeout> seconds after
         entering the cache.
-    :param evict_after_last_access: When True, this cache item will linger in the cache for 60s after its last use.
-
-                                                    evict_after_creation
-                                            True            False           None
-
-                                True         TT              TF              TF
-
-    evict_after_last_access     False        FT              W               W
-
-                                None         FT              TF              TF
-
+    :param evict_after_last_access: When True, this cache item will stay in the cache for 60s after its last use.
 
     :param ignore: a list of argument names that should not be part of the cache key
     :param cache_none: allow the caching of None values
@@ -170,7 +160,9 @@ def cache(
                 _evict_after_creation = not for_version
             else:
                 # "New" parameters are used: validate that both are not set to False
-                # and set sensible default values
+                # and set sensible default values if need be. The following table
+                # shows the expected value for the pair (evict_after_last_access, evict_after_creation)
+                # depending on their respective input value. `W` means an exception should be raised
 
                 #                                                evict_after_creation
                 #                                        None         True            False

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -104,9 +104,8 @@ class InvalidOperation(Exception):
 def cache(
     func: Optional[T_FUNC] = None,
     ignore: list[str] = [],
-    # deprecated parameter kept for backwards compatibility: if set along with for_version,
-    # overrides evict_after_creation/evict_after_last_access
-    timeout: int = 5000,
+    # deprecated parameter kept for backwards compatibility: alias for evict_after_creation
+    timeout: Optional[int] = None,
     # deprecated parameter kept for backwards compatibility: if set, overrides evict_after_creation/evict_after_last_access
     for_version: Optional[bool] = None,
     cache_none: bool = True,
@@ -157,7 +156,11 @@ def cache(
             _evict_after_last_access: float = evict_after_last_access
             _evict_after_creation: float = evict_after_creation
 
-            # Legacy parameter is passed, it overrides evict_after_last_access and evict_after_creation
+            # If legacy param `timeout` is set, it overrides `evict_after_creation`
+            if timeout and timeout > 0:
+                _evict_after_creation = timeout
+
+            # Legacy `for_version` parameter is passed, it overrides evict_after_last_access and evict_after_creation
             if for_version is not None:
                 if for_version:
                     if evict_after_last_access > 0:
@@ -165,7 +168,9 @@ def cache(
                     else:
                         _evict_after_last_access = 60
                 else:
-                    _evict_after_creation = timeout
+                    _evict_after_creation = 5000
+                    if timeout and timeout > 0:
+                        _evict_after_creation = timeout
                     _evict_after_last_access = 0
             else:
                 # If both params are unset/negative, keep entries alive

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -93,7 +93,7 @@ async def test_timeout_automatic_cleanup(set_custom_cache_cleanup_policy, agent_
     """
     cache = agent_cache
     value = "test too"
-    cache.cache_value("test", value, timeout=0.1, evict_after_creation=True)
+    cache.cache_value("test", value, evict_after_creation=0.1)
     cache.cache_value("test2", value)
 
     assert value == cache.find("test")
@@ -108,7 +108,7 @@ async def test_timeout_automatic_cleanup(set_custom_cache_cleanup_policy, agent_
 def test_timeout_manual_cleanup():
     cache = AgentCache()
     value = "test too"
-    cache.cache_value("test", value, timeout=0.1, evict_after_creation=True)
+    cache.cache_value("test", value, evict_after_creation=0.1)
     cache.cache_value("test2", value)
 
     assert value == cache.find("test")
@@ -162,7 +162,7 @@ def test_default_timeout(my_resource, time_machine):
     cache = AgentCache()
     value = "test too"
 
-    cache.cache_value("test", value)
+    cache.cache_value("test", value, evict_after_creation=5000)
     assert value == cache.find("test")
 
     resource = Id("test::Resource", "test", "key", "test", 100).get_instance()
@@ -218,9 +218,8 @@ async def test_multi_threaded(agent_cache: AgentCache):
         cache.get_or_else(
             "test",
             lambda: alpha.create(),
-            timeout=cache_entry_expiry,
             call_on_delete=lambda x: x.delete(),
-            evict_after_creation=True,
+            evict_after_creation=cache_entry_expiry,
         )
 
     t1 = Thread(target=target_1)
@@ -228,9 +227,8 @@ async def test_multi_threaded(agent_cache: AgentCache):
         target=lambda: cache.get_or_else(
             "test",
             lambda: beta.create(),
-            timeout=cache_entry_expiry,
             call_on_delete=lambda x: x.delete(),
-            evict_after_creation=True,
+            evict_after_creation=cache_entry_expiry,
         )
     )
 
@@ -579,68 +577,58 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
     """
     Test the behaviour of cache entries expiring after creation.
 
-    Cache entries will expire after a timeout since their creation if:
-      - for_version=False (legacy parameter)
-      - evict_after_creation=True
+    Test legacy parameters:
+        - for_version=False
+        - timeout (default 5000s)
 
-    This timeout is controlled via the timeout parameter.
-    Stale entries are cleaned up on the next call to `clean_stale_entries`.
-
-    Legacy behaviour tests:
-    This test checks the legacy behaviour via `test_method_1` to `test_method_3` and `short_lived_test_method_1`
-
-    `evict_after_last_access` is used as a baseline comparison of what happens to an entry
-    evicted after last access.
-
-    New behaviour tests:
-        `test_method_11` to `test_method_33` and `short_lived_test_method_11` test the same behaviour
-        as their single-digit counterparts but they use the new `evict_after_creation` parameter.
+    Test new parameter:
+        - evict_after_creation>0
 
     """
 
     class ExpireAfterCreationTest(CacheMissCounter):
         @cache(for_version=False)
-        def test_method_1(self):
+        def test_default_5000s_timeout_legacy(self):
             self.increment_miss_counter()
             return "x1"
 
         @cache(timeout=80, for_version=False)
-        def test_method_2(self):
+        def test_80s_timeout_legacy(self):
             self.increment_miss_counter()
             return "x2"
 
         @cache(timeout=80, for_version=False)
-        def test_method_3(self, dummy_arg: str):
+        def test_80s_timeout_with_arg_legacy(self, dummy_arg: str):
             self.increment_miss_counter()
             return dummy_arg
 
-        @cache
-        def evict_after_last_access(self):
-            self.increment_miss_counter()
-            return "x3"
-
         @cache(timeout=20, for_version=False)
-        def short_lived_test_method_1(self):
+        def test_20s_timeout_legacy(self):
             self.increment_miss_counter()
             return "x4"
 
-        @cache(evict_after_creation=True)
-        def test_method_11(self):
+        @cache
+        def baseline_evict_after_last_access(self):
+            self.increment_miss_counter()
+            return "x3"
+
+        @cache(evict_after_creation=5000)
+        def test_5000s_timeout(self):
             self.increment_miss_counter()
             return "x1"
 
-        @cache(timeout=80, evict_after_creation=True)
-        def test_method_22(self):
+        @cache(evict_after_creation=80)
+        def test_80s_timeout(self):
             self.increment_miss_counter()
             return "x2"
 
-        @cache(timeout=80, evict_after_creation=True)
-        def test_method_33(self, dummy_arg: str):
+        @cache(evict_after_creation=80)
+        def test_80s_timeout_with_arg(self, dummy_arg: str):
             self.increment_miss_counter()
             return dummy_arg
 
-        @cache(timeout=20, evict_after_creation=True)
-        def short_lived_test_method_11(self):
+        @cache(evict_after_creation=20)
+        def test_20s_timeout(self):
             self.increment_miss_counter()
             return "x4"
 
@@ -650,25 +638,25 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
     time_machine.move_to(datetime.datetime.now().astimezone(), tick=False)
 
     with agent_cache:
-        assert "initial_read" == test.test_method_3(dummy_arg="initial_read")  # +1 miss
-        assert "initial_read" == test.test_method_33(dummy_arg="initial_read")  # +1 miss
+        assert "initial_read" == test.test_80s_timeout_with_arg_legacy(dummy_arg="initial_read")  # +1 miss
+        assert "initial_read" == test.test_80s_timeout_with_arg(dummy_arg="initial_read")  # +1 miss
         test.check_n_cache_misses(2)
 
     test.reset_miss_counter()
 
     with agent_cache:
         # Populate the cache
-        assert "x1" == test.test_method_1()  # +1 miss
-        assert "x1" == test.test_method_11()  # +1 miss
-        assert "x2" == test.test_method_2()  # +1 miss
-        assert "x2" == test.test_method_22()  # +1 miss
-        assert "x3" == test.evict_after_last_access()  # +1 miss
-        assert "x4" == test.short_lived_test_method_1()  # +1 miss
-        assert "x4" == test.short_lived_test_method_11()  # +1 miss
+        assert "x1" == test.test_default_5000s_timeout_legacy()  # +1 miss
+        assert "x1" == test.test_5000s_timeout()  # +1 miss
+        assert "x2" == test.test_80s_timeout_legacy()  # +1 miss
+        assert "x2" == test.test_80s_timeout()  # +1 miss
+        assert "x3" == test.baseline_evict_after_last_access()  # +1 miss
+        assert "x4" == test.test_20s_timeout_legacy()  # +1 miss
+        assert "x4" == test.test_20s_timeout()  # +1 miss
         test.check_n_cache_misses(7)
 
-        assert "recurring_read" == test.test_method_3(dummy_arg="recurring_read")  # +1 miss
-        assert "recurring_read" == test.test_method_33(dummy_arg="recurring_read")  # +1 miss
+        assert "recurring_read" == test.test_80s_timeout_with_arg_legacy(dummy_arg="recurring_read")  # +1 miss
+        assert "recurring_read" == test.test_80s_timeout_with_arg(dummy_arg="recurring_read")  # +1 miss
         test.check_n_cache_misses(9)
 
     test.reset_miss_counter()
@@ -678,15 +666,15 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
 
     # The cache cleanup method is called upon entering the AgentCache context manager
     with agent_cache:
-        assert "x1" == test.test_method_1()  # cache hit
-        assert "x1" == test.test_method_11()  # cache hit
-        assert "x2" == test.test_method_2()  # cache hit
-        assert "x2" == test.test_method_22()  # cache hit
-        assert "recurring_read" == test.test_method_3(dummy_arg="recurring_read")  # cache hit
-        assert "recurring_read" == test.test_method_33(dummy_arg="recurring_read")  # cache hit
-        assert "x3" == test.evict_after_last_access()  # +1 miss
-        assert "x4" == test.short_lived_test_method_1()  # +1 miss
-        assert "x4" == test.short_lived_test_method_11()  # +1 miss
+        assert "x1" == test.test_default_5000s_timeout_legacy()  # cache hit
+        assert "x1" == test.test_5000s_timeout()  # cache hit
+        assert "x2" == test.test_80s_timeout_legacy()  # cache hit
+        assert "x2" == test.test_80s_timeout()  # cache hit
+        assert "recurring_read" == test.test_80s_timeout_with_arg_legacy(dummy_arg="recurring_read")  # cache hit
+        assert "recurring_read" == test.test_80s_timeout_with_arg(dummy_arg="recurring_read")  # cache hit
+        assert "x3" == test.baseline_evict_after_last_access()  # +1 miss
+        assert "x4" == test.test_20s_timeout_legacy()  # +1 miss
+        assert "x4" == test.test_20s_timeout()  # +1 miss
         test.check_n_cache_misses(3)
 
     test.reset_miss_counter()
@@ -695,26 +683,26 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
 
     with agent_cache:
         # Check that entries with a 'hard' 80s timeout got cleaned up:
-        assert "x2" == test.test_method_2()  # +1 miss
-        assert "x2" == test.test_method_22()  # +1 miss
-        assert "recurring_read" == test.test_method_3(dummy_arg="recurring_read")  # +1 miss
-        assert "recurring_read" == test.test_method_33(dummy_arg="recurring_read")  # +1 miss
-        assert "initial_read" == test.test_method_3(dummy_arg="initial_read")  # +1 miss
-        assert "initial_read" == test.test_method_33(dummy_arg="initial_read")  # +1 miss
+        assert "x2" == test.test_80s_timeout_legacy()  # +1 miss
+        assert "x2" == test.test_80s_timeout()  # +1 miss
+        assert "recurring_read" == test.test_80s_timeout_with_arg_legacy(dummy_arg="recurring_read")  # +1 miss
+        assert "recurring_read" == test.test_80s_timeout_with_arg(dummy_arg="recurring_read")  # +1 miss
+        assert "initial_read" == test.test_80s_timeout_with_arg_legacy(dummy_arg="initial_read")  # +1 miss
+        assert "initial_read" == test.test_80s_timeout_with_arg(dummy_arg="initial_read")  # +1 miss
         test.check_n_cache_misses(6)
         # Check that entry with default timeout of 5000s wasn't cleaned up:
-        assert "x1" == test.test_method_1()  # cache hit
-        assert "x1" == test.test_method_11()  # cache hit
+        assert "x1" == test.test_default_5000s_timeout_legacy()  # cache hit
+        assert "x1" == test.test_5000s_timeout()  # cache hit
         test.check_n_cache_misses(6)
 
     test.reset_miss_counter()
 
     # Wait out longer than the default timeout and check that the cache entry was cleaned up:
-    time_machine.shift(datetime.timedelta(seconds=5000))
+    time_machine.shift(datetime.timedelta(seconds=5001))
 
     with agent_cache:
-        assert "x1" == test.test_method_1()  # +1 miss
-        assert "x1" == test.test_method_11()  # +1 miss
+        assert "x1" == test.test_default_5000s_timeout_legacy()  # +1 miss
+        assert "x1" == test.test_5000s_timeout()  # +1 miss
         test.check_n_cache_misses(2)
 
 
@@ -834,66 +822,39 @@ async def test_cache_decorator_parameters(time_machine):
     """
     Test specific cache parameter combinations:
         - test that the legacy `for_version` parameter correctly overrides the 'new' parameters.
-        - test that exceptions are raised when invalid parameter combinations are used
 
     """
 
     class CacheParametersTest(CacheMissCounter):
-        @cache(for_version=False, evict_after_last_access=True)
-        def test_legacy_override_1(self):
+        @cache(for_version=False, evict_after_last_access=60)
+        def test_legacy_override_ela(self):
             """
-            evict_after_last_access should be overridden to False
+            for_version=False overrides evict_after_last_access behaviour:
+            Use default for evict_after_creation = 5000s
             """
             self.increment_miss_counter()
             return "x1"
 
-        @cache(for_version=True, evict_after_creation=True)
-        def test_legacy_override_2(self):
+        @cache(for_version=True, evict_after_creation=5000)
+        def test_legacy_override_eac(self):
             """
-            evict_after_creation should be overridden to True
+            for_version=True overrides evict_after_creation behaviour:
+            Use default for evict_after_last_access = 60
             """
             self.increment_miss_counter()
             return "x2"
-
-        @cache(evict_after_creation=False, evict_after_last_access=False)
-        def test_both_false(self):
-            self.increment_miss_counter()
-            return "x3"
-
-        @cache(evict_after_last_access=False)
-        def test_none_and_false(self):
-            self.increment_miss_counter()
-            return "x4"
 
     agent_cache = AgentCache()
     test = CacheParametersTest(agent_cache)
 
     time_machine.move_to(datetime.datetime.now().astimezone(), tick=False)
 
-    with pytest.raises(ValueError) as exc_info:
-        test.test_both_false()
-
-    assert (
-        "Invalid parameters for cache decorator for function test_both_false. "
-        "At least one of evict_after_last_access and evict_after_creation "
-        "should be True."
-    ) in str(exc_info.value)
-
-    with pytest.raises(ValueError) as exc_info:
-        test.test_none_and_false()
-
-    assert (
-        "Invalid parameters for cache decorator for function test_none_and_false. "
-        "At least one of evict_after_last_access and evict_after_creation "
-        "should be True."
-    ) in str(exc_info.value)
-
     test.reset_miss_counter()
 
     with agent_cache:
         # Populate the cache
-        assert "x1" == test.test_legacy_override_1()  # +1 miss
-        assert "x2" == test.test_legacy_override_2()  # +1 miss
+        assert "x1" == test.test_legacy_override_ela()  # +1 miss
+        assert "x2" == test.test_legacy_override_eac()  # +1 miss
         test.check_n_cache_misses(2)
 
     test.reset_miss_counter()
@@ -902,7 +863,7 @@ async def test_cache_decorator_parameters(time_machine):
 
     # The cache cleanup method is called upon entering the AgentCache context manager
     with agent_cache:
-        assert "x1" == test.test_legacy_override_1()  # cache hit
+        assert "x1" == test.test_legacy_override_ela()  # cache hit
         test.check_n_cache_misses(0)
-        assert "x2" == test.test_legacy_override_2()  # cache miss
+        assert "x2" == test.test_legacy_override_eac()  # cache miss
         test.check_n_cache_misses(1)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -429,7 +429,7 @@ async def test_cache_decorator_last_access_expiry(time_machine):
 
     Cache entries will expire 60s after their last access if:
       - for_version=True (legacy parameter)
-      - refresh_after_access=True
+      - evict_after_last_access=True
 
     The timeout argument is ignored for these entries.
     Stale entries are cleaned up on the next call to `clean_stale_entries`.
@@ -444,10 +444,10 @@ async def test_cache_decorator_last_access_expiry(time_machine):
 
     New behaviour tests:
         `test_method_1` and `test_method_3` already test the behaviour for the default
-        value for `refresh_after_access`.
+        value for `evict_after_last_access`.
 
         `test_method_22`, `test_method_44` and  `test_method_55` test the new behaviour
-        by explicitly providing the `refresh_after_access` parameter.
+        by explicitly providing the `evict_after_last_access` parameter.
 
     """
 
@@ -477,17 +477,17 @@ async def test_cache_decorator_last_access_expiry(time_machine):
             self.increment_miss_counter()
             return dummy_arg
 
-        @cache(refresh_after_access=True)
+        @cache(evict_after_last_access=True)
         def test_method_22(self):
             self.increment_miss_counter()
             return "x2"
 
-        @cache(timeout=1, refresh_after_access=True)
+        @cache(timeout=1, evict_after_last_access=True)
         def test_method_44(self):
             self.increment_miss_counter()
             return "x4"
 
-        @cache(refresh_after_access=True)
+        @cache(evict_after_last_access=True)
         def test_method_55(self, dummy_arg: str):
             self.increment_miss_counter()
             return dummy_arg
@@ -589,7 +589,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
     Legacy behaviour tests:
     This test checks the legacy behaviour via `test_method_1` to `test_method_3` and `short_lived_test_method_1`
 
-    `refresh_after_access` is used as a baseline comparison of what happens to an entry
+    `evict_after_last_access` is used as a baseline comparison of what happens to an entry
     evicted after last access.
 
     New behaviour tests:
@@ -615,7 +615,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
             return dummy_arg
 
         @cache
-        def refresh_after_access(self):
+        def evict_after_last_access(self):
             self.increment_miss_counter()
             return "x3"
 
@@ -662,7 +662,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
         assert "x1" == test.test_method_11()  # +1 miss
         assert "x2" == test.test_method_2()  # +1 miss
         assert "x2" == test.test_method_22()  # +1 miss
-        assert "x3" == test.refresh_after_access()  # +1 miss
+        assert "x3" == test.evict_after_last_access()  # +1 miss
         assert "x4" == test.short_lived_test_method_1()  # +1 miss
         assert "x4" == test.short_lived_test_method_11()  # +1 miss
         test.check_n_cache_misses(7)
@@ -684,7 +684,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
         assert "x2" == test.test_method_22()  # cache hit
         assert "recurring_read" == test.test_method_3(dummy_arg="recurring_read")  # cache hit
         assert "recurring_read" == test.test_method_33(dummy_arg="recurring_read")  # cache hit
-        assert "x3" == test.refresh_after_access()  # +1 miss
+        assert "x3" == test.evict_after_last_access()  # +1 miss
         assert "x4" == test.short_lived_test_method_1()  # +1 miss
         assert "x4" == test.short_lived_test_method_11()  # +1 miss
         test.check_n_cache_misses(3)
@@ -839,10 +839,10 @@ async def test_cache_decorator_parameters(time_machine):
     """
 
     class CacheParametersTest(CacheMissCounter):
-        @cache(for_version=False, refresh_after_access=True)
+        @cache(for_version=False, evict_after_last_access=True)
         def test_legacy_override_1(self):
             """
-            refresh_after_access should be overridden to False
+            evict_after_last_access should be overridden to False
             """
             self.increment_miss_counter()
             return "x1"
@@ -855,12 +855,12 @@ async def test_cache_decorator_parameters(time_machine):
             self.increment_miss_counter()
             return "x2"
 
-        @cache(evict_after_creation=False, refresh_after_access=False)
+        @cache(evict_after_creation=False, evict_after_last_access=False)
         def test_both_false(self):
             self.increment_miss_counter()
             return "x3"
 
-        @cache(refresh_after_access=False)
+        @cache(evict_after_last_access=False)
         def test_none_and_false(self):
             self.increment_miss_counter()
             return "x4"
@@ -875,7 +875,7 @@ async def test_cache_decorator_parameters(time_machine):
 
     assert (
         "Invalid parameters for cache decorator for function test_both_false. "
-        "At least one of refresh_after_access and evict_after_creation "
+        "At least one of evict_after_last_access and evict_after_creation "
         "should be True."
     ) in str(exc_info.value)
 
@@ -884,7 +884,7 @@ async def test_cache_decorator_parameters(time_machine):
 
     assert (
         "Invalid parameters for cache decorator for function test_none_and_false. "
-        "At least one of refresh_after_access and evict_after_creation "
+        "At least one of evict_after_last_access and evict_after_creation "
         "should be True."
     ) in str(exc_info.value)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -93,7 +93,7 @@ async def test_timeout_automatic_cleanup(set_custom_cache_cleanup_policy, agent_
     """
     cache = agent_cache
     value = "test too"
-    cache.cache_value("test", value, timeout=0.1, for_version=False)
+    cache.cache_value("test", value, timeout=0.1, evict_after_creation=True)
     cache.cache_value("test2", value)
 
     assert value == cache.find("test")
@@ -108,7 +108,7 @@ async def test_timeout_automatic_cleanup(set_custom_cache_cleanup_policy, agent_
 def test_timeout_manual_cleanup():
     cache = AgentCache()
     value = "test too"
-    cache.cache_value("test", value, timeout=0.1, for_version=False)
+    cache.cache_value("test", value, timeout=0.1, evict_after_creation=True)
     cache.cache_value("test2", value)
 
     assert value == cache.find("test")
@@ -216,13 +216,21 @@ async def test_multi_threaded(agent_cache: AgentCache):
 
     def target_1():
         cache.get_or_else(
-            "test", lambda: alpha.create(), timeout=cache_entry_expiry, call_on_delete=lambda x: x.delete(), for_version=False
+            "test",
+            lambda: alpha.create(),
+            timeout=cache_entry_expiry,
+            call_on_delete=lambda x: x.delete(),
+            evict_after_creation=True,
         )
 
     t1 = Thread(target=target_1)
     t2 = Thread(
         target=lambda: cache.get_or_else(
-            "test", lambda: beta.create(), timeout=cache_entry_expiry, call_on_delete=lambda x: x.delete(), for_version=False
+            "test",
+            lambda: beta.create(),
+            timeout=cache_entry_expiry,
+            call_on_delete=lambda x: x.delete(),
+            evict_after_creation=True,
         )
     )
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -431,26 +431,9 @@ async def test_cache_decorator_last_access_expiry(time_machine):
       - for_version=True (legacy parameter), timeout controlled by the `timeout` legacy parameter.
       - a timeout is set via the `evict_after_last_access` parameter.
 
-    Stale entries are cleaned up on the next call to `clean_stale_entries`.
-
-    Legacy behaviour tests:
-    This test checks that this behaviour is consistent for the 4 combinations
-    of (timeout, for_version) via `test_method_1` to `test_method_4`.
-
-    `test_method_5` is used to test that
-        - an entry is properly cleaned up if it is not being used ("initial_read" entry).
-        - the entry's expiry time is properly reset to 60s when it is read.
-
-    New behaviour tests:
-        `test_method_1` and `test_method_3` already test the behaviour for the default
-        value for `evict_after_last_access`.
-
-        `test_method_22`, `test_method_44` and  `test_method_55` test the new behaviour
-        by explicitly providing the `evict_after_last_access` parameter.
-
     """
 
-    class EvitctAfterLastAccessTest(CacheMissCounter):
+    class EvictAfterLastAccessTest(CacheMissCounter):
 
         @cache(for_version=True)
         def legacy_for_version_true(self):
@@ -507,7 +490,7 @@ async def test_cache_decorator_last_access_expiry(time_machine):
             return dummy_arg
 
     agent_cache = AgentCache()
-    test = EvitctAfterLastAccessTest(agent_cache)
+    test = EvictAfterLastAccessTest(agent_cache)
 
     time_machine.move_to(datetime.datetime.now().astimezone(), tick=False)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -877,3 +877,12 @@ async def test_cache_decorator_parameters(time_machine):
         test.check_n_cache_misses(0)
         assert "x2" == test.test_legacy_override_eac()  # cache miss
         test.check_n_cache_misses(1)
+
+    test.reset_miss_counter()
+    # Check that default timeout of 5000s is used
+    time_machine.shift(datetime.timedelta(seconds=5001))
+
+    # The cache cleanup method is called upon entering the AgentCache context manager
+    with agent_cache:
+        assert "x1" == test.test_legacy_override_ela()  # cache miss
+        test.check_n_cache_misses(1)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -429,7 +429,7 @@ async def test_cache_decorator_last_access_expiry(time_machine):
 
     Cache entries will expire 60s after their last access if:
       - for_version=True (legacy parameter)
-      - evict_after_last_access=True
+      - refresh_after_access=True
 
     The timeout argument is ignored for these entries.
     Stale entries are cleaned up on the next call to `clean_stale_entries`.
@@ -444,10 +444,10 @@ async def test_cache_decorator_last_access_expiry(time_machine):
 
     New behaviour tests:
         `test_method_1` and `test_method_3` already test the behaviour for the default
-        value for `evict_after_last_access`.
+        value for `refresh_after_access`.
 
         `test_method_22`, `test_method_44` and  `test_method_55` test the new behaviour
-        by explicitly providing the `evict_after_last_access` parameter.
+        by explicitly providing the `refresh_after_access` parameter.
 
     """
 
@@ -477,17 +477,17 @@ async def test_cache_decorator_last_access_expiry(time_machine):
             self.increment_miss_counter()
             return dummy_arg
 
-        @cache(evict_after_last_access=True)
+        @cache(refresh_after_access=True)
         def test_method_22(self):
             self.increment_miss_counter()
             return "x2"
 
-        @cache(timeout=1, evict_after_last_access=True)
+        @cache(timeout=1, refresh_after_access=True)
         def test_method_44(self):
             self.increment_miss_counter()
             return "x4"
 
-        @cache(evict_after_last_access=True)
+        @cache(refresh_after_access=True)
         def test_method_55(self, dummy_arg: str):
             self.increment_miss_counter()
             return dummy_arg
@@ -589,7 +589,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
     Legacy behaviour tests:
     This test checks the legacy behaviour via `test_method_1` to `test_method_3` and `short_lived_test_method_1`
 
-    `evict_after_last_access` is used as a baseline comparison of what happens to an entry
+    `refresh_after_access` is used as a baseline comparison of what happens to an entry
     evicted after last access.
 
     New behaviour tests:
@@ -615,7 +615,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
             return dummy_arg
 
         @cache
-        def evict_after_last_access(self):
+        def refresh_after_access(self):
             self.increment_miss_counter()
             return "x3"
 
@@ -662,7 +662,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
         assert "x1" == test.test_method_11()  # +1 miss
         assert "x2" == test.test_method_2()  # +1 miss
         assert "x2" == test.test_method_22()  # +1 miss
-        assert "x3" == test.evict_after_last_access()  # +1 miss
+        assert "x3" == test.refresh_after_access()  # +1 miss
         assert "x4" == test.short_lived_test_method_1()  # +1 miss
         assert "x4" == test.short_lived_test_method_11()  # +1 miss
         test.check_n_cache_misses(7)
@@ -684,7 +684,7 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
         assert "x2" == test.test_method_22()  # cache hitm
         assert "recurring_read" == test.test_method_3(dummy_arg="recurring_read")  # cache hit
         assert "recurring_read" == test.test_method_33(dummy_arg="recurring_read")  # cache hitm
-        assert "x3" == test.evict_after_last_access()  # +1 miss
+        assert "x3" == test.refresh_after_access()  # +1 miss
         assert "x4" == test.short_lived_test_method_1()  # +1 miss
         assert "x4" == test.short_lived_test_method_11()  # +1 miss
         test.check_n_cache_misses(3)
@@ -839,10 +839,10 @@ async def test_cache_decorator_parameters(time_machine):
     """
 
     class CacheParametersTest(CacheMissCounter):
-        @cache(for_version=False, evict_after_last_access=True)
+        @cache(for_version=False, refresh_after_access=True)
         def test_legacy_override_1(self):
             """
-            evict_after_last_access should be overridden to False
+            refresh_after_access should be overridden to False
             """
             self.increment_miss_counter()
             return "x1"
@@ -855,12 +855,12 @@ async def test_cache_decorator_parameters(time_machine):
             self.increment_miss_counter()
             return "x2"
 
-        @cache(evict_after_creation=False, evict_after_last_access=False)
+        @cache(evict_after_creation=False, refresh_after_access=False)
         def test_both_false(self):
             self.increment_miss_counter()
             return "x3"
 
-        @cache(evict_after_last_access=False)
+        @cache(refresh_after_access=False)
         def test_none_and_false(self):
             self.increment_miss_counter()
             return "x4"
@@ -875,7 +875,7 @@ async def test_cache_decorator_parameters(time_machine):
 
     assert (
         "Invalid parameters for cache decorator for function test_both_false. "
-        "At least one of evict_after_last_access and evict_after_creation "
+        "At least one of refresh_after_access and evict_after_creation "
         "should be True."
     ) in str(exc_info.value)
 
@@ -884,7 +884,7 @@ async def test_cache_decorator_parameters(time_machine):
 
     assert (
         "Invalid parameters for cache decorator for function test_none_and_false. "
-        "At least one of evict_after_last_access and evict_after_creation "
+        "At least one of refresh_after_access and evict_after_creation "
         "should be True."
     ) in str(exc_info.value)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -937,7 +937,7 @@ async def test_cache_warning(time_machine, caplog):
     """
 
     class CacheWarningTest(CacheMissCounter):
-        @cache(for_version=False, timeout=20, evict_after_creation=60)
+        @cache(for_version=False, timeout=60, evict_after_creation=20)
         def test_warning_and_override(self):
             """ """
             self.increment_miss_counter()
@@ -966,6 +966,8 @@ async def test_cache_warning(time_machine, caplog):
         caplog,
         "inmanta.agent.handler",
         logging.WARNING,
-        "Both the `evict_after_creation` and the `timeout` parameter are set for cached "
-        "method test_warning_and_override. `evict_after_creation` will be overridden.",
+        "Both the `evict_after_creation` and the deprecated `timeout` parameter are set "
+        "for cached method test_warning_and_override. Cached entries will be kept in the cache for 20.00s "
+        "after entering it."
     )
+

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -451,7 +451,7 @@ async def test_cache_decorator_last_access_expiry(time_machine):
 
     """
 
-    class ExpireAfterLastAccessTest(CacheMissCounter):
+    class RefreshAfterAccessTest(CacheMissCounter):
         @cache
         def test_method_1(self):
             self.increment_miss_counter()
@@ -493,7 +493,7 @@ async def test_cache_decorator_last_access_expiry(time_machine):
             return dummy_arg
 
     agent_cache = AgentCache()
-    test = ExpireAfterLastAccessTest(agent_cache)
+    test = RefreshAfterAccessTest(agent_cache)
 
     time_machine.move_to(datetime.datetime.now().astimezone(), tick=False)
 
@@ -679,11 +679,11 @@ async def test_cache_decorator_since_creation_expiry(time_machine):
     # The cache cleanup method is called upon entering the AgentCache context manager
     with agent_cache:
         assert "x1" == test.test_method_1()  # cache hit
-        assert "x1" == test.test_method_11()  # cache hitm
+        assert "x1" == test.test_method_11()  # cache hit
         assert "x2" == test.test_method_2()  # cache hit
-        assert "x2" == test.test_method_22()  # cache hitm
+        assert "x2" == test.test_method_22()  # cache hit
         assert "recurring_read" == test.test_method_3(dummy_arg="recurring_read")  # cache hit
-        assert "recurring_read" == test.test_method_33(dummy_arg="recurring_read")  # cache hitm
+        assert "recurring_read" == test.test_method_33(dummy_arg="recurring_read")  # cache hit
         assert "x3" == test.refresh_after_access()  # +1 miss
         assert "x4" == test.short_lived_test_method_1()  # +1 miss
         assert "x4" == test.short_lived_test_method_11()  # +1 miss

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -968,6 +968,5 @@ async def test_cache_warning(time_machine, caplog):
         logging.WARNING,
         "Both the `evict_after_creation` and the deprecated `timeout` parameter are set "
         "for cached method test_warning_and_override. Cached entries will be kept in the cache for 20.00s "
-        "after entering it."
+        "after entering it.",
     )
-

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -529,7 +529,7 @@ async def test_cache_decorator_last_access_expiry(time_machine):
         test.check_n_cache_misses(0)
 
     # Check that the "initial_read" entry was properly cleaned up but all other
-    # entries lingered on.
+    # entries remained in the cache.
     time_machine.shift(datetime.timedelta(seconds=50))
 
     with agent_cache:


### PR DESCRIPTION
# Description

- Remove all mentions of `lingering`
- Silently deprecate `for_version` parameter in favour of 2 new parameters `refresh_after_access` and `evict_after_creation`.
- Set sensible default values for these new parameters


closes https://github.com/inmanta/inmanta-core/issues/8052

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
~~- [ ] Correct, in line with design~~
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
~~- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
