### PR TITLE
Fix bug env var handing for config section with dot in their name

### DIFF
--- a/changelogs/unreleased/fix-bug-dot-in-name-config-section.yml
+++ b/changelogs/unreleased/fix-bug-dot-in-name-config-section.yml
@@ -1,0 +1,8 @@
+---
+description: Fix bug where configuration options with a dot in their section name could not be read from an environment variable.
+issue-nr: 1995
+issue-repo: inmanta-lsm
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -39,8 +39,27 @@ def _normalize_name(name: str) -> str:
     return name.replace("_", "-")
 
 
+def _get_env_var_name_for_config_option(section: str, name: str) -> str:
+    """
+    Return the name of the environment variable that belongs to the given config option.
+    """
+    env_var_name = f"INMANTA_{section}_{name}"
+    # The names of config sections and config options can be written using both - and _ characters in config files.
+    # For environment variables we support _ only.
+    env_var_name = env_var_name.replace("-", "_")
+    # The configuration section lsm.callback has a dot in its name. This character is not supported
+    # in the name of an environment variable. As such, we use an _ instead.
+    env_var_name = env_var_name.replace(".", "_")
+    return env_var_name.upper()
+
+
 def _get_from_env(section: str, name: str) -> Optional[str]:
-    return os.environ.get(f"INMANTA_{section}_{name}".replace("-", "_").upper(), default=None)
+    """
+    Return the value of the given config option set via an environment variable, or None if the config
+    option was not set via an environment variable.
+    """
+    env_var_name = _get_env_var_name_for_config_option(section, name)
+    return os.environ.get(env_var_name, default=None)
 
 
 class LenientConfigParser(ConfigParser):
@@ -403,7 +422,7 @@ class Option(Generic[T]):
         """
         Return the environment variable associated with this config option.
         """
-        return f"INMANTA_{self.section}_{self.name.replace('-', '_')}".upper()
+        return _get_env_var_name_for_config_option(self.section, self.name)
 
     def get_default_desc(self) -> str:
         defa = self.default

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -272,7 +272,7 @@ server_enabled_extensions: Option[list[str]] = Option(
     "enabled_extensions",
     list,
     "A list of extensions the server must load. Core is always loaded."
-    "If an extension listed in this list is not available, the server will refuse to start.",
+    " If an extension listed in this list is not available, the server will refuse to start.",
     is_list,
 )
 
@@ -281,7 +281,7 @@ server_access_control_allow_origin = Option(
     "access-control-allow-origin",
     None,
     "Configures the Access-Control-Allow-Origin setting of the http server."
-    "Defaults to not sending an Access-Control-Allow-Origin header.",
+    " Defaults to not sending an Access-Control-Allow-Origin header.",
     is_str_opt,
 )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,8 +41,10 @@ def test_options(monkeypatch):
     configa = Option("test", "a", "markerA", "test a docs")
     configb = Option("test", "B", option_as_default(configa), "test b docs")
     configc = Option("test", "c", "defaultc", "docstringc")
+    configd = Option("test.section", "d.option", "defaultd", "docstringd")
 
     monkeypatch.setenv("INMANTA_TEST_C", "environ_c")
+    monkeypatch.setenv("INMANTA_TEST_SECTION_D_OPTION", "environ_d")
 
     assert "test.a" in configb.get_default_desc()
 
@@ -54,9 +56,16 @@ def test_options(monkeypatch):
     configb.set("MB2")
     assert configb.get() == "MB2"
     assert configc.get() == "environ_c"
+    assert configd.get() == "environ_d"
 
-    for option, expected_sub_part in zip([configa, configb, configc], ["TEST_A", "TEST_B", "TEST_C"]):
-        assert option.get_environment_variable() == f"INMANTA_{expected_sub_part}"
+    option_to_env_var_name = {
+        configa: "INMANTA_TEST_A",
+        configb: "INMANTA_TEST_B",
+        configc: "INMANTA_TEST_C",
+        configd: "INMANTA_TEST_SECTION_D_OPTION",
+    }
+    for option, expected_env_var_name in option_to_env_var_name.items():
+        assert option.get_environment_variable() == expected_env_var_name
 
 
 def test_configfile_hierarchy(monkeypatch, tmpdir):


### PR DESCRIPTION
# Description

Fix bug where configuration options with a dot in their section name could not be read from an environment variable.

closes inmanta/inmanta-lsm#1995

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~