### PR TITLE
Fix race condition in  queue count test case

### DIFF
--- a/changelogs/unreleased/fix-race-queue-count-test-case.yml
+++ b/changelogs/unreleased/fix-race-queue-count-test-case.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix race condition in the `test_compileservice_queue_count_on_trx_based_api` test case."
+change-type: patch
+destination-branches: [master, iso7]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1316,8 +1316,11 @@ async def test_compileservice_queue_count_on_trx_based_api(mocked_compiler_servi
             assert len(compiler_service._env_to_compile_task) == 0
     # Transaction committed
     await compiler_service.notify_compile_request_committed(compile_id)
-    assert compiler_service._queue_count_cache == 1
+    # Wait until the compile request is picked up the compiler service.
+    await retry_limited(lambda: compiler_service._queue_count_cache == 0, timeout=10)
     assert len(compiler_service._env_to_compile_task) == 1
+    compile_obj = await data.Compile.get_by_id(compile_id)
+    assert compile_obj.started is not None
 
     await run_compile_and_wait_until_compile_is_done(compiler_service, mocked_compiler_service_block, env.id)
     assert len(compiler_service._env_to_compile_task) == 0


### PR DESCRIPTION
# Description

Fix race condition in the `test_compileservice_queue_count_on_trx_based_api` test case.

The `_queue_count_cache` parameter is incremented when `notify_compile_request_committed()` is called and immediately decremented when the compile is picked up by the compiler service. This results in a race condition that gives the following error:

```
02:47:36     async def test_compileservice_queue_count_on_trx_based_api(mocked_compiler_service_block, server, client, environment):
02:47:36         """
02:47:36         Verify that the `_queue_count_cache` is not incremented and that the compile is not scheduled until the
02:47:36         `notify_compile_request_committed()` method is called.
02:47:36         """
02:47:36         env = await data.Environment.get_by_id(environment)
02:47:36         compiler_service: CompilerService = server.get_slice(SLICE_COMPILER)
02:47:36     
02:47:36         async with data.Environment.get_connection() as connection:
02:47:36             async with connection.transaction():
02:47:36                 remote_id1 = uuid.uuid4()
02:47:36                 compile_id, warnings = await compiler_service.request_recompile(
02:47:36                     env=env,
02:47:36                     force_update=False,
02:47:36                     do_export=False,
02:47:36                     remote_id=remote_id1,
02:47:36                     connection=connection,
02:47:36                     in_db_transaction=True,
02:47:36                 )
02:47:36                 assert compile_id is not None, warnings
02:47:36                 assert compiler_service._queue_count_cache == 0
02:47:36                 assert len(compiler_service._env_to_compile_task) == 0
02:47:36         # Transaction committed
02:47:36         await compiler_service.notify_compile_request_committed(compile_id)
02:47:36 >       assert compiler_service._queue_count_cache == 1
02:47:36 E       assert 0 == 1
02:47:36 E        +  where 0 = <inmanta.server.services.compilerservice.CompilerService object at 0x7fb82f1f75f0>._queue_count_cache
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
