### PR TITLE
Implement GraphQL endpoint to figure out if environment is compiling

### DIFF
--- a/changelogs/unreleased/8737-graphql-endpoint-that-checks-if-env-is-compiling.yml
+++ b/changelogs/unreleased/8737-graphql-endpoint-that-checks-if-env-is-compiling.yml
@@ -1,0 +1,4 @@
+description: Add isCompiling option to GraphQL environments query
+issue-nr: 8737
+change-type: minor
+destination-branches: [master]

--- a/src/inmanta/graphql/graphql.py
+++ b/src/inmanta/graphql/graphql.py
@@ -14,17 +14,29 @@ Contact: code@inmanta.com
 
 from typing import Any
 
-import inmanta.graphql.schema
+from inmanta.graphql.schema import GraphQLMetadata, get_schema
 from inmanta.protocol import methods_v2
 from inmanta.protocol.decorators import handle
-from inmanta.server import SLICE_GRAPHQL, protocol
+from inmanta.server import SLICE_COMPILER, SLICE_GRAPHQL, protocol
+from inmanta.server.protocol import Server
+from inmanta.server.services.compilerservice import CompilerService
 
 
 class GraphQLSlice(protocol.ServerSlice):
+    metadata: GraphQLMetadata
 
     def __init__(self) -> None:
         super().__init__(name=SLICE_GRAPHQL)
 
+    def get_dependencies(self) -> list[str]:
+        return [SLICE_COMPILER]
+
+    async def prestart(self, server: Server) -> None:
+        compiler_service = server.get_slice(SLICE_COMPILER)
+        assert isinstance(compiler_service, CompilerService)
+        self.metadata = GraphQLMetadata(compiler_service=compiler_service)
+        await super().prestart(server)
+
     @handle(methods_v2.graphql)
     async def graphql(self, query: str) -> Any:  # Actual return type: strawberry.types.execution.ExecutionResult
-        return await inmanta.graphql.schema.get_schema().execute(query)
+        return await get_schema(self.metadata).execute(query)

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -77,6 +77,10 @@ class Environment:
 
 
 def get_schema(metadata: GraphQLMetadata) -> strawberry.Schema:
+    """
+    Fetches strawberry.Schema instance.
+    Initializes schema and metadata if they are None
+    """
     global METADATA
     global SCHEMA
     if SCHEMA is None:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -51,7 +51,7 @@ from inmanta.env import PipCommandBuilder, PythonEnvironment, VenvActivationFail
 from inmanta.protocol import encode_token, methods, methods_v2
 from inmanta.protocol.common import ReturnValue
 from inmanta.protocol.exceptions import BadRequest, NotFound
-from inmanta.server import SLICE_COMPILER, SLICE_DATABASE, SLICE_ENVIRONMENT, SLICE_SERVER, SLICE_TRANSPORT
+from inmanta.server import SLICE_COMPILER, SLICE_DATABASE, SLICE_ENVIRONMENT, SLICE_GRAPHQL, SLICE_SERVER, SLICE_TRANSPORT
 from inmanta.server import config as opt
 from inmanta.server.protocol import ServerSlice
 from inmanta.server.services import environmentservice
@@ -630,7 +630,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         return [SLICE_DATABASE]
 
     def get_depended_by(self) -> list[str]:
-        return [SLICE_ENVIRONMENT, SLICE_SERVER, SLICE_TRANSPORT]
+        return [SLICE_ENVIRONMENT, SLICE_SERVER, SLICE_TRANSPORT, SLICE_GRAPHQL]
 
     async def prestart(self, server: server.protocol.Server) -> None:
         await super().prestart(server)
@@ -949,9 +949,12 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         """
         await self._process_next_compile_in_queue(environment=environment)
 
+    def is_environment_compiling(self, environment_id: uuid.UUID) -> bool:
+        return environment_id in self._env_to_compile_task
+
     @protocol.handle(methods.is_compiling, environment_id="id")
     async def is_compiling(self, environment_id: uuid.UUID) -> Apireturn:
-        if environment_id in self._env_to_compile_task:
+        if self.is_environment_compiling(environment_id):
             return 200
         return 204
 


### PR DESCRIPTION
# Description

Add `isCompiling` field to GraphQL `environments` query

closes #8737 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
