### PR TITLE
Make the get_scheduler_status endpoint return a 404 if no scheduler is running

### DIFF
--- a/changelogs/unreleased/8516-fix-get-scheduler-status-endpoint
+++ b/changelogs/unreleased/8516-fix-get-scheduler-status-endpoint
@@ -1,0 +1,8 @@
+---
+description: "Make the `get_scheduler_status` endpoint return a 404 if the scheduler is not running."
+issue-nr: 8516
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, is8]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/8516-fix-get-scheduler-status-endpoint
+++ b/changelogs/unreleased/8516-fix-get-scheduler-status-endpoint
@@ -1,8 +1,0 @@
----
-description: "Make the `get_scheduler_status` endpoint return a 404 if the scheduler is not running."
-issue-nr: 8516
-issue-repo: inmanta-core
-change-type: patch
-destination-branches: [master, is8]
-sections:
-  bugfix: "{{description}}"

--- a/changelogs/unreleased/8516-fix-get-scheduler-status-endpoint.yml
+++ b/changelogs/unreleased/8516-fix-get-scheduler-status-endpoint.yml
@@ -1,0 +1,8 @@
+---
+description: "Make the `get_scheduler_status` endpoint return a 404 if the scheduler is not running."
+issue-nr: 8516
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/exceptions.py
+++ b/src/inmanta/exceptions.py
@@ -1,0 +1,21 @@
+"""
+    Copyright 2025 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
+
+
+class EnvironmentNotFound(Exception):
+    pass

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -405,7 +405,7 @@ def get_scheduler_status(tid: uuid.UUID) -> model.SchedulerStatusReport:
     Inspect the scheduler state from the given environment.
 
     :param tid: The id of the environment in which to inspect the scheduler.
-
+    :raise NotFound: No scheduler is running. For example because the environment is halted.
     """
 
 

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -34,6 +34,7 @@ from uuid import UUID
 import asyncpg.connection
 
 import inmanta.config
+import inmanta.exceptions
 import inmanta.server.services.environmentlistener
 from inmanta import config as global_config
 from inmanta import const, data, tracing
@@ -1163,7 +1164,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
                 # silently ignore requests if this environment is halted
                 refreshed_env: Optional[data.Environment] = await data.Environment.get_by_id(env, connection=connection)
                 if refreshed_env is None:
-                    raise Exception("Can't ensure scheduler: environment %s does not exist" % env)
+                    raise inmanta.exceptions.EnvironmentNotFound(f"Can't ensure scheduler: environment {env} does not exist")
                 if refreshed_env.halted:
                     return False
 

--- a/tests/server/test_server_status.py
+++ b/tests/server/test_server_status.py
@@ -85,7 +85,7 @@ async def test_server_status_timeout(server, client, monkeypatch):
 
 
 @pytest.mark.parametrize("auto_start_agent", [True])
-async def test_get_scheduler_status(server, client, environment, null_agent) -> None:
+async def test_get_scheduler_status(server, client, environment) -> None:
     result = await client.get_scheduler_status(tid=environment)
     assert result.code == 200
 
@@ -101,7 +101,7 @@ async def test_get_scheduler_status(server, client, environment, null_agent) -> 
     result = await client.resume_environment(tid=environment)
     assert result.code == 200
 
-    result = await client.halt_environment(tid=environment)
+    result = await client.get_scheduler_status(tid=environment)
     assert result.code == 200
 
     result = await client.get_scheduler_status(tid=uuid.uuid4())

--- a/tests/server/test_server_status.py
+++ b/tests/server/test_server_status.py
@@ -17,6 +17,9 @@
 """
 
 import asyncio
+import uuid
+
+import pytest
 
 from inmanta import data
 from inmanta.server.server import Server
@@ -79,3 +82,28 @@ async def test_server_status_timeout(server, client, monkeypatch):
             compiler_slice = slice
     assert compiler_slice
     assert "error" in compiler_slice["status"]
+
+
+@pytest.mark.parametrize("auto_start_agent", [True])
+async def test_get_scheduler_status(server, client, environment, null_agent) -> None:
+    result = await client.get_scheduler_status(tid=environment)
+    assert result.code == 200
+
+    result = await client.halt_environment(tid=environment)
+    assert result.code == 200
+
+    result = await client.get_scheduler_status(tid=environment)
+    assert result.code == 404
+    assert (
+        f"No scheduler is running for environment {environment}, because the environment is halted." in result.result["message"]
+    )
+
+    result = await client.resume_environment(tid=environment)
+    assert result.code == 200
+
+    result = await client.halt_environment(tid=environment)
+    assert result.code == 200
+
+    result = await client.get_scheduler_status(tid=uuid.uuid4())
+    assert result.code == 404
+    assert "The given environment id does not exist!" in result.result["message"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,12 +50,12 @@ from inmanta.agent import executor
 from inmanta.agent.code_manager import CodeManager
 from inmanta.agent.executor import ExecutorBlueprint, ResourceInstallSpec
 from inmanta.const import AGENT_SCHEDULER_ID
-from inmanta.data.model import LEGACY_PIP_DEFAULT, PipConfig
+from inmanta.data.model import LEGACY_PIP_DEFAULT, PipConfig, SchedulerStatusReport
 from inmanta.deploy import state
 from inmanta.deploy.scheduler import ResourceScheduler
 from inmanta.deploy.state import ResourceIntent
 from inmanta.moduletool import ModuleTool
-from inmanta.protocol import Client, SessionEndpoint, methods
+from inmanta.protocol import Client, SessionEndpoint, methods, methods_v2
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.extensions import ProductMetadata
 from inmanta.types import Apireturn, ResourceIdStr, ResourceType
@@ -971,6 +971,10 @@ class NullAgent(SessionEndpoint):
     @protocol.handle(methods.get_status)
     async def get_status(self) -> Apireturn:
         return 200, {}
+
+    @protocol.handle(methods_v2.trigger_get_status, env="tid")
+    async def get_scheduler_resource_state(self, env: data.Environment) -> SchedulerStatusReport:
+        return SchedulerStatusReport(scheduler_state={}, db_state={}, resource_states={}, discrepancies=[])
 
 
 def make_requires(resources: Mapping[ResourceIdStr, ResourceIntent]) -> Mapping[ResourceIdStr, Set[ResourceIdStr]]:


### PR DESCRIPTION
# Description

Make the `get_scheduler_status()` endpoint return a 404 if no scheduler is running.

closes #8516 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
