### PR TITLE
bugfix for dry-run code loading

### DIFF
--- a/changelogs/unreleased/scheduler-dryrun-bugfix.yml
+++ b/changelogs/unreleased/scheduler-dryrun-bugfix.yml
@@ -1,7 +1,7 @@
 description: Bugfix in dryrun code loading
 change-type: patch
 sections:
-  bugfix: Make sure dry-runs load the handler code apppropriate for their version
+  bugfix: Make sure dry-runs load the appropriate handler code for their version
 destination-branches:
   - master
   - iso8

--- a/changelogs/unreleased/scheduler-dryrun-bugfix.yml
+++ b/changelogs/unreleased/scheduler-dryrun-bugfix.yml
@@ -1,0 +1,4 @@
+description: Bugfix in dryrun code loading
+change-type: patch
+sections:
+  bugfix: Make sure dry-runs load the handler code apppropriate for their version

--- a/changelogs/unreleased/scheduler-dryrun-bugfix.yml
+++ b/changelogs/unreleased/scheduler-dryrun-bugfix.yml
@@ -2,3 +2,6 @@ description: Bugfix in dryrun code loading
 change-type: patch
 sections:
   bugfix: Make sure dry-runs load the handler code apppropriate for their version
+destination-branches:
+  - master
+  - iso8

--- a/src/inmanta/agent/code_manager.py
+++ b/src/inmanta/agent/code_manager.py
@@ -101,10 +101,15 @@ class CodeManager:
         Get the collection of installation specifications (i.e. pip config, python package dependencies,
         Inmanta modules sources) required to deploy a given version for the provided resource types.
 
+        Expects at least one resource type.
+
         :return: Tuple of:
             - collection of ResourceInstallSpec for resource_types with valid handler code and pip config
             - set of invalid resource_types (no handler code and/or invalid pip config)
         """
+        if not resource_types:
+            raise ValueError(f"{self.__class__.__name__}.get_code() expects at least one resource type")
+
         resource_install_specs: list[ResourceInstallSpec] = []
         invalid_resources: executor.FailedResources = {}
         for resource_type in set(resource_types):

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -616,10 +616,9 @@ class ExecutorManager(abc.ABC, typing.Generic[E]):
         :param agent_uri: The name of the host on which the agent is running.
         :param code: Collection of ResourceInstallSpec defining the configuration for the Executor i.e.
             which resource types it can act on and all necessary information to install the relevant
-            handler code in its venv.
+            handler code in its venv. Must have at least one element.
         :return: An Executor instance
         """
