### PR TITLE
Track skipped resources

### DIFF
--- a/changelogs/unreleased/track-resources-that-skipped-deployment.yml
+++ b/changelogs/unreleased/track-resources-that-skipped-deployment.yml
@@ -1,0 +1,3 @@
+description: Track resources that skipped deployment
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/deploy/state.py
+++ b/src/inmanta/deploy/state.py
@@ -79,11 +79,13 @@ class DeploymentResult(StrEnum):
     NEW: Resource has never been deployed before.
     DEPLOYED: Last resource deployment was successful.
     FAILED: Last resource deployment was unsuccessful.
+    SKIPPED: Resource skipped deployment.
     """
 
     NEW = enum.auto()
     DEPLOYED = enum.auto()
     FAILED = enum.auto()
+    SKIPPED = enum.auto()
 
 
 class AgentStatus(StrEnum):

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -130,13 +130,10 @@ class Deploy(Task):
         # The main difficulty off this code is exception handling
         # We collect state here to report back in the finally block
 
-        # Status of the deploy for the executor/requires/provides
-        success: bool = True
-
         # Full status of the deploy,
         # may be unset if we fail before signaling start to the server, will be set if we signaled start
         deploy_result: DeployResult | None = None
-        scheduler_deployment_result: state.DeploymentResult | None = None
+        scheduler_deployment_result: state.DeploymentResult
 
         try:
             # This try catch block ensures we report at the end of the task
@@ -148,7 +145,7 @@ class Deploy(Task):
                 )
             except Exception:
                 # Unrecoverable, can't reach server
-                success = False
+                scheduler_deployment_result = state.DeploymentResult.FAILED
                 LOGGER.error(
                     "Failed to report the start of the deployment to the server for %s",
                     resource_details.resource_id,
@@ -219,7 +216,6 @@ class Deploy(Task):
                         resource_details.resource_id,
                         exc_info=True,
                     )
-
             # Always notify scheduler
             await task_manager.report_resource_state(
                 resource=self.resource,

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -264,7 +264,7 @@ async def check_server_state_vs_scheduler_state(client, environment, scheduler):
 
         state_correspondence = {
             "deployed": DeploymentResult.DEPLOYED,
-            "skipped": DeploymentResult.FAILED,
+            "skipped": DeploymentResult.SKIPPED,
             "failed": DeploymentResult.FAILED,
         }
 

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -1143,8 +1143,7 @@ async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal)
     assert agent.scheduler._state.resource_state[rid2] == state.ResourceState(
         # we have no data indicating that operational state has deviated from desired state => still UP_TO_DATE
         status=state.ResourceStatus.UP_TO_DATE,
-        # latest deploy attempt failed
-        deployment_result=state.DeploymentResult.FAILED,
+        deployment_result=state.DeploymentResult.SKIPPED,
         blocked=state.BlockedStatus.NO,
     )
     assert agent.scheduler._state.dirty == {rid2}


### PR DESCRIPTION
# Description

In the current implementation we don't track skipped resources, and simply label them as failed. This PR changes that. In the future we will have a different state for resources that were skipped by a custom handler

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
