### PR TITLE
Bump pydantic versin to 2.10.6

### DIFF
--- a/changelogs/unreleased/bump-pydantic-to-2-10-6.yml
+++ b/changelogs/unreleased/bump-pydantic-to-2-10-6.yml
@@ -1,0 +1,4 @@
+---
+description: Bump Pydantic to 2.10.6
+change-type: patch
+destination-branches: [iso7]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ more-itertools==10.6.0
 packaging==24.2
 pip==24.3.1
 ply==3.11
-pydantic==2.10.5
+pydantic==2.10.6
 pyformance==0.4
 PyJWT==2.10.1
 pynacl==1.5.0


### PR DESCRIPTION
# Description

Bump pydantic versin to 2.10.6. This version bump is required to fix the documentation build.

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
