### PR TITLE
Added test for escaped characters in f-strings

### DIFF
--- a/changelogs/unreleased/6471-add-test-for-escaped-characters-in-f-strings.yml
+++ b/changelogs/unreleased/6471-add-test-for-escaped-characters-in-f-strings.yml
@@ -1,0 +1,4 @@
+change-type: patch
+description: Add test for escaped characters in f-strings
+issue-nr: 6471
+destination-branches: [master, iso8, iso7]

--- a/tests/compiler/test_strings.py
+++ b/tests/compiler/test_strings.py
@@ -167,6 +167,25 @@ world
     assert expected == out
 
 
+def test_escaping_rules_fstrings(snippetcompiler, capsys):
+    """
+    Check that new line characters are correctly interpreted in f-strings
+    """
+    snippetcompiler.setup_for_snippet(
+        r"""
+a = 1
+std::print(f"test\ntest{a}")
+""",
+        ministd=True,
+    )
+    expected = r"""test
+test1
+"""
+    compiler.do_compile()
+    out, err = capsys.readouterr()
+    assert expected == out
+
+
 def test_fstring_float_formatting(snippetcompiler, capsys):
     snippetcompiler.setup_for_snippet(
         """


### PR DESCRIPTION
# Description

The ticket seems to be outdated. I added a test for this feature anyway

closes #6471 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
