### PR TITLE
Add output option to print-default-logging-config command

### DIFF
--- a/changelogs/unreleased/add-output-option-to-print-log-config.yml
+++ b/changelogs/unreleased/add-output-option-to-print-log-config.yml
@@ -1,4 +1,4 @@
 ---
-description: "Add the --output option to the print-default-logging-config command"
+description: "Make it mandatory to pass an output file to the output-default-logging-config command"
 change-type: patch
 destination-branches: [master]

--- a/changelogs/unreleased/add-output-option-to-print-log-config.yml
+++ b/changelogs/unreleased/add-output-option-to-print-log-config.yml
@@ -1,0 +1,4 @@
+---
+description: "Add the --output option to the print-default-logging-config command"
+change-type: patch
+destination-branches: [master]

--- a/docs/administrators/logging.rst
+++ b/docs/administrators/logging.rst
@@ -128,7 +128,7 @@ Converting to fine grained configuration
 
 A tool is provided to convert the existing coarse grained configuration into a config file.
 
-For example, to convert the config for a component, take the command you use to start it, then put `print-default-logging-config` before the `server`, `compiler` or `scheduler`:
+For example, to convert the config for a component, take the command you use to start it, then put `print-default-logging-config --output <output_file>` before the `server`, `compiler` or `scheduler`:
 
 .. code-block:: sh
 
@@ -136,7 +136,9 @@ For example, to convert the config for a component, take the command you use to 
         --log-file /var/log/inmanta/server.log \
         --log-file-level INFO \
         --timed-logs \
-        print-default-logging-config server
+        print-default-logging-config \
+        --output config.yml \
+        server
 
 
 

--- a/docs/administrators/logging.rst
+++ b/docs/administrators/logging.rst
@@ -128,7 +128,7 @@ Converting to fine grained configuration
 
 A tool is provided to convert the existing coarse grained configuration into a config file.
 
-For example, to convert the config for a component, take the command you use to start it, then put `print-default-logging-config --output <output_file>` before the `server`, `compiler` or `scheduler`:
+For example, to convert the config for a component, use the `output-default-logging-config` command.
 
 .. code-block:: sh
 
@@ -136,9 +136,9 @@ For example, to convert the config for a component, take the command you use to 
         --log-file /var/log/inmanta/server.log \
         --log-file-level INFO \
         --timed-logs \
-        print-default-logging-config \
-        --output config.yml \
-        server
+        output-default-logging-config \
+        --component server \
+        config.yml
 
 
 

--- a/misc/scheduler_log.yml.tmpl
+++ b/misc/scheduler_log.yml.tmpl
@@ -1,4 +1,4 @@
-# Generated using inmanta -c /etc/inmanta/inmanta.cfg --log-file-level DEBUG --timed-logs print_default_logging_config scheduler
+# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file-level DEBUG --timed-logs print_default_logging_config --output scheduler_log.yml.tmpl scheduler
 formatters:
   core_console_formatter:
     # Console formatter with coloring

--- a/misc/scheduler_log.yml.tmpl
+++ b/misc/scheduler_log.yml.tmpl
@@ -1,4 +1,4 @@
-# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file-level DEBUG --timed-logs print_default_logging_config --output scheduler_log.yml.tmpl scheduler
+# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file-level DEBUG --timed-logs output-default-logging-config --component scheduler scheduler_log.yml.tmpl
 formatters:
   core_console_formatter:
     # Console formatter with coloring

--- a/misc/server_log.yml
+++ b/misc/server_log.yml
@@ -1,4 +1,4 @@
-# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs print_default_logging_config --output server_log.yml server
+# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs output-default-logging-config --component server server_log.yml
 formatters:
   core_console_formatter:
     # Console formatter with coloring

--- a/misc/server_log.yml
+++ b/misc/server_log.yml
@@ -1,4 +1,4 @@
-# Generated using inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs print_default_logging_config server
+# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs print_default_logging_config --output server_log.yml server
 formatters:
   core_console_formatter:
     # Console formatter with coloring

--- a/misc/server_lsm_log.yml
+++ b/misc/server_lsm_log.yml
@@ -1,4 +1,4 @@
-# Generated using inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs print_default_logging_config server
+# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs print_default_logging_config --output server_lsm_log.yml server
 formatters:
   core_console_formatter:
     # Console formatter with coloring.

