### PR TITLE
Add MLF to stable api

### DIFF
--- a/changelogs/unreleased/multi-line-formatter-to-stable-api.yml
+++ b/changelogs/unreleased/multi-line-formatter-to-stable-api.yml
@@ -1,0 +1,6 @@
+description: Added MultiLineFormatter to the stable api
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"
+

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -496,6 +496,7 @@ class LoggingConfigBuilder:
             "keep_logger_names": keep_logger_names,
         }
 
+
 @stable_api
 def convert_inmanta_log_level(inmanta_log_level: str, cli: bool = False) -> int:
     """

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -496,7 +496,7 @@ class LoggingConfigBuilder:
             "keep_logger_names": keep_logger_names,
         }
 
-
+@stable_api
 def convert_inmanta_log_level(inmanta_log_level: str, cli: bool = False) -> int:
     """
     Convert the given Inmanta log level to the corresponding Python log level.

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -901,6 +901,7 @@ class InmantaLoggerConfig:
         self._apply_logging_config(complete_config)
 
 
+@stable_api
 class MultiLineFormatter(colorlog.ColoredFormatter):
     """
     Formatter for multi-line log records.


### PR DESCRIPTION
# Description

Added multi line formatter to stable api, this is required as it is used in the config file 


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
