### PR TITLE
Refine error handling in dryrun method

### DIFF
--- a/changelogs/unreleased/8206-refine-error-in-dryrun.yml
+++ b/changelogs/unreleased/8206-refine-error-in-dryrun.yml
@@ -1,0 +1,5 @@
+description: Refined the error handling on the dryrun method
+issue-nr: 8206
+change-type: patch
+destination-branches: [master]
+

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -264,7 +264,7 @@ class DryRun(Task):
                 messages=[],
             )
         else:
-            dryrun_result: executor.DryrunResult = await my_executor.dry_run(executor_resource_details, self.dry_run_id)
+            dryrun_result = await my_executor.dry_run(executor_resource_details, self.dry_run_id)
 
         await task_manager.dryrun_update(env=task_manager.environment, dryrun_result=dryrun_result)
 


### PR DESCRIPTION
# Description

If something goes wrong with the dryrun, we expect the exception to be dealt with there, and this way, if something unexpected does happen, we will have more visibility on the error.

closes #8206 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
