### PR TITLE
added native support for dataclasses

### DIFF
--- a/changelogs/unreleased/dataclasses_native_annotations.yml
+++ b/changelogs/unreleased/dataclasses_native_annotations.yml
@@ -1,0 +1,3 @@
+description: Add support for native type annotation on dataclasses
+change-type: minor
+destination-branches: [master, iso8]

--- a/docs/model_developers/examples/dataclass_1.cf
+++ b/docs/model_developers/examples/dataclass_1.cf
@@ -1,0 +1,10 @@
+entity Virtualmachine extends std::Dataclass:
+    string name
+    int ram
+    int cpus
+end
+
+implement Virtualmachine using std::none
+
+vm = make_virtual_machine()
+std::print(vm.name)

--- a/docs/model_developers/examples/dataclass_1.py
+++ b/docs/model_developers/examples/dataclass_1.py
@@ -1,0 +1,13 @@
+import dataclasses
+
+from inmanta.plugins import plugin
+
+@dataclasses.dataclass(frozen=True)
+class Virtualmachine:
+    name: str
+    ram: int
+    cpus: int
+
+@plugin
+def make_virtual_machine() -> Virtualmachine:
+    return Virtualmachine(name="Test", ram=5, cpus=12)

--- a/docs/model_developers/examples/dataclass_2.cf
+++ b/docs/model_developers/examples/dataclass_2.cf
@@ -1,0 +1,11 @@
+entity Virtualmachine extends std::Dataclass:
+    string name
+    int ram
+    int cpus
+end
+
+implement Virtualmachine using std::none
+
+vm = Virtualmachine(name="test", ram=5, cpus=5)
+is_virtual_machine(vm)
+is_dynamic_proxy(vm)

--- a/docs/model_developers/examples/dataclass_2.py
+++ b/docs/model_developers/examples/dataclass_2.py
@@ -1,7 +1,9 @@
 import dataclasses
+from typing import Annotated
 
 from inmanta.execute.proxy import DynamicProxy
-from inmanta.plugins import plugin
+from inmanta.plugins import plugin, ModelType
+
 
 @dataclasses.dataclass(frozen=True)
 class Virtualmachine:
@@ -16,6 +18,6 @@ def is_virtual_machine(vm: Virtualmachine) -> None:
     assert isinstance(vm, Virtualmachine)
 
 @plugin
-def is_dynamic_proxy(vm: "Virtualmachine") -> None:
-    # The declared type is an inmanta type, so we receive a DynamicProxy
+def is_dynamic_proxy(vm: Annotated[DynamicProxy, ModelType["Virtualmachine"]]) -> None:
+    # Explicitly request DynamicProxy to prevent the dataclass from being converted
     assert isinstance(vm, DynamicProxy)

--- a/docs/model_developers/examples/dataclass_2.py
+++ b/docs/model_developers/examples/dataclass_2.py
@@ -1,0 +1,21 @@
+import dataclasses
+
+from inmanta.execute.proxy import DynamicProxy
+from inmanta.plugins import plugin
+
+@dataclasses.dataclass(frozen=True)
+class Virtualmachine:
+    name: str
+    ram: int
+    cpus: int
+
+
+@plugin
+def is_virtual_machine(vm: Virtualmachine) -> None:
+    # The declared type is a python type, so we receive an actual python object
+    assert isinstance(vm, Virtualmachine)
+
+@plugin
+def is_dynamic_proxy(vm: "Virtualmachine") -> None:
+    # The declared type is an inmanta type, so we receive a DynamicProxy
+    assert isinstance(vm, DynamicProxy)

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -219,8 +219,9 @@ The Inmanta entity is expect to:
     When the inmanta entity and python class don't match, the compiler will print out a correction for both.
     This means you only ever have to write the Entity, because the compiler will print the python class for you to copy paste.
 
-Dataclasses can also be passed into plugins. When the type is declared as a python type, a python instance will be passed into the plugin.
-When declared as an inmanta type (i.e. a string), a `DynamicProxy` will be returned
+Dataclasses can also be passed into plugins.
+When the type is a dataclass, it will always be converted to the python dataclass form.
+When you want pass it in as a normal entity, you have to use annotated types and declare the python type to be 'DynamicProxy`.
 
 .. literalinclude:: examples/dataclass_2.py
    :language: python

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -133,7 +133,7 @@ When used in a plugin, it is a normal python object, when used in the model, it 
         cpus: int
 
     @plugin
