### PR TITLE
bugfix in event propagation

### DIFF
--- a/changelogs/unreleased/scheduler-bugfix.yml
+++ b/changelogs/unreleased/scheduler-bugfix.yml
@@ -1,0 +1,4 @@
+description: event propagation bugfix in scheduler
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -1233,9 +1233,9 @@ class ResourceScheduler(TaskManager):
                     else f"Deploying because an event was received from {resource_id}"
                 ),
                 priority=priority,
-                # report no ongoing deploys because ongoing deploys can not capture the event. We desire new deploys
-                # to be scheduled, even if any are ongoing for the same intent.
-                deploying=set(),
+                # report no ongoing deploys for the given resources because ongoing deploys can not capture the event.
+                # We desire new deploys to be scheduled, even if any are ongoing for the same intent.
+                deploying=self._deploying_latest,
             )
 
     async def _get_last_non_deploying_state_for_dependencies(

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -1233,9 +1233,10 @@ class ResourceScheduler(TaskManager):
                     else f"Deploying because an event was received from {resource_id}"
                 ),
                 priority=priority,
-                # report no ongoing deploys for the given resources because ongoing deploys can not capture the event.
-                # We desire new deploys to be scheduled, even if any are ongoing for the same intent.
                 deploying=self._deploying_latest,
+                # force a new deploy to be scheduled because ongoing deploys can not capture the event.
+                # We desire new deploys to be scheduled, even if any are ongoing for the same intent.
+                force_deploy=True,
             )
 
     async def _get_last_non_deploying_state_for_dependencies(

--- a/src/inmanta/deploy/work.py
+++ b/src/inmanta/deploy/work.py
@@ -448,7 +448,7 @@ class ScheduledWork:
 
         # lookup caches for visited nodes
         # queued or running, pre-populate with in-progress deploys
-        queued: set[ResourceIdStr] = set(deploying) if not force_deploy else (deploying - resources)
+        queued: set[ResourceIdStr] = set(deploying) if not force_deploy else set(deploying - resources)
         not_scheduled: set[ResourceIdStr] = set()
 
         # Bump the priority of (non-stale) deploying tasks. This will only increase the priority of propagated events

--- a/src/inmanta/deploy/work.py
+++ b/src/inmanta/deploy/work.py
@@ -422,6 +422,7 @@ class ScheduledWork:
         deploying: Optional[Set[ResourceIdStr]] = None,
         added_requires: Optional[Mapping[ResourceIdStr, Set[ResourceIdStr]]] = None,
         dropped_requires: Optional[Mapping[ResourceIdStr, Set[ResourceIdStr]]] = None,
+        force_deploy: bool = False,
     ) -> None:
         """
         Add deploy tasks for the given resources. Additionally update the scheduled work state to reflect the new model state
@@ -436,6 +437,7 @@ class ScheduledWork:
             (it will still ensure they are scheduled if they have gotten new dependencies).
         :param added_requires: Requires edges that were added since the previous state update, if any.
         :param dropped_requires: Requires edges that were removed since the previous state update, if any.
+        :param force_deploy: Force the deploy of the given resources, even if a deploy is already running for the same intent.
         """
         deploying = deploying if deploying is not None else set()
         added_requires = added_requires if added_requires is not None else {}
@@ -445,7 +447,8 @@ class ScheduledWork:
         maybe_runnable: set[ResourceIdStr] = set()
 
         # lookup caches for visited nodes
-        queued: set[ResourceIdStr] = set(deploying)  # queued or running, pre-populate with in-progress deploys
+        # queued or running, pre-populate with in-progress deploys
+        queued: set[ResourceIdStr] = set(deploying) if not force_deploy else (deploying - resources)
         not_scheduled: set[ResourceIdStr] = set()
 
         # Bump the priority of (non-stale) deploying tasks. This will only increase the priority of propagated events

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -1277,6 +1277,85 @@ async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal)
     assert agent.executor_manager.executors["agent2"].execute_count == 3
     assert agent.executor_manager.executors["agent3"].execute_count == 0
 
