### PR TITLE
Scheduler recovery

### DIFF
--- a/changelogs/unreleased/8014-scheduler-recovery.yml
+++ b/changelogs/unreleased/8014-scheduler-recovery.yml
@@ -1,0 +1,6 @@
+---
+description: Implemented recovery of scheduler state at startup time.
+issue-nr: 8014
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -501,7 +501,8 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
             await child.stop()
 
     async def start(self) -> None:
-        pass
+        assert all(e.is_stopped() for e in self.executors.values())
+        self.executors.clear()
 
     async def stop_for_agent(self, agent_name: str) -> list[InProcessExecutor]:
         if agent_name in self.executors:

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -275,7 +275,9 @@ class ResourceScheduler(TaskManager):
         return require_mapping
 
     async def _get_resources_in_latest_version(
-        self, *, connection: Optional[data.Connection] = None,
+        self,
+        *,
+        connection: Optional[data.Connection] = None,
     ) -> tuple[int, Mapping[ResourceIdStr, ResourceDetails], Mapping[ResourceIdStr, Set[ResourceIdStr]]]:
         """
         Returns a tuple containing:

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -154,13 +154,44 @@ class ResourceScheduler(TaskManager):
         assert not self._running
         self._state.reset()
         self._work.reset()
+        self._workers.clear()
+        self._deploying_latest.clear()
 
     async def start(self) -> None:
+        if self._running:
+            return
         self.reset()
+        await self._initialize()
         self._running = True
-        await self.read_version()
+
+    async def _initialize(self) -> None:
+        """
+        Initialize the scheduler state and continue the deployment where we were before the server was shutdown.
+        """
+        async with data.ConfigurationModel.get_connection() as con:
+            # Get resources from the database
+            try:
+                version, resources, requires = await self._get_resources_in_latest_version(connection=con)
+            except KeyError:
+                # No model version has been released yet.
+                return
+
+            # Rely on the incremental calculation to determine which resources should be deployed and which not.
+            increment: set[ResourceIdStr]
+            increment, _ = await ConfigurationModel.get_increment(self.environment, version, connection=con)
+
+        resources_to_deploy: Mapping[ResourceIdStr, ResourceDetails] = {rid: resources[rid] for rid in increment}
+        up_to_date_resources: Mapping[ResourceIdStr, ResourceDetails] = {
+            rid: resources[rid] for rid in resources.keys() if rid not in increment
+        }
+
+        await self._new_version(
+            version, resources=resources_to_deploy, requires=requires, up_to_date_resources=up_to_date_resources
+        )
 
     async def stop(self) -> None:
+        if not self._running:
+            return
         self._running = False
         self._work.agent_queues.send_shutdown()
         await asyncio.gather(*self._workers.values())
@@ -169,6 +200,8 @@ class ResourceScheduler(TaskManager):
         """
         Trigger a deploy
         """
+        if not self._running:
+            return
         async with self._scheduler_lock:
             self._work.deploy_with_context(self._state.dirty, priority=priority, deploying=self._deploying_latest)
 
@@ -176,11 +209,15 @@ class ResourceScheduler(TaskManager):
         """
         Trigger a repair, i.e. mark all resources as dirty, then trigger a deploy.
         """
+        if not self._running:
+            return
         async with self._scheduler_lock:
             self._state.dirty.update(self._state.resources.keys())
             self._work.deploy_with_context(self._state.dirty, priority=priority, deploying=self._deploying_latest)
 
     async def dryrun(self, dry_run_id: uuid.UUID, version: int) -> None:
+        if not self._running:
+            return
         resources = await self._build_resource_mappings_from_db(version)
         for rid, resource in resources.items():
             self._work.agent_queues.queue_put_nowait(
@@ -196,6 +233,8 @@ class ResourceScheduler(TaskManager):
             )
 
     async def get_facts(self, resource: dict[str, object]) -> None:
+        if not self._running:
+            return
         rid = Id.parse_id(resource["id"]).resource_str()
         self._work.agent_queues.queue_put_nowait(
             PrioritizedTask(
@@ -204,13 +243,16 @@ class ResourceScheduler(TaskManager):
             )
         )
 
-    async def _build_resource_mappings_from_db(self, version: int) -> Mapping[ResourceIdStr, ResourceDetails]:
+    async def _build_resource_mappings_from_db(
+        self, version: int, *, connection: Optional[data.Connection] = None
+    ) -> Mapping[ResourceIdStr, ResourceDetails]:
         """
         Build a view on current resources. Might be filtered for a specific environment, used when a new version is released
 
         :return: resource_mapping {id -> resource details}
         """
-        resources_from_db = await data.Resource.get_resources_for_version(self.environment, version)
+        async with data.Resource.get_connection(connection) as con:
+            resources_from_db = await data.Resource.get_resources_for_version(self.environment, version, connection=con)
 
         resource_mapping = {
             resource.resource_id: ResourceDetails(
@@ -232,30 +274,52 @@ class ResourceScheduler(TaskManager):
         }
         return require_mapping
 
+    async def _get_resources_in_latest_version(
+        self, *, connection: Optional[data.Connection] = None,
+    ) -> tuple[int, Mapping[ResourceIdStr, ResourceDetails], Mapping[ResourceIdStr, Set[ResourceIdStr]]]:
+        """
+        Returns a tuple containing:
+            1. The version number of the latest released model.
+            2. A dict mapping every resource_id in the latest released version to its ResourceDetails.
+            3. A dict mapping every resource_id in the latest released version to the set of resources it requires.
+        """
+        async with ConfigurationModel.get_connection(connection) as con:
+            cm_version = await ConfigurationModel.get_latest_version(self.environment, connection=con)
+            if cm_version is None:
+                raise KeyError()
+            model_version = cm_version.version
+            resources_from_db = await self._build_resource_mappings_from_db(version=model_version, connection=con)
+            requires_from_db = self._construct_requires_mapping(resources_from_db)
+            return model_version, resources_from_db, requires_from_db
+
     async def read_version(
         self,
     ) -> None:
         """