-    def make_virtual_machine() -> "dataclasses::Virtualmachine":
+    def make_virtual_machine() -> Virtualmachine:
         return Virtualmachine(name="Test", ram=5, cpus=12)
 
 .. code-block:: inmanta

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -120,34 +120,12 @@ When you want to construct entities in a plugin, you can use dataclasses.
 An inmanta dataclass is an entity that has a python counterpart.
 When used in a plugin, it is a normal python object, when used in the model, it is a normal Entity.
 
-.. code-block:: python
+.. literalinclude:: examples/dataclass_1.py
+   :language: python
 
-    import dataclasses
 
-    from inmanta.plugins import plugin
-
-    @dataclasses.dataclass(frozen=True)
-    class Virtualmachine:
-        name: str
-        ram: int
-        cpus: int
-
-    @plugin
-    def make_virtual_machine() -> Virtualmachine:
-        return Virtualmachine(name="Test", ram=5, cpus=12)
-
-.. code-block:: inmanta
-
-    entity Virtualmachine extends std::Dataclass:
-        string name
-        int ram
-        int cpus
-    end
-
-    implement Virtualmachine using std::none
-
-    vm = make_virtual_machine()
-    std::print(vm.name)
+.. literalinclude:: examples/dataclass_1.cf
+   :language: inmanta
 
 When using dataclasses, the object can be passed around freely into and out of plugins.
 
@@ -171,6 +149,16 @@ The Inmanta entity is expect to:
 
     When the inmanta entity and python class don't match, the compiler will print out a correction for both.
     This means you only ever have to write the Entity, because the compiler will print the python class for you to copy paste.
+
+Dataclasses can also be passed into plugins. When the type is declared as a python type, a python instance will be passed into the plugin.
+When declared as an inmanta type (i.e. a string), a `DynamicProxy` will be returned
+
+.. literalinclude:: examples/dataclass_2.py
+   :language: python
+
+
+.. literalinclude:: examples/dataclass_2.cf
+   :language: inmanta
 
 
 Deprecate plugins

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -822,11 +822,9 @@ src/inmanta/ast/entity.py:0: error: Argument 2 to "DuplicateException" has incom
 src/inmanta/ast/entity.py:0: error: Missing type parameters for generic type "ResultVariable"  [type-arg]
 src/inmanta/ast/entity.py:0: error: Item "None" of "Attribute | None" has no attribute "type"  [union-attr]
 src/inmanta/ast/entity.py:0: error: Returning Any from function declared to return "Location"  [no-any-return]
-src/inmanta/ast/entity.py:0: error: Incompatible types in assignment (expression has type "DataclassInstance | type[DataclassInstance]", variable has type "type[DataclassInstance]")  [assignment]
 src/inmanta/ast/entity.py:0: error: "type[DataclassInstance]" has no attribute "__dataclass_params__"  [attr-defined]
 src/inmanta/ast/entity.py:0: error: Argument 2 to "DataClassMismatchException" has incompatible type "type[DataclassInstance]"; expected "DataclassInstance | None"  [arg-type]
 src/inmanta/ast/entity.py:0: note: ClassVar protocol member DataclassInstance.__dataclass_fields__ can never be matched by a class object
-src/inmanta/ast/entity.py:0: error: "type[DataclassInstance]" has no attribute "_paired_inmanta_entity"  [attr-defined]
 src/inmanta/ast/entity.py:0: error: Returning Any from function declared to return "Location"  [no-any-return]
 src/inmanta/ast/entity.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "ExpressionStatement")  [assignment]
 src/inmanta/agent/handler.py:0: error: Argument 3 to "log" of "LogLine" has incompatible type "**dict[str, object]"; expected "datetime | None"  [arg-type]

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -528,23 +528,38 @@ class Entity(NamedType, WithComment):
     def get_location(self) -> Location:
         return self.location
 
-    def pair_dataclass(self) -> None:
+    def pair_dataclass_stage1(self) -> None:
         """
         Attach the associated dataclass in the python domain
+
+        should only be called on children of std::Dataclass
+
+        Called early to make plugins able to resolve this type from python domain
+        """
+        # Find the dataclass name
+        namespace = self.namespace.get_full_name()
+        module_name = "inmanta_plugins." + namespace.replace("::", ".")
+        # Find the dataclass
+        dataclass_module = importlib.import_module(module_name)
+        dataclass_raw = getattr(dataclass_module, self.name, None)
+        self._paired_dataclass = dataclass_raw
+        if dataclass_raw is not None:
+            dataclass_raw._paired_inmanta_entity = self
+
+    def pair_dataclass(self) -> None:
+        """
+        Validate the associated dataclass in the python domain
 
         should only be called on children of std::Dataclass
         should be called after normalization
         """
         assert self.normalized
 
