### PR TITLE
hold back pydantic-core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
   ignore:
     - dependency-name: "pytest-inmanta-extensions"
       versions: [">=0.0.1"]
-    - dependency-name: "pydantic"
-      update-types: ["version-update:semver-major"]
+    # pydantic/pydantic#10494
+    - dependency-name: "pydantic-core"
     - dependency-name: "execnet"
       update-types: ["version-update:semver-major"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,10 @@ more-itertools==10.5.0
 packaging==24.1
 pip==24.2
 ply==3.11
-pydantic==2.9.2
+pydantic==2.9.1
+# held back due to pydantic/pydantic#10494. pydantic-core is not a direct dependency:
+# when the issue is resolved, the dependency can be dropped altogether
+pydantic-core==2.23.3
 pyformance==0.4
 PyJWT==2.9.0
 pynacl==1.5.0


### PR DESCRIPTION
# Description

Hold back pydantic-core because of pydantic/pydantic#10494.

Does not affect inmanta-core directly, but it does inmanta-lsm (inmanta/inmanta-lsm#1912) so we need to make sure the core requirements file is in line for the iso RPM build.

part of inmanta/inmanta-lsm#1900

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
