### PR TITLE
Remove multiprocessing option from test coverage

### DIFF
--- a/changelogs/unreleased/bm-2024-11-26-drop-multiprocessing-from-testcoverage-config.yml
+++ b/changelogs/unreleased/bm-2024-11-26-drop-multiprocessing-from-testcoverage-config.yml
@@ -1,0 +1,3 @@
+description: Effort to stabilize traffic light -> remove test coverage option
+change-type: patch
+destination-branches: [master]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ log_format = "%(asctime)s.%(msecs)03d %(levelname)s %(message)s"
 
 [tool.coverage.run]
 # Needed by pytest-cov:  https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing
-concurrency = ["multiprocessing","thread"]
+concurrency = "thread"
 parallel = true
 sigterm = true
 branch = false


### PR DESCRIPTION
# Description

Attempt 1 suggested [here](https://docs.google.com/presentation/d/1pcIHQqReFRn2oa0cSOEF9elQcnIuG-JUd_nlHw4h8Vk/edit#slide=id.g164f51ea5f1_0_0) 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
