### PR TITLE
Log warning if old logging configuration option is ignored

### DIFF
--- a/changelogs/unreleased/8338-log-warning-if-old-logging-configuration-option-is-ignored.yml
+++ b/changelogs/unreleased/8338-log-warning-if-old-logging-configuration-option-is-ignored.yml
@@ -1,0 +1,5 @@
+---
+description: Log warning if old logging configuration option is ignored
+issue-nr: 8338
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -803,7 +803,7 @@ class InmantaLoggerConfig:
                 "keep_logger_names": "--keep-logger-names",
             }
             ignored_options = [
-                f"{value} {options.__getattribute__(key)}" for key, value in option_to_cli.items() if key in options
+                f"{value} {getattr(options, key)}" for key, value in option_to_cli.items() if key in options
             ]
             if len(ignored_options) != 0:
                 return ", ".join(ignored_options)

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -792,12 +792,25 @@ class InmantaLoggerConfig:
         :param context: context variables to use if the config file is a template
         """
 
-        def user_defined_options() -> dict[str, bool]:
+        def user_defined_options() -> Optional[str]:
             """
-            Returns a dictionary with the options (excluding "verbose" and "logging_config") that were set by the user
+            Returns a string with the options (excluding "--verbose" and "--logging-config") that were set by the user
             """
             ignore_keys = ["verbose", "logging_config"]
-            return {key: value for key, value in options.__dict__.items() if key not in ignore_keys and key in options}
+
+            option_to_cli = {
+                "log_file": "--log-file",
+                "log_file_level": "--log-file-level",
+                "timed": "--timed-logs",
+                "keep_logger_names": "--keep-logger-names",
+            }
+            ignored_options = [
+                f"{option_to_cli[key]} {value}"
+                for key, value in options.__dict__.items()
+                if key not in ignore_keys and key in options
+            ]
+            if len(ignored_options) != 0:
+                return ", ".join(ignored_options)
 
         if self._options_applied:
             raise Exception("Options can only be applied once to a handler.")

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -285,10 +285,10 @@ class Options(Namespace):
     """
 
     log_file: Optional[str] = None
-    log_file_level: Optional[str] = None
+    log_file_level: str = "INFO"
     verbose: int = 1
-    timed: Optional[bool] = None
-    keep_logger_names: Optional[bool] = None
+    timed: bool = False
+    keep_logger_names: bool = False
     logging_config: Optional[str] = None
 
 
@@ -343,15 +343,6 @@ class LoggingConfigBuilder:
         )
         return logging_config_core
 