-        # Find the dataclass name
         namespace = self.namespace.get_full_name()
         module_name = "inmanta_plugins." + namespace.replace("::", ".")
         dataclass_name = module_name + "." + self.name
 
-        # Find the dataclass
-        dataclass_module = importlib.import_module(module_name)
-        dataclass_raw = getattr(dataclass_module, self.name, None)
+        dataclass_raw = self._paired_dataclass
         if dataclass_raw is None:
             raise DataClassMismatchException(
                 self,
@@ -662,9 +677,6 @@ class Entity(NamedType, WithComment):
                 f"defined at {index_locations}. Dataclasses can not have any indexes.",
             )
 
-        self._paired_dataclass = dataclass
-        dataclass._paired_inmanta_entity = self
-
     def get_paired_dataclass(self) -> Optional[type[object]]:
         return self._paired_dataclass
 
@@ -682,7 +694,7 @@ class Entity(NamedType, WithComment):
         return dataclass_name
 
     def has_custom_to_python(self) -> bool:
-        return self._paired_dataclass is not None
+        return False
 
     def to_python(self, instance: object) -> "object":
         if self._paired_dataclass is None:

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -694,7 +694,7 @@ class Entity(NamedType, WithComment):
         return dataclass_name
 
     def has_custom_to_python(self) -> bool:
-        return False
+        return self._paired_dataclass is not None
 
     def to_python(self, instance: object) -> "object":
         if self._paired_dataclass is None:

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -22,6 +22,7 @@ import inspect
 import typing
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union  # noqa: F401
 
