### PR TITLE
Add overall status to the status endpoint

### DIFF
--- a/changelogs/unreleased/6813-add-overall-status-to-the-status-endpoint.yml
+++ b/changelogs/unreleased/6813-add-overall-status-to-the-status-endpoint.yml
@@ -1,0 +1,4 @@
+change-type: minor
+issue-nr: 6813
+description: Add overall status to the status endpoint
+destination-branches: [master, iso8]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -128,7 +128,7 @@ class StatusResponse(BaseModel):
     features: list[FeatureStatus]
 
     @property
-    def status(self):
+    def status(self) -> ReportedStatus:
         """
         Returns the status of the response.
         It is the worst of the reported slice statuses.

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -92,13 +92,12 @@ class ReportedStatus(StrEnum):
     Warning = "Warning"
     Error = "Error"
 
-
-# Determines the order of severity of the reported status
-STATUS_ORDER = {
-    ReportedStatus.OK: 0,
-    ReportedStatus.Warning: 1,
-    ReportedStatus.Error: 2,
-}
+    def __gt__(self, other: str) -> bool:
+        # Determines the order of severity of the reported status
+        order: list[str] = [ReportedStatus.OK, ReportedStatus.Warning, ReportedStatus.Error]
+        if self not in order or other not in order:
+            raise ValueError
+        return order.index(self) > order.index(other)
 
 
 class SliceStatus(BaseModel):

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -87,6 +87,12 @@ class ExtensionStatus(BaseModel):
     package: str
 
 
+class ReportedStatus(Enum):
+    OK = 1
+    Warning = 2
+    Error = 3
+
+
 class SliceStatus(BaseModel):
     """
     Status response for slices loaded in the server
@@ -94,6 +100,8 @@ class SliceStatus(BaseModel):
 
     name: str
     status: Mapping[str, ArgumentTypes | Mapping[str, ArgumentTypes]]
+    reported_status: ReportedStatus
+    message: str | None = None
 
 
 class FeatureStatus(BaseModel):
@@ -118,6 +126,14 @@ class StatusResponse(BaseModel):
     extensions: list[ExtensionStatus]
     slices: list[SliceStatus]
     features: list[FeatureStatus]
+
+    @property
+    def status(self):
+        """
+        Returns the status of the response.
+        It is the worst of the reported slice statuses.
+        """
+        return ReportedStatus(max([slice.reported_status.value for slice in self.slices]))
 
 
 @stable_api

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -87,10 +87,18 @@ class ExtensionStatus(BaseModel):
     package: str
 
 
-class ReportedStatus(Enum):
-    OK = 1
-    Warning = 2
-    Error = 3
+class ReportedStatus(StrEnum):
+    OK = "OK"
+    Warning = "Warning"
+    Error = "Error"
+
+
+# Determines the order of severity of the reported status
+STATUS_ORDER = {
+    ReportedStatus.OK: 0,
+    ReportedStatus.Warning: 1,
+    ReportedStatus.Error: 2,
+}
 
 
 class SliceStatus(BaseModel):
@@ -126,14 +134,7 @@ class StatusResponse(BaseModel):
     extensions: list[ExtensionStatus]
     slices: list[SliceStatus]
     features: list[FeatureStatus]
-
-    @property
-    def status(self) -> ReportedStatus:
-        """
-        Returns the status of the response.
-        It is the worst of the reported slice statuses.
-        """
-        return ReportedStatus(max([slice.reported_status.value for slice in self.slices]))
+    status: ReportedStatus
 
 
 @stable_api

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -179,7 +179,7 @@ class AgentManager(ServerSlice, SessionListener):
 
         # Try to get more info from scheduler, but make sure not to timeout
         schedulers = self.get_all_schedulers()
-        deadline = 0.9 * Server.GET_SERVER_STATUS_TIMEOUT
+        deadline = 0.9 * Server.GET_SLICE_STATUS_TIMEOUT
 
         async def get_report(env: uuid.UUID, session: protocol.Session) -> tuple[uuid.UUID, DataBaseReport]:
             result = await asyncio.wait_for(session.client.get_db_status(), deadline)

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -32,7 +32,7 @@ from tornado import gen, queues, routing, web
 
 import inmanta.protocol.endpoints
 from inmanta import tracing
-from inmanta.data.model import ExtensionStatus
+from inmanta.data.model import ExtensionStatus, ReportedStatus, SliceStatus
 from inmanta.protocol import Client, Result, TypedClient, common, endpoints, handle, methods
 from inmanta.protocol.exceptions import ShutdownInProgress
 from inmanta.protocol.rest import server