--- a/misc/server_lsm_log.yml
+++ b/misc/server_lsm_log.yml
@@ -1,4 +1,4 @@
-# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs print_default_logging_config --output server_lsm_log.yml server
+# Generated using: inmanta -c /etc/inmanta/inmanta.cfg --log-file /var/log/inmanta/server.log --log-file-level 2 --timed-logs output-default-logging-config --component server server_lsm_log.yml
 formatters:
   core_console_formatter:
     # Console formatter with coloring.

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -931,7 +931,7 @@ def default_log_config_parser(parser: ArgumentParser, parent_parsers: abc.Sequen
     parser.add_argument(
         "output_file",
         help="The file where the logging config should be saved. For the scheduler component, this file must end with a .tmpl"
-             " suffix, because a logging configuration template will be generated.",
+        " suffix, because a logging configuration template will be generated.",
     )
 
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -930,7 +930,8 @@ def default_log_config_parser(parser: ArgumentParser, parent_parsers: abc.Sequen
     )
     parser.add_argument(
         "output_file",
-        help="The file where the logging config should be saved.",
+        help="The file where the logging config should be saved. For the scheduler component, this file must end with a .tmpl"
+             " suffix, because a logging configuration template will be generated.",
     )
 
 

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -916,8 +916,14 @@ def cmd_parser() -> argparse.ArgumentParser:
 
 
 def default_log_config_parser(parser: ArgumentParser, parent_parsers: abc.Sequence[ArgumentParser]) -> None:
-    subparser = parser.add_subparsers(title="subcommand", dest="cmd")
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="file",
+        help="The file to which the logging config has to be written.",
+    )
 
