### PR TITLE
clarify atomicity of deploy start

### DIFF
--- a/changelogs/unreleased/8325-atomic_deploy_start.yml
+++ b/changelogs/unreleased/8325-atomic_deploy_start.yml
@@ -1,0 +1,5 @@
+description: Ensure deploy tasks always report when done
+issue-nr: 8325
+change-type: patch
+destination-branches: [master]
+

--- a/src/inmanta/deploy/persistence.py
+++ b/src/inmanta/deploy/persistence.py
@@ -44,6 +44,12 @@ class StateUpdateManager(abc.ABC):
 
     @abc.abstractmethod
     async def send_in_progress(self, action_id: UUID, resource_id: ResourceVersionIdStr) -> None:
+        """
+        This method sets the state to in_progress.
+
+        It is important that this method is atomic: if it fails, we assume the state to be not set and will not re-set it
+
+        """
         # FIXME: get rid of version in the id
         pass
 

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -120,17 +120,7 @@ class Deploy(Task):
             if intent is None:
                 # Stale resource, can simply be dropped.
                 return
-
-            # Dependencies are always set when calling get_resource_intent_for_deploy
-            assert intent.dependencies is not None
-            # Resolve to exector form
-            version = intent.model_version
-            resource_details = intent.details
-            executor_resource_details: executor.ResourceDetails = self.get_executor_resource_details(version, resource_details)
-
-            # Make id's
-            gid = uuid.uuid4()
-            action_id = uuid.uuid4()  # can this be gid ?
+            # From this point on, we HAVE to call report_resource_state to make the scheduler propagate state
 
             # The main difficulty off this code is exception handling
             # We collect state here to report back in the finally block
@@ -138,16 +128,29 @@ class Deploy(Task):
             # Full status of the deploy,
             # may be unset if we fail before signaling start to the server, will be set if we signaled start
             deploy_result: DeployResult | None = None
-            scheduler_deployment_result: state.DeploymentResult
+            scheduler_deployment_result: state.DeploymentResult = state.DeploymentResult.FAILED
 
             try:
                 # This try catch block ensures we report at the end of the task
 
-                # Signal start to server
+                # Dependencies are always set when calling get_resource_intent_for_deploy
+                assert intent.dependencies is not None
+                # Resolve to exector form
+                version = intent.model_version
+                resource_details = intent.details
+                executor_resource_details: executor.ResourceDetails = self.get_executor_resource_details(
+                    version, resource_details
+                )
+
+                # Make id's
+                gid = uuid.uuid4()
+                action_id = uuid.uuid4()  # can this be gid ?
+
+                # Signal start to DB
                 try:
                     await task_manager.send_in_progress(action_id, executor_resource_details.rvid)
                 except Exception:
-                    # Unrecoverable, can't reach server
+                    # Unrecoverable, can't reach DB
                     scheduler_deployment_result = state.DeploymentResult.FAILED
                     LOGGER.error(
                         "Failed to report the start of the deployment to the server for %s",
@@ -155,6 +158,9 @@ class Deploy(Task):
                         exc_info=True,
                     )
                     return
+                # From this point on, we HAVE to call send_deploy_done to make sure we are not stuck in deploying
+                # This is done by setting deploy_result
+                # The surrounding try_catch will call report_resource_state
 
                 # Get executor
                 try:


### PR DESCRIPTION
# Description

Ensure we end the deploy if we start it, all part where in place, this is mostly docs 

closes #8325 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
