### PR TITLE
Limit pydantic version to 2.10.6

### DIFF
--- a/changelogs/unreleased/limit-pydantic-version.yml
+++ b/changelogs/unreleased/limit-pydantic-version.yml
@@ -1,0 +1,5 @@
+---
+description: Limit pydantic version to 2.10.6 due to an incompatibility with the strawberry library
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requires = [
     # pip>=21.3 required for editable pyproject.toml + setup.cfg based install support
     "pip>=21.3",
     "ply~=3.0",
-    "pydantic~=2.5,!=2.9.2",
+    "pydantic~=2.5,!=2.9.2,<2.10.7",
     "pyformance~=0.4",
     "PyJWT~=2.0",
     "pynacl~=1.5",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ requires = [
     # pip>=21.3 required for editable pyproject.toml + setup.cfg based install support
     "pip>=21.3",
     "ply~=3.0",
+    # Beta version of pydantic is incompatible with the strawberry library at the moment
+    # https://github.com/strawberry-graphql/strawberry/issues/3807
     "pydantic~=2.5,!=2.9.2,<2.10.7",
     "pyformance~=0.4",
     "PyJWT~=2.0",


### PR DESCRIPTION
# Description

Beta version of pydantic is incompatible with the strawberry library at the moment
https://github.com/strawberry-graphql/strawberry/issues/3807

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
