### PR TITLE
Fix race in test autostart test case

### DIFF
--- a/changelogs/unreleased/fix-race-in-test-autostart-test-case.yml
+++ b/changelogs/unreleased/fix-race-in-test-autostart-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix race condition in `test_autostart` test case."
+change-type: patch
+destination-branches: [iso7]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,8 +70,7 @@ async def test_autostart(server, client, environment, caplog):
     await agentmanager.ensure_agent_registered(env, "iaas_agent")
     await agentmanager.ensure_agent_registered(env, "iaas_agentx")
 
-    res = await autostarted_agentmanager._ensure_agents(env, ["iaas_agent"])
-    assert res
+    await autostarted_agentmanager._ensure_agents(env, ["iaas_agent"])
 
     await retry_limited(lambda: len(sessionendpoint._sessions) == 1, 20)
     assert len(sessionendpoint._sessions) == 1


### PR DESCRIPTION
# Description

This PR fixes a race condition in the `test_autostart` test case.

When the server starts up, it starts an agent process for the internal agent. This agent process makes a call to the server to obtain the autostarted_agent_map. Like this it might happen that the agent map is updated before it's fetched by the agent. The result is that the call to `_ensure_agents()` returns False, because the agent is already running, causing the assertion to fail.

I remove the assertion, because I don't see the value of it. Let me know if you see any reason to keep it.

```
02:41:36 ________________________________ test_autostart ________________________________
02:41:36 
02:41:36 server = <inmanta.server.protocol.Server object at 0x7fdf6940b5d0>
02:41:36 client = <inmanta.protocol.endpoints.Client object at 0x7fdf29b064d0>
02:41:36 environment = '69cb542a-3f75-48a2-b28a-2b20197309c3'
02:41:36 caplog = <_pytest.logging.LogCaptureFixture object at 0x7fdf5f073510>
02:41:36 
02:41:36     @pytest.mark.slowtest
02:41:36     async def test_autostart(server, client, environment, caplog):
02:41:36         """
02:41:36         Test auto start of agent
02:41:36         An agent is started and then killed to simulate unexpected failure
02:41:36         When the second agent is started for the same environment, the first is terminated in a controlled manner
02:41:36         """
02:41:36         env = await data.Environment.get_by_id(uuid.UUID(environment))
02:41:36         await env.set(data.AUTOSTART_AGENT_MAP, {"internal": "", "iaas_agent": "", "iaas_agentx": ""})
02:41:36     
02:41:36         agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
02:41:36         autostarted_agentmanager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
02:41:36         sessionendpoint = server.get_slice(SLICE_SESSION_MANAGER)
02:41:36     
02:41:36         await agentmanager.ensure_agent_registered(env, "iaas_agent")
02:41:36         await agentmanager.ensure_agent_registered(env, "iaas_agentx")
02:41:36     
02:41:36         res = await autostarted_agentmanager._ensure_agents(env, ["iaas_agent"])
02:41:36 >       assert res
02:41:36 E       assert False
02:41:36 
02:41:36 tests/test_server.py:74: AssertionError
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