-    def set_defaults_for_options(self, options: Options) -> Options:
-        """
-        Sets the default value of fields that were not set by the user and have a default value
-        """
-        options.log_file_level = options.log_file_level if options.log_file_level is not None else "INFO"
-        options.timed = options.timed if options.timed is not None else False
-        options.keep_logger_names = options.keep_logger_names if options.keep_logger_names is not None else False
-        return options
-
     def get_logging_config_from_options(
         self,
         stream: TextIO,
@@ -373,8 +364,6 @@ class LoggingConfigBuilder:
         handler_root_logger: str
         log_level: int
 
-        # Set the default values for fields that were not set by the user
-        options = self.set_defaults_for_options(options)
         log_file_cli_option = options.log_file
 
         short_names = False
@@ -396,7 +385,6 @@ class LoggingConfigBuilder:
 
         # Shared config
         if log_file_cli_option:
-            assert options.log_file_level is not None  # make mypy happy, always set in set_defaults_for_options()
             log_level = convert_inmanta_log_level(options.log_file_level)
             handler_root_logger = f"{component}_handler" if component is not None else "root_handler"
             handlers[handler_root_logger] = {
@@ -809,7 +797,7 @@ class InmantaLoggerConfig:
             Returns a dictionary with the options (excluding "verbose" and "logging_config") that were set by the user
             """
             ignore_keys = ["verbose", "logging_config"]
-            return {key: value for key, value in options.__dict__.items() if key not in ignore_keys and value is not None}
+            return {key: value for key, value in options.__dict__.items() if key not in ignore_keys and key in options}
 
         if self._options_applied:
             raise Exception("Options can only be applied once to a handler.")

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -795,6 +795,11 @@ class InmantaLoggerConfig:
 
         try:
             self.logging_config_source = self._get_logging_config_source(options, component)
+            if options.log_file or options.log_file_level:
+                LOGGER.warning(
+                    "log_file and log_file_level options were ignored. Using logging config from %s",
+                    self.logging_config_source.source(),
+                )
         except NoLoggingConfigFound:
             # No logging config was defined by the user. Compose the logging config from the old CLI options.
             self._apply_logging_config_from_options(options, component, context)

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -802,11 +802,8 @@ class InmantaLoggerConfig:
                 "timed": "--timed-logs",
                 "keep_logger_names": "--keep-logger-names",
             }
-            ignored_options = [
-                f"{value} {getattr(options, key)}" for key, value in option_to_cli.items() if key in options
-            ]
-            if len(ignored_options) != 0:
-                return ", ".join(ignored_options)
+            ignored_options = [f"{value} {getattr(options, key)}" for key, value in option_to_cli.items() if key in options]
+            return ", ".join(ignored_options) if ignored_options else None
 
         if self._options_applied:
             raise Exception("Options can only be applied once to a handler.")

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -796,8 +796,6 @@ class InmantaLoggerConfig:
             """
             Returns a string with the options (excluding "--verbose" and "--logging-config") that were set by the user
             """
-            ignore_keys = ["verbose", "logging_config"]
-
             option_to_cli = {
                 "log_file": "--log-file",
                 "log_file_level": "--log-file-level",
@@ -805,9 +803,7 @@ class InmantaLoggerConfig:
                 "keep_logger_names": "--keep-logger-names",
             }
             ignored_options = [
-                f"{option_to_cli[key]} {value}"
-                for key, value in options.__dict__.items()
-                if key not in ignore_keys and key in options
+                f"{value} {options.__getattribute__(key)}" for key, value in option_to_cli.items() if key in options
             ]
             if len(ignored_options) != 0:
                 return ", ".join(ignored_options)

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -396,7 +396,7 @@ class LoggingConfigBuilder:
 
         # Shared config
         if log_file_cli_option:
-            assert options.log_file_level is not None  # make mypy happy, always set in options.set_defaults()
+            assert options.log_file_level is not None  # make mypy happy, always set in set_defaults_for_options()
             log_level = convert_inmanta_log_level(options.log_file_level)
             handler_root_logger = f"{component}_handler" if component is not None else "root_handler"
             handlers[handler_root_logger] = {

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -184,6 +184,15 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
         stream.truncate(0)
         return value
 
+    def options_to_output(options: dict) -> str:
+        option_to_cli = {
+            "log_file": "--log-file",
+            "log_file_level": "--log-file-level",
+            "timed": "--timed-logs",
+            "keep_logger_names": "--keep-logger-names",
+        }
+        return ", ".join([f"{option_to_cli[key]} {value}" for key, value in options.items()])
+
     # Log file to pass in the options.
     # This config option will be overridden by the other config in this test case.
     old_log_file = os.path.join(tmpdir, "old_log_file.txt")
@@ -202,7 +211,10 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
     logger.info("test")
     output = get_output_and_clear()
     assert "AAA test" in output
-    assert f"{options1} options were ignored. Using logging config from file {path_logging_config_file1}" in output
+    assert (
+        f"{options_to_output(options1)} options were ignored. Using logging config from file {path_logging_config_file1}"
+        in output
+    )
 
     # Set logging_config option in cfg file only
     write_logging_config_file(path=path_logging_config_file1, formatter="BBB %(message)s")
@@ -214,7 +226,10 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
     logger.info("test")
     output = get_output_and_clear()
     assert "BBB test" in output
-    assert f"{options2} options were ignored. Using logging config from file {path_logging_config_file1}" in output
+    assert (
+        f"{options_to_output(options2)} options were ignored. Using logging config from file {path_logging_config_file1}"
+        in output
+    )
 
     # Set the logging-config config option both on CLI and cfg file. CLI option takes precedence.
     write_logging_config_file(path=path_logging_config_file1, formatter="CCC %(message)s")
@@ -226,7 +241,10 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
     logger.info("test")
     output = get_output_and_clear()
     assert "CCC test" in output
-    assert f"{options2} options were ignored. Using logging config from file {path_logging_config_file1}" in output
+    assert (
+        f"{options_to_output(options2)} options were ignored. Using logging config from file {path_logging_config_file1}"
+        in output
+    )
 
     # Set the logging-config config option in the cfg config file and using the environment variable.
     # The environment variable takes precedence.
@@ -242,7 +260,10 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
         logger.info("test")
         output = get_output_and_clear()
         assert "EEE test" in output
-        assert f"{options3} options were ignored. Using logging config from file {path_logging_config_file1}" in output
+        assert (
+            f"{options_to_output(options3)} options were ignored. Using logging config from file {path_logging_config_file1}"
+            in output
+        )
 
     # Set the logging-config config option on the CLI, in the cfg config file and using the environment variable.
     # The CLI option takes precedence.
@@ -259,7 +280,10 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
         logger.info("test")
         output = get_output_and_clear()
         assert "HHH test" in output
-        assert f"{options3} options were ignored. Using logging config from file {path_logging_config_file2}" in output
+        assert (
+            f"{options_to_output(options3)} options were ignored. Using logging config from file {path_logging_config_file2}"
+            in output
+        )
 
     # After all of these logs, we assert that the log file passed to the options (old_log_file)
     # Was ignored and nothing was written to it.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -198,7 +198,8 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
     # Set logging_config option in cfg file only
     write_logging_config_file(path=path_logging_config_file1, formatter="BBB %(message)s")
     setup_logging_config(
-        cli_options=Options(log_file=old_log_file, log_file_level="4"), file_option_value=path_logging_config_file1
+        cli_options=Options(log_file=old_log_file, log_file_level="4", timed_logs=True),
+        file_option_value=path_logging_config_file1,
     )
     logger.info("test")
     assert "BBB test" in stream.getvalue()
@@ -207,7 +208,7 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
     write_logging_config_file(path=path_logging_config_file1, formatter="CCC %(message)s")
     write_logging_config_file(path=path_logging_config_file2, formatter="DDD %(message)s")
     setup_logging_config(
-        cli_options=Options(logging_config=path_logging_config_file1, log_file=old_log_file, log_file_level="4"),
+        cli_options=Options(logging_config=path_logging_config_file1, keep_logger_names=False),
         file_option_value=path_logging_config_file2,
     )
     logger.info("test")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -270,11 +270,11 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
     write_logging_config_file(path=path_logging_config_file1, formatter="GGG %(message)s")
     write_logging_config_file(path=path_logging_config_file2, formatter="HHH %(message)s")
     write_logging_config_file(path=path_logging_config_file3, formatter="III %(message)s")
-    options3["log_file"] = old_log_file
+    options4 = {"log_file": old_log_file, **options3}
     with monkeypatch.context() as m:
         m.setenv("INMANTA_CONFIG_LOGGING_CONFIG", path_logging_config_file1)
         setup_logging_config(
-            cli_options=Options(logging_config=path_logging_config_file2, **options3),
+            cli_options=Options(logging_config=path_logging_config_file2, **options4),
             file_option_value=path_logging_config_file3,
         )
         logger.info("test")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -178,6 +178,12 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
         # Reset stream buffer
         stream.truncate()
 
+    def get_output_and_clear() -> str:
+        value = stream.getvalue()
+        stream.seek(0)
+        stream.truncate(0)
+        return value
+
     # Log file to pass in the options.
     # This config option will be overridden by the other config in this test case.
     old_log_file = os.path.join(tmpdir, "old_log_file.txt")
@@ -188,58 +194,72 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
     # Set --logging-config option on CLI only
     write_logging_config_file(path=path_logging_config_file1, formatter="AAA %(message)s")
     # Also assert that the other config options are ignored when logging_config is set.
+    options1 = {"log_file": old_log_file, "log_file_level": "4", "keep_logger_names": False}
     setup_logging_config(
-        cli_options=Options(logging_config=path_logging_config_file1, verbose=1, log_file=old_log_file, log_file_level="4"),
+        cli_options=Options(logging_config=path_logging_config_file1, **options1),
         file_option_value=None,
     )
     logger.info("test")
-    assert "AAA test" in stream.getvalue()
+    output = get_output_and_clear()
+    assert "AAA test" in output
+    assert f"{options1} options were ignored. Using logging config from file {path_logging_config_file1}" in output
 
     # Set logging_config option in cfg file only
     write_logging_config_file(path=path_logging_config_file1, formatter="BBB %(message)s")
+    options2 = {"keep_logger_names": False}
     setup_logging_config(
-        cli_options=Options(log_file=old_log_file, log_file_level="4", timed_logs=True),
+        cli_options=Options(**options2),
         file_option_value=path_logging_config_file1,
     )
     logger.info("test")
-    assert "BBB test" in stream.getvalue()
+    output = get_output_and_clear()
+    assert "BBB test" in output
+    assert f"{options2} options were ignored. Using logging config from file {path_logging_config_file1}" in output
 
     # Set the logging-config config option both on CLI and cfg file. CLI option takes precedence.
     write_logging_config_file(path=path_logging_config_file1, formatter="CCC %(message)s")
     write_logging_config_file(path=path_logging_config_file2, formatter="DDD %(message)s")
     setup_logging_config(
-        cli_options=Options(logging_config=path_logging_config_file1, keep_logger_names=False),
+        cli_options=Options(logging_config=path_logging_config_file1, **options2),
         file_option_value=path_logging_config_file2,
     )
     logger.info("test")
-    assert "CCC test" in stream.getvalue()
+    output = get_output_and_clear()
+    assert "CCC test" in output
+    assert f"{options2} options were ignored. Using logging config from file {path_logging_config_file1}" in output
 
     # Set the logging-config config option in the cfg config file and using the environment variable.
     # The environment variable takes precedence.
     write_logging_config_file(path=path_logging_config_file1, formatter="EEE %(message)s")
     write_logging_config_file(path=path_logging_config_file2, formatter="FFF %(message)s")
+    options3 = {"timed": True, "keep_logger_names": False}
     with monkeypatch.context() as m:
         m.setenv("INMANTA_CONFIG_LOGGING_CONFIG", path_logging_config_file1)
         setup_logging_config(
-            cli_options=Options(log_file=old_log_file, log_file_level="4"),
+            cli_options=Options(**options3),
             file_option_value=path_logging_config_file2,
         )
         logger.info("test")
-        assert "EEE test" in stream.getvalue()
+        output = get_output_and_clear()
+        assert "EEE test" in output
+        assert f"{options3} options were ignored. Using logging config from file {path_logging_config_file1}" in output
 
     # Set the logging-config config option on the CLI, in the cfg config file and using the environment variable.
     # The CLI option takes precedence.
     write_logging_config_file(path=path_logging_config_file1, formatter="GGG %(message)s")
     write_logging_config_file(path=path_logging_config_file2, formatter="HHH %(message)s")
     write_logging_config_file(path=path_logging_config_file3, formatter="III %(message)s")
+    options3["log_file"] = old_log_file
     with monkeypatch.context() as m:
         m.setenv("INMANTA_CONFIG_LOGGING_CONFIG", path_logging_config_file1)
         setup_logging_config(
-            cli_options=Options(logging_config=path_logging_config_file2, log_file=old_log_file, log_file_level="4"),
+            cli_options=Options(logging_config=path_logging_config_file2, **options3),
             file_option_value=path_logging_config_file3,
         )
         logger.info("test")
-        assert "HHH test" in stream.getvalue()
+        output = get_output_and_clear()
+        assert "HHH test" in output
+        assert f"{options3} options were ignored. Using logging config from file {path_logging_config_file2}" in output
 
     # After all of these logs, we assert that the log file passed to the options (old_log_file)
     # Was ignored and nothing was written to it.
@@ -247,11 +267,15 @@ def test_handling_logging_config_option(tmpdir, monkeypatch, allow_overriding_ro
 
     # If given no other options, we can still use the old logging cli options
     setup_logging_config(
-        cli_options=Options(log_file=old_log_file, log_file_level="4"),
+        cli_options=Options(**options1),
     )
     logger.info("test")
     # Assert that the file gets created
     assert os.path.exists(old_log_file)
+    with open(old_log_file, "r") as file:
+        content = file.read()
+        assert "test" in content
+        assert "WARNING" not in content
 
 
 def test_log_file_or_template(tmp_path):


### PR DESCRIPTION
# Description

Log warning if we successfully found a logging config but have any of these options set:
- log_file
- log_file_level

closes #8338 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
