### PR TITLE
scheduler state fixes

### DIFF
--- a/changelogs/unreleased/scheduler-state-fixes.yml
+++ b/changelogs/unreleased/scheduler-state-fixes.yml
@@ -1,0 +1,4 @@
+description: Addressed some bugged edge conditions on the scheduler
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -596,7 +596,7 @@ class ResourceScheduler(TaskManager):
         resource: ResourceIdStr,
         *,
         attribute_hash: str,
-        status: ResourceStatus,
+        status: Optional[ResourceStatus] = None,
         deployment_result: Optional[DeploymentResult] = None,
     ) -> None:
         if deployment_result is DeploymentResult.NEW:

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -84,7 +84,7 @@ class TaskManager(StateUpdateManager, abc.ABC):
         resource: ResourceIdStr,
         *,
         attribute_hash: str,
-        status: ResourceStatus,
+        status: Optional[ResourceStatus] = None,
         deployment_result: Optional[DeploymentResult] = None,
     ) -> None:
         """
@@ -96,7 +96,7 @@ class TaskManager(StateUpdateManager, abc.ABC):
         :param resource: The resource to report state for.
         :param attribute_hash: The resource's attribute hash for which this state applies. No scheduler state is updated if the
             hash indicates the state information is stale.
-        :param status: The new resource status.
+        :param status: The new resource status. If none, the old one is kept.
         :param deployment_result: The result of the deploy, iff one just finished, otherwise None.
         """
 
@@ -610,7 +610,8 @@ class ResourceScheduler(TaskManager):
                 # There is also no need to send out events because a newer version will have been scheduled.
                 return
             state: ResourceState = self._state.resource_state[resource]
-            state.status = status
+            if status is not None:
+                state.status = status
             if deployment_result is not None:
                 # first update state, then send out events
                 self._deploying_latest.remove(resource)
@@ -618,6 +619,11 @@ class ResourceScheduler(TaskManager):
                 self._work.finished_deploy(resource)
                 if deployment_result is DeploymentResult.DEPLOYED:
                     self._state.dirty.discard(resource)
+                else:
+                    # In most cases it will already be marked as dirty but in rare cases the deploy that just finished might
+                    # have been triggered by an event, on a previously successful deployed resource. Either way, a failure
+                    # (or skip) causes it to become dirty now.
+                    self._state.dirty.add(resource)
                 # propagate events
                 if details.attributes.get(const.RESOURCE_ATTRIBUTE_SEND_EVENTS, False):
                     provides: Set[ResourceIdStr] = self._state.requires.provides_view().get(resource, set())

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -216,7 +216,7 @@ class Deploy(Task):
             await task_manager.report_resource_state(
                 resource=self.resource,
                 attribute_hash=resource_details.attribute_hash,
-                status=state.ResourceStatus.UP_TO_DATE if success else state.ResourceStatus.HAS_UPDATE,
+                status=state.ResourceStatus.UP_TO_DATE if success else None,
                 deployment_result=state.DeploymentResult.DEPLOYED if success else state.DeploymentResult.FAILED,
             )
 

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -1119,8 +1119,8 @@ async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal)
     assert len(agent.scheduler._state.dirty) == 0
 
     # release change for r1, sending event to r2 when it finishes
-    resources = make_resources(version=16, r1_value=5, r2_value=0, r3_value=0)
-    await agent.scheduler._new_version(16, resources, make_requires(resources))
+    resources = make_resources(version=17, r1_value=5, r2_value=0, r3_value=0)
+    await agent.scheduler._new_version(17, resources, make_requires(resources))
     await retry_limited_fast(lambda: rid2 in executor2.deploys)
 
     # verify that r2 is still in an assumed good state, even though we're deploying it

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -1141,7 +1141,9 @@ async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal)
     assert agent.executor_manager.executors["agent3"].execute_count == 0
     # verify that r2 is considered dirty now, despite being in an assumed good operational state
     assert agent.scheduler._state.resource_state[rid2] == state.ResourceState(
+        # we have no data indicating that operational state has deviated from desired state => still UP_TO_DATE
         status=state.ResourceStatus.UP_TO_DATE,
+        # latest deploy attempt failed
         deployment_result=state.DeploymentResult.FAILED,
         blocked=state.BlockedStatus.NO,
     )

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -1095,6 +1095,67 @@ async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal)
     assert len(agent.scheduler._work.agent_queues) == 0
     assert len(agent.scheduler._work.agent_queues._in_progress) == 0
 
