### PR TITLE
Fix linkcheck breaks on scroll to text fragment anchor

### DIFF
--- a/changelogs/unreleased/ignore-scroll-to-text-fragment-anchor.yml
+++ b/changelogs/unreleased/ignore-scroll-to-text-fragment-anchor.yml
@@ -1,0 +1,4 @@
+---
+description: Make the link check ignore scroll to text fragment anchors.
+change-type: patch
+destination-branches: [master]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 # serve to show the default.
 import importlib.metadata
 import shutil
-import sys, os, datetime
+import sys, os, datetime, re
 from importlib.metadata import PackageNotFoundError
 from sphinx.errors import ConfigError
 
@@ -389,6 +389,11 @@ linkcheck_ignore = [
     '../../reference/modules/std.html#std.validate_type',
     '../reference/modules/std.html#std.getfact',
     r'https://github.com/inmanta/examples/tree/master/Networking/SR%20Linux#user-content-sr-linux-topology',
+]
+
+linkcheck_anchors_ignore=[
+    # Ignore Scroll To Text Fragment anchors, because they are not supposed to be present in the HTML body.
+    f"{re.escape(':~:text=')}.*",
 ]
 
 graphviz_output_format = "svg"


### PR DESCRIPTION
# Description

[This PR](https://github.com/inmanta/inmanta-core/commit/0f64a0b842c5800017d3413987444515e42996ff) introduced a link that uses a scroll to text fragment anchor (`https://raw.githubusercontent.com/inmanta/inmanta/refs/heads/master/docker/native_image/Dockerfile#:~:text=ENV`). The link check fails on this because the anchor is not present in the HTML body. Since this is intentional for these types of anchors, the config now ignores these anchors.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [ ] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
