### PR TITLE
fix utils import on inmanta tests

### DIFF
--- a/changelogs/unreleased/fix-utils-import-on-inmanta-tests.yml
+++ b/changelogs/unreleased/fix-utils-import-on-inmanta-tests.yml
@@ -1,0 +1,3 @@
+description: Fix utils import on the test suite
+change-type: patch
+destination-branches: [master]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,6 @@ from inmanta.protocol import auth
 from inmanta.resources import IgnoreResourceException, PurgeableResource, Resource, resource
 from inmanta.util import ScheduledTask, Scheduler, TaskMethod, TaskSchedule
 from packaging.requirements import Requirement
-from utils import get_done_and_total
 
 """
 About the use of @parametrize_any and @slowtest:
@@ -2524,7 +2523,7 @@ def resource_container(clean_reset):
 
         # unhang waiters
         now = time.time()
-        done, total = await get_done_and_total(client, env_id)
+        done, total = await utils.get_done_and_total(client, env_id)
 
         log_progress(done, total)
         while (total - done) > 0:
@@ -2532,7 +2531,7 @@ def resource_container(clean_reset):
                 raise Exception("Timeout")
             if wait_for_this_amount_of_resources_in_done and done - wait_for_this_amount_of_resources_in_done >= 0:
                 break
-            done, total = await get_done_and_total(client, env_id)
+            done, total = await utils.get_done_and_total(client, env_id)
             log_progress(done, total)
             waiter.acquire()
             waiter.notify_all()


### PR DESCRIPTION
# Description

Remove the `from utils import get_done_and_total`  import and import it using the correct approach

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
