### PR TITLE
Issue/8799 empty version

### DIFF
--- a/changelogs/unreleased/8799-emtpy-version.yml
+++ b/changelogs/unreleased/8799-emtpy-version.yml
@@ -1,0 +1,6 @@
+description: Ensure empty versions are correctly passed to the scheduler
+issue-nr: 8799
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/8799-emtpy-version.yml
+++ b/changelogs/unreleased/8799-emtpy-version.yml
@@ -1,4 +1,4 @@
-description: Ensure empty versions are correctly passed to the scheduler
+description: Fix issue where empty versions are not correctly passed to the scheduler
 issue-nr: 8799
 change-type: patch
 destination-branches: [master, iso8]

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -1174,9 +1174,6 @@ class OrchestrationService(protocol.ServerSlice):
                     # This has to be done after the resources outside of the increment have been marked as deployed.
                     await model.update_fields(released=True, connection=connection)
 
-            if model.total == 0:
-                return 200, {"model": model}
-
             if connection.is_in_transaction():
                 raise RuntimeError(
                     "The release of a new version cannot be in a transaction! "

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -492,26 +492,20 @@ async def test_deploy_to_empty(server, client, clienthelper, environment, agent,
     env_id = environment
     scheduler = agent.scheduler
 
-    async def make_version(is_different=False):
-        """
-
-        :param is_different: make the standard version or one with a change
-        :return:
-        """
+    async def make_version():
         version = await clienthelper.get_version()
         agent = "agent1"
         resources = [
-                    {
-                        "key": "key1",
-                        "value": "value",
-                        "id": "test::Resourcex[%s,key=key1],v=%d" % (agent, version),
-                        "requires": [],
-                        "purged": False,
-                        "send_event": False,
-                        "attributes": {"A": "B"},
-                    }
-
-            ]
+            {
+                "key": "key1",
+                "value": "value",
+                "id": "test::Resourcex[%s,key=key1],v=%d" % (agent, version),
+                "requires": [],
+                "purged": False,
+                "send_event": False,
+                "attributes": {"A": "B"},
+            }
+        ]
         return version, resources
 
     logger.info("setup done")

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -473,6 +473,93 @@ async def test_deploy_empty(server, client, clienthelper, environment, agent):
     assert result.code == 200
     assert result.result["model"]["released"]
 
+    async def is_active():
+        r_versions = await client.list_desired_state_versions(environment)
+        assert r_versions.code == 200
+        versions = r_versions.result["data"]
+        assert len(versions) == 1
+        return versions[0]["status"] == "active"
+
+    await retry_limited(is_active, 1)
+
+
+async def test_deploy_to_empty(server, client, clienthelper, environment, agent, resource_container):
+    """
+    Test deployment of empty model after a not-empty model
+
+    Ensure we unload all resources
+    """
+    env_id = environment
+    scheduler = agent.scheduler
+
+    async def make_version(is_different=False):
+        """
+
+        :param is_different: make the standard version or one with a change
+        :return:
+        """
+        version = await clienthelper.get_version()
+        agent = "agent1"
+        resources = [
+                    {
+                        "key": "key1",
+                        "value": "value",
+                        "id": "test::Resourcex[%s,key=key1],v=%d" % (agent, version),
+                        "requires": [],
+                        "purged": False,
+                        "send_event": False,
+                        "attributes": {"A": "B"},
+                    }
+
+            ]
+        return version, resources
+
+    logger.info("setup done")
+    version1, resources = await make_version()
+    await clienthelper.put_version_simple(version=version1, resources=resources)
+
+    logger.info("first version pushed")
+
+    # deploy and wait until one is ready
+    result = await client.release_version(env_id, version1)
+    assert result.code == 200
+
+    await clienthelper.wait_for_released(version1)
+
+    logger.info("first version released")
+
+    await clienthelper.wait_for_deployed(version=1)
+
+    assert len(scheduler._state.resource_state) == 1
+
+    version = await clienthelper.get_version()
+    resources = []
+    result = await client.put_version(
+        tid=environment,
+        version=version,
+        resources=resources,
+        resource_state={},
+        unknowns=[],
+        version_info={},
+        compiler_version=get_compiler_version(),
+    )
+    assert result.code == 200
+
+    # do a deploy
+    result = await client.release_version(environment, version)
+    assert result.code == 200
+    assert result.result["model"]["released"]
+
+    async def is_active():
+        r_versions = await client.list_desired_state_versions(environment)
+        assert r_versions.code == 200
+        versions = r_versions.result["data"]
+        assert len(versions) == 2
+        return versions[0]["status"] == "active"
+
+    await retry_limited(is_active, 1)
+    assert len(scheduler._state.resource_state) == 0
+
 
 async def test_deploy_with_undefined(server, client, resource_container, agent, environment, clienthelper):
     """


### PR DESCRIPTION
# Description

Fix issue where empty versions are not correctly passed to the scheduler

closes #8799 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