+    ###########################################################################################
+    # Verify resources wait for all dependencies to finish when they receive an event (#8514) #
+    ###########################################################################################
+    agent.executor_manager.reset_executor_counters()
+
+    # set up initial state: have rid3 depend on both other resources
+    resources = make_resources(
+        r1_value=1,
+        r2_value=1,
+        r3_value=1,
+        requires={
+            rid3: [rid1, rid2],
+        },
+        r1_send_event=True,
+        r2_send_event=False,
+    )
+    await agent.scheduler._new_version(18, resources, make_requires(resources))
+    await retry_limited_fast(lambda: rid2 in executor2.deploys)
+    executor2.deploys[rid2].set_result(const.HandlerResourceState.deployed)
+    await retry_limited_fast(lambda: len(agent.scheduler._work.agent_queues._in_progress) == 0)
+    assert len(agent.scheduler._work._waiting) == 0
+    assert len(agent.scheduler._work.agent_queues.queued()) == 0
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 1
+    assert agent.executor_manager.executors["agent3"].execute_count == 1
+
+    # release a change for rid2 to get it in a deploying state
+    resources = make_resources(
+        r1_value=1,
+        r2_value=2,
+        r3_value=1,
+        requires={
+            rid3: [rid1, rid2],
+        },
+        r1_send_event=True,
+        r2_send_event=False,
+    )
+    await agent.scheduler._new_version(19, resources, make_requires(resources))
+    await retry_limited_fast(lambda: rid2 in executor2.deploys)
+    # leave it hanging in deploying state for now. Assert that all else is stable
+    assert agent.scheduler._work.agent_queues._in_progress.keys() == {tasks.Deploy(resource=rid2)}
+    assert len(agent.scheduler._work.agent_queues.queued()) == 0
+    assert len(agent.scheduler._work._waiting) == 0
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 1
+    assert agent.executor_manager.executors["agent3"].execute_count == 1
+
+    # release a change for rid1
+    resources = make_resources(
+        r1_value=2,
+        r2_value=2,
+        r3_value=1,
+        requires={
+            rid3: [rid1, rid2],
+        },
+        r1_send_event=True,
+        r2_send_event=False,
+    )
+    await agent.scheduler._new_version(20, resources, make_requires(resources))
+    # wait until rid1 is done
+    await retry_limited_fast(lambda: agent.executor_manager.executors["agent1"].execute_count == 2)
+    # verify that rid2 is still in a deploying state
+    assert rid2 in executor2.deploys
+    assert agent.scheduler._work.agent_queues._in_progress.keys() == {tasks.Deploy(resource=rid2)}
+    # verify that rid3 got the event and is waiting for rid2
+    assert agent.scheduler._work._waiting.keys() == {rid3}
+    assert agent.scheduler._work._waiting[rid3].blocked_on == {rid2}
+    assert agent.scheduler._work._waiting[rid3].reason == f"Deploying because an event was received from {rid1}"
+
+    # finish rid2 deploy, assert end condition
+    executor2.deploys[rid2].set_result(const.HandlerResourceState.deployed)
+    await retry_limited_fast(lambda: agent.executor_manager.executors["agent3"].execute_count == 2)
+    assert len(agent.scheduler._work.agent_queues._in_progress) == 0
+    assert len(agent.scheduler._work.agent_queues.queued()) == 0
+    assert len(agent.scheduler._work._waiting) == 0
+    assert agent.executor_manager.executors["agent1"].execute_count == 2
+    assert agent.executor_manager.executors["agent2"].execute_count == 2
+    assert agent.executor_manager.executors["agent3"].execute_count == 2
+
 
 async def test_receive_events(agent: TestAgent, make_resource_minimal):
     """


### PR DESCRIPTION
# Description

Bugfix in event propagation. We had a special case for sending events where we set `deploying=set()` in order to force the receiving resource to be scheduled, even if it happens to already be running. But this also hid any other resources that are running. In other words, if another dependency of the receiving resource happens to be running, it becomes invisible and the receiving resource will not wait for it. It will then see that resource in the available state and skip.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
