### PR TITLE
Issue/bm 2025 02 12 fix mypy 1 15

### DIFF
--- a/changelogs/unreleased/bm-2025-02-12-fix-mypy-errors.yml
+++ b/changelogs/unreleased/bm-2025-02-12-fix-mypy-errors.yml
@@ -1,0 +1,3 @@
+description: Fix mypy errors
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -27,11 +27,8 @@ from inmanta.execute.util import Unknown
 from inmanta.stable_api import stable_api
 from inmanta.types import DataclassProtocol
 from inmanta.warnings import InmantaWarning
+from typing import TYPE_CHECKING
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute  # noqa: F401

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -19,7 +19,7 @@ Contact: code@inmanta.com
 import traceback
 from abc import abstractmethod
 from functools import lru_cache
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from inmanta import warnings
 from inmanta.ast import export
@@ -27,8 +27,6 @@ from inmanta.execute.util import Unknown
 from inmanta.stable_api import stable_api
 from inmanta.types import DataclassProtocol
 from inmanta.warnings import InmantaWarning
-from typing import TYPE_CHECKING
-
 
 if TYPE_CHECKING:
     from inmanta.ast.attribute import Attribute  # noqa: F401

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -16,14 +16,13 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from inmanta.ast import CompilerException, Locatable, Location, RuntimeException, TypingException
 from inmanta.ast.type import NullableType, TypedList
 from inmanta.execute import runtime
 from inmanta.execute.util import Unknown
 from inmanta.stable_api import stable_api
-
 
 if TYPE_CHECKING:
     from inmanta.ast.entity import Entity  # noqa: F401

--- a/src/inmanta/ast/attribute.py
+++ b/src/inmanta/ast/attribute.py
@@ -16,7 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, TYPE_CHECKING
 
 from inmanta.ast import CompilerException, Locatable, Location, RuntimeException, TypingException
 from inmanta.ast.type import NullableType, TypedList
@@ -24,10 +24,6 @@ from inmanta.execute import runtime
 from inmanta.execute.util import Unknown
 from inmanta.stable_api import stable_api
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from inmanta.ast.entity import Entity  # noqa: F401

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -20,7 +20,7 @@ import dataclasses
 import importlib
 import inspect
 import typing
