### PR TITLE
Dump tool fix

### DIFF
--- a/changelogs/unreleased/dump-tool-fix.yml
+++ b/changelogs/unreleased/dump-tool-fix.yml
@@ -1,0 +1,4 @@
+description: Fixed dump tool
+change-type: patch
+destination-branches:
+  - master

--- a/tests/db/migration_tests/dump_tool.py
+++ b/tests/db/migration_tests/dump_tool.py
@@ -144,9 +144,7 @@ async def test_dump_db(
 
     shutil.copytree(project_source, project_dir)
 
-    check_result(await client.set_setting(env_id_1, "autostart_agent_deploy_splay_time", 0))
     check_result(await client.set_setting(env_id_1, "autostart_agent_deploy_interval", "0"))
-    check_result(await client.set_setting(env_id_1, "autostart_agent_repair_splay_time", 0))
     check_result(await client.set_setting(env_id_1, "autostart_agent_repair_interval", "600"))
     check_result(await client.set_setting(env_id_1, "auto_deploy", False))
 
@@ -159,7 +157,7 @@ async def test_dump_db(
         await client.release_version(env_id_1, v1, push=True, agent_trigger_method=const.AgentTriggerMethod.push_full_deploy)
     )
 
-    await wait_until_deployment_finishes(client, env_id_1, 20)
+    await wait_until_deployment_finishes(client, env_id_1, timeout=20)
 
     check_result(await client.notify_change(id=env_id_1, update=False))
 
@@ -180,7 +178,7 @@ async def test_dump_db(
         )
     )
 
-    await wait_until_deployment_finishes(client, env_id_1, 20)
+    await wait_until_deployment_finishes(client, env_id_1, timeout=20)
 
     # a version that is release, but not deployed
     check_result(await client.notify_change(id=env_id_1, update=False))
@@ -233,9 +231,7 @@ async def test_dump_db(
     env_id_3 = result.result["environment"]["id"]
     await agent_factory(env_id_3)
 
-    check_result(await client.set_setting(env_id_3, "autostart_agent_deploy_splay_time", 0))
     check_result(await client.set_setting(env_id_3, "autostart_agent_deploy_interval", "0"))
-    check_result(await client.set_setting(env_id_3, "autostart_agent_repair_splay_time", 0))
     check_result(await client.set_setting(env_id_3, "autostart_agent_repair_interval", "600"))
     check_result(await client.set_setting(env_id_3, "auto_deploy", False))
 

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -1147,7 +1147,7 @@ async def test_resource_status(resource_container, server, client, clienthelper,
         result = await client.get_version(env_id, version)
         assert result.code == 200
 
-        await wait_until_deployment_finishes(client, env_id, version)
+        await wait_until_deployment_finishes(client, env_id, version=version)
 
     resource_container.Provider.set_fail("agent1", "key2", 1)
     version = await clienthelper.get_version()

--- a/tests/deploy/e2e/test_resource_handler.py
+++ b/tests/deploy/e2e/test_resource_handler.py
@@ -108,7 +108,7 @@ async def test_logging_error(resource_container, environment, client, agent, cli
     result = await client.get_version(environment, version)
     assert result.code == 200
 
-    await wait_until_deployment_finishes(client, environment, version)
+    await wait_until_deployment_finishes(client, environment, version=version)
     result = await client.resource_details(tid=environment, rid=rid_1)
     assert result.code == 200
     assert result.result["data"]["status"] == "failed"

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -173,7 +173,7 @@ async def test_docs_snippets_unmanaged_resources_basic(
     version, _ = await snippetcompiler.do_export_and_deploy()
 
     await clienthelper.wait_for_released(version)
-    await wait_until_deployment_finishes(client, environment, version)
+    await wait_until_deployment_finishes(client, environment, version=version)
 
     result = await client.discovered_resources_get_batch(tid=environment)
     assert result.code == 200
@@ -234,7 +234,7 @@ async def test_docs_snippets_unmanaged_resources_shared_attributes(
 
     await clienthelper.wait_for_released(version)
 
-    await wait_until_deployment_finishes(client, environment, version)
+    await wait_until_deployment_finishes(client, environment, version=version)
 
     result = await client.discovered_resources_get_batch(tid=environment)
     assert result.code == 200

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -410,7 +410,7 @@ async def get_done_count(
 
 
 async def wait_until_deployment_finishes(
-    client: Client, environment: str, version: int = -1, timeout: int = 10, wait_for_n: int | None = None
+    client: Client, environment: str, *, version: int = -1, timeout: int = 10, wait_for_n: int | None = None
 ) -> None:
     async def done() -> bool:
 
@@ -516,7 +516,7 @@ class ClientHelper:
         return lookup[version]
 
     async def wait_for_deployed(self, version: int = -1, timeout=10) -> None:
-        await wait_until_deployment_finishes(self.client, str(self.environment), version, timeout)
+        await wait_until_deployment_finishes(self.client, str(self.environment), version=version, timeout=timeout)
 
     async def wait_full_success(self) -> None:
         await wait_full_success(self.client, self.environment)
@@ -927,7 +927,7 @@ async def _deploy_resources(client, environment, resources, version: int, push, 
     result = await client.release_version(environment, version, push, agent_trigger_method)
     assert result.code == 200
 
-    await wait_until_deployment_finishes(client, environment, version)
+    await wait_until_deployment_finishes(client, environment, version=version)
 
     result = await client.get_version(environment, version)
     assert result.code == 200


### PR DESCRIPTION
Fixed the dump tool. The `version` argument was added to `wait_until_deployment_finishes` [here](https://github.com/inmanta/inmanta-core/commit/c595ef69a98a745262b378d8127186796af552a8#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6R413) but the dump tool was not updated, making its intended timeout argument to be interpreted as the version argument. I made all these args kw-only now so this can not happen again.