### PR TITLE
Fix broken Keycloak link in documentation

### DIFF
--- a/changelogs/unreleased/fix-broken-keycloak-link.yml
+++ b/changelogs/unreleased/fix-broken-keycloak-link.yml
@@ -1,0 +1,3 @@
+description: Fix broken Keycloak link
+change-type: patch
+destination-branches: [master, iso7]

--- a/docs/administrators/auth.rst
+++ b/docs/administrators/auth.rst
@@ -416,7 +416,7 @@ able to access this url).
 
 Both the correct url for the issuer and the jwks_uri is also defined in the openid-configuration endpoint of keycloack. For
 the examples above this url is http://localhost:8080/realms/inmanta/.well-known/openid-configuration
-(https://www.keycloak.org/docs/latest/securing_apps/index.html#endpoints)
+(https://www.keycloak.org/securing-apps/oidc-layers#_endpoints)
 
 .. warning:: When the certificate of keycloak is not trusted by the system on which inmanta is installed, set ``validate_cert``
     to false in the ``auth_jwt_keycloak`` block for keycloak.


### PR DESCRIPTION
# Description

Fixed broken Keycloak link in documentation

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
