### PR TITLE
Fix test that broke due to missing CompianceStatus ORPHAN

### DIFF
--- a/changelogs/unreleased/fix-broken-test-orphan-status-missing.yml
+++ b/changelogs/unreleased/fix-broken-test-orphan-status-missing.yml
@@ -1,0 +1,4 @@
+---
+description: Fix test that broke due to missing CompianceStatus ORPHAN.
+change-type: patch
+destination-branches: [master]

--- a/tests/db/migration_tests/test_v202410310_to_v202411140.py
+++ b/tests/db/migration_tests/test_v202410310_to_v202411140.py
@@ -98,7 +98,7 @@ async def test_add_new_resource_status_column(
         # would require an expensive query in the database migration script.
         deployment_result=state.DeploymentResult.NEW,
         blocked_status=state.BlockedStatus.NO,
-        expected_compliance_status=ComplianceStatus.ORPHAN,
+        expected_compliance_status=None,
     )
     assert_resource_persistent_state(
         resource_state_by_resource_id[inmanta.types.ResourceIdStr("test::Resource[agent1,key=key7]")],


### PR DESCRIPTION
# Description

Fix test that broke due to missing CompianceStatus ORPHAN.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x]  Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
