### PR TITLE
Issue/use posix spawn

### DIFF
--- a/changelogs/unreleased/agent_executor_7_8.yml
+++ b/changelogs/unreleased/agent_executor_7_8.yml
@@ -1,0 +1,4 @@
+description: Attempt to bypass python bug
+change-type: patch
+destination-branches: [master]
+

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -24,7 +24,6 @@ import json
 import logging
 import os
 import re
-import shlex
 import site
 import subprocess
 import sys

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -1086,11 +1086,11 @@ class CommandRunner:
         of the sub-process.
         """
         full_output = []
-        # We use shell here to avoid
+        # We use close_fds here to avoid
         # the bug https://github.com/python/cpython/issues/103911#issuecomment-2333963137
-        cmd_as_str = " ".join(shlex.quote(x) for x in cmd)
-        process = await asyncio.create_subprocess_shell(
-            cmd_as_str, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env_vars, cwd="/"
+        # We attempt to get on the code path that uses _posix_spawn instead of _fork_exec
+        process = await asyncio.create_subprocess_exec(
+            *cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env_vars, close_fds=False
         )
         assert process.stdout is not None  # Make mypy happy
         async for line in process.stdout:

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -1089,6 +1089,8 @@ class CommandRunner:
         # We use close_fds here to avoid
         # the bug https://github.com/python/cpython/issues/103911#issuecomment-2333963137
         # We attempt to get on the code path that uses _posix_spawn instead of _fork_exec
+        # Subprocess shell did not work to prevent it
+        # Improved escaping (shlex.quote) to prevent `>` from leaking did not help
         process = await asyncio.create_subprocess_exec(
             *cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env_vars, close_fds=False
         )

--- a/tests/deploy/e2e/test_resource_handler.py
+++ b/tests/deploy/e2e/test_resource_handler.py
@@ -226,6 +226,7 @@ async def test_deploy_handler_method(server, client, environment, agent, clienth
         ]
 
         await _deploy_resources(client, environment, resources, version, push=True)
+        await clienthelper.wait_for_released(version)
         await wait_until_deployment_finishes(client, environment, version=version)
 
         result = await client.get_resource(


### PR DESCRIPTION
# Description

The race we observed before is still there.

I now attempt to bypass the C code in cpython that causes this.
It forces me to leak FD's to the child. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
