### PR TITLE
Issue/8576 native types warn for implicit conversion to any iso7

### DIFF
--- a/changelogs/unreleased/8576-native-types-warn-for-implicit-conversion-to-any-iso7.yml
+++ b/changelogs/unreleased/8576-native-types-warn-for-implicit-conversion-to-any-iso7.yml
@@ -1,4 +1,4 @@
 description: Add warning when implicitly casting python type to `Any` in plugin code.
 issue-nr: 8576
 change-type: patch
-destination-branches: [master, iso8]
+destination-branches: [iso7]

--- a/changelogs/unreleased/8576-native-types-warn-for-implicit-conversion-to-any.yml
+++ b/changelogs/unreleased/8576-native-types-warn-for-implicit-conversion-to-any.yml
@@ -1,0 +1,4 @@
+description: Add warning when implicitly casting python type to `Any` in plugin code.
+issue-nr: 8576
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -329,6 +329,13 @@ def to_dsl_type(python_type: type[object]) -> inmanta_type.Type:
     if python_type in python_to_model:
         return python_to_model[python_type]
 
+    warnings.warn(
+        InmantaWarning(
+            f"Python type {python_type} was implicitly cast to 'Any' because no matching type was found in the Inmanta DSL. "
+            f"Please refer to the documentation for an overview of supported types at the plugin boundary."
+        )
+    )
+
     return inmanta_type.Type()
 
 

--- a/tests/compiler/test_plugin_types.py
+++ b/tests/compiler/test_plugin_types.py
@@ -26,7 +26,10 @@ from inmanta.ast import RuntimeException
 from inmanta.plugins import Null, to_dsl_type
 
 
-def test_conversion():
+def test_conversion(caplog):
+    """
+    Test behaviour of to_dsl_type function.
+    """
     assert inmanta_type.Integer() == to_dsl_type(int)
     assert inmanta_type.Float() == to_dsl_type(float)
     assert inmanta_type.NullableType(inmanta_type.Float()) == to_dsl_type(float | None)
@@ -68,3 +71,13 @@ def test_conversion():
 
     with pytest.raises(RuntimeException):
         to_dsl_type(CustomDict[str, str])
+
+    # Check that a warning is produced when implicit cast to 'Any'
+    caplog.clear()
+    to_dsl_type(complex)
+    warning_message = (
+        "InmantaWarning: Python type <class 'complex'> was implicitly cast to 'Any' because no matching type "
+        "was found in the Inmanta DSL. Please refer to the documentation for an overview of supported types at the "
+        "plugin boundary."
+    )
+    assert warning_message in caplog.messages


### PR DESCRIPTION
# Description

iso7 pr for https://github.com/inmanta/inmanta-core/issues/8576

- Cherry picks https://github.com/inmanta/inmanta-core/commit/15b88d1877327700c52ce14e8db59f543e847cc3
- Renamed change entry + set destination branch to iso7



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
