### PR TITLE
Improve the stability and speed of tests autostarted agent tests

### DIFF
--- a/changelogs/unreleased/improve-stability-e2e-tests.yml
+++ b/changelogs/unreleased/improve-stability-e2e-tests.yml
@@ -1,0 +1,4 @@
+---
+description: "Improve the stability and speed of tests in `tests/deploy/e2e/test_autostarted.py`"
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/data/modules/minimalwaitingmodule/model/_init.cf
+++ b/tests/data/modules/minimalwaitingmodule/model/_init.cf
@@ -1,22 +1,13 @@
-entity SleepBase extends std::PurgeableResource:
-    string name
-    string agent
-    bool managed=true
-    bool purged=false
-end
-
-entity Sleep extends SleepBase:
-    int time_to_sleep=120
-end
-
-implement Sleep using std::none
-
-entity WaitForFileRemoval extends SleepBase:
+entity WaitForFileRemoval std::PurgeableResource:
     """
     Resource that will remain in the deploying state until
     the file at the given path doesn't exist anymore.
     """
+    string name
+    string agent
     string path
+    bool managed=true
+    bool purged=false
 end
 
 implement WaitForFileRemoval using std::none

--- a/tests/data/modules/minimalwaitingmodule/model/_init.cf
+++ b/tests/data/modules/minimalwaitingmodule/model/_init.cf
@@ -1,9 +1,22 @@
-entity Sleep extends std::PurgeableResource:
+entity SleepBase extends std::PurgeableResource:
     string name
     string agent
-    int time_to_sleep=120
     bool managed=true
     bool purged=false
 end
 
+entity Sleep extends SleepBase:
+    int time_to_sleep=120
+end
+
 implement Sleep using std::none
+
+entity WaitForFileRemoval extends SleepBase:
+    """
+    Resource that will remain in the deploying state until
+    the file at the given path doesn't exist anymore.
+    """
+    string path
+end
+
+implement WaitForFileRemoval using std::none

--- a/tests/data/modules/minimalwaitingmodule/model/_init.cf
+++ b/tests/data/modules/minimalwaitingmodule/model/_init.cf
@@ -1,4 +1,4 @@
-entity WaitForFileRemoval std::PurgeableResource:
+entity WaitForFileRemoval extends std::PurgeableResource:
     """
     Resource that will remain in the deploying state until
     the file at the given path doesn't exist anymore.

--- a/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
+++ b/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
@@ -22,29 +22,6 @@ import os.path
 from inmanta import resources
 from inmanta.agent.handler import provider, CRUDHandler, HandlerContext, ResourcePurged
 
-@resources.resource("minimalwaitingmodule::Sleep", agent="agent", id_attribute="name")
-class SleepResource(resources.PurgeableResource):
-    """
-    This class represents a service on a system.
-    """
-
-    name: str
-    agent: str
-    time_to_sleep: int
-
-    fields = ("name", "agent", "time_to_sleep")
-
-
-@provider("minimalwaitingmodule::Sleep", name="mysleephandler")
-class SleepHandler(CRUDHandler):
-    def read_resource(self, ctx: HandlerContext, resource: SleepResource) -> None:
-        raise ResourcePurged()
-
-    def create_resource(self, ctx: HandlerContext, resource: SleepResource) -> None:
-        time.sleep(resource.time_to_sleep)
-        ctx.set_created()
-
-
 @resources.resource("minimalwaitingmodule::WaitForFileRemoval", agent="agent", id_attribute="name")
 class WaitForFileRemoval(resources.PurgeableResource):
     """

--- a/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
+++ b/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
@@ -22,6 +22,7 @@ import os.path
 from inmanta import resources
 from inmanta.agent.handler import provider, CRUDHandler, HandlerContext, ResourcePurged
 
