### PR TITLE
dropped deprecated pip option

### DIFF
--- a/changelogs/unreleased/drop-deprecated-pip-option.yml
+++ b/changelogs/unreleased/drop-deprecated-pip-option.yml
@@ -1,0 +1,6 @@
+description: Dropped deprecated (and NOOP) pip option
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+  - iso7

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -378,7 +378,7 @@ class PipCommandBuilder:
             "list",
             # we disable pip-version check to prevent the json format from getting other output
             # deeply confusing issue: https://github.com/pypa/pip/issues/10715
-            *(["--disable-pip-version-check", "--no-python-version-warning", "--format", format.value] if format else []),
+            *(["--disable-pip-version-check", "--format", format.value] if format else []),
             *(["--editable"] if only_editable else []),
         ]
 

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -812,12 +812,12 @@ async def test_workon_compile(
         post_activate=textwrap.dedent(
             """
             declare -F inmanta > /dev/null 2>&1 || exit 1  # check that inmanta is a shell function
-            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) \
+            (pip --disable-pip-version-check list | grep lorem > /dev/null 2>&1) \
                 && exit 1  # check that lorem is not installed yet
             echo lorem >> requirements.txt
             # verify that the inmanta command works, accepts options, and is contained within this environment
             inmanta project install > /dev/null 2>&1 || exit 1
-            (pip --disable-pip-version-check --no-python-version-warning list | grep lorem > /dev/null 2>&1) \
+            (pip --disable-pip-version-check list | grep lorem > /dev/null 2>&1) \
                 || exit 1  # check that lorem is now installed
             deactivate
             declare -F inmanta > /dev/null 2>&1


### PR DESCRIPTION
Pip raises a warning about it now. The changelog states that "it has long done nothing since Python 2 support was removed in pip 21.0".