### PR TITLE
Fix race condition in test_halt_deploy test case

### DIFF
--- a/changelogs/unreleased/fix-race-condition-test-halt-deploy.yml
+++ b/changelogs/unreleased/fix-race-condition-test-halt-deploy.yml
@@ -1,0 +1,4 @@
+---
+description: Fix race condition in the test_halt_deploy test case where the scheduler process is not detected correctly.
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/deploy/e2e/test_autostarted.py
+++ b/tests/deploy/e2e/test_autostarted.py
@@ -395,20 +395,13 @@ def construct_scheduler_children(current_pid: int) -> SchedulerChildren:
         - Executor(s)
     """
 
-    def get_process_children(current_pid: int) -> list[Process]:
-        """
-        Retrieves the current list of processes running under this process
-
-        :param current_pid: The PID of this process
-        """
-        return psutil.Process(current_pid).children(recursive=True)
-
-    def find_scheduler(children: list[Process]) -> Optional[Process]:
+    def find_scheduler() -> Optional[Process]:
         """
         Find and return the Scheduler. Make sure only one scheduler is running
-
-        :param children: The list of processes that are currently running
         """
+        # Only consider the direct children. The scheduler process is always
+        # a direct child of the server process.
+        children = psutil.Process(current_pid).children(recursive=False)
         current_scheduler = None
 
         for child in children:
@@ -457,8 +450,7 @@ def construct_scheduler_children(current_pid: int) -> SchedulerChildren:
             executors=executors,
         )
 
-    children = get_process_children(current_pid)
-    latest_scheduler = find_scheduler(children)
+    latest_scheduler = find_scheduler()
     if latest_scheduler is None:
         return SchedulerChildren(
             scheduler=None,


### PR DESCRIPTION
# Description

The test case incorrecty considers the child process of the scheduler as a scheduler as well. This is probably the fork server that is starting.

<details>
<summary>Output Jenkins</summary>
<pre>
_______________________ test_halt_deploy[True-True-120] ________________________

current_pid = 7, should_scheduler_be_defined = True
should_fork_server_be_defined = True, nb_executor_to_be_defined = 1

    async def wait_for_consistent_children(
        current_pid: int,
        should_scheduler_be_defined: bool,
        should_fork_server_be_defined: bool,
        nb_executor_to_be_defined: int,
    ) -> None:
        """
        Wait for consistent children for the Scheduler:
            - When the Scheduler is started, it can take some time before every process is actually running
            - This is especially True for the `Executor process`.
            - Besides, when the executor process is created, it can have, for a very short time, the same name as the fork server
                (because it was forked from it).
        """
    
        async def wait_consistent_scheduler() -> bool:
            # This can occur, when the fork server forks and for a small amount of time, there will be two fork servers
            # even though one of them is actually the executor process (will be shortly renamed)
            current = construct_scheduler_children(current_pid)
            is_scheduler_defined = current.scheduler is not None
            is_fork_server_defined = current.fork_server is not None
            return (
                (is_scheduler_defined == should_scheduler_be_defined)
                and (is_fork_server_defined == should_fork_server_be_defined)
                and (len(current.executors) == nb_executor_to_be_defined)
            )
    
        try:
>           await retry_limited(wait_consistent_scheduler, 10)

/home/user/code/tests/deploy/e2e/test_autostarted.py:509: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/user/code/tests/utils.py:85: in retry_limited
    await util.retry_limited(fun, timeout, interval, *args, **kwargs)
/opt/inmanta/lib64/python3.12/site-packages/inmanta/util/__init__.py:615: in retry_limited
    result = await fun_wrapper()
/opt/inmanta/lib64/python3.12/site-packages/inmanta/util/__init__.py:606: in fun_wrapper
    return await fun(*args, **kwargs)
/home/user/code/tests/deploy/e2e/test_autostarted.py:499: in wait_consistent_scheduler
    current = construct_scheduler_children(current_pid)
/home/user/code/tests/deploy/e2e/test_autostarted.py:461: in construct_scheduler_children
    latest_scheduler = find_scheduler(children)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

children = [psutil.Process(pid=100, name='pg_ctl', status='zombie', started='01:23:32'), psutil.Process(pid=375, name='python3.12', status='sleeping', started='01:23:44'), psutil.Process(pid=569, name='python3.12', status='sleeping', started='01:25:08'), psutil.Process(pid=578, name='python3.12', status='sleeping', started='01:25:10'), psutil.Process(pid=579, name='python3.12', status='running', started='01:25:10')]

    def find_scheduler(children: list[Process]) -> Optional[Process]:
        """
        Find and return the Scheduler. Make sure only one scheduler is running
    
        :param children: The list of processes that are currently running
        """
        current_scheduler = None
    
        for child in children:
            # ignore zombie children
            if child.status() == psutil.STATUS_ZOMBIE:
                continue
            if "python" in child.name():
                cmd_line_process = " ".join(child.cmdline())
                if "inmanta.app" in cmd_line_process and "scheduler" in cmd_line_process:
>                   assert current_scheduler is None, (
                        f"A scheduler was already found: {current_scheduler} (spawned via {current_scheduler.cmdline()} in "
                        f"parent process {current_scheduler.parent()}) but we found a new one: {child} (spawned via "
                        f"{child.cmdline()} in parent process {child.parent()}), this is unexpected!"
                    )
E                   AssertionError: A scheduler was already found: psutil.Process(pid=569, name='python3.12', status='sleeping', started='01:25:08') (spawned via ['/opt/inmanta/bin/python3.12', '-m', 'inmanta.app', '--log-file-level', 'DEBUG', '--config', '/tmp/tmpxh9tl3w3/server/4da899f7-4876-4a72-b6c1-3c2b8ca5dcda/scheduler.cfg', 'scheduler'] in parent process psutil.Process(pid=7, name='py.test', status='running', started='01:22:34')) but we found a new one: psutil.Process(pid=579, name='python3.12', status='running', started='01:25:10') (spawned via ['/opt/inmanta/bin/python3.12', '-m', 'inmanta.app', '--log-file-level', 'DEBUG', '--config', '/tmp/tmpxh9tl3w3/server/4da899f7-4876-4a72-b6c1-3c2b8ca5dcda/scheduler.cfg', 'scheduler'] in parent process psutil.Process(pid=569, name='python3.12', status='sleeping', started='01:25:08')), this is unexpected!
E                   assert psutil.Process(pid=569, name='python3.12', status='sleeping', started='01:25:08') is None

/home/user/code/tests/deploy/e2e/test_autostarted.py:421: AssertionError
</pre>
</details>
# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