-        pass
 
     @abc.abstractmethod
     async def stop_for_agent(self, agent_name: str) -> list[E]:

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -1051,9 +1051,12 @@ class MPManager(
         :param agent_uri: The name of the host on which the agent is running.
         :param code: Collection of ResourceInstallSpec defining the configuration for the Executor i.e.
             which resource types it can act on and all necessary information to install the relevant
-            handler code in its venv.
+            handler code in its venv. Must have at least one element.
         :return: An Executor instance
         """
+        if not code:
+            raise ValueError(f"{self.__class__.__name__}.get_executor() expects at least one resource install specification")
+
         blueprint = executor.ExecutorBlueprint.from_specs(code)
         executor_id = executor.ExecutorId(agent_name, agent_uri, blueprint)
 

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -527,11 +527,13 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
         :param agent_uri: The name of the host on which the agent is running.
         :param code: Collection of ResourceInstallSpec defining the configuration for the Executor i.e.
             which resource types it can act on and all necessary information to install the relevant
-            handler code in its venv.
+            handler code in its venv. Must have at least one element.
         :return: An Executor instance
         """
         if not self._running:
             raise InvalidStateError("This executor manager is not running")
+        if not code:
+            raise ValueError(f"{self.__class__.__name__}.get_executor() expects at least one resource install specification")
         if agent_name in self.executors:
             out = self.executors[agent_name]
         else:

--- a/src/inmanta/agent/write_barier_executor.py
+++ b/src/inmanta/agent/write_barier_executor.py
@@ -88,6 +88,8 @@ class WriteBarierExecutorManager(executor.ExecutorManager[WriteBarierExecutor]):
     async def get_executor(
         self, agent_name: str, agent_uri: str, code: typing.Collection[ResourceInstallSpec]
     ) -> WriteBarierExecutor:
+        if not code:
+            raise ValueError(f"{self.__class__.__name__}.get_executor() expects at least one resource install specification")
         return WriteBarierExecutor(await self.delegate.get_executor(agent_name, agent_uri, code))
 
     async def stop_for_agent(self, agent_name: str) -> list[WriteBarierExecutor]:

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -70,6 +70,8 @@ class ResourceVersionIntent:
 
     model_version: int
     intent: ResourceIntent
+    # All types that live on this agent. Should be dropped once this functionality moves to the code manager.
+    # At that point, the state's types_per_agent can be dropped as well
     all_types_for_agent: Collection[ResourceType]
 
 

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -70,8 +70,10 @@ class ResourceVersionIntent:
 
     model_version: int
     intent: ResourceIntent
-    # All types that live on this agent. Should be dropped once this functionality moves to the code manager.
-    # At that point, the state's types_per_agent can be dropped as well
+    # All types that live on this agent. Required to ensure that the executor loads the appropriate code for this version,
+    # even if new versions come in before the executor is constructed.
+    # Should be dropped once this functionality moves to the code manager.
+    # At that point, the state's types_per_agent can be dropped as well.
     all_types_for_agent: Collection[ResourceType]
 
 

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -63,6 +63,9 @@ class StaleResource(Exception):
 class ResourceVersionIntent:
     """
     Resource intent for a single resource at a specific version.
+
+    Includes model version and resource intent, as well as the full set of resource types that live on the resource's agent.
+    This list will never be empty, and will always include the resource's own type.
     """
 
     model_version: int

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -68,7 +68,7 @@ class ResourceVersionIntent:
     model_version: int
     intent: ResourceIntent
     # TODO: name
-    resource_types_for_agent: Collection[ResourceType]
+    all_types_for_agent: Collection[ResourceType]
 
 
 @dataclass(frozen=True)
@@ -1134,7 +1134,7 @@ class ResourceScheduler(TaskManager):
             return ResourceVersionIntent(
                 model_version=self._state.version,
                 intent=resource_intent,
-                resource_types_for_agent=list(self._state.types_per_agent[self._state.intent[resource].id.agent_name]),
+                all_types_for_agent=list(self._state.types_per_agent[self._state.intent[resource].id.agent_name]),
             )
 
     async def deploy_start(self, action_id: uuid.UUID, resource: ResourceIdStr) -> Optional[DeployIntent]:
@@ -1151,7 +1151,7 @@ class ResourceScheduler(TaskManager):
                 intent=resource_intent,
                 dependencies=dependencies,
                 deploy_start=datetime.datetime.now().astimezone(),
-                resource_types_for_agent=list(self._state.types_per_agent[self._state.intent[resource].id.agent_name]),
+                all_types_for_agent=list(self._state.types_per_agent[self._state.intent[resource].id.agent_name]),
             )
             # Update the state in the database.
             await self.state_update_manager.send_in_progress(

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -67,7 +67,6 @@ class ResourceVersionIntent:
 
     model_version: int
     intent: ResourceIntent
-    # TODO: name
     all_types_for_agent: Collection[ResourceType]
 
 

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -76,13 +76,12 @@ class Task(abc.ABC):
         self,
         *,
         task_manager: "scheduler.TaskManager",
-        # TODO: review this type signature
-        agent: tuple[str, Collection[ResourceType]],
+        agent_spec: tuple[str, Collection[ResourceType]],
         resource_type: ResourceType,
         version: int,
     ) -> executor.Executor:
         """Helper method to produce the executor"""
