### PR TITLE
Don't collect agent metrics for scheduler

### DIFF
--- a/changelogs/unreleased/fix-metrics-collection-agents
+++ b/changelogs/unreleased/fix-metrics-collection-agents
@@ -1,0 +1,6 @@
+---
+description: Make sure we don't collect Agent metrics for the scheduler.
+issue-nr: 8612
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -28,6 +28,7 @@ from typing import Optional, Union
 
 import asyncpg
 
+from inmanta import const
 from inmanta.data import (
     ENVIRONMENT_METRICS_RETENTION,
     Agent,
@@ -39,7 +40,6 @@ from inmanta.data import (
     Resource,
     Setting,
 )
-from inmanta import const
 from inmanta.data.model import EnvironmentMetricsResult
 from inmanta.protocol import methods_v2
 from inmanta.protocol.decorators import handle

--- a/tests/server/test_environment_metrics.py
+++ b/tests/server/test_environment_metrics.py
@@ -650,7 +650,6 @@ async def test_resource_count_empty_datapoint(client, server):
     assert all(hasattr(res, "category") and res.category != "__None__" and res.count == 0 for res in result_gauge)
 
 
-@pytest.mark.skip("To be fixed with agent view")
 async def test_agent_count_metric(clienthelper, client, server):
     project = data.Project(name="test")
     await project.insert()
@@ -673,7 +672,7 @@ async def test_agent_count_metric(clienthelper, client, server):
     agent3 = data.Agent(environment=env2.id, name="agent3", paused=True)
     await agent3.insert()
 
-    agents = await data.Agent.get_list()
+    agents = [a for a in await data.Agent.get_list() if a.name != const.AGENT_SCHEDULER_ID]
     assert len(agents) == 3
 
     # Add dummy resources that use some (but not all) of the agents


### PR DESCRIPTION
# Description

Make sure we don't collect Agent metrics for the scheduler.

Part of #8612 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
