### PR TITLE
changed default for InmantaBootloader's logging config argument

### DIFF
--- a/changelogs/unreleased/bootloader-logging-config-default.yml
+++ b/changelogs/unreleased/bootloader-logging-config-default.yml
@@ -1,0 +1,4 @@
+description: "Changed default for InmantaBootloader's logging config argument"
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -99,7 +99,7 @@ def start_server(options: argparse.Namespace) -> None:
     tracing.configure_logfire("server")
     util.ensure_event_loop()
 
-    ibl = InmantaBootloader()
+    ibl = InmantaBootloader(configure_logging=False)
 
     setup_signal_handlers(ibl.stop)
 
@@ -900,7 +900,7 @@ def default_logging_config(options: argparse.Namespace) -> None:
 
     if options.cmd == "server":
         # Upgrade with extensions
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=False)
         ibl.start_loggers_for_extensions(component_config)
 
     assert component_config._loaded_config is not None  # make mypy happy
@@ -922,7 +922,7 @@ def default_logging_config(options: argparse.Namespace) -> None:
 def print_versions_installed_components_and_exit() -> None:
     # coroutine to make sure event loop is running for server slices
     async def print_status() -> None:
-        bootloader = InmantaBootloader()
+        bootloader = InmantaBootloader(configure_logging=False)
         app_context = bootloader.load_slices()
         product_metadata = app_context.get_product_metadata()
         extension_statuses = app_context.get_extension_statuses()

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -82,10 +82,11 @@ class InmantaBootloader:
     # Cache field for available extensions
     AVAILABLE_EXTENSIONS: Optional[dict[str, str]] = None
 
-    def __init__(self, configure_logging: bool = False) -> None:
+    def __init__(self, *, configure_logging: bool = True) -> None:
         """
         :param configure_logging: This config option is used by the tests to configure the logging framework.
                                   In normal execution, the logging framework is configured by the app.py
+                                  Defaults to true for backwards compatibility.
         """
         self.restserver = Server()
         self.started = False

--- a/tests/test_extension_loading.py
+++ b/tests/test_extension_loading.py
@@ -286,7 +286,7 @@ async def test_register_setting() -> None:
 
     config.server_enabled_extensions.set("testlogextender")
     with splice_extension_in("test_module_path"):
-        ibl = InmantaBootloader()
+        ibl = InmantaBootloader(configure_logging=False)
         ibl.start_loggers_for_extensions()
         logging.info("This is a log line")
     assert "TEST TEST TEST" in io.getvalue()


### PR DESCRIPTION
# Description

This new parameter was breaking all extension pipelines because they call the bootloader without arguments. The current implementation then breaks later on when `get_current_instance()` is called.

I'm not sure if this is the proper solution, but it's the cheapest to get the builds unstuck until it can be properly considered after the holidays.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
