### PR TITLE
Issue/log file loading

### DIFF
--- a/changelogs/unreleased/log_config.yml
+++ b/changelogs/unreleased/log_config.yml
@@ -1,0 +1,7 @@
+description: Fix issue where log file config was not correctly applied when specified via the config file
+issue-nr: 8858
+change-type: patch
+destination-branches: [iso7]
+sections:
+  bugfix: "{{description}}"
+

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -937,15 +937,15 @@ def app() -> None:
     options, other = parser.parse_known_args()
     options.other = other
 
-    log_config.apply_options(options)
-
-    logging.captureWarnings(True)
-
     if options.config_file and not os.path.exists(options.config_file):
         LOGGER.warning("Config file %s doesn't exist", options.config_file)
 
     # Load the configuration
     Config.load_config(options.config_file, options.config_dir)
+
+    log_config.apply_options(options)
+
+    logging.captureWarnings(True)
 
     if options.inmanta_version:
         print_versions_installed_components_and_exit()


### PR DESCRIPTION
# Description

Fixes issue where log file could not be written for resource action log

closes #8858


!! I didn't add an automated test because it is very difficult to reproduce (lots of custom setup that is slow), and it only affects the resource action log on iso7. I tested by hand

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
