### PR TITLE
Make wait for released wait for the version to be active

### DIFF
--- a/changelogs/unreleased/improve_wait_for_released.yml
+++ b/changelogs/unreleased/improve_wait_for_released.yml
@@ -1,0 +1,3 @@
+description: Improve wait for released
+change-type: patch
+destination-branches: [master, iso8]


### PR DESCRIPTION
# Description

1. I updated the wait for version fixture to wait for the version to be scheduled/active. 
   - This makes the name a bit weird
   - But it makes it behave as it did prior to the scheduler
2. I switched to the V2 endpoint, which reports the status in accordance to the new rules (updated in https://github.com/inmanta/inmanta-core/pull/8685)
3. I did not update the V1 endpoint, which is now a bit weird/deceptive. I just don't see a good way of fixing it. Ideas welcome.  



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
