### PR TITLE
Fix race condition in test_redeploy_after_dependency_recovered

### DIFF
--- a/changelogs/unreleased/fix-race-test-redeploy-after-dependency-recovered.yml
+++ b/changelogs/unreleased/fix-race-test-redeploy-after-dependency-recovered.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix race condition in test_redeploy_after_dependency_recovered test case."
+change-type: patch
+destination-branches: [master]


### PR DESCRIPTION
# Description

Fix race condition in `test_redeploy_after_dependency_recovered` test case.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
