### PR TITLE
Fix bugs and inefficiencies in report resource state query

### DIFF
--- a/changelogs/unreleased/8324-fix-bugs-in-report-resource-state-query.yml
+++ b/changelogs/unreleased/8324-fix-bugs-in-report-resource-state-query.yml
@@ -1,0 +1,4 @@
+description: Fix bugs and inefficiencies in report resource state query
+issue-nr: 8324
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4683,11 +4683,11 @@ class Resource(BaseDocument):
             UPDATE {Resource.table_name()} r
             SET status=ps.last_non_deploying_status::TEXT::resourcestate
             FROM {ResourcePersistentState.table_name()} ps
-            WHERE r.resource_id = ps.resource_id
-                AND r.environment = ps.environment
-                AND r.status = 'deploying'
-                AND r.environment = $1
-                AND r.model = (
+            WHERE r.resource_id=ps.resource_id
+                AND r.environment=ps.environment
+                AND r.status='deploying'
+                AND r.environment=$1
+                AND r.model=(
                     SELECT version
                     FROM {ConfigurationModel.table_name()}
                     WHERE environment=$1

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4672,8 +4672,8 @@ class Resource(BaseDocument):
         connection: Optional[asyncpg.connection.Connection] = None,
     ) -> None:
         """
-        Update resources on the latest version of the model stuck in "deploying" state. The status will be reset to the latest
-        non deploying status.
+        Update resources on the latest released version of the model stuck in "deploying" state.
+        The status will be reset to the latest non deploying status.
 
         :param environment: The environment impacted by this
         :param connection: The connection to use

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4668,7 +4668,6 @@ class Resource(BaseDocument):
     async def reset_resource_state(
         cls,
         environment: uuid.UUID,
-        version: int,
         *,
         connection: Optional[asyncpg.connection.Connection] = None,
     ) -> None:
@@ -4677,22 +4676,27 @@ class Resource(BaseDocument):
         non deploying status.
 
         :param environment: The environment impacted by this
-        :param version: The version of the model impacted by this
         :param connection: The connection to use
         """
+
         query = f"""
-            UPDATE resource AS updated_r
-            SET status=inconsistent_r.last_non_deploying_status::TEXT::resourcestate
-            FROM (
-                SELECT r.resource_id, r.status, r.model, ps.last_non_deploying_status
-                FROM {Resource.table_name()} r
-                INNER JOIN {ResourcePersistentState.table_name()} ps ON r.resource_id = ps.resource_id
+            UPDATE {Resource.table_name()} r
+            SET status=ps.last_non_deploying_status::TEXT::resourcestate
+            FROM {ResourcePersistentState.table_name()} ps
+            WHERE r.resource_id = ps.resource_id
                 AND r.environment = ps.environment
-                WHERE r.environment=$1 AND r.model = $2 AND r.status = 'deploying'
-            ) AS inconsistent_r
-            WHERE inconsistent_r.resource_id = updated_r.resource_id AND inconsistent_r.model = updated_r.model
+                AND r.status = 'deploying'
+                AND r.environment = $1
+                AND r.model = (
+                    SELECT version
+                    FROM {ConfigurationModel.table_name()}
+                    WHERE environment=$1
+                        AND released=true
+                    ORDER BY version DESC
+                    LIMIT 1
+                )
         """
-        values = [cls._get_value(environment), cls._get_value(version)]
+        values = [cls._get_value(environment)]
         async with cls.get_connection(connection) as connection:
             await connection.execute(query, *values)
 

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -436,8 +436,8 @@ class ResourceScheduler(TaskManager):
 
     async def reset_resource_state(self) -> None:
         """
-        Update resources on the latest version of the model stuck in "deploying" state. This can occur when the Scheduler is
-        killed in the middle of a deployment.
+        Update resources on the latest released version of the model stuck in "deploying" state.
+        This can occur when the Scheduler is killed in the middle of a deployment.
         """
 
         await data.Resource.reset_resource_state(self.environment)

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -439,12 +439,8 @@ class ResourceScheduler(TaskManager):
         Update resources on the latest version of the model stuck in "deploying" state. This can occur when the Scheduler is
         killed in the middle of a deployment.
         """
-        cm_version = await ConfigurationModel.get_latest_version(self.environment)
-        if cm_version is None:
-            return
-        version = cm_version.version
 
-        await data.Resource.reset_resource_state(self.environment, version)
+        await data.Resource.reset_resource_state(self.environment)
 
     async def _new_version(
         self,


### PR DESCRIPTION
# Description

`report_resource_state` query now fetches  the latest released version of the model directly instead of it being provided by an argument

closes #8324 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
