### PR TITLE
Bump inmanta-dev-dependencies[async,core,pytest] from 2.146.0 to 2.147.0 (#8663)

### DIFF
--- a/changelogs/unreleased/8663-dependabot.yml
+++ b/changelogs/unreleased/8663-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump inmanta-dev-dependencies[async,core,pytest] from 2.146.0 to 2.147.0
+destination-branches:
+- master
+- iso8
+sections: {}

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[pytest,async,core]==2.146.0
+inmanta-dev-dependencies[pytest,async,core]==2.147.0
 bumpversion==0.6.0
 logfire>=0.46,<4.0
 openapi_spec_validator==0.7.1


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #8663