### PR TITLE
More fixes for the serializer

### DIFF
--- a/changelogs/unreleased/agent_executor_7_12.yml
+++ b/changelogs/unreleased/agent_executor_7_12.yml
@@ -1,0 +1,4 @@
+description: Ensure serialization safety
+change-type: patch
+destination-branches: [master]
+

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -146,6 +146,10 @@ src/inmanta/execute/runtime.py:0: error: Argument 2 to "assign" of "AssignableNo
 src/inmanta/execute/runtime.py:0: error: Argument 1 to "AttributeException" has incompatible type "Instance"; expected "Locatable"  [arg-type]
 src/inmanta/execute/runtime.py:0: error: Missing type parameters for generic type "ResultVariable"  [type-arg]
 src/inmanta/execute/runtime.py:0: error: Argument 1 to "RuntimeException" has incompatible type "Instance"; expected "Locatable | None"  [arg-type]
+src/inmanta/data/model.py:0: error: Return type "str" of "__getstate__" incompatible with return type "dict[Any, Any]" in supertype "BaseModel"  [override]
+src/inmanta/data/model.py:0: error: Argument 1 of "__setstate__" is incompatible with supertype "BaseModel"; supertype defines the argument type as "dict[Any, Any]"  [override]
+src/inmanta/data/model.py:0: note: This violates the Liskov substitution principle
+src/inmanta/data/model.py:0: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
 src/inmanta/data/model.py:0: error: Function is missing a type annotation  [no-untyped-def]
 src/inmanta/data/model.py:0: error: Unused "type: ignore" comment, use narrower [prop-decorator] instead of [misc] code  [unused-ignore]
 src/inmanta/ast/attribute.py:0: error: Incompatible types in assignment (expression has type "property", variable has type "Type")  [assignment]