+
 @resources.resource("minimalwaitingmodule::WaitForFileRemoval", agent="agent", id_attribute="name")
 class WaitForFileRemoval(resources.PurgeableResource):
     """

--- a/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
+++ b/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
@@ -37,7 +37,7 @@ class WaitForFileRemoval(resources.PurgeableResource):
 
 
 @provider("minimalwaitingmodule::WaitForFileRemoval", name="wait_for_file_removal")
-class SleepHandler(CRUDHandler):
+class WaitForFileRemovalHandler(CRUDHandler):
     def read_resource(self, ctx: HandlerContext, resource: WaitForFileRemoval) -> None:
         if os.path.exists(resource.path):
             raise ResourcePurged()

--- a/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
+++ b/tests/data/modules/minimalwaitingmodule/plugins/__init__.py
@@ -31,7 +31,7 @@ class WaitForFileRemoval(resources.PurgeableResource):
 
     name: str
     agent: str
-    path = str
+    path: str
 
     fields = ("name", "agent", "path")
 

--- a/tests/deploy/e2e/test_autostarted.py
+++ b/tests/deploy/e2e/test_autostarted.py
@@ -35,7 +35,7 @@ from psutil import NoSuchProcess, Process
 
 from inmanta import config, const, data
 from inmanta.const import AgentAction
-from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER, SLICE_CODE
+from inmanta.server import SLICE_AGENT_MANAGER, SLICE_AUTOSTARTED_AGENT_MANAGER
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.util import get_compiler_version
 from typing_extensions import Optional
@@ -48,6 +48,7 @@ async def wait_for_resources_in_state(client, environment: uuid.UUID, nr_of_reso
     """
     Wait until the given number of resources in environment have the given resource state (exact match).
     """
+
     async def _done_waiting() -> bool:
         result = await client.resource_list(environment, deploy_summary=True)
         assert result.code == 200
@@ -845,6 +846,7 @@ async def test_agent_paused_scheduler_server_restart(
         - The server (and thus the scheduler) is (are) restarted
         - The agent should remain paused (the Scheduler shouldn't do anything after the restart)
     """
+
     async def return_none(*args, **kwargs):
         return None
 

--- a/tests/deploy/e2e/test_autostarted.py
+++ b/tests/deploy/e2e/test_autostarted.py
@@ -43,6 +43,7 @@ from utils import ClientHelper, retry_limited, wait_until_deployment_finishes
 
 logger = logging.getLogger("inmanta.test.server_agent")
 
+
 async def wait_for_resources_in_state(client, environment: uuid.UUID, nr_of_resources: int, state: const.ResourceState) -> bool:
     async def _done_waiting() -> bool:
         result = await client.resource_list(environment, deploy_summary=True)
