### PR TITLE
Change GraphQL schema endpoint to GET instead of POST

### DIFF
--- a/changelogs/unreleased/change-graphql-schema-endpoint-to-get.yml
+++ b/changelogs/unreleased/change-graphql-schema-endpoint-to-get.yml
@@ -1,0 +1,4 @@
+---
+description: "Change GraphQL schema endpoint to GET instead of POST"
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1625,7 +1625,7 @@ def graphql(query: str) -> Any:  # Actual return type: strawberry.types.executio
 
 @typedmethod(
     path="/graphql/schema",
-    operation="POST",
+    operation="GET",
     client_types=[ClientType.api],
     api_version=2,
     strict_typing=False,


### PR DESCRIPTION
# Description

Missed this on the previous PR. But I think it makes sense for it to be a GET.

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