@@ -238,6 +238,9 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler[Result | No
 
     feature_manager: "FeatureManager"
 
+    # The number of seconds after which the call to the get_status() endpoint of this server slice should time out.
+    GET_SERVER_STATUS_TIMEOUT: int = 1
+
     def __init__(self, name: str) -> None:
         super().__init__()
 
@@ -404,6 +407,45 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler[Result | No
         Get the status of this slice.
         """
         return {}
+
+    async def get_reported_status(self) -> tuple[ReportedStatus, Optional[str]]:
+        """
+        Get the reported status of this slice as well as a message if applicable.
+        """
+        return ReportedStatus.OK, None
+
+    async def get_slice_status(self) -> SliceStatus:
+        """
+        Get the reported status of this slice
+        """
+        try:
+            status, message = await self.get_reported_status()
+            return SliceStatus(
+                name=self.name,
+                status=await asyncio.wait_for(self.get_status(), self.GET_SERVER_STATUS_TIMEOUT),
+                reported_status=status,
+                message=message,
+            )
+        except asyncio.TimeoutError:
+            return SliceStatus(
+                name=self.name,
+                status={
+                    "error": f"timeout on data collection for {self.name}, " "consult the server log for additional information"
+                },
+                reported_status=ReportedStatus.Error,
+                message="Timeout on data collection",
+            )
+        except Exception:
+            LOGGER.error(
+                f"The following error occurred while trying to determine the status of slice {self.name}",
+                exc_info=True,
+            )
+            return SliceStatus(
+                name=self.name,
+                status={"error": "An unexpected error occurred, reported to server log"},
+                reported_status=ReportedStatus.Error,
+                message="An unexpected error occurred, reported to server log",
+            )
 
     def define_features(self) -> list["Feature[object]"]:
         """Return a list of feature that this slice offers"""

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -239,7 +239,7 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler[Result | No
     feature_manager: "FeatureManager"
 
     # The number of seconds after which the call to the get_status() endpoint of this server slice should time out.
-    GET_SERVER_STATUS_TIMEOUT: int = 1
+    GET_SLICE_STATUS_TIMEOUT: int = 1
 
     def __init__(self, name: str) -> None:
         super().__init__()
@@ -422,7 +422,7 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler[Result | No
             status, message = await self.get_reported_status()
             return SliceStatus(
                 name=self.name,
-                status=await asyncio.wait_for(self.get_status(), self.GET_SERVER_STATUS_TIMEOUT),
+                status=await asyncio.wait_for(self.get_status(), self.GET_SLICE_STATUS_TIMEOUT),
                 reported_status=status,
                 message=message,
             )

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -430,7 +430,7 @@ class ServerSlice(inmanta.protocol.endpoints.CallTarget, TaskHandler[Result | No
             return SliceStatus(
                 name=self.name,
                 status={
-                    "error": f"timeout on data collection for {self.name}, " "consult the server log for additional information"
+                    "error": f"Timeout on data collection for {self.name}, consult the server log for additional information"
                 },
                 reported_status=ReportedStatus.Error,
                 message="Timeout on data collection",

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -55,9 +55,6 @@ class Server(protocol.ServerSlice):
     compiler: "CompilerService"
     _server: protocol.Server
 
-    # The number of seconds after which the call to the get_status() endpoint of a server slice should time out.
-    GET_SERVER_STATUS_TIMEOUT: int = 1
-
     def __init__(self) -> None:
         super().__init__(name=SLICE_SERVER)
         LOGGER.info("Starting server endpoint")

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -28,7 +28,7 @@ from tornado import routing, web
 
 from inmanta import config, const, data
 from inmanta.const import ApiDocsFormat
-from inmanta.data.model import STATUS_ORDER, FeatureStatus, StatusResponse
+from inmanta.data.model import FeatureStatus, ReportedStatus, StatusResponse
 from inmanta.protocol import exceptions, handle, methods, methods_v2
 from inmanta.protocol.common import HTML_CONTENT_WITH_UTF8_CHARSET, ReturnValue, attach_warnings
 from inmanta.protocol.openapi.converter import OpenApiConverter
@@ -143,7 +143,7 @@ class Server(protocol.ServerSlice):
                 FeatureStatus(slice=feature.slice, name=feature.name, value=self.feature_manager.get_value(feature))
                 for feature in self.feature_manager.get_features()
             ],
-            status=max(slices, key=lambda slice: STATUS_ORDER[slice.reported_status]).reported_status,
+            status=max(ReportedStatus(slice.reported_status) for slice in slices),
         )
 
         return response

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -28,7 +28,7 @@ from tornado import routing, web
 
 from inmanta import config, const, data
 from inmanta.const import ApiDocsFormat
-from inmanta.data.model import FeatureStatus, StatusResponse
+from inmanta.data.model import STATUS_ORDER, FeatureStatus, StatusResponse
 from inmanta.protocol import exceptions, handle, methods, methods_v2
 from inmanta.protocol.common import HTML_CONTENT_WITH_UTF8_CHARSET, ReturnValue, attach_warnings
 from inmanta.protocol.openapi.converter import OpenApiConverter
@@ -143,6 +143,7 @@ class Server(protocol.ServerSlice):
                 FeatureStatus(slice=feature.slice, name=feature.name, value=self.feature_manager.get_value(feature))
                 for feature in self.feature_manager.get_features()
             ],
+            status=max(slices, key=lambda slice: STATUS_ORDER[slice.reported_status]).reported_status,
         )
 
         return response

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -258,8 +258,12 @@ class DatabaseService(protocol.ServerSlice):
             - Warning: The pool has less than 5 connections or 10% of the max pool size
             - OK: Otherwise
         """
-        status = await self._db_monitor.get_status()
-        if not status.connected:
+
+        try:
+            assert self._db_monitor
+            status = await self._db_monitor.get_status()
+            assert status.connected
+        except Exception:
             return ReportedStatus.Error, "Database is not connected"
 
         if status.free_pool < min(5, status.max_pool // 10):

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -31,7 +31,7 @@ from inmanta.data import (
     start_engine,
     stop_engine,
 )
-from inmanta.data.model import DataBaseReport
+from inmanta.data.model import DataBaseReport, ReportedStatus
 from inmanta.server import SLICE_DATABASE
 from inmanta.server import config as opt
 from inmanta.server import protocol
@@ -250,6 +250,22 @@ class DatabaseService(protocol.ServerSlice):
     async def disconnect_database(self) -> None:
         """Disconnect the database"""
         await stop_engine()
+
+    async def get_reported_status(self) -> tuple[ReportedStatus, Optional[str]]:
+        """
+        Returns the reported status of this slice:
+            - Error: Not Connected
+            - Warning: The pool has less than 5 connections or 10% of the max pool size
+            - OK: Otherwise
+        """
+        status = await self._db_monitor.get_status()
+        if not status.connected:
+            return ReportedStatus.Error, "Database is not connected"
+
+        if status.free_pool < min(5, status.max_pool // 10):
+            return ReportedStatus.Warning, f"Only {status.free_pool} connections left in the pool."
+
+        return ReportedStatus.OK, None
 
     async def get_status(self) -> Mapping[str, ArgumentTypes]:
         """Get the status of the database connection"""

--- a/tests/server/test_databaseservice.py
+++ b/tests/server/test_databaseservice.py
@@ -22,6 +22,7 @@ import pytest
 
 from inmanta import data
 from inmanta.data import get_connection_ctx_mgr
+from inmanta.data.model import ReportedStatus
 from inmanta.server import SLICE_AGENT_MANAGER
 from inmanta.server import config as opt
 from inmanta.server.services import databaseservice
@@ -94,3 +95,38 @@ async def test_pool_exhaustion_watcher(set_pool_size_to_one, server, caplog):
             logging.WARNING,
             "Database pool was exhausted",
         )
+
+
+async def test_database_service_status(monkeypatch, server, client):
+    """
+    Test the status of the database service and if it changes with the reduction of the connection pool
+    or if we are not connected to the database.
+    """
+    database_slice = server.get_slice(databaseservice.SLICE_DATABASE)
+    status = await database_slice.get_slice_status()
+    assert status.reported_status == ReportedStatus.OK
+
+    monitor_status = status.status
+    max_pool = monitor_status["max_pool"]
+    mocked_free_pool = max_pool // 10 - 1
+
+    def return_free_pool(self, pool):
+        return mocked_free_pool
+
+    monkeypatch.setattr(databaseservice.DatabaseMonitor, "get_free_connections", return_free_pool)
+
+    status = await database_slice.get_slice_status()
+    assert status.reported_status == ReportedStatus.Warning
+    assert status.message == f"Only {mocked_free_pool} connections left in the pool."
+
+    original_get_status = database_slice._db_monitor.get_status
+
+    async def modified_get_status(self):
+        status = await original_get_status()
+        status.connected = False
+        return status
+
+    monkeypatch.setattr(databaseservice.DatabaseMonitor, "get_status", modified_get_status)
+
+    status = await database_slice.get_slice_status()
+    assert status.reported_status == ReportedStatus.Error

--- a/tests/server/test_server_status.py
+++ b/tests/server/test_server_status.py
@@ -22,7 +22,6 @@ import uuid
 import pytest
 
 from inmanta.data import stop_engine
-from inmanta.server.server import Server
 from inmanta.server.services.compilerservice import CompilerService
 
 
@@ -66,7 +65,7 @@ async def test_server_status_database_unreachable(server, client):
 
 
 async def test_server_status_timeout(server, client, monkeypatch):
-    monkeypatch.setattr(Server, "GET_SERVER_STATUS_TIMEOUT", 0.1)
+    monkeypatch.setattr(CompilerService, "GET_SLICE_STATUS_TIMEOUT", 0.1)
 
     async def hang(self):
         await asyncio.sleep(0.2)


### PR DESCRIPTION
# Description

Moved `GET_SLICE_STATUS_TIMEOUT` up to the generic class, which makes each get status timeout configurable. Not sure if desired but it was helpful because I also moved `get_slice_status` which was using it.

Not sure if `status=max(slices, key=lambda slice: STATUS_ORDER[slice.reported_status]).reported_status` is overengineered


closes #6813 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
