### PR TITLE
Fix race condition in test case envs dir deletion

### DIFF
--- a/changelogs/unreleased/fix-race-condition-in-test-remove-env-dirs.yml
+++ b/changelogs/unreleased/fix-race-condition-in-test-remove-env-dirs.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in the `test_environment_delete_removes_env_directories_on_server` test case.
+change-type: patch
+destination-branches: [master, iso7]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1989,8 +1989,14 @@ async def test_environment_delete_removes_env_directories_on_server(
     assert result.code == 200
 
     async def wait_for_compile() -> bool:
-        result = await client.is_compiling(env_id)
-        return result.code == 204
+        result = await client.get_compile_reports(tid=env_id)
+        assert result.code == 200
+        if len(result.result["data"]) == 0:
+            # The compile request is registered in the database asynchronously with respect to the notify_change() API call.
+            # Here we check that the compile request finished.
+            return False
+        # Check whether the compilation finished.
+        return result.result["data"][0]["completed"] is not None
 
     await utils.retry_limited(wait_for_compile, 15)
 


### PR DESCRIPTION
# Description

Fix race condition in `test_environment_delete_removes_env_directories_on_server` test case. The registration of the compile request happens asynchronously with respect to the `notify_change()` API call. So the `is_compiling()` API call can happen before the compile request is created or before the compilation has started.

```
02:45:43 __________ test_environment_delete_removes_env_directories_on_server ___________
02:45:43 
02:45:43 server = <inmanta.server.protocol.Server object at 0x7f67cc481c50>
02:45:43 client = <inmanta.protocol.endpoints.Client object at 0x7f67cc786610>
02:45:43 
02:45:43     async def test_environment_delete_removes_env_directories_on_server(
02:45:43         server,
02:45:43         client,
02:45:43     ) -> None:
02:45:43         """
02:45:43         Make sure the environment_delete endpoint deletes the environment directory on the server.
02:45:43         """
02:45:43         state_dir: Optional[str] = config.Config.get("config", "state-dir")
02:45:43         assert state_dir is not None
02:45:43         env_dir = py.path.local(state_dir).join("server", "environments")
02:45:43     
02:45:43         result = await client.create_project("env-test")
02:45:43         assert result.code == 200
02:45:43         project_id = result.result["project"]["id"]
02:45:43     
02:45:43         result = await client.create_environment(project_id=project_id, name="env1")
02:45:43         assert result.code == 200
02:45:43         env_id = result.result["environment"]["id"]
02:45:43     
02:45:43         result: Result = await client.notify_change(env_id)
02:45:43         assert result.code == 200
02:45:43     
02:45:43         async def wait_for_compile() -> bool:
02:45:43             result = await client.is_compiling(env_id)
02:45:43             return result.code == 204
02:45:43     
02:45:43         await utils.retry_limited(wait_for_compile, 15)
02:45:43     
02:45:43 >       assert os.path.exists(os.path.join(env_dir, env_id))
02:45:43 E       AssertionError: assert False
02:45:43 E        +  where False = <function exists at 0x7f680b8b7420>('/tmp/tmpmm37oya2/server/environments/a75c6da0-c84b-4ab7-b1d9-b661c109bc96')
02:45:43 E        +    where <function exists at 0x7f680b8b7420> = <module 'posixpath' (frozen)>.exists
02:45:43 E        +      where <module 'posixpath' (frozen)> = os.path
02:45:43 E        +    and   '/tmp/tmpmm37oya2/server/environments/a75c6da0-c84b-4ab7-b1d9-b661c109bc96' = <function join at 0x7f6809a305e0>(local('/tmp/tmpmm37oya2/server/environments'), 'a75c6da0-c84b-4ab7-b1d9-b661c109bc96')
02:45:43 E        +      where <function join at 0x7f6809a305e0> = <module 'posixpath' (frozen)>.join
02:45:43 E        +        where <module 'posixpath' (frozen)> = os.path
02:45:43 
02:45:43 tests/server/test_compilerservice.py:1979: AssertionError
```

# Self Check

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
