### PR TITLE
Fix bug that causes pytest logging options to be ignored

### DIFF
--- a/changelogs/unreleased/fix-pytest-logging-options.yml
+++ b/changelogs/unreleased/fix-pytest-logging-options.yml
@@ -1,0 +1,4 @@
+---
+description: Fix bug that causes the pytest logging options to be ignored.
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -592,7 +592,6 @@ class InmantaLoggerConfig:
             logging.root.removeHandler(handler)
             handler.flush()
             handler.close()
-        logging.shutdown()
         cls._instance = None
 
     def _get_path_to_logging_config_file(self, options: Options) -> Optional[str]:
@@ -649,8 +648,7 @@ class InmantaLoggerConfig:
 
     def _apply_logging_config_from_options(self, options: Options) -> None:
         """
-        Apply the logging configuration as defined by the CLI options when the
-        --logging-config option is not set.
+        Apply the logging configuration as defined by the CLI options when the --logging-config option is not set.
         """
         config_builder = LoggingConfigBuilder()
         logging_config: FullLoggingConfig = config_builder.get_logging_config_from_options(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1893,7 +1893,7 @@ async def dont_remove_caplog_handlers(request, monkeypatch):
     """
     Caplog captures log messages by attaching handlers to the root logger. Applying a logging config with
     `inmanta_logging.FullLoggingConfig.apply_config()` removes any existing logging configuration.
-    As such, this fixtures puts a wrapper around the `apply_config()` method to make sure that:
+    As such, this fixture puts a wrapper around the `apply_config()` method to make sure that:
 
      * The pytest handlers are not removed/closed after the execution of the apply_config() method.
      * The configured root log level is not altered by the call to apply_config().

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ environment.
 """
 
 import asyncio
-import weakref
 import concurrent
 import csv
 import datetime
@@ -90,6 +89,7 @@ import time
 import traceback
 import uuid
 import venv
+import weakref
 from collections import abc
 from collections.abc import AsyncIterator, Awaitable, Iterator
 from configparser import ConfigParser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1898,9 +1898,9 @@ async def dont_remove_caplog_handlers(request, monkeypatch):
 
     def patched_apply_config(self) -> None:
         # Make sure the root log level is not altered.
-        root_log_level = logging.root.level
+        root_log_level: int = logging.root.level
         # Make sure that the caplog root handlers are not removed/closed.
-        caplog_root_handler = [h for h in logging.root.handlers if is_caplog_handler(h)]
+        caplog_root_handler: list[logging.Handler] = [h for h in logging.root.handlers if is_caplog_handler(h)]
         for current_handler in caplog_root_handler:
             logging.root.removeHandler(current_handler)
         # Make sure that the weak references to the caplog handlers in the logging._handlerList are not removed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1896,7 +1896,7 @@ async def dont_remove_caplog_handlers(request, monkeypatch):
     As such, this fixtures puts a wrapper around the `apply_config()` method to make sure that:
 
      * The pytest handlers are not removed/closed after the execution of the apply_config() method.
-     * The root log level, configured by pytest, is not altered by the call to apply_config().
+     * The configured root log level is not altered by the call to apply_config().
     """
     original_apply_config = inmanta_logging.FullLoggingConfig.apply_config
 


### PR DESCRIPTION
# Description

This PR fixes a bug that causes the pytest logging options (`--log-cli-level`, `--log-file-level`, etc.)  to be ignored. The bug was causes by the fact that a call to `logging.config.dictConfig()` closes all existing handlers, including the handlers added by pytest to handle the logs.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
