### PR TITLE
Fix e2e tests fail to install std module

### DIFF
--- a/changelogs/unreleased/fix-e2e-tests-fail-to-install-std.yml
+++ b/changelogs/unreleased/fix-e2e-tests-fail-to-install-std.yml
@@ -1,0 +1,4 @@
+---
+description: Fix issue where the e2e tests fail to install the std module.
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1402,7 +1402,7 @@ class SnippetCompilationTest(KeepOnFail):
         project_requires = project_requires if project_requires is not None else []
         python_requires = python_requires if python_requires is not None else []
         relation_precedence_rules = relation_precedence_rules if relation_precedence_rules else []
-        ministd_path = os.path.join(__file__, "..", "data/mini_str_container")
+        ministd_path = os.path.join(__file__, "..", "data/mini_std_container")
         if ministd:
             add_to_module_path += ministd_path
         with open(os.path.join(self.project_dir, "project.yml"), "w", encoding="utf-8") as cfg:

--- a/tests/deploy/e2e/test_autostarted.py
+++ b/tests/deploy/e2e/test_autostarted.py
@@ -552,7 +552,8 @@ import minimalwaitingmodule
 
 a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep={time_to_sleep})
 """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
 
     # Now, let's deploy some resources
@@ -621,7 +622,8 @@ a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep
 
     a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep={time_to_sleep})
     """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
     version, res, status = await snippetcompiler.do_export_and_deploy(include_status=True)
     result = await client.release_version(environment, version, push=False)
@@ -727,7 +729,8 @@ a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep
 b = minimalwaitingmodule::Sleep(name="test_sleep2", agent="agent1", time_to_sleep=5)
 c = minimalwaitingmodule::Sleep(name="test_sleep3", agent="agent1", time_to_sleep=5)
 """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
 
     # Now, let's deploy some resources
@@ -879,7 +882,8 @@ import minimalwaitingmodule
 
 a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep=120)
 """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
 
     # Now, let's deploy a resource
@@ -980,7 +984,8 @@ a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep
 b = minimalwaitingmodule::Sleep(name="test_sleep2", agent="agent1", time_to_sleep=5)
 c = minimalwaitingmodule::Sleep(name="test_sleep3", agent="agent1", time_to_sleep=5)
 """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
 
     # Now, let's deploy some resources
@@ -1123,7 +1128,8 @@ a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep
 b = minimalwaitingmodule::Sleep(name="test_sleep2", agent="agent2", time_to_sleep=5)
 c = minimalwaitingmodule::Sleep(name="test_sleep3", agent="agent3", time_to_sleep=5)
 """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
 
     # Now, let's deploy some resources
@@ -1279,7 +1285,8 @@ import minimalwaitingmodule
 
 a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep=120)
 """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
 
     # Now, let's deploy a resource
@@ -1362,7 +1369,8 @@ a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep
 
 a = minimalwaitingmodule::Sleep(name="test_sleep", agent="agent1", time_to_sleep=120)
     """,
-        autostd=True,
+        ministd=True,
+        index_url="https://pypi.org/simple",
     )
     version, res, status = await snippetcompiler.do_export_and_deploy(include_status=True)
     result = await client.release_version(environment, version, push=False)


### PR DESCRIPTION
# Description

Fix issue where the e2e tests fail to install the std module. These tests didn't need python code from the std module before, but since std version `8.3.0` they do because that version added a reference definition. When a reference is defined, the python code is always exported (for now) independent from whether the reference is used or not.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