-        agent_name, all_types_for_agent = agent
+        agent_name, all_types_for_agent = agent_spec
 
         code, invalid_resources = await task_manager.code_manager.get_code(
             environment=task_manager.environment,
@@ -165,7 +164,7 @@ class Deploy(Task):
 
                     my_executor: executor.Executor = await self.get_executor(
                         task_manager=task_manager,
-                        agent=(agent, deploy_intent.all_types_for_agent),
+                        agent_spec=(agent, deploy_intent.all_types_for_agent),
                         resource_type=executor_resource_details.id.entity_type,
                         version=version,
                     )
@@ -238,7 +237,7 @@ class DryRun(Task):
         try:
             my_executor: executor.Executor = await self.get_executor(
                 task_manager=task_manager,
-                agent=(agent, [executor_resource_details.id.entity_type]),
+                agent_spec=(agent, [executor_resource_details.id.entity_type]),
                 resource_type=executor_resource_details.id.entity_type,
                 version=self.version,
             )
@@ -296,7 +295,7 @@ class RefreshFact(Task):
         try:
             my_executor = await self.get_executor(
                 task_manager=task_manager,
-                agent=(agent, version_intent.all_types_for_agent),
+                agent_spec=(agent, version_intent.all_types_for_agent),
                 resource_type=self.id.entity_type,
                 version=version,
             )

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -80,8 +80,21 @@ class Task(abc.ABC):
         resource_type: ResourceType,
         version: int,
     ) -> executor.Executor:
-        """Helper method to produce the executor"""
+        """
+        Helper method to produce the executor
+
+        :param task_manager: A reference to the task manager instance.
+        :param agent_spec: agent name and all resource types that live on it.
+        :param resource_type: The resource type that we specifically care about for this resource action.
+            Should also be in the agent's resource types.
+        :param version: The version of the code to load on the executor.
+        """
         agent_name, all_types_for_agent = agent_spec
