### PR TITLE
Add useful consts to stable API

### DIFF
--- a/changelogs/unreleased/8803-add-consts-to-stable-api.yml
+++ b/changelogs/unreleased/8803-add-consts-to-stable-api.yml
@@ -2,13 +2,9 @@ change-type: patch
 description: >
   Adds the following consts to the stable api:
     - UNDEPLOYABLE_STATES
-    - UNDEPLOYABLE_NAMES
     - TRANSIENT_STATES
     - NOT_DONE_STATES
     - DONE_STATES
-    - INITIAL_STATES
-    - TERMINAL_STATES
-    - VALID_STATES_ON_UPDATE
 
 destination-branches: [master]
 sections:

--- a/changelogs/unreleased/8803-add-consts-to-stable-api.yml
+++ b/changelogs/unreleased/8803-add-consts-to-stable-api.yml
@@ -1,0 +1,15 @@
+change-type: patch
+description: >
+  Adds the following consts to the stable api:
+    - UNDEPLOYABLE_STATES
+    - UNDEPLOYABLE_NAMES
+    - TRANSIENT_STATES
+    - NOT_DONE_STATES
+    - DONE_STATES
+    - INITIAL_STATES
+    - TERMINAL_STATES
+    - VALID_STATES_ON_UPDATE
+
+destination-branches: [master]
+sections:
+  other-note: "{{description}}"

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -77,6 +77,18 @@ class DeprecatedResourceState(str, Enum):
     processing_events = "processing_events"
 
 
+"""
+The following consts are considered to be part of the stable API.
+Modifying them may consist a breaking change for some libraries:
+    - UNDEPLOYABLE_STATES
+    - UNDEPLOYABLE_NAMES
+    - TRANSIENT_STATES
+    - NOT_DONE_STATES
+    - DONE_STATES
+    - INITIAL_STATES
+    - TERMINAL_STATES
+    - VALID_STATES_ON_UPDATE
+"""
 # undeployable
 UNDEPLOYABLE_STATES = [ResourceState.undefined, ResourceState.skipped_for_undefined]
 UNDEPLOYABLE_NAMES = [s.name for s in UNDEPLOYABLE_STATES]

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -79,7 +79,7 @@ class DeprecatedResourceState(str, Enum):
 
 """
 The following consts are considered to be part of the stable API.
-Modifying them may consist a breaking change for some libraries:
+Modifying them may break some libraries:
     - UNDEPLOYABLE_STATES
     - UNDEPLOYABLE_NAMES
     - TRANSIENT_STATES

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -81,13 +81,9 @@ class DeprecatedResourceState(str, Enum):
 The following consts are considered to be part of the stable API.
 Modifying them may break some libraries:
     - UNDEPLOYABLE_STATES
-    - UNDEPLOYABLE_NAMES
     - TRANSIENT_STATES
     - NOT_DONE_STATES
     - DONE_STATES
-    - INITIAL_STATES
-    - TERMINAL_STATES
-    - VALID_STATES_ON_UPDATE
 """
 # undeployable
 UNDEPLOYABLE_STATES = [ResourceState.undefined, ResourceState.skipped_for_undefined]


### PR DESCRIPTION
# Description

  Adds the following consts to the stable api:
    - UNDEPLOYABLE_STATES
    - TRANSIENT_STATES
    - NOT_DONE_STATES
    - DONE_STATES

closes #8803 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