@@ -551,11 +555,8 @@ src/inmanta/data/__init__.py:0: error: Incompatible return value type (got "Reso
 src/inmanta/data/__init__.py:0: error: Argument 1 to "add_logs" of "ResourceAction" has incompatible type "list[dict[str, object]]"; expected "str | None"  [arg-type]
 src/inmanta/data/__init__.py:0: error: "object" has no attribute "__iter__"; maybe "__dir__" or "__str__"? (not iterable)  [attr-defined]
 src/inmanta/data/__init__.py:0: error: Argument "changes" to "ResourceAction" has incompatible type "dict[ResourceVersionIdStr, dict[str, object]] | None"; expected "dict[str, Any] | None"  [arg-type]
-src/inmanta/data/__init__.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/inmanta/data/__init__.py:0: error: Missing type parameters for generic type "dict"  [type-arg]
 src/inmanta/data/__init__.py:0: error: Unsupported left operand type for + ("object")  [operator]
-src/inmanta/data/__init__.py:0: error: Function is missing a type annotation  [no-untyped-def]
-src/inmanta/data/__init__.py:0: error: Call to untyped function "convert_or_ignore" in typed context  [no-untyped-call]
 src/inmanta/data/__init__.py:0: error: Incompatible return value type (got "Sequence[Resource]", expected "list[Resource]")  [return-value]
 src/inmanta/data/__init__.py:0: error: Argument 1 to "ResourceIdStr" has incompatible type "object"; expected "str"  [arg-type]
 src/inmanta/data/__init__.py:0: error: Enum index should be a string (actual index type "object")  [misc]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -63,7 +63,6 @@ from inmanta.data.model import (
 )
 from inmanta.protocol.common import custom_json_encoder
 from inmanta.protocol.exceptions import BadRequest, NotFound
-from inmanta.resources import Id
 from inmanta.server import config
 from inmanta.stable_api import stable_api
 from inmanta.types import JsonType, PrimitiveTypes
@@ -4610,7 +4609,7 @@ class Resource(BaseDocument):
             return []
         query_lock: str = lock.value if lock is not None else ""
 
-        def convert_or_ignore(rvid: m.ResourceVersionIdStr) -> Id | None:
+        def convert_or_ignore(rvid: m.ResourceVersionIdStr) -> resources.Id | None:
             """Method to retain backward compatibility, ignore bad ID's"""
             try:
                 return resources.Id.parse_resource_version_id(rvid)

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -17,6 +17,7 @@
 """
 
 import datetime
+import json
 import typing
 import urllib
 import uuid
@@ -241,6 +242,16 @@ class AttributeStateChange(BaseModel):
                 # In production, try to cast the non-serializable value to str to prevent the handler from failing.
                 return str(v)
         return v
+
+    def __getstate__(self) -> str:
+        # make pickle use json to keep leaking stuff
+        # Will make the objects into json-like things
+        # This method exists only to keep IPC light compatible with the json based RPC
+        return protocol.common.json_encode(self)
+
+    def __setstate__(self, state: str) -> None:
+        # This method exists only to keep IPC light compatible with the json based RPC
+        self.__dict__.update(json.loads(state))
 
 
 EnvSettingType = Union[bool, int, float, str, dict[str, Union[str, int, bool]]]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -244,7 +244,7 @@ class AttributeStateChange(BaseModel):
         return v
 
     def __getstate__(self) -> str:
-        # make pickle use json to keep leaking stuff
+        # make pickle use json to keep from leaking stuff
         # Will make the objects into json-like things
         # This method exists only to keep IPC light compatible with the json based RPC
         return protocol.common.json_encode(self)

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -793,7 +793,7 @@ class ResourceService(protocol.ServerSlice, EnvironmentListener):
         self.add_background_task(data.ConfigurationModel.mark_done_if_done(env.id, resource.model))
 
         waiting_agents = {(Id.parse_id(prov).get_agent_name(), resource.resource_version_id) for prov in resource.provides}
-        for agent, resource_id in waiting_agents:
+        for agent, aresource_id in waiting_agents:
             aclient = self.agentmanager_service.get_agent_client(env.id, agent)
             if aclient is not None:
                 if change is None:
@@ -801,7 +801,7 @@ class ResourceService(protocol.ServerSlice, EnvironmentListener):
                 await aclient.resource_event(
                     tid=env.id,
                     id=agent,
-                    resource=resource_id,
+                    resource=aresource_id,
                     send_events=False,
                     state=status,
                     change=change,

--- a/tests/forking_agent/test_pickle.py
+++ b/tests/forking_agent/test_pickle.py
@@ -1,0 +1,66 @@
+"""
+    Copyright 2024 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+import datetime
+import pickle
+import uuid
+
+from inmanta.agent.executor import DeployResult, DryrunResult
+from inmanta.const import Change, ResourceState
+from inmanta.data import LogLine
+from inmanta.data.model import AttributeStateChange
+
+
+def test_risky_objects():
+    class EvilString(str):
+        """
+        This can't be pickled as it is an inner class
+        Can be json serialized as it is a string
+        """
+
+        pass
+
+    dryrun = DryrunResult(
+        "std::Test[a1,k=v],v=3",
+        uuid.uuid4(),
+        {"a": AttributeStateChange(current="a", desired=EvilString("B"))},
+        datetime.datetime.now(),
+        datetime.datetime.now(),
+        [LogLine(msg="test", args=[], level="INFO", kwargs={"A": EvilString("X")})],
+    )
+    out = pickle.loads(pickle.dumps(dryrun))
+
+    assert isinstance(out, DryrunResult)
+    assert isinstance(out.changes["a"], AttributeStateChange)
+    assert isinstance(out.changes["a"].desired, str)
+    assert isinstance(out.messages[0], LogLine)
+
+    deploy = DeployResult(
+        "std::Test[a1,k=v],v=3",
+        uuid.uuid4(),
+        ResourceState.deployed,
+        [LogLine(msg="test", args=[], level="INFO", kwargs={"A": EvilString("X")})],
+        {"a": AttributeStateChange(current="a", desired=EvilString("B"))},
+        Change.updated,
+    )
+
+    deploy_out = pickle.loads(pickle.dumps(deploy))
+    assert isinstance(deploy_out, DeployResult)
+    assert isinstance(deploy_out.changes["a"], AttributeStateChange)
+    assert isinstance(deploy_out.changes["a"].desired, str)
+    assert isinstance(deploy_out.messages[0], LogLine)


### PR DESCRIPTION
# Description

Make serializer more safe by switching to json when needed

dis-advantages:
1. doesn't reconstruct objects  (which is why it is applied only at the leaves)

closes #8267 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