+from inmanta import plugins
 from inmanta.ast import (
     CompilerException,
     DataClassException,
@@ -43,7 +44,6 @@ from inmanta.ast.type import Any as inm_Any
 from inmanta.ast.type import Float, NamedType, NullableType, Type
 from inmanta.execute.runtime import Instance, QueueScheduler, Resolver, ResultVariable, dataflow
 from inmanta.execute.util import AnyType, NoneValue
-from inmanta.plugins import to_dsl_type
 from inmanta.types import DataclassProtocol
 
 # pylint: disable-msg=R0902,R0904
@@ -619,7 +619,7 @@ class Entity(NamedType, WithComment):
                     dc_fields.pop(rel_or_attr_name)
                     # Type correspondence
                     try:
-                        dsl_type = to_dsl_type(dc_types[rel_or_attr_name], self.location, self.namespace)
+                        dsl_type = plugins.to_dsl_type(dc_types[rel_or_attr_name], self.location, self.namespace)
                         if not inm_type.corresponds_to(dsl_type):
                             failures.append(
                                 f"The attribute {rel_or_attr_name} does not have the same type as "

--- a/src/inmanta/ast/statements/define.py
+++ b/src/inmanta/ast/statements/define.py
@@ -184,6 +184,7 @@ class DefineEntity(TypeDefinitionStatement):
         try:
             entity_type = self.type
             entity_type.comment = self.comment
+            is_dataclass = False
 
             add_attributes: dict[str, Attribute] = {}
             attribute: DefineAttribute
@@ -226,6 +227,7 @@ class DefineEntity(TypeDefinitionStatement):
 
                 entity_type.parent_entities.append(parent_type)
                 parent_type.child_entities.append(entity_type)
+                is_dataclass |= parent_type.get_full_name() == "std::Dataclass"
 
             for parent_type in entity_type.get_all_parent_entities():
                 for attr_name, other_attr in parent_type.attributes.items():
@@ -239,6 +241,9 @@ class DefineEntity(TypeDefinitionStatement):
                             add_attributes[attr_name] = other_attr
                         else:
                             raise DuplicateException(my_attr, other_attr, "Incompatible attributes")
+
+            if is_dataclass:
+                entity_type.pair_dataclass_stage1()
             # verify all attribute compatibility
         except TypeNotFoundException as e:
             e.set_statement(self)

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -55,6 +55,7 @@ from inmanta.execute.runtime import (
     Waiter,
     WaiterSet,
 )
+from inmanta.plugins import Plugin
 
 if TYPE_CHECKING:
     from inmanta.ast import BasicBlock, NamedType, Statement  # noqa: F401
@@ -258,9 +259,9 @@ class Scheduler:
         compiler.plugins = {k: v for k, v in types_and_impl.items() if isinstance(v, plugins.Plugin)}
         self.types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
 
-        # give type info to all types (includes plugins), to normalize blocks inside them
+        # give type info to all types (excluding plugins), to normalize blocks inside them
         for t in sorted(
-            self.types.values(),
+            (t for t in self.types.values() if not isinstance(t, Plugin)),
             key=lambda t: (
                 # normalize implementations last because they have subblocks that might depend on other type information
                 isinstance(t, Implementation),
@@ -269,10 +270,6 @@ class Scheduler:
             ),
         ):
             t.normalize()
-
-        # normalize root blocks
-        for block in blocks:
-            block.normalize()
 
         # Dataclass validation
         data_class_root = self.types.get("std::Dataclass")
@@ -285,6 +282,14 @@ class Scheduler:
             # We don't warn because if they are used they will produce a warning (class not found)
             # If not, all is fine
             pass
+
+        # normalize plugins (can use dataclasses)
+        for plugin in compiler.plugins.values():
+            plugin.normalize()
+
+        # normalize root blocks
+        for block in blocks:
+            block.normalize()
 
     def get_anchormap(
         self, compiler: "Compiler", statements: Sequence["Statement"], blocks: Sequence["BasicBlock"]

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -55,7 +55,6 @@ from inmanta.execute.runtime import (
     Waiter,
     WaiterSet,
 )
-from inmanta.plugins import Plugin
 
 if TYPE_CHECKING:
     from inmanta.ast import BasicBlock, NamedType, Statement  # noqa: F401
@@ -261,7 +260,7 @@ class Scheduler:
 
         # give type info to all types (excluding plugins), to normalize blocks inside them
         for t in sorted(
-            (t for t in self.types.values() if not isinstance(t, Plugin)),
+            (t for t in self.types.values() if not isinstance(t, plugins.Plugin)),
             key=lambda t: (
                 # normalize implementations last because they have subblocks that might depend on other type information
                 isinstance(t, Implementation),

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -258,9 +258,9 @@ class Scheduler:
         compiler.plugins = {k: v for k, v in types_and_impl.items() if isinstance(v, plugins.Plugin)}
         self.types = {k: v for k, v in types_and_impl.items() if isinstance(v, Type)}
 
-        # give type info to all types (excluding plugins), to normalize blocks inside them
+        # give type info to all types (includes plugins), to normalize blocks inside them
         for t in sorted(
-            (t for t in self.types.values() if not isinstance(t, plugins.Plugin)),
+            self.types.values(),
             key=lambda t: (
                 # normalize implementations last because they have subblocks that might depend on other type information
                 isinstance(t, Implementation),
@@ -269,6 +269,10 @@ class Scheduler:
             ),
         ):
             t.normalize()
+
+        # normalize root blocks
+        for block in blocks:
+            block.normalize()
 
         # Dataclass validation
         data_class_root = self.types.get("std::Dataclass")
@@ -281,14 +285,6 @@ class Scheduler:
             # We don't warn because if they are used they will produce a warning (class not found)
             # If not, all is fine
             pass
-
-        # normalize plugins (can use dataclasses)
-        for plugin in compiler.plugins.values():
-            plugin.normalize()
-
-        # normalize root blocks
-        for block in blocks:
-            block.normalize()
 
     def get_anchormap(
         self, compiler: "Compiler", statements: Sequence["Statement"], blocks: Sequence["BasicBlock"]

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -58,6 +58,7 @@ T = TypeVar("T")
 T_FUNC = TypeVar("T_FUNC", bound=Callable[..., object])
 
 if TYPE_CHECKING:
+    from inmanta.ast.entity import Entity
     from inmanta.ast.statements import DynamicStatement
     from inmanta.ast.statements.call import FunctionCall
     from inmanta.compiler import Compiler
@@ -239,6 +240,50 @@ class Null(inmanta_type.Type):
         return None
 
 
+class ConvertibleEntity(inmanta_type.Type):
+
+    # TODO: cache
+    def __init__(self, base_entity: "Entity") -> None:
+        super().__init__()
+        self.base_entity = base_entity
+
+    def validate(self, value: Optional[object]) -> bool:
+        return self.base_entity.validate(value)
+
+    def type_string(self) -> Optional[str]:
+        return self.base_entity.type_string()
+
+    def type_string_internal(self) -> str:
+        return self.base_entity.type_string_internal()
+
+    def normalize(self) -> None:
+        pass
+
+    def is_attribute_type(self) -> bool:
+        return False
+
+    def get_base_type(self) -> "inmanta_type.Type":
+        return self.base_entity.get_base_type()
+
+    def with_base_type(self, base_type: "inmanta_type.Type") -> "inmanta_type.Type":
+        return self.base_entity.with_base_type(base_type)
+
+    def corresponds_to(self, type: "inmanta_type.Type") -> bool:
+        raise NotImplementedError()
+
+    def as_python_type_string(self) -> "str | None":
+        return self.base_entity.as_python_type_string()
+
+    def has_custom_to_python(self) -> bool:
+        return self.base_entity._paired_dataclass is not None
+
+    def to_python(self, instance: object) -> "object":
+        return self.base_entity.to_python(instance)
+
+    def get_location(self) -> Optional[Location]:
+        return self.base_entity.get_location()
+
+
 # Define some types which are used in the context of plugins.
 PLUGIN_TYPES = {
     "any": inmanta_type.Any(),  # Any value will pass validation
@@ -297,7 +342,7 @@ def to_dsl_type(python_type: type[object]) -> inmanta_type.Type:
     if dataclasses.is_dataclass(python_type):
         entity = get_inmanta_type_for_dataclass(python_type)
         if entity:
-            return entity
+            return ConvertibleEntity(entity)
         raise TypingException(None, f"invalid type {python_type}, this dataclass has no associated inmanta entity")
 
     # Lists and dicts

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -48,7 +48,7 @@ from inmanta.ast import (
 )
 from inmanta.ast.type import NamedType
 from inmanta.config import Config
-from inmanta.execute.proxy import DynamicProxy, DynamicUnwrapContext
+from inmanta.execute.proxy import DynamicProxy, DynamicUnwrapContext, get_inmanta_type_for_dataclass
 from inmanta.execute.runtime import QueueScheduler, Resolver, ResultVariable
 from inmanta.execute.util import NoneValue, Unknown
 from inmanta.stable_api import stable_api
@@ -293,6 +293,12 @@ def to_dsl_type(python_type: type[object]) -> inmanta_type.Type:
         else:
             bases = [to_dsl_type(arg) for arg in typing.get_args(python_type)]
             return inmanta_type.Union(bases)
+
+    if dataclasses.is_dataclass(python_type):
+        entity = get_inmanta_type_for_dataclass(python_type)
+        if entity:
+            return entity
+        raise TypingException(None, f"invalid type {python_type}, this dataclass has no associated inmanta entity")
 
     # Lists and dicts
     if typing_inspect.is_generic_type(python_type):

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -240,7 +240,10 @@ class Null(inmanta_type.Type):
         return None
 
 
-class ConvertibleEntity(inmanta_type.Type):
+class UnConvertibleEntity(inmanta_type.Type):
+    """
+    Entity that does not convert to a dataclass.
+    """
 
     # TODO: cache
     def __init__(self, base_entity: "Entity") -> None:
@@ -275,7 +278,7 @@ class ConvertibleEntity(inmanta_type.Type):
         return self.base_entity.as_python_type_string()
 
     def has_custom_to_python(self) -> bool:
-        return self.base_entity._paired_dataclass is not None
+        return False
 
     def to_python(self, instance: object) -> "object":
         return self.base_entity.to_python(instance)
@@ -342,7 +345,7 @@ def to_dsl_type(python_type: type[object]) -> inmanta_type.Type:
     if dataclasses.is_dataclass(python_type):
         entity = get_inmanta_type_for_dataclass(python_type)
         if entity:
-            return ConvertibleEntity(entity)
+            return entity
         raise TypingException(None, f"invalid type {python_type}, this dataclass has no associated inmanta entity")
 
     # Lists and dicts

--- a/tests/compiler/test_dataclasses.py
+++ b/tests/compiler/test_dataclasses.py
@@ -210,7 +210,8 @@ two = dataclasses::eat_vm("test")""",
 
     with pytest.raises(
         PluginTypeException,
-        match="Value 'test' for argument inp of plugin dataclasses::eat_vm has incompatible type. Expected type: dataclasses::Virtualmachine",
+        match="Value 'test' for argument inp of plugin dataclasses::eat_vm has incompatible type. "
+              "Expected type: dataclasses::Virtualmachine",
     ):
         compiler.do_compile()
 

--- a/tests/compiler/test_dataclasses.py
+++ b/tests/compiler/test_dataclasses.py
@@ -16,6 +16,8 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import os.path
+
 import pytest
 
 from inmanta import compiler
@@ -39,6 +41,9 @@ two = dataclasses::Virtualmachine(name="A", os={}, ram=1, cpus={"a":5}, disk=[10
 
 # from python into plugin
 dataclasses::eat_vm(two)
+
+# from python into plugin
+dataclasses::eat_vm_dynamic(two)
 
 # Construct in python
 one=dataclasses::make_virtual_machine()
@@ -226,3 +231,21 @@ a= "Test"
         ministd=True,
     )
     compiler.do_compile()
+
+
+def test_docs(snippetcompiler):
+    base_path = os.path.join(os.path.dirname(__file__), "..", "..", "docs", "model_developers", "examples")
+    if not os.path.exists(base_path):
+        pytest.skip("Documentation not found")
+
+    def read_file(name: str) -> str:
+        with open(os.path.join(base_path, name), "r") as fh:
+            return fh.read()
+
+    def run_for_example(name: str) -> None:
+        snippetcompiler.create_module(f"datatest{name}", read_file(f"dataclass_{name}.cf"), read_file(f"dataclass_{name}.py"))
+        snippetcompiler.setup_for_snippet(f"import datatest{name}", autostd=True)
+        compiler.do_compile()
+
+    run_for_example("1")
+    run_for_example("2")

--- a/tests/compiler/test_dataclasses.py
+++ b/tests/compiler/test_dataclasses.py
@@ -25,6 +25,7 @@ from inmanta.ast import (
     AttributeException,
     DataClassException,
     DataClassMismatchException,
+    PluginTypeException,
     RuntimeException,
     WrappingRuntimeException,
 )
@@ -195,6 +196,23 @@ class Virtualmachine:
 end"""
         in explanation
     )
+
+
+def test_dataclass_type_check(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """
+import dataclasses
+
+# Construct in model
+two = dataclasses::eat_vm("test")""",
+        ministd=True,
+    )
+
+    with pytest.raises(
+        PluginTypeException,
+        match="Value 'test' for argument inp of plugin dataclasses::eat_vm has incompatible type. Expected type: dataclasses::Virtualmachine",
+    ):
+        compiler.do_compile()
 
 
 def test_dataclass_instance_failure(snippetcompiler):

--- a/tests/compiler/test_dataclasses.py
+++ b/tests/compiler/test_dataclasses.py
@@ -211,7 +211,7 @@ two = dataclasses::eat_vm("test")""",
     with pytest.raises(
         PluginTypeException,
         match="Value 'test' for argument inp of plugin dataclasses::eat_vm has incompatible type. "
-              "Expected type: dataclasses::Virtualmachine",
+        "Expected type: dataclasses::Virtualmachine",
     ):
         compiler.do_compile()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1554,6 +1554,28 @@ class SnippetCompilationTest(KeepOnFail):
         os.symlink(self.env, venv)
         return self._load_project(autostd=False, install_project=True, main_file=main_file)
 
+    def create_module(self, name: str, initcf: str = "", initpy: str = "") -> None:
+        module_dir = os.path.join(self.libs, name)
+        os.mkdir(module_dir)
+        os.mkdir(os.path.join(module_dir, "model"))
+        os.mkdir(os.path.join(module_dir, "files"))
+        os.mkdir(os.path.join(module_dir, "templates"))
+        os.mkdir(os.path.join(module_dir, "plugins"))
+
+        with open(os.path.join(module_dir, "model", "_init.cf"), "w+") as fd:
+            fd.write(initcf)
+
+        with open(os.path.join(module_dir, "plugins", "__init__.py"), "w+") as fd:
+            fd.write(initpy)
+
+        with open(os.path.join(module_dir, "module.yml"), "w+") as fd:
+            fd.write(
+                f"""name: {name}
+version: 0.1
+license: Test License
+                """
+            )
+
 
 @pytest.fixture(scope="session")
 def snippetcompiler_global() -> Iterator[SnippetCompilationTest]:

--- a/tests/data/modules/dataclasses/plugins/__init__.py
+++ b/tests/data/modules/dataclasses/plugins/__init__.py
@@ -18,9 +18,10 @@ Contact: code@inmanta.com
 
 import dataclasses
 from collections.abc import Sequence
+from typing import Annotated
 
 from inmanta.execute.proxy import DynamicProxy
-from inmanta.plugins import plugin
+from inmanta.plugins import plugin, ModelType
 
 
 @dataclasses.dataclass(frozen=True)
@@ -41,7 +42,7 @@ def eat_vm(inp: Virtualmachine) -> None:
 
 
 @plugin
-def eat_vm_dynamic(inp: "Virtualmachine") -> None:
+def eat_vm_dynamic(inp: Annotated[DynamicProxy, ModelType["dataclasses::Virtualmachine"]]) -> None:
     assert isinstance(inp, DynamicProxy)
     print(inp)
     return None

--- a/tests/data/modules/dataclasses/plugins/__init__.py
+++ b/tests/data/modules/dataclasses/plugins/__init__.py
@@ -46,7 +46,7 @@ def make_virtual_machine() -> "dataclasses::Virtualmachine":
 
 
 @plugin
-def select_vm(inp: "dataclasses::Virtualmachine[]", name: "string") -> "dataclasses::Virtualmachine?":
+def select_vm(inp: "dataclasses::Virtualmachine[]", name: "string") -> Virtualmachine | None:
     for vm in inp:
         if vm.name == name:
             return vm

--- a/tests/data/modules/dataclasses/plugins/__init__.py
+++ b/tests/data/modules/dataclasses/plugins/__init__.py
@@ -17,7 +17,9 @@ Contact: code@inmanta.com
 """
 
 import dataclasses
+from collections.abc import Sequence
 
+from inmanta.execute.proxy import DynamicProxy
 from inmanta.plugins import plugin
 
 
@@ -32,8 +34,15 @@ class Virtualmachine:
 
 
 @plugin
-def eat_vm(inp: "dataclasses::Virtualmachine") -> None:
+def eat_vm(inp: Virtualmachine) -> None:
     assert isinstance(inp, Virtualmachine)
+    print(inp)
+    return None
+
+
+@plugin
+def eat_vm_dynamic(inp: "Virtualmachine") -> None:
+    assert isinstance(inp, DynamicProxy)
     print(inp)
     return None
 
@@ -46,7 +55,7 @@ def make_virtual_machine() -> "dataclasses::Virtualmachine":
 
 
 @plugin
-def select_vm(inp: "dataclasses::Virtualmachine[]", name: "string") -> Virtualmachine | None:
+def select_vm(inp: Sequence[Virtualmachine], name: str) -> Virtualmachine | None:
     for vm in inp:
         if vm.name == name:
             return vm
@@ -55,7 +64,7 @@ def select_vm(inp: "dataclasses::Virtualmachine[]", name: "string") -> Virtualma
 
 
 @plugin
-def make_vms() -> "dataclasses::Virtualmachine[]?":
+def make_vms() -> Sequence[Virtualmachine] | None:
     return [
         Virtualmachine(name="Test", os={"X": "x"}, ram=5, cpus={"s": 5}, disk=[15], slots=[6]),
         Virtualmachine(name="Test", os={"X": "x"}, ram=5, cpus={"s": 5}, disk=[15], slots=[7]),
@@ -64,7 +73,7 @@ def make_vms() -> "dataclasses::Virtualmachine[]?":
 
 
 @plugin
-def make_bad_virtual_machine() -> "dataclasses::Virtualmachine":
+def make_bad_virtual_machine() -> Virtualmachine:
     # Disks should be int
     out = Virtualmachine(name="Test", os={"X": "x"}, ram=5, cpus={"s": 5}, disk=["root"], slots=None)
 


### PR DESCRIPTION
# Description

added native support for dataclasses

# TODO

1. [x] update docs on details https://github.com/inmanta/designs/pull/148
2. [x] wait for annotated types #8665
3. [x] produce warning if a string is both a valid python and inmanta type and they are different -> https://github.com/inmanta/inmanta-core/issues/8750
4. [x] make annotated type with dynamic proxy the way of getting a dynamic proxy

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