-from typing import Any, Dict, List, Optional, Set, Tuple, Union  # noqa: F401
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, TYPE_CHECKING  # noqa: F401
 
 from inmanta.ast import (
     CompilerException,
@@ -49,10 +49,7 @@ from inmanta.types import DataclassProtocol
 # pylint: disable-msg=R0902,R0904
 
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
+
 
 if TYPE_CHECKING:
     from inmanta.ast import Namespaced

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -20,7 +20,7 @@ import dataclasses
 import importlib
 import inspect
 import typing
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, TYPE_CHECKING  # noqa: F401
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union  # noqa: F401
 
 from inmanta.ast import (
     CompilerException,
@@ -47,8 +47,6 @@ from inmanta.plugins import to_dsl_type
 from inmanta.types import DataclassProtocol
 
 # pylint: disable-msg=R0902,R0904
-
-
 
 
 if TYPE_CHECKING:

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -21,7 +21,7 @@ import typing
 from collections import abc
 from itertools import chain
 from string import Formatter
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, TYPE_CHECKING
 
 import inmanta.execute.dataflow as dataflow
 from inmanta.ast import (
@@ -61,11 +61,6 @@ from inmanta.execute.runtime import (
 from inmanta.execute.util import Unknown
 
 from . import ReferenceStatement
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 
 if TYPE_CHECKING:

--- a/src/inmanta/ast/statements/assign.py
+++ b/src/inmanta/ast/statements/assign.py
@@ -21,7 +21,7 @@ import typing
 from collections import abc
 from itertools import chain
 from string import Formatter
-from typing import Optional, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 import inmanta.execute.dataflow as dataflow
 from inmanta.ast import (
@@ -61,7 +61,6 @@ from inmanta.execute.runtime import (
 from inmanta.execute.util import Unknown
 
 from . import ReferenceStatement
-
 
 if TYPE_CHECKING:
     from inmanta.ast.statements.generator import WrappedKwargs  # noqa: F401

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -24,7 +24,7 @@ import uuid
 from collections import abc
 from collections.abc import Iterator
 from itertools import chain
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 import inmanta.ast.entity
 import inmanta.ast.type as inmanta_type
@@ -75,10 +75,6 @@ from inmanta.execute.runtime import (
 )
 from inmanta.execute.util import Unknown
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from inmanta.ast.entity import Entity, Implement  # noqa: F401

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -24,7 +24,7 @@ import uuid
 from collections import abc
 from collections.abc import Iterator
 from itertools import chain
-from typing import Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 import inmanta.ast.entity
 import inmanta.ast.type as inmanta_type
@@ -74,7 +74,6 @@ from inmanta.execute.runtime import (
     WrappedValueVariable,
 )
 from inmanta.execute.util import Unknown
-
 
 if TYPE_CHECKING:
     from inmanta.ast.entity import Entity, Implement  # noqa: F401

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -20,7 +20,7 @@ import copy
 import functools
 import numbers
 from collections.abc import Sequence
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Optional
 
 from inmanta.ast import (
     DuplicateException,
@@ -34,7 +34,6 @@ from inmanta.ast import (
 )
 from inmanta.execute.util import AnyType, NoneValue, Unknown
 from inmanta.stable_api import stable_api
-
 
 if TYPE_CHECKING:
     from inmanta.ast.statements import ExpressionStatement

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -20,7 +20,7 @@ import copy
 import functools
 import numbers
 from collections.abc import Sequence
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 
 from inmanta.ast import (
     DuplicateException,
@@ -35,10 +35,6 @@ from inmanta.ast import (
 from inmanta.execute.util import AnyType, NoneValue, Unknown
 from inmanta.stable_api import stable_api
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from inmanta.ast.statements import ExpressionStatement

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -20,7 +20,7 @@ import dataclasses
 from collections.abc import Iterable, Mapping, Sequence
 from copy import copy
 from dataclasses import is_dataclass
-from typing import Callable, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Union
 
 # Keep UnsetException, UnknownException and AttributeNotFound in place for backward compat with <iso8
 from inmanta.ast import AttributeNotFound as AttributeNotFound
@@ -31,8 +31,6 @@ from inmanta.execute.util import NoneValue, Unknown
 from inmanta.stable_api import stable_api
 from inmanta.types import PrimitiveTypes
 from inmanta.util import JSONSerializable
-
-
 
 if TYPE_CHECKING:
     from inmanta.ast.entity import Entity

--- a/src/inmanta/execute/proxy.py
+++ b/src/inmanta/execute/proxy.py
@@ -20,7 +20,7 @@ import dataclasses
 from collections.abc import Iterable, Mapping, Sequence
 from copy import copy
 from dataclasses import is_dataclass
-from typing import Callable, Union
+from typing import Callable, Union, TYPE_CHECKING
 
 # Keep UnsetException, UnknownException and AttributeNotFound in place for backward compat with <iso8
 from inmanta.ast import AttributeNotFound as AttributeNotFound
@@ -32,10 +32,7 @@ from inmanta.stable_api import stable_api
 from inmanta.types import PrimitiveTypes
 from inmanta.util import JSONSerializable
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
+
 
 if TYPE_CHECKING:
     from inmanta.ast.entity import Entity

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -40,7 +40,7 @@ from enum import Enum
 from functools import reduce
 from importlib.abc import Loader
 from importlib.metadata import PackageNotFoundError
-from io import BytesIO, TextIOBase
+from io import BytesIO, TextIOWrapper
 from itertools import chain
 from subprocess import CalledProcessError
 from tarfile import TarFile
@@ -72,10 +72,6 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from ruamel.yaml.comments import CommentedMap
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1123,7 +1119,7 @@ class YamlParser(RawParser):
         try:
             return yaml.safe_load(source)
         except yaml.YAMLError as e:
-            if isinstance(source, TextIOBase):
+            if isinstance(source, TextIOWrapper):
                 raise InvalidMetadata(msg=f"Invalid yaml syntax in {source.name}:\n{str(e)}") from e
             else:
                 raise InvalidMetadata(msg=str(e)) from e
@@ -1142,12 +1138,12 @@ class CfgParser(RawParser):
             version_tag: str = config.get("egg_info", "tag_build", fallback="")
             return {**config["metadata"], "install_requires": install_requires, "version_tag": version_tag}
         except configparser.Error as e:
-            if isinstance(source, TextIOBase):
+            if isinstance(source, TextIOWrapper):
                 raise InvalidMetadata(msg=f"Invalid syntax in {source.name}:\n{str(e)}") from e
             else:
                 raise InvalidMetadata(msg=str(e)) from e
         except KeyError as e:
-            if isinstance(source, TextIOBase):
+            if isinstance(source, TextIOWrapper):
                 raise InvalidMetadata(msg=f"Metadata file {source.name} doesn't have a metadata section.") from e
             else:
                 raise InvalidMetadata(msg="Metadata file doesn't have a metadata section.") from e
@@ -1236,7 +1232,7 @@ class Metadata(BaseModel):
                 **raw,
             )
         except ValidationError as e:
-            if isinstance(source, TextIOBase):
+            if isinstance(source, TextIOWrapper):
                 raise InvalidMetadata(msg=f"Metadata defined in {source.name} is invalid:", validation_error=e) from e
             else:
                 raise InvalidMetadata(msg=str(e), validation_error=e) from e

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -72,7 +72,6 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from ruamel.yaml.comments import CommentedMap
 
-
 LOGGER = logging.getLogger(__name__)
 
 Path = NewType("Path", str)


### PR DESCRIPTION
# Description

bumping mypy to v1.15 raised the following new errors:

```
src/inmanta/ast/__init__.py:34: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/ast/type.py:41: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/ast/attribute.py:30: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/ast/statements/assign.py:68: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/ast/statements/generator.py:81: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/execute/proxy.py:38: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/ast/entity.py:55: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/module.py:78: error: Cannot assign to final name "TYPE_CHECKING"  [misc]
src/inmanta/module.py:1127: error: Item "<subclass of "TextIOBase" and "str">" of "<subclass of "TextIOBase" and "str"> | <subclass of "TextIOBase" and "TextIO">" has no attribute "name"  [union-attr]
src/inmanta/module.py:1146: error: Item "<subclass of "TextIOBase" and "str">" of "<subclass of "TextIOBase" and "str"> | <subclass of "TextIOBase" and "TextIO">" has no attribute "name"  [union-attr]
src/inmanta/module.py:1151: error: Item "<subclass of "TextIOBase" and "str">" of "<subclass of "TextIOBase" and "str"> | <subclass of "TextIOBase" and "TextIO">" has no attribute "name"  [union-attr]
src/inmanta/module.py:1240: error: Item "<subclass of "TextIOBase" and "str">" of "<subclass of "TextIOBase" and "str"> | <subclass of "TextIOBase" and "TextIO">" has no attribute "name"  [union-attr]
```
------

Error of type 1 e.g.  ` error: Cannot assign to final name "TYPE_CHECKING"  [misc]`

was caused by the fact that `TYPE_CHECKING` is now of type [final](https://mypy.readthedocs.io/en/stable/final_attrs.html#final-names) -> new mypy type that disallows assigning a value to a variable after it was initialized

Solution:  remove the try/catch block around the import (I think this was kept for compatibility with python <= 3.9 ?) + the assignation.

-----

Error of type 2 e.g. `error: Item "<subclass of "TextIOBase" and "str">" of "<subclass of "TextIOBase" and "str"> | <subclass of "TextIOBase" and "TextIO">" has no attribute "name"  [union-attr]`

I think these are an actual bug

Solution change the instance type check from `TextIOBase` to `TextIOWrapper`, which is the type of the objects returned by `open()` and has a `name` attribute


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