@@ -52,6 +53,7 @@ async def wait_for_resources_in_state(client, environment: uuid.UUID, nr_of_reso
         return deploying == nr_of_resources
 
     await retry_limited(_done_waiting, timeout=10)
+
 
 @dataclass(frozen=True, kw_only=True)
 class SchedulerChildren:
@@ -567,9 +569,7 @@ async def test_halt_deploy(
     assert result.code == 200
 
     # Wait for at least one resource to be in deploying
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deploying
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deploying)
 
     # Let's check the agent table and check that agent1 is present and not paused
     await assert_is_paused(client, environment, {"agent1": False})
@@ -723,9 +723,7 @@ minimalwaitingmodule::WaitForFileRemoval(name="test_sleep3", agent="agent1", pat
 
     # Wait for one resource in deployed state.
     file_to_remove1.unlink()
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deployed
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deployed)
 
     # Make sure the children of the scheduler are consistent
     await wait_for_consistent_children(
@@ -756,9 +754,7 @@ minimalwaitingmodule::WaitForFileRemoval(name="test_sleep3", agent="agent1", pat
     # still needs to be deployed
     file_to_remove2.unlink()
     file_to_remove3.unlink()
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=2, state=const.ResourceState.deployed
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=2, state=const.ResourceState.deployed)
     result = await client.resource_list(environment, deploy_summary=True)
     assert result.code == 200
     summary = result.result["metadata"]["deploy_summary"]
@@ -875,9 +871,7 @@ minimalwaitingmodule::WaitForFileRemoval(name="test_sleep", agent="agent1", path
     assert result.code == 200
 
     # Wait for this resource to be deploying
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deploying
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deploying)
 
     # Executors are reporting to be deploying before deploying the first executor, we need to wait for them to be sure that
     # something is moving
@@ -906,10 +900,7 @@ minimalwaitingmodule::WaitForFileRemoval(name="test_sleep", agent="agent1", path
     assert result.code == 200
     summary = result.result["metadata"]["deploy_summary"]
     assert summary["total"] == 1, f"Unexpected summary: {summary}"
-    assert (
-        summary["by_state"]["unavailable"] == 1 or summary["by_state"]["deploying"] == 1,
-        f"Unexpected summary: {summary}",
-    )
+    assert summary["by_state"]["unavailable"] == 1 or summary["by_state"]["deploying"] == 1, f"Unexpected summary: {summary}"
 
     # Wait for the scheduler
     await wait_for_consistent_children(
@@ -969,9 +960,7 @@ c = minimalwaitingmodule::WaitForFileRemoval(name="test_sleep3", agent="agent1",
 
     # Wait for one resource to be deployed
     file_to_remove1.unlink()
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deployed
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deployed)
 
     # Make sure the children of the scheduler are consistent
     await wait_for_consistent_children(
@@ -1002,9 +991,7 @@ c = minimalwaitingmodule::WaitForFileRemoval(name="test_sleep3", agent="agent1",
 
     # Wait for the current deployment of the agent to end
     file_to_remove2.unlink()
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=2, state=const.ResourceState.deployed
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=2, state=const.ResourceState.deployed)
 
     # Let's make sure there is only one resource left to deploy
     result = await client.resource_list(environment, deploy_summary=True)
@@ -1035,7 +1022,7 @@ c = minimalwaitingmodule::WaitForFileRemoval(name="test_sleep3", agent="agent1",
         wait_for_terminated_status,
         timeout=const.EXECUTOR_GRACE_HARD + 2,
         current_children=state_after_deployment.children,
-        expected_terminated_process=3, # Scheduler + executor + forkserver
+        expected_terminated_process=3,  # Scheduler + executor + forkserver
     )
 
     # Let's recheck the number of processes after pausing the environment
@@ -1120,9 +1107,7 @@ minimalwaitingmodule::WaitForFileRemoval(name="test_sleep3", agent="agent3", pat
     assert result.code == 200
 
     # Wait for one resource to be deploying
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=3, state=const.ResourceState.deploying
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=3, state=const.ResourceState.deploying)
 
     result = await client.list_versions(tid=environment)
     assert result.code == 200
@@ -1273,9 +1258,7 @@ minimalwaitingmodule::WaitForFileRemoval(name="test_sleep", agent="agent1", path
     assert result.code == 200
 
     # Wait for this resource to be deploying
-    await wait_for_resources_in_state(
-        client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deploying
-    )
+    await wait_for_resources_in_state(client, uuid.UUID(environment), nr_of_resources=1, state=const.ResourceState.deploying)
 
     # Executors are reporting to be deploying before deploying the first executor, we need to wait for them to be sure that
     # something is moving

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -416,6 +416,7 @@ async def wait_until_deployment_finishes(
         assert result.code == 200
 
         summary = result.result["metadata"]["deploy_summary"]
+        print(summary)
 
         # {'by_state': {'available': 3, 'cancelled': 0, 'deployed': 12, 'deploying': 0, 'failed': 0, 'skipped': 0,
         #               'skipped_for_undefined': 0, 'unavailable': 0, 'undefined': 0}, 'total': 15}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -416,7 +416,6 @@ async def wait_until_deployment_finishes(
         assert result.code == 200
 
         summary = result.result["metadata"]["deploy_summary"]
-        print(summary)
 
         # {'by_state': {'available': 3, 'cancelled': 0, 'deployed': 12, 'deploying': 0, 'failed': 0, 'skipped': 0,
         #               'skipped_for_undefined': 0, 'unavailable': 0, 'undefined': 0}, 'total': 15}


### PR DESCRIPTION
# Description

Improve the stability and speed of tests in `tests/deploy/e2e/test_autostarted.py`. This on average removes 30 seconds from the total runtime of the file.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
