### PR TITLE
Fix truncation on multi-version lsm documentation

### DIFF
--- a/changelogs/unreleased/fix-truncation-error-on-documentation.yml
+++ b/changelogs/unreleased/fix-truncation-error-on-documentation.yml
@@ -1,0 +1,3 @@
+description: Fix truncation error on multi-version lsm docs
+change-type: patch
+destination-branches: [master, iso7]

--- a/docs/lsm/multi_version/multi_version.rst
+++ b/docs/lsm/multi_version/multi_version.rst
@@ -40,7 +40,7 @@ previously created version) or just use the same entity but with different bindi
 .. literalinclude:: multi_version_sources/multiple_versions.cf
     :linenos:
     :language: inmanta
-    :lines: 1-86
+    :lines: 1-90
 
 In this example we add two new versions. Version 1 links to the same entity model but has a different lifecycle while
 Version 2 is a different entity altogether.

--- a/docs/lsm/multi_version/multi_version_sources/isr_service_entity_version_migration.py
+++ b/docs/lsm/multi_version/multi_version_sources/isr_service_entity_version_migration.py
@@ -43,7 +43,7 @@ def main(args):
         # 4) Set the state to 'update_start' so that our new candidate attribute set is validated and, eventually, promoted.
         if instance["state"] not in ["failed", "up"]:
             print(
-                f"Instance with id {instance['id']} is being skipped because it is on state {instance['state']}"
+                f"Instance with id {instance['id']} is being skipped because it is on state {instance['state']} "
                 f"and not on state 'up' or 'failed'."
             )
             continue

--- a/docs/lsm/multi_version/multi_version_sources/service_entity_version_migration.py
+++ b/docs/lsm/multi_version/multi_version_sources/service_entity_version_migration.py
@@ -42,7 +42,7 @@ def main(args):
         # 3) Set the state to 'start' so that our new candidate attribute set is validated and, eventually, promoted.
         if instance["state"] not in ["failed", "up"]:
             print(
-                f"Instance with id {instance['id']} is being skipped because it is on state {instance['state']}"
+                f"Instance with id {instance['id']} is being skipped because it is on state {instance['state']} "
                 f"and not on state 'up' or 'failed'."
             )
             continue


### PR DESCRIPTION
# Description

Fix truncation of model file and added a missing space on the scripts

Related to: https://github.com/inmanta/lsm/pull/810

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