-        Update model state and scheduled work based on the latest released version in the database, e.g. when the scheduler is
-        started or when a new version is released. Triggers a deploy after updating internal state:
+        Update model state and scheduled work based on the latest released version in the database,
+        e.g. when a new version is released. Triggers a deploy after updating internal state:
         - schedules new or updated resources to be deployed
         - schedules any resources that are not in a known good state.
         - rearranges deploy tasks by requires if required
         """
-        cm_version = await ConfigurationModel.get_latest_version(self.environment)
-        if cm_version is None:
+        if not self._running:
             return
-        version = cm_version.version
-        resources_from_db = await self._build_resource_mappings_from_db(version=version)
-        requires_from_db = self._construct_requires_mapping(resources_from_db)
-        await self._new_version(version, resources_from_db, requires_from_db)
+        try:
+            version, resources, requires = await self._get_resources_in_latest_version()
+        except KeyError:
+            # No model version has been released yet.
+            return
+        else:
+            await self._new_version(version, resources, requires)
 
     async def _new_version(
         self,
         version: int,
         resources: Mapping[ResourceIdStr, ResourceDetails],
         requires: Mapping[ResourceIdStr, Set[ResourceIdStr]],
+        up_to_date_resources: Optional[Mapping[ResourceIdStr, ResourceDetails]] = None,
     ) -> None:
+        up_to_date_resources = {} if up_to_date_resources is None else up_to_date_resources
         async with self._intent_lock:
             # Inspect new state and compare it with the old one before acquiring scheduler the lock.
             # This is safe because we only read intent-related state here, for which we've already acquired the lock
@@ -270,6 +334,9 @@ class ResourceScheduler(TaskManager):
             unblocked_resources: set[ResourceIdStr] = set()
             added_requires: dict[ResourceIdStr, Set[ResourceIdStr]] = {}
             dropped_requires: dict[ResourceIdStr, Set[ResourceIdStr]] = {}
+            for resource, details in up_to_date_resources.items():
+                self._state.add_up_to_date_resource(resource, details)
+
             for resource, details in resources.items():
                 if details.status is const.ResourceState.undefined:
                     blocked_resources.add(resource)

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -24,6 +24,8 @@ from abc import abstractmethod
 from collections.abc import Collection, Mapping, Set
 from typing import Optional
 
+import asyncpg
+
 from inmanta import const, data
 from inmanta.agent import executor
 from inmanta.agent.code_manager import CodeManager
@@ -244,7 +246,7 @@ class ResourceScheduler(TaskManager):
         )
 
     async def _build_resource_mappings_from_db(
-        self, version: int, *, connection: Optional[data.Connection] = None
+        self, version: int, *, connection: Optional[asyncpg.connection.Connection] = None
     ) -> Mapping[ResourceIdStr, ResourceDetails]:
         """
         Build a view on current resources. Might be filtered for a specific environment, used when a new version is released