+    subparser = parser.add_subparsers(title="subcommand", dest="cmd")
     subparser.add_parser(
         "server",
         help="Output default log file for the server, given the current configuration file and options",
@@ -989,7 +995,11 @@ def default_logging_config(options: argparse.Namespace) -> None:
             for context_var in context_vars:
                 raw_dump = raw_dump.replace(f"{place_holder}{context_var}{place_holder}", "{" + context_var + "}")
 
-        print(raw_dump)
+        if options.file is not None:
+            with open(options.file, "w") as fh:
+                fh.write(raw_dump)
+        else:
+            print(raw_dump)
     finally:
         # Revert this env var back to its original state
         if original_force_tty is None:

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -63,7 +63,7 @@ from inmanta.compiler import do_compile
 from inmanta.config import Config, Option
 from inmanta.const import ALL_LOG_CONTEXT_VARS, EXIT_START_FAILED, LOG_CONTEXT_VAR_ENVIRONMENT
 from inmanta.export import cfg_env
-from inmanta.logging import InmantaLoggerConfig, Options, _is_on_tty
+from inmanta.logging import InmantaLoggerConfig, _is_on_tty
 from inmanta.server import config as opt
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.services.databaseservice import initialize_database_connection_pool

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -948,6 +948,9 @@ def default_log_config_parser(parser: ArgumentParser, parent_parsers: abc.Sequen
     parser_config=default_log_config_parser,
 )
 def default_logging_config(options: argparse.Namespace) -> None:
+    if options.file is not None and os.path.exists(options.file):
+        raise Exception(f"The requested output location already exists: {options.file}")
+
     # Because we want to have contex vars in the files,
     #   but the file can also contain other f-string formatters, this is a bit tricky.
     # We want to be able to

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -923,12 +923,6 @@ def default_log_config_parser(parser: ArgumentParser, parent_parsers: abc.Sequen
         help="The component for which the logging configuration has to be generated.",
     )
     parser.add_argument(
-        "-e",
-        dest="environment",
-        help="The environment this logging config belongs to. This parameter must be provided when the"
-        " `--component scheduler` option is set.",
-    )
-    parser.add_argument(
         "output_file",
         help="The file where the logging config should be saved. For the scheduler component, this file must end with a .tmpl"
         " suffix, because a logging configuration template will be generated.",
@@ -947,8 +941,6 @@ def default_logging_config(options: argparse.Namespace) -> None:
         raise Exception(
             "The config being generated will be a template, but the given filename doesn't end with the .tmpl suffix."
         )
-    if options.config_for_component == "scheduler" and not options.environment:
-        raise Exception("The -e option must be set when generating the config for the scheduler component.")
 
     # Because we want to have contex vars in the files,
     #   but the file can also contain other f-string formatters, this is a bit tricky.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -626,3 +626,16 @@ async def test_print_default_logging_cmd(inmanta_config, tmp_path):
 
         with open(output_file, "r") as fh:
             assert fh.read().strip() == tty_config_stdout.strip()
+
+        # Assert we get an error if the output file already exists
+        process = await subprocess.create_subprocess_exec(*args,  stderr=subprocess.PIPE)
+        try:
+            (_, stderr) = await wait_for(process.communicate(), timeout=5)
+            assert f"The requested output location already exists: {output_file}" in stderr.decode()
+        except TimeoutError as e:
+            process.kill()
+            await process.communicate()
+            raise e
+        assert process.returncode == 1
+
+        os.remove(output_file)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -611,3 +611,18 @@ async def test_print_default_logging_cmd(inmanta_config, tmp_path):
         normal_config_stdout = stdout.decode("utf-8")
         # Assert that the outputs are equal
         assert normal_config_stdout == tty_config_stdout
+
+        # Use the --output option
+        output_file = tmp_path / "test.yml"
+        args = [sys.executable, "-m", "inmanta.app", "print-default-logging-config", "--output", output_file, component]
+        process = await subprocess.create_subprocess_exec(*args)
+        try:
+            await wait_for(process.communicate(), timeout=5)
+        except TimeoutError as e:
+            process.kill()
+            await process.communicate()
+            raise e
+        assert process.returncode == 0
+
+        with open(output_file, "r") as fh:
+            assert fh.read().strip() == tty_config_stdout.strip()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -580,7 +580,6 @@ async def test_output_default_logging_cmd(inmanta_config, tmp_path):
         else:
             output_file = str(tmp_path / f"{component}.yml")
 
-        context_var = ["-e", str(uuid.uuid4())] if component == "scheduler" else []
         args = [
             sys.executable,
             "-m",
@@ -588,7 +587,6 @@ async def test_output_default_logging_cmd(inmanta_config, tmp_path):
             "output-default-logging-config",
             "--component",
             component,
-            *context_var,
             output_file,
         ]
         process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE)
@@ -618,27 +616,6 @@ async def test_output_default_logging_cmd(inmanta_config, tmp_path):
         assert process.returncode == 1
 
         os.remove(output_file)
-
-    # Assert we get a proper error when the environment is not set when generating the logging config for the scheduler.
-    output_file = str(tmp_path / "test.yml.tmpl")
-    args = [
-        sys.executable,
-        "-m",
-        "inmanta.app",
-        "output-default-logging-config",
-        "--component",
-        "scheduler",
-        output_file,
-    ]
-    process = await subprocess.create_subprocess_exec(*args, stderr=subprocess.PIPE)
-    try:
-        (_, stderr) = await wait_for(process.communicate(), timeout=5)
-    except TimeoutError as e:
-        process.kill()
-        await process.communicate()
-        raise e
-    assert process.returncode == 1
-    assert "The -e option must be set when generating the config for the scheduler component." in stderr.decode()
 
     # Assert that the .tmpl suffix is enforced when generating the logging config for the scheduler.
     output_file = str(tmp_path / "test.yml")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -571,51 +571,27 @@ def test_logging_config_content_environment_variables(monkeypatch, capsys, tmpdi
     assert "CLI -- test" in captured.out
 
 
-async def test_print_default_logging_cmd(inmanta_config, tmp_path):
-    """
-    Test that piping to file does not change the logging config
-    """
+async def test_output_default_logging_cmd(inmanta_config, tmp_path):
+
     components = ["scheduler", "server", "compiler"]
     for component in components:
-        args = [sys.executable, "-m", "inmanta.app", "print-default-logging-config", component]
+        if component == "scheduler":
+            output_file = str(tmp_path / f"{component}.yml.tmpl")
+        else:
+            output_file = str(tmp_path / f"{component}.yml")
 
-        # Output the logging config on the CLI.
-        # Here we force ENVIRON_FORCE_TTY to be set to simulate that we are on a TTY
-        process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE, env={ENVIRON_FORCE_TTY: "yes"})
-        try:
-            (stdout, _) = await wait_for(process.communicate(), timeout=5)
-        except TimeoutError as e:
-            process.kill()
-            await process.communicate()
-            raise e
-        assert process.returncode == 0
-
-        tty_config_stdout = stdout.decode("utf-8")
-        # Assert that TTY was present
-        assert "no_color: false" in tty_config_stdout
-        assert "reset: true" in tty_config_stdout
-        assert "log_colors: null" not in tty_config_stdout
-
-        # Output the logging config on the CLI with TTY unset
-        # This is the same as piping to a file
-        assert "ENVIRON_FORCE_TTY" not in os.environ
+        context_var = ["-e", str(uuid.uuid4())] if component == "scheduler" else []
+        args = [
+            sys.executable,
+            "-m",
+            "inmanta.app",
+            "output-default-logging-config",
+            "--component",
+            component,
+            *context_var,
+            output_file,
+        ]
         process = await subprocess.create_subprocess_exec(*args, stdout=subprocess.PIPE)
-        try:
-            (stdout, _) = await wait_for(process.communicate(), timeout=5)
-        except TimeoutError as e:
-            process.kill()
-            await process.communicate()
-            raise e
-        assert process.returncode == 0
-
-        normal_config_stdout = stdout.decode("utf-8")
-        # Assert that the outputs are equal
-        assert normal_config_stdout == tty_config_stdout
-
-        # Use the --output option
-        output_file = tmp_path / "test.yml"
-        args = [sys.executable, "-m", "inmanta.app", "print-default-logging-config", "--output", output_file, component]
-        process = await subprocess.create_subprocess_exec(*args)
         try:
             await wait_for(process.communicate(), timeout=5)
         except TimeoutError as e:
@@ -625,7 +601,10 @@ async def test_print_default_logging_cmd(inmanta_config, tmp_path):
         assert process.returncode == 0
 
         with open(output_file, "r") as fh:
-            assert fh.read().strip() == tty_config_stdout.strip()
+            logging_config = fh.read()
+        assert "no_color: false" in logging_config
+        assert "reset: true" in logging_config
+        assert "log_colors: null" not in logging_config
 
         # Assert we get an error if the output file already exists
         process = await subprocess.create_subprocess_exec(*args, stderr=subprocess.PIPE)
@@ -639,3 +618,50 @@ async def test_print_default_logging_cmd(inmanta_config, tmp_path):
         assert process.returncode == 1
 
         os.remove(output_file)
+
+    # Assert we get a proper error when the environment is not set when generating the logging config for the scheduler.
+    output_file = str(tmp_path / "test.yml.tmpl")
+    args = [
+        sys.executable,
+        "-m",
+        "inmanta.app",
+        "output-default-logging-config",
+        "--component",
+        "scheduler",
+        output_file,
+    ]
+    process = await subprocess.create_subprocess_exec(*args, stderr=subprocess.PIPE)
+    try:
+        (_, stderr) = await wait_for(process.communicate(), timeout=5)
+    except TimeoutError as e:
+        process.kill()
+        await process.communicate()
+        raise e
+    assert process.returncode == 1
+    assert "The -e option must be set when generating the config for the scheduler component." in stderr.decode()
+
+    # Assert that the .tmpl suffix is enforced when generating the logging config for the scheduler.
+    output_file = str(tmp_path / "test.yml")
+    args = [
+        sys.executable,
+        "-m",
+        "inmanta.app",
+        "output-default-logging-config",
+        "--component",
+        "scheduler",
+        "-e",
+        str(uuid.uuid4()),
+        output_file,
+    ]
+    process = await subprocess.create_subprocess_exec(*args, stderr=subprocess.PIPE)
+    try:
+        (_, stderr) = await wait_for(process.communicate(), timeout=5)
+    except TimeoutError as e:
+        process.kill()
+        await process.communicate()
+        raise e
+    assert process.returncode == 1
+    assert (
+        "The config being generated will be a template, but the given filename doesn't end with the .tmpl suffix."
+        in stderr.decode()
+    )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -628,7 +628,7 @@ async def test_print_default_logging_cmd(inmanta_config, tmp_path):
             assert fh.read().strip() == tty_config_stdout.strip()
 
         # Assert we get an error if the output file already exists
-        process = await subprocess.create_subprocess_exec(*args,  stderr=subprocess.PIPE)
+        process = await subprocess.create_subprocess_exec(*args, stderr=subprocess.PIPE)
         try:
             (_, stderr) = await wait_for(process.communicate(), timeout=5)
             assert f"The requested output location already exists: {output_file}" in stderr.decode()


### PR DESCRIPTION
# Description

Add the --output option to the print-default-logging-config command.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
