### PR TITLE
Fix mypy export of symbols

### DIFF
--- a/changelogs/unreleased/cleanup_module_structure_3.yml
+++ b/changelogs/unreleased/cleanup_module_structure_3.yml
@@ -1,0 +1,3 @@
+description: Fix for mypy
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -34,9 +34,11 @@ import inmanta.ast.export as ast_export
 import pydantic_core.core_schema
 from inmanta import const, data, protocol, resources
 from inmanta.stable_api import stable_api
-from inmanta.types import ArgumentTypes, JsonType, ResourceIdStr, ResourceType, ResourceVersionIdStr, SimpleTypes
-
-# Keep ResourceIdStr, ResourceType, ResourceVersionIdStr in place for backwards compat with <=ISO8
+from inmanta.types import ArgumentTypes, JsonType
+from inmanta.types import ResourceIdStr as ResourceIdStr  # Keep in place for backwards compat with <=ISO8
+from inmanta.types import ResourceType as ResourceType  # Keep in place for backwards compat with <=ISO8
+from inmanta.types import ResourceVersionIdStr as ResourceVersionIdStr  # Keep in place for backwards compat with <=ISO8
+from inmanta.types import SimpleTypes
 
 
 def api_boundary_datetime_normalizer(value: datetime.datetime) -> datetime.datetime:

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -21,10 +21,10 @@ from copy import copy
 from typing import Callable, Union
 
 # Keep UnsetException, UnknownException and AttributeNotFound in place for backward compat with <iso8
-from inmanta.ast import AttributeNotFound as AttributeNotFound  # noqa F401
+from inmanta.ast import AttributeNotFound as AttributeNotFound
 from inmanta.ast import NotFoundException, RuntimeException
 from inmanta.ast import UnknownException as UnknownException
-from inmanta.ast import UnsetException as UnsetException
+from inmanta.ast import UnsetException as UnsetException  # noqa F401
 from inmanta.execute.util import NoneValue, Unknown
 from inmanta.stable_api import stable_api
 from inmanta.types import PrimitiveTypes

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -21,7 +21,10 @@ from copy import copy
 from typing import Callable, Union
 
 # Keep UnsetException, UnknownException and AttributeNotFound in place for backward compat with <iso8
-from inmanta.ast import AttributeNotFound, NotFoundException, RuntimeException, UnknownException, UnsetException  # noqa F401
+from inmanta.ast import AttributeNotFound as AttributeNotFound  # noqa F401
+from inmanta.ast import NotFoundException, RuntimeException
+from inmanta.ast import UnknownException as UnknownException
+from inmanta.ast import UnsetException as UnsetException
 from inmanta.execute.util import NoneValue, Unknown
 from inmanta.stable_api import stable_api
 from inmanta.types import PrimitiveTypes


### PR DESCRIPTION
# Description

Fix mypy export of tokens

see https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport

