### PR TITLE
Ignore zombie and terminated processes in process discovery

### DIFF
--- a/changelogs/unreleased/ignore-zombie-and-terminated-processes.yml
+++ b/changelogs/unreleased/ignore-zombie-and-terminated-processes.yml
@@ -1,0 +1,4 @@
+---
+description: Fix bug in the test suite where the subprocess discovery fails if a process became a zombie or terminated while processing it.
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/deploy/e2e/test_autostarted.py
+++ b/tests/deploy/e2e/test_autostarted.py
@@ -444,8 +444,8 @@ def construct_scheduler_children(current_pid: int) -> SchedulerChildren:
                     case py if "python" in py:
                         cmd_line_process = " ".join(child.cmdline())
                         resource_tracker_import = "from multiprocessing.resource_tracker"
-                        if resource_tracker_import in cmd_line_process:
-                            continue
+                        if resource_tracker_import not in cmd_line_process:
+                            assert False, f"Unexpected process: {py}"
                     case _ as e:
                         assert False, f"Unexpected process: {e}"
             except psutil.NoSuchProcess:

--- a/tests/deploy/e2e/test_autostarted.py
+++ b/tests/deploy/e2e/test_autostarted.py
@@ -441,13 +441,6 @@ def construct_scheduler_children(current_pid: int) -> SchedulerChildren:
                         fork_server = child
                     case executor if "inmanta: executor process" in executor:
                         executors.append(child)
-                    case py if "python" in py:
-                        cmd_line_process = " ".join(child.cmdline())
-                        resource_tracker_import = "from multiprocessing.resource_tracker"
-                        if resource_tracker_import not in cmd_line_process:
-                            assert False, f"Unexpected process: {py}"
-                    case _ as e:
-                        assert False, f"Unexpected process: {e}"
             except psutil.NoSuchProcess:
                 # The process terminated or it became a zombie process
                 continue


### PR DESCRIPTION
# Description

Calling a method on a process that became a zombie or has terminated, raises an exception. If this happens the test suite fails on that. This fix makes sure that we ignore the exception.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
