### PR TITLE
added ManagedExecutor test helper

### DIFF
--- a/tests/agent_server/deploy/test_scheduler_agent.py
+++ b/tests/agent_server/deploy/test_scheduler_agent.py
@@ -102,7 +102,7 @@ class ManagedExecutor(DummyExecutor):
 
     async def execute(self, gid: uuid.UUID, resource_details: ResourceDetails, reason: str) -> const.ResourceState:
         assert resource_details.rid not in self._deploys
-        self._deploys[resource_details.rid] = asyncio.Future()
+        self._deploys[resource_details.rid] = asyncio.get_running_loop().create_future()
         # wait until the test case sets desired resource state
         result: const.ResourceState = await self._deploys[resource_details.rid]
         del self._deploys[resource_details.rid]


### PR DESCRIPTION
# Description

Adds a test helper class for scheduler testing. `ManagedExecutor` expects to be driven by the test case itself. It hangs at the start of deploy on a future for which the result should be set by the test case. You can find usage examples in #8131.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
