### PR TITLE
make sure plugins are only normalized once

### DIFF
--- a/changelogs/unreleased/plugin-normalization-fix.yml
+++ b/changelogs/unreleased/plugin-normalization-fix.yml
@@ -1,0 +1,7 @@
+description: Make sure we only normalize plugins once
+change-type: patch
+# no bugfix section since this should not be user visible
+destination-branches:
+  - master
+  - iso8
+  - iso7

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -479,8 +479,16 @@ class DefineTypeConstraint(TypeDefinitionStatement):
         constraint_type.comment = self.comment
         constraint_type.basetype = basetype
         constraint_type.constraint = self.expression
-        self.expression.normalize()
-        self.anchors.extend(self.expression.get_anchors())
+
+    def get_anchors(self) -> list[Anchor]:
+        """
+        This method overrides the default get_anchors() to accommodate the two-stage normalization process.
+        DefineTypeConstraint registers anchors for its condition expression. However, these anchors only come into existence
+        after the type normalization phase.
+        This implementation ensures that anchors are correctly gathered from both the condition expression and
+        the statement itself.
+        """
+        return [*self.anchors, *self.expression.get_anchors()]
 
 
 Relationside = tuple[LocatableString, Optional[LocatableString], Optional[tuple[int, Optional[int]]]]

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -259,8 +259,15 @@ class Scheduler:
         self.types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
 
         # give type info to all types (includes plugins), to normalize blocks inside them
-        # normalize implementations last because they have subblocks that might depend on other type information
-        for t in sorted(self.types.values(), key=lambda t: isinstance(t, Implementation)):
+        for t in sorted(
+            self.types.values(),
+            key=lambda t: (
+                # normalize implementations last because they have subblocks that might depend on other type information
+                isinstance(t, Implementation),
+                # normalize entities second last because it may call validate on its attribute types to validate defaults
+                isinstance(t, Entity),
+            ),
+        ):
             t.normalize()
 
         # normalize root blocks

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -256,22 +256,16 @@ class Scheduler:
             implement.evaluate()
 
         compiler.plugins = {k: v for k, v in types_and_impl.items() if isinstance(v, plugins.Plugin)}
-        types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
+        self.types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
 
-        # normalize plugins
-        for p in compiler.plugins.values():
-            p.normalize()
-
-        # give type info to all types, to normalize blocks inside them
+        # give type info to all types (includes plugins), to normalize blocks inside them
         # normalize implementations last because they have subblocks that might depend on other type information
-        for t in sorted(types.values(), key=lambda t: isinstance(t, Implementation)):
+        for t in sorted(self.types.values(), key=lambda t: isinstance(t, Implementation)):
             t.normalize()
 
         # normalize root blocks
         for block in blocks:
             block.normalize()
-
-        self.types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
 
     def get_anchormap(
         self, compiler: "Compiler", statements: Sequence["Statement"], blocks: Sequence["BasicBlock"]


### PR DESCRIPTION
# Description

Plugins were normalized twice: once explicitly and once when we loop over all types to normalize. This PR drops the first, and makes sure we normalize `Entity` near the end because it may depend on plugins and other types for its default validation.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
