### PR TITLE
Document Annotated types

### DIFF
--- a/changelogs/unreleased/8577-document-annotated-types.yml
+++ b/changelogs/unreleased/8577-document-annotated-types.yml
@@ -1,0 +1,5 @@
+description: >
+  Add support for Annotated types in plugins
+issue-nr: 8577
+change-type: patch
+destination-branches: [master, iso8]

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -76,13 +76,12 @@ This is done by combining ``typing.Annotated`` with ``inmanta.plugins.ModelType`
 will be the python type we want to assume for typechecking and the second will be the ``inmanta.plugins.ModelType``
 with the Inmanta DSL type that we want the compiler to validate.
 
-For example, if we want to pass a ``std::Entity`` to our plugins and have python validate it's type as ``typing.Any``, we could do this:
+For example, if we want to pass a ``std::Entity`` to our plugins and have python validate its type as ``typing.Any``, we could do this:
 
 .. code-block:: python
     :linenos:
 
     from inmanta.plugins import plugin, ModelType
-    from collections.abc import Sequence
     from typing import Annotated, Any
 
     type Entity = Annotated[Any, ModelType["std::Entity"]]
@@ -92,7 +91,7 @@ For example, if we want to pass a ``std::Entity`` to our plugins and have python
         ...
 
 
-Our compiler will validate ``my_entity`` as ``std::Entity`` meaning that we will only be able to provide a ``std::Entity``
+Our compiler will validate ``my_entity`` as ``std::Entity``, meaning that we will only be able to provide a ``std::Entity``
 as an argument to this plugin, but for IDE and static typing purposes it will be treated as ``typing.Any``.
 
 

--- a/docs/model_developers/plugins.rst
+++ b/docs/model_developers/plugins.rst
@@ -70,6 +70,33 @@ The table below shows correspondence between types from the Inmanta DSL and thei
 
 ``any`` is a special type that effectively disables type validation.
 
+We also give some liberty to the user to define python types for Inmanta DSL types that are not present on this table.
+
+This is done by combining ``typing.Annotated`` with ``inmanta.plugins.ModelType``. The first parameter of ``typing.Annotated``
+will be the python type we want to assume for typechecking and the second will be the ``inmanta.plugins.ModelType``
+with the Inmanta DSL type that we want the compiler to validate.
+
+For example, if we want to pass a ``std::Entity`` to our plugins and have python validate it's type as ``typing.Any``, we could do this:
+
+.. code-block:: python
+    :linenos:
+
+    from inmanta.plugins import plugin, ModelType
+    from collections.abc import Sequence
+    from typing import Annotated, Any
+
+    type Entity = Annotated[Any, ModelType["std::Entity"]]
+
+    @plugin
+    def my_plugin(my_entity: Entity) -> None:
+        ...
+
+
+Our compiler will validate ``my_entity`` as ``std::Entity`` meaning that we will only be able to provide a ``std::Entity``
+as an argument to this plugin, but for IDE and static typing purposes it will be treated as ``typing.Any``.
+
+
+
 Type hinting using Inmanta DSL types
 ------------------------------------
 


### PR DESCRIPTION
# Description

Document the support for Annotated types in plugins

closes #8577 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