+
+        if not all_types_for_agent:
+            raise ValueError(
+                f"{self.__class__.__name__}.get_executor() expects at least one resource type in the agent spec parameter"
+            )
 
         code, invalid_resources = await task_manager.code_manager.get_code(
             environment=task_manager.environment,

--- a/tests/deploy/scheduler_mocks.py
+++ b/tests/deploy/scheduler_mocks.py
@@ -178,6 +178,8 @@ class DummyManager(executor.ExecutorManager[executor.Executor]):
     async def get_executor(
         self, agent_name: str, agent_uri: str, code: typing.Collection[ResourceInstallSpec]
     ) -> DummyExecutor:
+        if not code:
+            raise ValueError(f"{self.__class__.__name__}.get_executor() expects at least one resource install specification")
         if agent_name not in self.executors:
             self.executors[agent_name] = DummyExecutor()
         return self.executors[agent_name]

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -102,7 +102,7 @@ async def config(inmanta_config, tmp_path):
 
 
 @pytest.fixture
-async def agent(environment, config, monkeypatch):
+async def agent(environment, config):
     """
     Provide a new agent, with a scheduler that uses the dummy executor
 
@@ -1559,7 +1559,7 @@ async def test_removal(agent: TestAgent, make_resource_minimal):
     assert len(agent.scheduler._state.intent) == 1
 
 
-async def test_dryrun(agent: TestAgent, make_resource_minimal, monkeypatch):
+async def test_dryrun(agent: TestAgent, make_resource_minimal):
     """
     Ensure the simples deploy scenario works: 2 dependant resources
     """

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -25,7 +25,7 @@ import json
 import logging
 import typing
 import uuid
-from collections.abc import Awaitable, Callable, Set
+from collections.abc import Awaitable, Callable, Collection, Set
 from concurrent.futures import ThreadPoolExecutor
 from typing import Mapping, Optional, Sequence
 
@@ -43,7 +43,7 @@ from inmanta.deploy.scheduler import ModelVersion, ResourceScheduler
 from inmanta.deploy.state import Blocked, Compliance, DeployResult
 from inmanta.deploy.work import ScheduledWork, TaskPriority
 from inmanta.protocol.common import custom_json_encoder
-from inmanta.types import ResourceIdStr
+from inmanta.types import ResourceIdStr, ResourceType
 from inmanta.util import retry_limited
 from utils import make_requires
 
@@ -137,6 +137,10 @@ def make_resource_minimal(environment):
         return state.ResourceIntent(resource_id=rid, attributes=attributes, attribute_hash=attribute_hash)
 
     return make_resource_minimal
+
+
+def get_types_for_agent(scheduler: ResourceScheduler, agent: str) -> Collection[ResourceType]:
+    return list(scheduler._state.types_per_agent[agent])
 
 
 async def test_basic_deploy(agent: TestAgent, make_resource_minimal):
@@ -1541,7 +1545,7 @@ async def test_removal(agent: TestAgent, make_resource_minimal):
         [ModelVersion(version=5, resources=resources, requires=make_requires(resources), undefined=set())]
     )
 
-    assert len(agent.scheduler.get_types_for_agent("agent1")) == 2
+    assert len(get_types_for_agent(agent.scheduler, "agent1")) == 2
 
     resources = {
         ResourceIdStr(rid1): make_resource_minimal(rid1, {"value": "a"}, []),
@@ -1551,7 +1555,7 @@ async def test_removal(agent: TestAgent, make_resource_minimal):
         [ModelVersion(version=6, resources=resources, requires=make_requires(resources), undefined=set())]
     )
 
-    assert len(agent.scheduler.get_types_for_agent("agent1")) == 1
+    assert len(get_types_for_agent(agent.scheduler, "agent1")) == 1
     assert len(agent.scheduler._state.intent) == 1
 
 
@@ -1666,7 +1670,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
     )
     await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.intent) == 7
-    assert len(agent.scheduler.get_types_for_agent("agent1")) == 1
+    assert len(get_types_for_agent(agent.scheduler, "agent1")) == 1
 
     # rid1: transitively blocked on rid4
     # rid2: deployed
@@ -1895,7 +1899,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
     )
     await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.intent) == 2
-    assert len(agent.scheduler.get_types_for_agent("agent1")) == 1
+    assert len(get_types_for_agent(agent.scheduler, "agent1")) == 1
 
     assert_resource_state(
         rid8,
@@ -1927,7 +1931,7 @@ async def test_unknowns(agent: TestAgent, make_resource_minimal) -> None:
     )
     await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
     assert len(agent.scheduler._state.intent) == 2
-    assert len(agent.scheduler.get_types_for_agent("agent1")) == 1
+    assert len(get_types_for_agent(agent.scheduler, "agent1")) == 1
 
     assert_resource_state(
         rid8,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -992,6 +992,9 @@ class DummyCodeManager(CodeManager):
     async def get_code(
         self, environment: uuid.UUID, version: int, resource_types: Collection[ResourceType]
     ) -> tuple[Collection[ResourceInstallSpec], executor.FailedResources]:
+        if not resource_types:
+            raise ValueError(f"{self.__class__.__name__}.get_code() expects at least one resource type")
+
         return ([ResourceInstallSpec(rt, version, dummyblueprint) for rt in resource_types], {})
 
 


### PR DESCRIPTION
# Description

Fixed bug in scheduler code loading:
- dry-runs will now load appropriate code version. They will also work (while they did not before) if no version for that agent has been released yet.
- fixed rare race condition in code loading for deploys and get-facts: ensure collection of resource types for an agent is fetched atomically when the resource's intent is fetched. (No change entry for this one because it is more a theoretical issue than a practical one.)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
