### PR TITLE
Make the assertion on the firetime of the timer in the tests less strict

### DIFF
--- a/changelogs/unreleased/make-assert-on-firetime-of-timer-less-strict.yml
+++ b/changelogs/unreleased/make-assert-on-firetime-of-timer-less-strict.yml
@@ -1,0 +1,4 @@
+---
+description: Make the assertion on the firetime of the timer in the tests less strict.
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/deploy/test_timer_handling.py
+++ b/tests/deploy/test_timer_handling.py
@@ -138,7 +138,7 @@ async def test_time_manager_basics():
     await t4[0].activation_lock.wait()
 
     def assert_fired(timer: MockTimer, at: datetime.datetime) -> None:
-        assert timedelta(milliseconds=0) < (timer.activated_at - at) < timedelta(milliseconds=5)
+        assert timedelta(milliseconds=0) < (timer.activated_at - at) < timedelta(milliseconds=10)
 
     assert_fired(*t1)
     assert_fired(*t2)


### PR DESCRIPTION
# Description

The `test_time_manager_basics` test case failed because the difference between the expected and the actual firetime of the timer was slightly larger than 5ms. As such, I increased it to 10ms.

```
03:59:09  ___________________________ test_time_manager_basics ___________________________
03:59:09  
03:59:09      async def test_time_manager_basics():
03:59:09      
03:59:09          class MockTimer(ResourceTimer):
03:59:09      
03:59:09              def __init__(self):
03:59:09                  super().__init__("the_resource", None)
03:59:09                  self.activated_at: datetime.datetime | None = None
03:59:09                  self.activation_lock: Event = Event()
03:59:09      
03:59:09              def _activate(self) -> None:
03:59:09                  self.activated_at = datetime.datetime.now()
03:59:09                  self.activation_lock.set()
03:59:09      
03:59:09          start_time = datetime.datetime.now()
03:59:09      
03:59:09          def set_time(delta: int) -> tuple[MockTimer, datetime.datetime]:
03:59:09              t = MockTimer()
03:59:09              call_in = timedelta(milliseconds=delta)
03:59:09              call_at = start_time + call_in
03:59:09              t.set_timer(call_at, "I say so", TaskPriority.DRYRUN)
03:59:09              return t, call_at if delta >= 0 else start_time
03:59:09      
03:59:09          t1 = set_time(30)
03:59:09          t2 = set_time(30)
03:59:09          t3 = set_time(100)
03:59:09          t4 = set_time(100)
03:59:09          t3[0].cancel()
03:59:09          t5 = set_time(80)
03:59:09          t6 = set_time(-10_000)
03:59:09      
03:59:09          await t4[0].activation_lock.wait()
03:59:09      
03:59:09          def assert_fired(timer: MockTimer, at: datetime.datetime) -> None:
03:59:09              assert timedelta(milliseconds=0) < (timer.activated_at - at) < timedelta(milliseconds=5)
03:59:09      
03:59:09          assert_fired(*t1)
03:59:09          assert_fired(*t2)
03:59:09  >       assert_fired(*t4)
03:59:09  
03:59:09  tests/deploy/test_timer_handling.py:145: 
03:59:09  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
03:59:09  
03:59:09  timer = <test_timer_handling.test_time_manager_basics.<locals>.MockTimer object at 0x7fc51e7f6480>
03:59:09  at = datetime.datetime(2025, 3, 14, 3, 29, 0, 8275)
03:59:09  
03:59:09      def assert_fired(timer: MockTimer, at: datetime.datetime) -> None:
03:59:09  >       assert timedelta(milliseconds=0) < (timer.activated_at - at) < timedelta(milliseconds=5)
03:59:09  E       assert (datetime.datetime(2025, 3, 14, 3, 29, 0, 14625) - datetime.datetime(2025, 3, 14, 3, 29, 0, 8275)) < datetime.timedelta(microseconds=5000)
03:59:09  E        +  where datetime.datetime(2025, 3, 14, 3, 29, 0, 14625) = <test_timer_handling.test_time_manager_basics.<locals>.MockTimer object at 0x7fc51e7f6480>.activated_at
03:59:09  E        +  and   datetime.timedelta(microseconds=5000) = timedelta(milliseconds=5)
03:59:09  
03:59:09  tests/deploy/test_timer_handling.py:141: AssertionError
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
