### PR TITLE
make sure transaction does not wrap scheduler lock

### DIFF
--- a/changelogs/unreleased/8541-bugfix-interleaving-lock-and-transaction.yml
+++ b/changelogs/unreleased/8541-bugfix-interleaving-lock-and-transaction.yml
@@ -1,0 +1,5 @@
+description: "Make sure transaction does not wrap scheduler lock"
+issue-nr: 8541
+change-type: patch
+destination-branches:
+  - master


### PR DESCRIPTION
# Description

This PR addresses a concurrency issue that I forgot about in #8560: the transaction must not wrap the scheduler lock, because then parts that have been written explicitly under the lock, would only really be persisted when the transaction commits later, defeating the purpose of writing it under the lock in the first place.

Now that (since #8560) we no longer write the transient state, we can afford to simply write all state outside of the lock (which was part of the motivation for #8560).

Since the diff is quite large for such a conceptually small change, I'll make sure to mark all effective changes with a comment on the diff. You can safely assume all else has remained unchanged, apart from indentation.

part of #8541 (first stage)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
