### PR TITLE
stop persisting transient state in database

### DIFF
--- a/changelogs/unreleased/8541-stop-persisting-transient.yml
+++ b/changelogs/unreleased/8541-stop-persisting-transient.yml
@@ -1,0 +1,5 @@
+description: "No longer persist transient state in the database (for now)"
+issue-nr: 8541
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4489,7 +4489,7 @@ class ResourcePersistentState(BaseDocument):
                 resource_details.attribute_hash,
                 resource_state.status is state.ComplianceStatus.UNDEFINED,
                 False,
-                *([resource_state.blocked.name] if update_blocked_state else []),
+                *([resource_state.blocked.db_value().name] if update_blocked_state else []),
             )
             for resource_id, (resource_state, resource_details) in intent.items()
         ]
@@ -5537,7 +5537,8 @@ class Resource(BaseDocument):
         last_produced_events: Optional[datetime.datetime] = None,
         last_deployed_attribute_hash: Optional[str] = None,
         connection: Optional[asyncpg.connection.Connection] = None,
-        state: Optional[state.ResourceState] = None,
+        # TODO[#8541]: accept state.ResourceState and write blocked status as well
+        deployment_result: Optional[state.DeploymentResult] = None,
     ) -> None:
         """Update the data in the resource_persistent_state table"""
         args = ArgumentCollector(2)
@@ -5551,10 +5552,8 @@ class Resource(BaseDocument):
             "last_deployed_version": last_deployed_version,
         }
         query_parts = [f"{k}={args(v)}" for k, v in invalues.items() if v is not None]
-        if state:
-            query_parts.append(f"deployment_result={args(state.deployment_result.name)}")
-            # TODO: split blocked status field to make raceless
-            query_parts.append(f"blocked_status={args(state.blocked.name)}")
+        if deployment_result:
+            query_parts.append(f"deployment_result={args(deployment_result.name)}")
         if not query_parts:
             return
         query = f"UPDATE public.resource_persistent_state SET {','.join(query_parts)} WHERE environment=$1 and resource_id=$2"

--- a/src/inmanta/deploy/persistence.py
+++ b/src/inmanta/deploy/persistence.py
@@ -271,7 +271,7 @@ class ToDbUpdateManager(StateUpdateManager):
                     last_deployed_version=resource_id_parsed.version,
                     last_deployed_attribute_hash=resource.attribute_hash,
                     last_non_deploying_status=const.NonDeployingResourceState(status),
-                    state=state,
+                    deployment_result=state.deployment_result if state is not None else None,
                     **extra_datetime_fields,
                     connection=connection,
                 )

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -1203,7 +1203,7 @@ class ResourceScheduler(TaskManager):
             # These resources might be able to progress now -> unblock them in addition to sending the event
             self._state.dirty.update(recovery_listeners)
             for skipped_dependent in recovery_listeners:
-                # TODO[#8541]: this is never written!
+                # TODO[#8541]: persist in database
                 self._state.resource_state[skipped_dependent].blocked = BlockedStatus.NO
 
         all_listeners: Set[ResourceIdStr] = event_listeners | recovery_listeners

--- a/src/inmanta/deploy/state.py
+++ b/src/inmanta/deploy/state.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Set
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Self
 
 import asyncpg
 
@@ -146,6 +146,17 @@ class BlockedStatus(StrEnum):
     YES = enum.auto()
     NO = enum.auto()
     TRANSIENT = enum.auto()
+
+    def db_value(self: "BlockedStatus") -> "BlockedStatus":
+        """
+        Convert this blocked status to one appropriate for writing to the database.
+
+        This method exists to work around #8541 until a proper solution can be devised.
+        """
+        # TODO[#8541]: also persist TRANSIENT in database
+        if self is BlockedStatus.TRANSIENT:
+            return BlockedStatus.NO
+        return self
 
 
 @dataclass

--- a/src/inmanta/deploy/state.py
+++ b/src/inmanta/deploy/state.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Set
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Optional, Self
+from typing import TYPE_CHECKING, Optional
 
 import asyncpg
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -875,6 +875,8 @@ async def agent_factory(server, monkeypatch) -> AsyncIterator[Callable[[uuid.UUI
                 await agent.stop_working()
                 the_state = copy.deepcopy(dict(agent.scheduler._state.resource_state))
                 for r, state in the_state.items():
+                    # TODO[#8541]: also persist TRANSIENT in database
+                    state.blocked = state.blocked.db_value()
                     print(r, state)
                 monkeypatch.setattr(agent.scheduler._work.agent_queues, "_new_agent_notify", lambda x: x)
                 await agent.start_working()

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -320,7 +320,7 @@ async def test_basics(agent, resource_container, clienthelper, client, environme
                 is_undefined=False,
                 is_orphan=False,
                 deployment_result=deployment_result,
-                blocked_status=blocked_status,
+                blocked_status=blocked_status.db_value(),
                 expected_compliance_status=compliance_status,
             )
 
@@ -366,7 +366,7 @@ async def test_basics(agent, resource_container, clienthelper, client, environme
                 is_undefined=False,
                 is_orphan=False,
                 deployment_result=deployment_result,
-                blocked_status=blocked_status,
+                blocked_status=blocked_status.db_value(),
                 expected_compliance_status=compliance_status,
             )
     # Unreleased resources are not present in the resource_persistent_state table.
@@ -795,7 +795,7 @@ async def test_fail(resource_container, client, agent, environment, clienthelper
             is_undefined=False,
             is_orphan=False,
             deployment_result=DeploymentResult.FAILED if status == "failed" else DeploymentResult.SKIPPED,
-            blocked_status=BlockedStatus.NO if status == "failed" else BlockedStatus.TRANSIENT,
+            blocked_status=BlockedStatus.NO if status == "failed" else BlockedStatus.TRANSIENT.db_value(),
             expected_compliance_status=ComplianceStatus.NON_COMPLIANT,
         )
 
@@ -1007,7 +1007,7 @@ async def test_reload(server, client, clienthelper, environment, resource_contai
         is_undefined=False,
         is_orphan=False,
         deployment_result=DeploymentResult.SKIPPED if dep_state.name in {"skip", "fail"} else DeploymentResult.DEPLOYED,
-        blocked_status=BlockedStatus.TRANSIENT if dep_state.name in {"skip", "fail"} else BlockedStatus.NO,
+        blocked_status=BlockedStatus.TRANSIENT.db_value() if dep_state.name in {"skip", "fail"} else BlockedStatus.NO,
         expected_compliance_status=(
             ComplianceStatus.NON_COMPLIANT if dep_state.name in {"skip", "fail"} else ComplianceStatus.COMPLIANT
         ),
@@ -1180,7 +1180,7 @@ async def test_resource_status(resource_container, server, client, clienthelper,
         is_undefined=False,
         is_orphan=False,
         deployment_result=DeploymentResult.SKIPPED,
-        blocked_status=BlockedStatus.TRANSIENT,
+        blocked_status=BlockedStatus.TRANSIENT.db_value(),
         expected_compliance_status=ComplianceStatus.NON_COMPLIANT,
     )
     assert_resource_persistent_state(


### PR DESCRIPTION
# Description

Turns out we had some races on the persisting of the transient state. We decided that we'd leave them out of the database for now to prevent these races. This should have no adverse effects, except that the field will never be reported to the user. At initialization time, we'll simply read `NO` for all previously transiently blocked resources, causing us to deploy them once more (which is fine, if not optimal).

first part of #8541

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
