### PR TITLE
added fix for coverage

### DIFF
--- a/changelogs/unreleased/pytest-coverage-fix-1.yml
+++ b/changelogs/unreleased/pytest-coverage-fix-1.yml
@@ -1,0 +1,4 @@
+description: Attempt to fix pytest-coverage configuration
+change-type: patch
+destination-branches: [master]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ public = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+addopts = "--cov-config=pyproject.toml"
 markers = [
     "slowtest",
     "link_check",


### PR DESCRIPTION
# Description

I turns out that pytest-coverage doesn't load config correctly if it is not explicitly configured, this is particularly bad when using multiprocessing.

This should not affect the normal runs, but only the nightly coverage runs 


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
