### PR TITLE
Fix SQLAlchemy duplicated logs

### DIFF
--- a/changelogs/unreleased/8798-fix-sqlalchemy-duplicated-logs.yml
+++ b/changelogs/unreleased/8798-fix-sqlalchemy-duplicated-logs.yml
@@ -1,0 +1,4 @@
+description: Fix SQLAlchemy duplicated logs.
+issue-nr: 8798
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -282,6 +282,7 @@ class Options(Namespace):
                               instead of the component of the compiler that was executing while the log record was created
                               or the name of the module that created the log message.
     :param logging_config: Path to the dict-based logging config file.
+    :param echo_sqlalchemy_logging: Output SqlAlchemy logs to stdout.
     """
 
     log_file: Optional[str] = None
@@ -290,6 +291,7 @@ class Options(Namespace):
     timed: bool = False
     keep_logger_names: bool = False
     logging_config: Optional[str] = None
+    echo_sqlalchemy_logging: bool = False
 
 
 class LoggingConfigBuilderExtension(abc.ABC):

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -95,7 +95,7 @@ class InmantaBootloader:
 
         if configure_logging:
             inmanta_logger_config = inmanta_logging.InmantaLoggerConfig.get_instance()
-            inmanta_logger_config.apply_options(inmanta_logging.Options())
+            inmanta_logger_config.apply_options(inmanta_logging.Options(echo_sqlalchemy_logging=True))
 
     async def start(self) -> None:
         self.start_loggers_for_extensions()

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -22,6 +22,7 @@ from typing import Mapping, Optional
 from pyformance import gauge, global_registry
 from pyformance.meters import CallbackGauge
 
+from inmanta import logging as inmanta_logging
 from inmanta.data import (
     CORE_SCHEMA_NAME,
     PACKAGE_WITH_UPDATE_FILES,
@@ -230,6 +231,9 @@ class DatabaseService(protocol.ServerSlice):
 
     async def connect_database(self) -> None:
         """Connect to the database"""
+
+        inmanta_logger_options = inmanta_logging.InmantaLoggerConfig.get_instance()._options_applied
+        echo = getattr(inmanta_logger_options, "echo_sqlalchemy_logging", False)
         await initialize_sql_alchemy_engine(
             database_host=opt.db_host.get(),
             database_port=opt.db_port.get(),
@@ -240,6 +244,7 @@ class DatabaseService(protocol.ServerSlice):
             connection_pool_min_size=opt.server_db_connection_pool_min_size.get(),
             connection_pool_max_size=opt.server_db_connection_pool_max_size.get(),
             connection_timeout=opt.server_db_connection_timeout.get(),
+            echo=echo,
         )
         async with get_connection_ctx_mgr() as connection:
             # Check if JIT is enabled
@@ -267,6 +272,7 @@ async def initialize_sql_alchemy_engine(
     connection_pool_min_size: int = 10,
     connection_pool_max_size: int = 10,
     connection_timeout: float = 60.0,
+    echo: bool = False,
 ) -> None:
     """
     Initialize the sql alchemy engine for the current process.
@@ -280,6 +286,7 @@ async def initialize_sql_alchemy_engine(
     :param connection_pool_min_size: Initialize the pool with this number of connections .
     :param connection_pool_max_size: Limit the size of the pool to this number of connections .
     :param connection_timeout: Connection timeout (in seconds) when interacting with the database.
+    :param echo: Also output the logging to stdout (only set to true in testing environments).
     """
 
     await start_engine(
@@ -291,7 +298,7 @@ async def initialize_sql_alchemy_engine(
         pool_size=connection_pool_min_size,
         max_overflow=connection_pool_max_size - connection_pool_min_size,
         pool_timeout=connection_timeout,
-        echo=True,
+        echo=echo,
     )
 
     if create_db_schema:

--- a/src/inmanta/user_setup.py
+++ b/src/inmanta/user_setup.py
@@ -110,7 +110,6 @@ async def connect_to_db() -> None:
         pool_size=connection_pool_min_size,
         max_overflow=connection_pool_max_size - connection_pool_min_size,
         pool_timeout=connection_timeout,
-        echo=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -398,6 +398,7 @@ def sqlalchemy_url_parameters(postgres_db, database_name_internal: str) -> dict[
         "database_host": postgres_db.host,
         "database_port": postgres_db.port,
         "database_name": database_name_internal,
+        "echo": True,
     }
 
 
@@ -421,6 +422,7 @@ async def init_dataclasses_and_load_schema(postgres_db, database_name, clean_res
         database_username=postgres_db.user,
         database_password=postgres_db.password,
         create_db_schema=True,
+        echo=True,
     )
     yield
     await stop_engine()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -83,6 +83,7 @@ async def test_connection_failure(postgres_db, unused_tcp_port_factory, database
         database_host=postgres_db.host,
         database_port=wrong_port,
         database_name=database_name,
+        echo=True,
     )
     engine = get_engine()
     with pytest.raises(ConnectionRefusedError):


### PR DESCRIPTION
# Description

SQLAlchemy was producing duplicated logs. This is because the `echo` was enabled which copies the logs to stdout. 
This is useful in the tests but when spinning up a server we get these duplicated logs.

I tried to make `echo=True` only while testing. 

closes #8798 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
