### PR TITLE
Make the assertion on the firetime of the timer in the tests less strict (#8836)

### DIFF
--- a/changelogs/unreleased/make-assert-on-firetime-of-timer-less-strict.yml
+++ b/changelogs/unreleased/make-assert-on-firetime-of-timer-less-strict.yml
@@ -1,0 +1,4 @@
+---
+description: Make the assertion on the firetime of the timer in the tests less strict.
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/deploy/test_timer_handling.py
+++ b/tests/deploy/test_timer_handling.py
@@ -138,7 +138,7 @@ async def test_time_manager_basics():
     await t4[0].activation_lock.wait()
 
     def assert_fired(timer: MockTimer, at: datetime.datetime) -> None:
-        assert timedelta(milliseconds=0) < (timer.activated_at - at) < timedelta(milliseconds=5)
+        assert timedelta(milliseconds=0) < (timer.activated_at - at) < timedelta(milliseconds=10)
 
     assert_fired(*t1)
     assert_fired(*t2)


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #8836