### PR TITLE
fix bug when loading versions from the DB

### DIFF
--- a/changelogs/unreleased/8118-load_only_released_versions.yml
+++ b/changelogs/unreleased/8118-load_only_released_versions.yml
@@ -1,0 +1,4 @@
+description: Fixes bug to only load released versions
+issue-nr: 8118
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4739,7 +4739,6 @@ class Resource(BaseDocument):
         attributes: dict[PrimitiveTypes, PrimitiveTypes] = {},
         *,
         connection: Optional[asyncpg.connection.Connection] = None,
-        released_only: bool = False,
     ) -> list["Resource"]:
         """
         Returns the resources in the latest version of the configuration model of the given environment, that satisfy the
@@ -4748,20 +4747,14 @@ class Resource(BaseDocument):
         :param environment: The resources should belong to this environment.
         :param resource_type: The environment should have this resource_type.
         :param attributes: The resource should contain these key-value pairs in its attributes list.
-        :param released_only: Consider only released versions
         """
         values = [cls._get_value(environment)]
-
-        verion_filter = ""
-        if released_only:
-            verion_filter = " AND cm.released "
-
         query = f"""
             SELECT *
             FROM {Resource.table_name()} AS r1
             WHERE r1.environment=$1 AND r1.model=(SELECT MAX(cm.version)
                                                   FROM {ConfigurationModel.table_name()} AS cm
-                                                  WHERE cm.environment=$1{verion_filter})
+                                                  WHERE cm.environment=$1)
         """
         if resource_type:
             query += " AND r1.resource_type=$2"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4748,6 +4748,7 @@ class Resource(BaseDocument):
         :param environment: The resources should belong to this environment.
         :param resource_type: The environment should have this resource_type.
         :param attributes: The resource should contain these key-value pairs in its attributes list.
+        :param released_only: Consider only released versions
         """
         values = [cls._get_value(environment)]
 
@@ -4764,7 +4765,6 @@ class Resource(BaseDocument):
         """
         if resource_type:
             query += " AND r1.resource_type=$2"
-            values.append(cls._get_value(resource_type))
 
         result = []
         async with cls.get_connection(connection) as con:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4765,6 +4765,7 @@ class Resource(BaseDocument):
         """
         if resource_type:
             query += " AND r1.resource_type=$2"
+            values.append(cls._get_value(resource_type))
 
         result = []
         async with cls.get_connection(connection) as con:

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -207,18 +207,13 @@ class ResourceScheduler(TaskManager):
             )
         )
 
-    async def _build_resource_mappings_from_db(self, version: int | None = None) -> Mapping[ResourceIdStr, ResourceDetails]:
+    async def _build_resource_mappings_from_db(self, version: int) -> Mapping[ResourceIdStr, ResourceDetails]:
         """
         Build a view on current resources. Might be filtered for a specific environment, used when a new version is released
 
         :return: resource_mapping {id -> resource details}
         """
-        if version is None:
-            resources_from_db: list[Resource] = await data.Resource.get_resources_in_latest_version(
-                environment=self.environment, released_only=True
-            )
-        else:
-            resources_from_db = await data.Resource.get_resources_for_version(self.environment, version)
+        resources_from_db = await data.Resource.get_resources_for_version(self.environment, version)
 
         resource_mapping = {
             resource.resource_id: ResourceDetails(
@@ -253,7 +248,7 @@ class ResourceScheduler(TaskManager):
         if cm_version is None:
             return
         version = cm_version.version
-        resources_from_db = await self._build_resource_mappings_from_db()
+        resources_from_db = await self._build_resource_mappings_from_db(version=version)
         requires_from_db = self._construct_requires_mapping(resources_from_db)
         await self._new_version(version, resources_from_db, requires_from_db)
 

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -151,7 +151,7 @@ class ResourceScheduler:
         """
         if version is None:
             resources_from_db: list[Resource] = await data.Resource.get_resources_in_latest_version(
-                environment=self._environment
+                environment=self._environment, released_only=True
             )
         else:
             resources_from_db = await data.Resource.get_resources_for_version(self._environment, version)

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -27,7 +27,7 @@ from typing import Optional
 from inmanta import data
 from inmanta.agent import executor
 from inmanta.agent.code_manager import CodeManager
-from inmanta.data import ConfigurationModel, Resource
+from inmanta.data import ConfigurationModel
 from inmanta.data.model import ResourceIdStr, ResourceType
 from inmanta.deploy import work
 from inmanta.deploy.state import DeploymentResult, ModelState, ResourceDetails, ResourceState, ResourceStatus

--- a/tests/agent_server/deploy/e2e/test_scheduler_e2e_deploy.py
+++ b/tests/agent_server/deploy/e2e/test_scheduler_e2e_deploy.py
@@ -101,6 +101,21 @@ async def test_basics(agent, resource_container, clienthelper, client, environme
             )
         return version, resources
 
+    async def make_marker_version() -> int:
+        version = await clienthelper.get_version()
+        resources = [
+            {
+                "key": "key",
+                "value": "value",
+                "id": "test::Resource[agentx,key=key],v=%d" % version,
+                "requires": [],
+                "purged": False,
+                "send_event": False,
+            },
+        ]
+        await clienthelper.put_version_simple(version=version, resources=resources)
+        return version
+
     logger.info("setup done")
 
     version1, resources = await make_version()
@@ -135,6 +150,7 @@ async def test_basics(agent, resource_container, clienthelper, client, environme
 
     version1, resources = await make_version(True)
     await clienthelper.put_version_simple(version=version1, resources=resources)
+    await make_marker_version()
 
     # deploy and wait until one is ready
     result = await client.release_version(env_id, version1, push=False)
@@ -145,6 +161,7 @@ async def test_basics(agent, resource_container, clienthelper, client, environme
     await check_scheduler_state(resources, scheduler)
 
     await resource_action_consistency_check()
+    assert resource_container.Provider.readcount("agentx", "key") == 0
 
     # deploy trigger
     await client.deploy(environment, agent_trigger_method=const.AgentTriggerMethod.push_incremental_deploy)


### PR DESCRIPTION
# Description

closes #8118 
closes #8119 

## The proverbial can of worms

It is very likely the method 'get_resources_in_latest_version' was always intended to return only released version. 

It's only use I can find is in lsm to find all resources that are required by a service.

```python
lifecycle_transfer_resources = await self.resource_service.get_resources_in_latest_version(
                environment=env,
                resource_type="lsm::LifecycleTransfer",
                attributes={"instance_id": str(service_id)},
                connection=con,
            )
```

In this context, 
1. it makes little sense to take into account unreleased version (it does make a little sense, because if all versions are produced by lsm, the last version, released or not, best reflects the latest inventory state)
2. it is absolutely whack to pull **every** `lsm::LifecycleTransfer` out of the DB to do what is essentially a match on the primary key.

I propose to make a ticket to 
1. remove the usage of this method from lsm and just do a query. (it is probably a remnant from the time where we expect a need to run lsm on a separate DB)
2. drop the additional argument and make the behavior needed here the default 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
