### PR TITLE
Change the name of the disk layout flag file

### DIFF
--- a/changelogs/unreleased/8360-change-the-name-of-the-disk-layout-flag.yml
+++ b/changelogs/unreleased/8360-change-the-name-of-the-disk-layout-flag.yml
@@ -1,0 +1,5 @@
+description: Change the name of the disk layout flag file
+issue-nr: 8360
+change-type: patch
+destination-branches: [master]
+

--- a/docs/administrators/on_disk_layout.rst
+++ b/docs/administrators/on_disk_layout.rst
@@ -10,7 +10,7 @@ The server stores
 
     /var/lib/inmanta
        ├─ server/
-           ├─ .inmanta_use_new_disk_layout   # marker file for new disk layout
+           ├─ .inmanta_disk_layout_version   # version of the disk layout
            ├─ env_uuid_1/                    # uuid for this environment
            │   ├─ executors/                 # storage for all executors
            │   │   ├─ venvs/                 # python virtual envs for all executors
@@ -48,7 +48,7 @@ In detail, the creation and cleanup policy for every file:
 +--------------------------------+-----------------------------------------+--------------------------------+---------------------------------------------------------------------------+
 | Path                           | Safe to remove when                     | Reconstructed                  | Automatic cleanup                                                         |
 +================================+=========================================+================================+===========================================================================+
-| `.inmanta_use_new_disk_layout` | Always                                  | At server start                |                                                                           |
+| `.inmanta_disk_layout_version` | Always                                  | At server start                |                                                                           |
 +--------------------------------+-----------------------------------------+--------------------------------+---------------------------------------------------------------------------+
 | `<env_id>`                     |                                         |                                | When environment is cleared or deleted                                    |
 +--------------------------------+-----------------------------------------+--------------------------------+---------------------------------------------------------------------------+

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -358,9 +358,10 @@ INMANTA_REMOVED_SET_ID = "INMANTA_REMOVED_RESOURCE_SET_ID"
 INMANTA_VENV_STATUS_FILENAME = ".inmanta_venv_status"
 
 
-# File present in the root of the state dir to indicate that this orchestrator
-# uses the new disk layout.
-INMANTA_USE_NEW_DISK_LAYOUT_FILENAME = ".inmanta_use_new_disk_layout"
+# File present in the root of the state dir to indicate the version of disk layout that this orchestrator uses.
+INMANTA_DISK_LAYOUT_VERSION = ".inmanta_disk_layout_version"
+# If no file is present, create it with this version
+DEFAULT_INMANTA_DISK_LAYOUT_VERSION = 2
 
 
 # ID to represent the new scheduler as an agent

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -19,6 +19,7 @@
 import asyncio
 import json
 import logging
+import os
 import pathlib
 import uuid
 from typing import TYPE_CHECKING, Optional, Union, cast
@@ -83,9 +84,12 @@ class Server(protocol.ServerSlice):
 
         state_dir = config.state_dir.get()
 
-        # Add marker file to indicate we are using the new disk layout
-        path = pathlib.Path(state_dir) / const.INMANTA_USE_NEW_DISK_LAYOUT_FILENAME
-        path.touch()
+        # Check version of disk layout
+        path = pathlib.Path(state_dir) / const.INMANTA_DISK_LAYOUT_VERSION
+        if not os.path.exists(path):
+            # If the file doesn't exist, create and write the default version to it
+            with open(path, "w") as file:
+                file.write(str(const.DEFAULT_INMANTA_DISK_LAYOUT_VERSION))
 
         dir_map = {
             "server": ensure_directory_exist(state_dir, "server"),

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -101,7 +101,7 @@ async def test_on_disk_layout(server, agent, environment):
         assert sub_dir.exists()
 
     # Check for presence of the new disk layout marker file
-    marker_file_path = state_dir / const.INMANTA_USE_NEW_DISK_LAYOUT_FILENAME
+    marker_file_path = state_dir / const.INMANTA_DISK_LAYOUT_VERSION
     assert pathlib.Path(marker_file_path).exists()
 
 

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -104,6 +104,10 @@ async def test_on_disk_layout(server, agent, environment):
     marker_file_path = state_dir / const.INMANTA_DISK_LAYOUT_VERSION
     assert pathlib.Path(marker_file_path).exists()
 
+    # Check that the version matches the established default version
+    with open(marker_file_path, "r") as file:
+        assert file.read() == str(const.DEFAULT_INMANTA_DISK_LAYOUT_VERSION)
+
 
 async def test_basics(agent, resource_container, clienthelper, client, environment):
     """


### PR DESCRIPTION
# Description

It now holds the version of the disk layout

closes #8360 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