@@ -277,7 +279,7 @@ class ResourceScheduler(TaskManager):
     async def _get_resources_in_latest_version(
         self,
         *,
-        connection: Optional[data.Connection] = None,
+        connection: Optional[asyncpg.connection.Connection] = None,
     ) -> tuple[int, Mapping[ResourceIdStr, ResourceDetails], Mapping[ResourceIdStr, Set[ResourceIdStr]]]:
         """
         Returns a tuple containing:

--- a/src/inmanta/deploy/state.py
+++ b/src/inmanta/deploy/state.py
@@ -184,6 +184,23 @@ class ModelState:
         self.resource_state.clear()
         self.types_per_agent.clear()
 
+    def add_up_to_date_resource(self, resource: ResourceIdStr, details: ResourceDetails) -> None:
+        """
+        Add a resource to this ModelState for which the desired state was successfully deployed before, has an up-to-date
+        desired state and for which the deployment isn't blocked at the moment.
+        """
+        self.resources[resource] = details
+        if resource in self.resource_state:
+            self.resource_state[resource].status = ResourceStatus.UP_TO_DATE
+            self.resource_state[resource].deployment_result = DeploymentResult.DEPLOYED
+            self.resource_state[resource].blocked = BlockedStatus.NO
+        else:
+            self.resource_state[resource] = ResourceState(
+                status=ResourceStatus.UP_TO_DATE, deployment_result=DeploymentResult.DEPLOYED, blocked=BlockedStatus.NO
+            )
+            self.types_per_agent[details.id.agent_name][details.id.entity_type] += 1
+        self.dirty.discard(resource)
+
     def block_resource(self, resource: ResourceIdStr, details: ResourceDetails, transient: bool) -> None:
         """
         Mark the given resource as blocked, i.e. it's not deployable. This method updates the resource details

--- a/tests/agent_server/deploy/e2e/test_scheduler_initialization.py
+++ b/tests/agent_server/deploy/e2e/test_scheduler_initialization.py
@@ -15,10 +15,12 @@
 
     Contact: code@inmanta.com
 """
+
 import pytest
 
-from inmanta import config, const
 import utils
+from inmanta import config, const
+
 
 @pytest.fixture
 async def server_pre_start(server_config):
@@ -26,9 +28,7 @@ async def server_pre_start(server_config):
     config.Config.set("config", "agent-repair-interval", "0")
 
 
-async def test_scheduler_initialization(
-    agent, resource_container, clienthelper, server, client, environment
-) -> None:
+async def test_scheduler_initialization(agent, resource_container, clienthelper, server, client, environment) -> None:
     """
     Ensure that when the scheduler starts, it only deploys the resources that need to be deployed,
     i.e. the resources that are not up-to-date or have outstanding events.
