### PR TITLE
Fix test cases related to logging

### DIFF
--- a/changelogs/unreleased/fix-logging-related-test-cases.yml
+++ b/changelogs/unreleased/fix-logging-related-test-cases.yml
@@ -1,0 +1,4 @@
+---
+description: Fix logging-related test cases.
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -585,13 +585,7 @@ class InmantaLoggerConfig:
         By default, this method removes and closes all root handlers from the logging framework. If the
         root_handlers_to_remove argument is not None, only the provided root handlers will be removed and closed.
         """
-        to_remove = root_handlers_to_remove if root_handlers_to_remove is not None else logging.root.handlers
-        for handler in to_remove:
-            # File-based handlers automatically re-open after close() if log records are written to them.
-            # As such, we explicitly remove the handler from the root logger here.
-            logging.root.removeHandler(handler)
-            handler.flush()
-            handler.close()
+        logging.shutdown()
         cls._instance = None
 
     def _get_path_to_logging_config_file(self, options: Options) -> Optional[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -556,7 +556,7 @@ def reset_all_objects():
     V2ModuleBuilder.DISABLE_DEFAULT_ISOLATED_ENV_CACHED = False
     compiler.Finalizers.reset_finalizers()
     auth.AuthJWTConfig.reset()
-    InmantaLoggerConfig.clean_instance(root_handlers_to_remove=[h for h in logging.root.handlers if not is_caplog_handler(h)])
+    InmantaLoggerConfig.clean_instance()
     AsyncHTTPClient.configure(None)
 
 
@@ -1887,6 +1887,21 @@ def is_caplog_handler(handler: logging.Handler) -> bool:
         ),
     )
 
+ALLOW_OVERRIDING_ROOT_LOG_LEVEL: bool = False
+
+@pytest.fixture(scope="function")
+def allow_overriding_root_log_level() -> None:
+    """
+    Fixture that allows a test case to indicate that the root log level, specified in a call to
+    `inmanta_logging.FullLoggingConfig.apply_config()`, should be taken into account. By default,
+    it's ignored to make sure that pytest logging works correctly. This fixture is mainly intended
+    for the test cases that test the logging framework itself.
+    """
+    global ALLOW_OVERRIDING_ROOT_LOG_LEVEL
+    ALLOW_OVERRIDING_ROOT_LOG_LEVEL = True
+    yield
+    ALLOW_OVERRIDING_ROOT_LOG_LEVEL = False
+
 
 @pytest.fixture(scope="function", autouse=True)
 async def dont_remove_caplog_handlers(request, monkeypatch):
@@ -1925,7 +1940,8 @@ async def dont_remove_caplog_handlers(request, monkeypatch):
             logging._handlerList.append(weak_ref)
         for current_handler in caplog_root_handler:
             logging.root.addHandler(current_handler)
-        logging.root.setLevel(root_log_level)
+        if not ALLOW_OVERRIDING_ROOT_LOG_LEVEL:
+            logging.root.setLevel(root_log_level)
 
     monkeypatch.setattr(inmanta_logging.FullLoggingConfig, "apply_config", apply_config_wrapper)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1887,7 +1887,9 @@ def is_caplog_handler(handler: logging.Handler) -> bool:
         ),
     )
 
+
 ALLOW_OVERRIDING_ROOT_LOG_LEVEL: bool = False
+
 
 @pytest.fixture(scope="function")
 def allow_overriding_root_log_level() -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -32,7 +32,11 @@ from inmanta.logging import InmantaLoggerConfig, MultiLineFormatter, Options
 
 @pytest.fixture(autouse=True)
 def cleanup_logger():
+    root_log_level = logging.root.level
     InmantaLoggerConfig.clean_instance()
+    yield
+    # Make sure we maintain the initial root log level, so that logging in pytest works as expected.
+    logging.root.setLevel(root_log_level)
 
 
 def test_setup_instance():
@@ -62,7 +66,7 @@ def test_setup_instance_2_times():
     assert message in str(e.value)
 
 
-def test_setup_instance_with_stream():
+def test_setup_instance_with_stream(allow_overriding_root_log_level: None):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -78,7 +82,7 @@ def test_setup_instance_with_stream():
     assert log_output == expected_output
 
 
-def test_set_log_level():
+def test_set_log_level(allow_overriding_root_log_level: None):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     handler = inmanta_logger.get_handler()
@@ -99,7 +103,7 @@ def test_set_log_level():
     assert expected_output in log_output
 
 
-def test_set_log_formatter():
+def test_set_log_formatter(allow_overriding_root_log_level: None):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
 
@@ -127,6 +131,7 @@ def test_set_log_formatter():
 
 def test_set_logfile_location(
     tmpdir,
+    allow_overriding_root_log_level: None,
 ):
     log_file = tmpdir.join("test.log")
     inmanta_logger = InmantaLoggerConfig.get_instance()
@@ -149,7 +154,7 @@ def test_set_logfile_location(
     "log_file, log_file_level, verbose",
     [(None, "INFO", 1), (None, "ERROR", 4), ("test.log", "WARNING", 4), ("test.log", "DEBUG", 4)],
 )
-def test_apply_options(tmpdir, log_file, log_file_level, verbose):
+def test_apply_options(tmpdir, log_file, log_file_level, verbose, allow_overriding_root_log_level: None):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     logger = logging.getLogger("test_logger")
@@ -187,7 +192,7 @@ def test_apply_options(tmpdir, log_file, log_file_level, verbose):
             assert error_in_output
 
 
-def test_logging_apply_options_2_times():
+def test_logging_apply_options_2_times(allow_overriding_root_log_level: None):
     stream = StringIO()
     inmanta_logger = InmantaLoggerConfig.get_instance(stream)
     options1 = Options(log_file=None, log_file_level="INFO", verbose="1")
@@ -199,7 +204,7 @@ def test_logging_apply_options_2_times():
     assert message in str(e.value)
 
 
-def test_logging_cleaned_after_apply_options(tmpdir):
+def test_logging_cleaned_after_apply_options(tmpdir, allow_overriding_root_log_level: None):
     # verifies that when changing the stream with apply_option, the old stream is properly cleaned up
     # and not used anymore.
     stream = StringIO()
@@ -225,7 +230,7 @@ def test_logging_cleaned_after_apply_options(tmpdir):
     assert log_output == expected_output
 
 
-def test_handling_logging_config_option(tmpdir, monkeypatch) -> None:
+def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_root_log_level: None) -> None:
     """
     Verify the behavior of the logging_config option.
     """


### PR DESCRIPTION
# Description

This PR fixes the logging-related test cases that broke due to https://github.com/inmanta/inmanta-core/commit/fc81b36711235eb10bf9aa0a4764b8422d42d34a.

**Root cause of failures:**

The above-mentioned commit made sure that the root log level is not changed by the `apply_config()` method. This broke the logging-related test cases because they assume that they can change the root log level.

**Changes made by this PR:**

* Add `allow_overriding_root_log_level` fixture that makes sure that the `apply_config` can change the root log level.
* Simplify the `InmantaLoggerConfig.clean_instance()` method. In the previous implementation it made a call to `logging.shutdown()`, which closes all the handlers. This PR re-adds that method invocation to simplify the method. This is not an issue for pytest, because pytest re-adds their handlers after each test case.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [ ] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
