### PR TITLE
Do not skip test_get_current_resource_state

### DIFF
--- a/changelogs/unreleased/do-not-skip-test-get-current-resource-state.yml
+++ b/changelogs/unreleased/do-not-skip-test-get-current-resource-state.yml
@@ -1,0 +1,3 @@
+description: Do not skip test_get_current_resource_state
+change-type: patch
+destination-branches: [master]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3009,7 +3009,6 @@ async def test_retrieve_optional_field_no_default(init_dataclasses_and_load_sche
     assert report.returncode is None
 
 
-@pytest.mark.skip("std loading is currently a bit broken")
 async def test_get_current_resource_state(server, environment, client, clienthelper, agent):
     """
     Verify the behavior of the Resource.get_current_resource_state() method.


### PR DESCRIPTION
# Description

I believe loading std is no longer broken, right? This should be safe to revert

related to #8612 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