+    #################################################################################################
+    # Verify resources are marked as dirty after event propagation causes success->failure transfer #
+    #################################################################################################
+    agent.executor_manager.reset_executor_counters()
+
+    # set up initial state
+    resources = make_resources(version=16, r1_value=4, r2_value=0, r3_value=0)
+    await agent.scheduler._new_version(16, resources, make_requires(resources))
+    await retry_limited_fast(lambda: rid2 in executor2.deploys)
+    executor2.deploys[rid2].set_result(const.ResourceState.deployed)
+    await retry_limited_fast(lambda: len(agent.scheduler._work.agent_queues._in_progress) == 0)
+    # verify initial state
+    assert rid2 not in executor2.deploys
+    assert agent.executor_manager.executors["agent1"].execute_count == 0
+    assert agent.executor_manager.executors["agent2"].execute_count == 1
+    assert agent.executor_manager.executors["agent3"].execute_count == 0
+    assert agent.scheduler._state.resource_state[rid2] == state.ResourceState(
+        status=state.ResourceStatus.UP_TO_DATE,
+        deployment_result=state.DeploymentResult.DEPLOYED,
+        blocked=state.BlockedStatus.NO,
+    )
+    assert len(agent.scheduler._state.dirty) == 0
+
+    # release change for r1, sending event to r2 when it finishes
+    resources = make_resources(version=16, r1_value=5, r2_value=0, r3_value=0)
+    await agent.scheduler._new_version(16, resources, make_requires(resources))
+    await retry_limited_fast(lambda: rid2 in executor2.deploys)
+
+    # verify that r2 is still in an assumed good state, even though we're deploying it
+    assert agent.scheduler._state.resource_state[rid2] == state.ResourceState(
+        status=state.ResourceStatus.UP_TO_DATE,
+        deployment_result=state.DeploymentResult.DEPLOYED,
+        blocked=state.BlockedStatus.NO,
+    )
+    assert len(agent.scheduler._state.dirty) == 0
+
+    # fail r2
+    # failed works just as well but skipped is even more of an edge case
+    executor2.deploys[rid2].set_result(const.ResourceState.skipped)
+    await retry_limited_fast(lambda: len(agent.scheduler._work.agent_queues._in_progress) == 0)
+    assert rid2 not in executor2.deploys
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 2
+    assert agent.executor_manager.executors["agent3"].execute_count == 0
+    # verify that r2 is considered dirty now, despite being in an assumed good operational state
+    assert agent.scheduler._state.resource_state[rid2] == state.ResourceState(
+        status=state.ResourceStatus.UP_TO_DATE,
+        deployment_result=state.DeploymentResult.FAILED,
+        blocked=state.BlockedStatus.NO,
+    )
+    assert agent.scheduler._state.dirty == {rid2}
+
+    # trigger a deploy, verify that r2 gets scheduled because it is dirty
+    await agent.scheduler.deploy(reason="Test")
+    await retry_limited_fast(lambda: rid2 in executor2.deploys)
+    executor2.deploys[rid2].set_result(const.ResourceState.deployed)
+    await retry_limited_fast(lambda: len(agent.scheduler._work.agent_queues._in_progress) == 0)
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 3
+    assert agent.executor_manager.executors["agent3"].execute_count == 0
+
 
 async def test_receive_events(agent: TestAgent, make_resource_minimal):
     """


### PR DESCRIPTION
# Description

Fixed two small bugs in scheduler state updates:
- when a deploy fails, make sure to mark it as dirty (e.g. when it was scheduled despite being in an assumed good state due to an event)
- when a deploy fails, leave its status what it was before, rather than to overwrite it with `HAS_UPDATE`. If the operational state previously satisfied the resource's desired state, a handler failure does not necessarily change that. We have the `deployment_result` to reflect that aspect of a resource's state.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
