### PR TITLE
delete scheduler records on environment clear

### DIFF
--- a/changelogs/unreleased/8502-delete-scheduler-on-environment-clear.yml
+++ b/changelogs/unreleased/8502-delete-scheduler-on-environment-clear.yml
@@ -1,0 +1,5 @@
+description: Delete scheduler records on environment clear
+issue-nr: 8502
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -89,6 +89,7 @@ are as follows. This list should be extended when new locks (explicit or implici
 as `A -> B`, meaning A should be locked before B in any transaction that acquires a lock on both.
 - Code -> ConfigurationModel
 - Agentprocess -> Agentinstance -> Agent
+- ResourcePersistentState -> Scheduler
 """
 
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2722,6 +2722,7 @@ class Environment(BaseDocument):
             await Resource.delete_all(environment=self.id, connection=con)
             await ConfigurationModel.delete_all(environment=self.id, connection=con)
             await ResourcePersistentState.delete_all(environment=self.id, connection=con)
+            await Scheduler.delete_all(environment=self.id, connection=con)
 
     async def get_next_version(self, connection: Optional[asyncpg.connection.Connection] = None) -> int:
         """


### PR DESCRIPTION
# Description

Make sure the scheduler table is cleared on environment clear.

@jptrindade confirmed [here](https://github.com/inmanta/inmanta-core/issues/8502#issuecomment-2569461240) that it is already covered by cascade on environment delete.

As to point 3 in the ticket, it's not relevant for the clear, because it uses separate transactions. For delete, cascading on environment is OK, because we only ever write to the scheduler table at the end of a transaction.

closes #8502

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