@@ -75,7 +75,7 @@ async def test_scheduler_initialization(
     for rid, expected_status in [
         ("test::Resource[agent1,key=key1]", const.ResourceState.deployed),
         ("test::Resource[agent1,key=key2]", const.ResourceState.failed),
-        ("test::Resource[agent1,key=key3]", const.ResourceState.skipped)
+        ("test::Resource[agent1,key=key3]", const.ResourceState.skipped),
     ]:
         result = await client.resource_details(tid=environment, rid=rid)
         assert result.code == 200
@@ -91,7 +91,6 @@ async def test_scheduler_initialization(
     assert len(result.result["data"]) == 1
     assert result.result["data"][0]["resource_version_ids"] == ["test::Resource[agent1,key=key1],v=1"]
 
-
     result = await client.get_resource_actions(
         tid=environment,
         resource_type="test::Resource",
@@ -99,21 +98,17 @@ async def test_scheduler_initialization(
     )
     assert result.code == 200
 
-
-
     # Pause the agent to stop the scheduler
     result = await client.agent_action(tid=environment, name=const.AGENT_SCHEDULER_ID, action=const.AgentAction.pause.value)
     assert result.code == 200
     result = await client.agent_action(tid=environment, name=const.AGENT_SCHEDULER_ID, action=const.AgentAction.unpause.value)
     assert result.code == 200
-    await utils.retry_limited(
-        utils.is_agent_done, scheduler=agent.scheduler, agent_name="agent1", timeout=10, interval=0.05
-    )
+    await utils.retry_limited(utils.is_agent_done, scheduler=agent.scheduler, agent_name="agent1", timeout=10, interval=0.05)
 
     for rid, expected_status in [
         ("test::Resource[agent1,key=key1]", const.ResourceState.deployed),
         ("test::Resource[agent1,key=key2]", const.ResourceState.deployed),
-        ("test::Resource[agent1,key=key3]", const.ResourceState.deployed)
+        ("test::Resource[agent1,key=key3]", const.ResourceState.deployed),
     ]:
         result = await client.resource_details(tid=environment, rid=rid)
         assert result.code == 200

--- a/tests/agent_server/deploy/e2e/test_scheduler_initialization.py
+++ b/tests/agent_server/deploy/e2e/test_scheduler_initialization.py
@@ -1,0 +1,140 @@
+"""
+    Copyright 2024 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+import pytest
+
+from inmanta import config, const
+import utils
+
+@pytest.fixture
+async def server_pre_start(server_config):
+    config.Config.set("config", "agent-deploy-interval", "0")
+    config.Config.set("config", "agent-repair-interval", "0")
+
+
+async def test_scheduler_initialization(
+    agent, resource_container, clienthelper, server, client, environment
+) -> None:
+    """
+    Ensure that when the scheduler starts, it only deploys the resources that need to be deployed,
+    i.e. the resources that are not up-to-date or have outstanding events.
+    """
+    resource_container.Provider.reset()
+    resource_container.Provider.set(agent="agent1", key="key", value="key1")
+    resource_container.Provider.set(agent="agent1", key="key", value="key2")
+    resource_container.Provider.set(agent="agent1", key="key", value="key3")
+    resource_container.Provider.set_fail(agent="agent1", key="key2", failcount=1)
+
+    version = await clienthelper.get_version()
+    resources = [
+        {
+            "key": "key1",
+            "value": "val1",
+            "id": f"test::Resource[agent1,key=key1],v={version}",
+            "requires": [],
+            "purged": False,
+            "send_event": False,
+        },
+        {
+            "key": "key2",
+            "value": "val2",
+            "id": f"test::Resource[agent1,key=key2],v={version}",
+            "requires": [f"test::Resource[agent1,key=key1],v={version}"],
+            "purged": False,
+            "send_event": False,
+        },
+        {
+            "key": "key3",
+            "value": "val3",
+            "id": f"test::Resource[agent1,key=key3],v={version}",
+            "requires": [f"test::Resource[agent1,key=key2],v={version}"],
+            "purged": False,
+            "send_event": False,
+        },
+    ]
+    # Deploy and release version
+    await clienthelper.put_version_simple(version=version, resources=resources)
+    result = await client.release_version(environment, version)
+    assert result.code == 200
+    await clienthelper.wait_for_deployed()
+
+    for rid, expected_status in [
+        ("test::Resource[agent1,key=key1]", const.ResourceState.deployed),
+        ("test::Resource[agent1,key=key2]", const.ResourceState.failed),
+        ("test::Resource[agent1,key=key3]", const.ResourceState.skipped)
+    ]:
+        result = await client.resource_details(tid=environment, rid=rid)
+        assert result.code == 200
+        assert result.result["data"]["status"] == expected_status.value
+
+    result = await client.get_resource_actions(
+        tid=environment,
+        resource_type="test::Resource",
+        agent="agent1",
+        exclude_changes=[const.Change.nochange.value],
+    )
+    assert result.code == 200
+    assert len(result.result["data"]) == 1
+    assert result.result["data"][0]["resource_version_ids"] == ["test::Resource[agent1,key=key1],v=1"]
+
+
+    result = await client.get_resource_actions(
+        tid=environment,
+        resource_type="test::Resource",
+        agent="agent1",
+    )
+    assert result.code == 200
+
+
+
+    # Pause the agent to stop the scheduler
+    result = await client.agent_action(tid=environment, name=const.AGENT_SCHEDULER_ID, action=const.AgentAction.pause.value)
+    assert result.code == 200
+    result = await client.agent_action(tid=environment, name=const.AGENT_SCHEDULER_ID, action=const.AgentAction.unpause.value)
+    assert result.code == 200
+    await utils.retry_limited(
+        utils.is_agent_done, scheduler=agent.scheduler, agent_name="agent1", timeout=10, interval=0.05
+    )
+
+    for rid, expected_status in [
+        ("test::Resource[agent1,key=key1]", const.ResourceState.deployed),
+        ("test::Resource[agent1,key=key2]", const.ResourceState.deployed),
+        ("test::Resource[agent1,key=key3]", const.ResourceState.deployed)
+    ]:
+        result = await client.resource_details(tid=environment, rid=rid)
+        assert result.code == 200
+        assert result.result["data"]["status"] == expected_status.value, f"{rid} has unexpected state"
+
+    result = await client.get_resource_actions(
+        tid=environment,
+        resource_type="test::Resource",
+        agent="agent1",
+        exclude_changes=[const.Change.nochange.value],
+    )
+    assert result.code == 200
+
+    result = await client.get_resource_actions(
+        tid=environment,
+        resource_type="test::Resource",
+        agent="agent1",
+        exclude_changes=[const.Change.nochange.value],
+    )
+    assert result.code == 200
+    assert len(result.result["data"]) == 3
+    for i in range(3):
+
+        assert result.result["data"][i]["resource_version_ids"] == [f"test::Resource[agent1,key=key{3-i}],v=1"]

--- a/tests/agent_server/deploy/test_scheduler_agent.py
+++ b/tests/agent_server/deploy/test_scheduler_agent.py
@@ -25,13 +25,14 @@ import typing
 import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from typing import Mapping, Optional, Sequence, Set
+from typing import Mapping, Optional, Sequence
 
 import pytest
 
 import inmanta.types
+import utils
 from agent_server.deploy.scheduler_test_util import DummyCodeManager, make_requires
-from inmanta import const, util, data
+from inmanta import const, util
 from inmanta.agent import executor
 from inmanta.agent.agent_new import Agent
 from inmanta.agent.executor import ResourceDetails, ResourceInstallSpec
@@ -42,7 +43,6 @@ from inmanta.deploy.state import BlockedStatus
 from inmanta.deploy.work import TaskPriority
 from inmanta.protocol.common import custom_json_encoder
 from inmanta.util import retry_limited
-import utils
 
 FAIL_DEPLOY: str = "fail_deploy"
 
@@ -269,8 +269,6 @@ def make_resource_minimal(environment):
         return state.ResourceDetails(resource_id=rid, attributes=attributes, attribute_hash=attribute_hash, status=status)
 
     return make_resource_minimal
-
-
 
 
 async def test_basic_deploy(agent: TestAgent, make_resource_minimal):

--- a/tests/agent_server/deploy/test_scheduler_agent.py
+++ b/tests/agent_server/deploy/test_scheduler_agent.py
@@ -25,24 +25,24 @@ import typing
 import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from typing import Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence, Set
 
 import pytest
 
 import inmanta.types
 from agent_server.deploy.scheduler_test_util import DummyCodeManager, make_requires
-from inmanta import const, util
+from inmanta import const, util, data
 from inmanta.agent import executor
 from inmanta.agent.agent_new import Agent
 from inmanta.agent.executor import ResourceDetails, ResourceInstallSpec
 from inmanta.config import Config
 from inmanta.data import ResourceIdStr
 from inmanta.deploy import state, tasks
-from inmanta.deploy.scheduler import ResourceScheduler
 from inmanta.deploy.state import BlockedStatus
 from inmanta.deploy.work import TaskPriority
 from inmanta.protocol.common import custom_json_encoder
 from inmanta.util import retry_limited
+import utils
 
 FAIL_DEPLOY: str = "fail_deploy"
 
@@ -62,6 +62,13 @@ async def retry_limited_fast(
 
 
 class DummyExecutor(executor.Executor):
+    """
+    A dummy executor:
+        * It doesn't actually do any deploys, but instead keeps track of the actions
+          (execute, dryrun, get_facts, etc.) that were requested on it.
+        * It reports a deploy as failed if the resource has an attribute with the value of the `FAIL_DEPLOY` variable.
+          Otherwise, the deploy is reported as successful.
+    """
 
     def __init__(self):
         self.execute_count = 0
@@ -134,6 +141,9 @@ class ManagedExecutor(DummyExecutor):
 
 
 class DummyManager(executor.ExecutorManager[executor.Executor]):
+    """
+    An ExecutorManager that allows you to set a custom (mocked) executor for a certain agent.
+    """
 
     def __init__(self):
         self.executors = {}
@@ -167,10 +177,25 @@ class DummyManager(executor.ExecutorManager[executor.Executor]):
 
 
 async def pass_method():
+    """
+    A dummy method that does nothing at all.
+    """
     pass
 
 
 class TestAgent(Agent):
+    """
+    An agent (scheduler) that mock everything:
+
+    * It uses a mocked ExecutorManager.
+    * A dummy code CodeManager.
+    * It mock the methods that interact with the database.
+
+    This allows you to:
+       * Test the interactions between the scheduler and the executor, without the overhead of any other components,
+         like the Inmanta server.
+       * The mocked components allow inspection of the deploy actions done by the executor.
+    """
 
     def __init__(
         self,
@@ -182,6 +207,7 @@ class TestAgent(Agent):
         self.scheduler.code_manager = DummyCodeManager(self._client)
         # Bypass DB
         self.scheduler.read_version = pass_method
+        self.scheduler._initialize = pass_method
         self.scheduler.mock_versions = {}
 
         async def build_resource_mappings_from_db(version: int | None) -> Mapping[ResourceIdStr, ResourceDetails]:
@@ -245,18 +271,6 @@ def make_resource_minimal(environment):
     return make_resource_minimal
 
 
-async def is_agent_done(scheduler: ResourceScheduler, agent_name: str) -> bool:
-    """
-    Return True iff the given agent has finished executing all its tasks.
-
-    :param scheduler: The resource scheduler that hands out work to the agent for which the done status has to be checked.
-    :param agent_name: The name of the agent for which the done status has to be checked.
-    """
-    agent_queue = scheduler._work.agent_queues._agent_queues.get(agent_name)
-    if not agent_queue:
-        # Agent queue doesn't exist -> Tasks have not been queued yet
-        return False
-    return agent_queue._unfinished_tasks == 0
 
 
 async def test_basic_deploy(agent: TestAgent, make_resource_minimal):
@@ -272,7 +286,7 @@ async def test_basic_deploy(agent: TestAgent, make_resource_minimal):
     }
 
     await agent.scheduler._new_version(5, resources, make_requires(resources))
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
 
     assert agent.executor_manager.executors["agent1"].execute_count == 2
 
@@ -780,7 +794,7 @@ async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal)
 
     await retry_limited_fast(lambda: rid2 in executor2.deploys)
     executor2.deploys[rid2].set_result(const.ResourceState.deployed)
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent3")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent3")
 
     assert agent.executor_manager.executors["agent1"].execute_count == 1
     assert agent.executor_manager.executors["agent2"].execute_count == 1
@@ -1105,7 +1119,7 @@ async def test_dryrun(agent: TestAgent, make_resource_minimal, monkeypatch):
 
     dryrun = uuid.uuid4()
     await agent.scheduler.dryrun(dryrun, 5)
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
 
     assert agent.executor_manager.executors["agent1"].dry_run_count == 2
 
@@ -1126,7 +1140,7 @@ async def test_get_facts(agent: TestAgent, make_resource_minimal):
 
     await agent.scheduler.get_facts({"id": rid1})
 
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
 
     assert agent.executor_manager.executors["agent1"].facts_count == 1
 
@@ -1175,7 +1189,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
         rid7: make_resource_minimal(rid=rid7, values={"value": "a"}, requires=[]),
     }
     await agent.scheduler._new_version(version=1, resources=resources, requires=make_requires(resources))
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.resources) == 7
     assert len(agent.scheduler.get_types_for_agent("agent1")) == 1
 
@@ -1209,7 +1223,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
         rid=rid3, values={"value": "a"}, requires=[rid5, rid6], status=const.ResourceState.skipped_for_undefined
     )
     await agent.scheduler._new_version(version=2, resources=resources, requires=make_requires(resources))
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.resources) == 7
 
     # rid1: transitively blocked on rid5 and rid6
@@ -1233,7 +1247,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
         rid=rid2, values={"value": "b"}, requires=[rid5], status=const.ResourceState.available
     )
     await agent.scheduler._new_version(version=3, resources=resources, requires=make_requires(resources))
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.resources) == 7
 
     # rid1: transitively blocked on rid6
@@ -1259,7 +1273,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
         rid9: make_resource_minimal(rid=rid9, values={"value": "a"}, requires=[rid8], status=const.ResourceState.undefined),
     }
     await agent.scheduler._new_version(version=4, resources=resources, requires=make_requires(resources))
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.resources) == 2
     assert len(agent.scheduler.get_types_for_agent("agent1")) == 1
 
@@ -1270,7 +1284,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
     resources[rid8] = make_resource_minimal(rid=rid8, values={"value": "a"}, requires=[], status=const.ResourceState.available)
 
     await agent.scheduler._new_version(version=5, resources=resources, requires=make_requires(resources))
-    await retry_limited(is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.resources) == 2
     assert len(agent.scheduler.get_types_for_agent("agent1")) == 1
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,13 +47,13 @@ from _pytest.mark import MarkDecorator
 from inmanta import config, const, data, env, module, protocol, util
 from inmanta.data import ResourceIdStr
 from inmanta.data.model import PipConfig
+from inmanta.deploy.scheduler import ResourceScheduler
 from inmanta.moduletool import ModuleTool
 from inmanta.protocol import Client
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.extensions import ProductMetadata
 from inmanta.util import get_compiler_version, hash_file
 from libpip2pi.commands import dir2pi
-from inmanta.deploy.scheduler import ResourceScheduler
 
 T = TypeVar("T")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,6 +53,7 @@ from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.extensions import ProductMetadata
 from inmanta.util import get_compiler_version, hash_file
 from libpip2pi.commands import dir2pi
+from inmanta.deploy.scheduler import ResourceScheduler
 
 T = TypeVar("T")
 
@@ -820,3 +821,17 @@ def make_random_file(size: int = 0) -> tuple[str, bytes, str]:
     body = base64.b64encode(content).decode("ascii")
 
     return hash, content, body
+
+
+async def is_agent_done(scheduler: ResourceScheduler, agent_name: str) -> bool:
+    """
+    Return True iff the given agent has finished executing all its tasks.
+
+    :param scheduler: The resource scheduler that hands out work to the agent for which the done status has to be checked.
+    :param agent_name: The name of the agent for which the done status has to be checked.
+    """
+    agent_queue = scheduler._work.agent_queues._agent_queues.get(agent_name)
+    if not agent_queue:
+        # Agent queue doesn't exist -> Tasks have not been queued yet
+        return False
+    return agent_queue._unfinished_tasks == 0


### PR DESCRIPTION
# Description

This PR ensures that the scheduler state is recovered from the database at startup time.

closes #8014

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~