### PR TITLE
Add the ability to attach references to compiles

### DIFF
--- a/changelogs/unreleased/7558-add-the-ability-to-attach-references-to-compiles.yml
+++ b/changelogs/unreleased/7558-add-the-ability-to-attach-references-to-compiles.yml
@@ -1,0 +1,4 @@
+description: Add the ability to attach references to compiles
+issue-nr: 7558
+change-type: minor
+destination-branches: [master, iso8]

--- a/docs/reference/apilinks.rst
+++ b/docs/reference/apilinks.rst
@@ -17,3 +17,5 @@ The following table documents all these links and their format:
      - ``/api/v2/compilereport/<compile_id>``
    * - Managed resource
      - ``/api/v2/resource/<resource_id>``
+   * - Service instance
+     - ``/lsm/v1/service_inventory/<service_entity>/<service_id>``

--- a/docs/reference/apilinks.rst
+++ b/docs/reference/apilinks.rst
@@ -7,15 +7,28 @@ API self-referencing links
 Some API endpoints can provide additional information or context by returning links to other API endpoints.
 The following table documents all these links and their format:
 
+.. only:: oss
 
-.. list-table:: Self-referencing links
-   :header-rows: 1
+    .. list-table:: Self-referencing links
+       :header-rows: 1
 
-   * - Link target type
-     - Link format
-   * - Compile report
-     - ``/api/v2/compilereport/<compile_id>``
-   * - Managed resource
-     - ``/api/v2/resource/<resource_id>``
-   * - Service instance
-     - ``/lsm/v1/service_inventory/<service_entity>/<service_id>``
+       * - Link target type
+         - Link format
+       * - Compile report
+         - ``/api/v2/compilereport/<compile_id>``
+       * - Managed resource
+         - ``/api/v2/resource/<resource_id>``
+
+.. only:: iso
+
+    .. list-table:: Self-referencing links
+       :header-rows: 1
+
+       * - Link target type
+         - Link format
+       * - Compile report
+         - ``/api/v2/compilereport/<compile_id>``
+       * - Managed resource
+         - ``/api/v2/resource/<resource_id>``
+       * - Service instance
+         - ``/lsm/v1/service_inventory/<service_entity>/<service_id>``

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3845,24 +3845,27 @@ class Compile(BaseDocument):
             return None
         requested_compile = records[0]
 
-        # Reports should be included from the substituted compile (as well)
+        # Concatenate the links of the requested compile and all substitute compiles
+        links: m.JsonApiLinks = {}
         reports = []
-        links = cast(m.JsonApiLinks, requested_compile.get("links", {}))
-        for report in result:
-            if report.get("report_id"):
+        for compile in result:
+            # Reports should be included from the substituted compile (as well)
+            if compile.get("report_id"):
                 reports.append(
                     m.CompileRunReport(
-                        id=report["report_id"],
-                        started=report["report_started"],
-                        completed=report["report_completed"],
-                        command=report["command"],
-                        name=report["name"],
-                        errstream=report["errstream"],
-                        outstream=report["outstream"],
-                        returncode=report["returncode"],
+                        id=compile["report_id"],
+                        started=compile["report_started"],
+                        completed=compile["report_completed"],
+                        command=compile["command"],
+                        name=compile["name"],
+                        errstream=compile["errstream"],
+                        outstream=compile["outstream"],
+                        returncode=compile["returncode"],
                     )
                 )
-                links.update(cast(m.JsonApiLinks, report.get("links", {})))
+            links.update(cast(m.JsonApiLinks, compile.get("links", {})))
+        # If there are repeated links, keep the ones on the requested compile
+        links.update(cast(m.JsonApiLinks, requested_compile.get("links", {})))
 
         return m.CompileDetails(
             id=requested_compile["id"],

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -760,7 +760,7 @@ class CompileReportView(DataView[CompileReportOrder, CompileReport]):
                 exporter_plugin=compile["exporter_plugin"],
                 notify_failed_compile=compile["notify_failed_compile"],
                 failed_compile_message=compile["failed_compile_message"],
-                links=cast(JsonApiLinks, compile["links"]),
+                links=cast(JsonApiLinks, compile.get("links", {})),
             )
             for compile in records
         ]

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -759,6 +759,7 @@ class CompileReportView(DataView[CompileReportOrder, CompileReport]):
                 exporter_plugin=compile["exporter_plugin"],
                 notify_failed_compile=compile["notify_failed_compile"],
                 failed_compile_message=compile["failed_compile_message"],
+                links=compile["links"],
             )
             for compile in records
         ]

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -63,6 +63,7 @@ from inmanta.data.model import (
     DesiredStateLabel,
     DesiredStateVersion,
     Fact,
+    JsonApiLinks,
     LatestReleasedResource,
     PagingBoundaries,
     ResourceHistory,
@@ -759,7 +760,7 @@ class CompileReportView(DataView[CompileReportOrder, CompileReport]):
                 exporter_plugin=compile["exporter_plugin"],
                 notify_failed_compile=compile["notify_failed_compile"],
                 failed_compile_message=compile["failed_compile_message"],
-                links=compile["links"],
+                links=cast(JsonApiLinks, compile["links"]),
             )
             for compile in records
         ]

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -63,7 +63,6 @@ from inmanta.data.model import (
     DesiredStateLabel,
     DesiredStateVersion,
     Fact,
-    JsonApiLinks,
     LatestReleasedResource,
     PagingBoundaries,
     ResourceHistory,
@@ -760,7 +759,7 @@ class CompileReportView(DataView[CompileReportOrder, CompileReport]):
                 exporter_plugin=compile["exporter_plugin"],
                 notify_failed_compile=compile["notify_failed_compile"],
                 failed_compile_message=compile["failed_compile_message"],
-                links=cast(JsonApiLinks, compile.get("links", {})),
+                links=cast(dict[str, list[str]], compile.get("links", {})),
             )
             for compile in records
         ]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -148,32 +148,6 @@ class CompileData(BaseModel):
     """
 
 
-class LinkObject(BaseModel):
-    """
-
-    :param href: a string whose value is a URI-reference pointing to the link’s target.
-
-    :param rel: a string indicating the link’s relation type. The string MUST be a valid link relation type.
-    :param describedby: a link to a description document (e.g. OpenAPI or JSON Schema) for the link target.
-    :param title: a string which serves as a label for the destination of a link
-        such that it can be used as a human-readable identifier (e.g., a menu entry).
-    :param type: a string indicating the media type of the link’s target.
-    :param hreflang: a string or an array of strings indicating the language(s) of the link’s target.
-        An array of strings indicates that the link’s target is available in multiple languages.
-        Each string MUST be a valid language tag [RFC5646].
-    :param meta: a meta object containing non-standard meta-information about the link.
-
-    """
-
-    href: str
-    rel: Optional[str] = None
-    describedby: Optional[str] = None
-    title: Optional[str] = None
-    type: Optional[str] = None
-    hreflang: Optional[str] = None
-    meta: Optional[dict[typing.Any, typing.Any]] = None
-
-
 class CompileRunBase(BaseModel):
     """
     :param requested_environment_variables: environment variables requested to be passed to the compiler

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -174,9 +174,6 @@ class LinkObject(BaseModel):
     meta: Optional[dict[typing.Any, typing.Any]] = None
 
 
-JsonApiLinks: typing.TypeAlias = dict[str, Union[str, LinkObject, None]]
-
-
 class CompileRunBase(BaseModel):
     """
     :param requested_environment_variables: environment variables requested to be passed to the compiler
@@ -185,7 +182,8 @@ class CompileRunBase(BaseModel):
             If multiple values are compacted, they will be joined using spaces.
     :param environment_variables: environment variables passed to the compiler
     :param links: An object that contains relevant links to this compile.
-        Conforms with the json api: https://jsonapi.org/format/#document-links
+        It is a dictionary where the key is something that identifies one or more links
+        and the value is a list of urls. i.e. {"instances": ["link-1',"link-2"], "compiles": ["link-3"]}
     """
 
     id: uuid.UUID
@@ -208,7 +206,7 @@ class CompileRunBase(BaseModel):
 
     notify_failed_compile: Optional[bool] = None
     failed_compile_message: Optional[str] = None
-    links: JsonApiLinks = {}
+    links: dict[str, list[str]] = {}
 
     @pydantic.field_validator("environment_variables", mode="before")
     @classmethod

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -148,6 +148,35 @@ class CompileData(BaseModel):
     """
 
 
+class LinkObject(BaseModel):
+    """
+
+    :param href: a string whose value is a URI-reference pointing to the link’s target.
+
+    :param rel: a string indicating the link’s relation type. The string MUST be a valid link relation type.
+    :param describedby: a link to a description document (e.g. OpenAPI or JSON Schema) for the link target.
+    :param title: a string which serves as a label for the destination of a link
+        such that it can be used as a human-readable identifier (e.g., a menu entry).
+    :param type: a string indicating the media type of the link’s target.
+    :param hreflang: a string or an array of strings indicating the language(s) of the link’s target.
+        An array of strings indicates that the link’s target is available in multiple languages.
+        Each string MUST be a valid language tag [RFC5646].
+    :param meta: a meta object containing non-standard meta-information about the link.
+
+    """
+
+    href: str
+    rel: Optional[str] = None
+    describedby: Optional[str] = None
+    title: Optional[str] = None
+    type: Optional[str] = None
+    hreflang: Optional[str] = None
+    meta: Optional[dict[typing.Any, typing.Any]] = None
+
+
+JsonApiLinks: typing.TypeAlias = dict[str, Union[str, LinkObject, None]]
+
+
 class CompileRunBase(BaseModel):
     """
     :param requested_environment_variables: environment variables requested to be passed to the compiler
@@ -177,6 +206,7 @@ class CompileRunBase(BaseModel):
 
     notify_failed_compile: Optional[bool] = None
     failed_compile_message: Optional[str] = None
+    links: JsonApiLinks = {}
 
     @pydantic.field_validator("environment_variables", mode="before")
     @classmethod

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -184,6 +184,8 @@ class CompileRunBase(BaseModel):
             These env vars can be compacted over multiple compiles.
             If multiple values are compacted, they will be joined using spaces.
     :param environment_variables: environment variables passed to the compiler
+    :param links: An object that contains relevant links to this compile.
+        Conforms with the json api: https://jsonapi.org/format/#document-links
     """
 
     id: uuid.UUID

--- a/src/inmanta/db/versions/v20250404.py
+++ b/src/inmanta/db/versions/v20250404.py
@@ -1,0 +1,29 @@
+"""
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+from asyncpg import Connection
+
+
+async def update(connection: Connection) -> None:
+    """
+    Rename some rps columns and values
+    """
+    schema = """
+        ALTER TABLE public.compile ADD COLUMN links jsonb DEFAULT '{}' NOT NULL;
+    """
+    await connection.execute(schema)

--- a/src/inmanta/db/versions/v20250404.py
+++ b/src/inmanta/db/versions/v20250404.py
@@ -21,7 +21,7 @@ from asyncpg import Connection
 
 async def update(connection: Connection) -> None:
     """
-    Rename some rps columns and values
+    Add links column to compile table
     """
     schema = """
         ALTER TABLE public.compile ADD COLUMN links jsonb DEFAULT '{}' NOT NULL;

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -878,7 +878,7 @@ def get_reports(tid: uuid.UUID, start: Optional[str] = None, end: Optional[str] 
     """
     Return compile reports newer then start
 
-    The returned compile run objects may carry links to other objects, e.g. a service instance. The full list of supported links
+    The returned compile report objects may carry links to other objects, e.g. a service instance. The full list of supported links
     can be found :ref:`here <api_self_referencing_links>`.
 
     :param tid: The id of the environment to get a report from

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -878,8 +878,8 @@ def get_reports(tid: uuid.UUID, start: Optional[str] = None, end: Optional[str] 
     """
     Return compile reports newer then start
 
-    The returned compile report objects may carry links to other objects, e.g. a service instance. The full list of supported links
-    can be found :ref:`here <api_self_referencing_links>`.
+    The returned compile report objects may carry links to other objects, e.g. a service instance.
+    The full list of supported links can be found :ref:`here <api_self_referencing_links>`.
 
     :param tid: The id of the environment to get a report from
     :param start: Optional. Reports after start

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -878,6 +878,9 @@ def get_reports(tid: uuid.UUID, start: Optional[str] = None, end: Optional[str] 
     """
     Return compile reports newer then start
 
+    The returned compile run objects may carry links to other objects, e.g. a service instance. The full list of supported links
+    can be found :ref:`here <api_self_referencing_links>`.
+
     :param tid: The id of the environment to get a report from
     :param start: Optional. Reports after start
     :param end: Optional. Reports before end
@@ -890,6 +893,9 @@ def get_reports(tid: uuid.UUID, start: Optional[str] = None, end: Optional[str] 
 def get_report(id: uuid.UUID):
     """
     Get a compile report from the server
+
+    The returned compile report object may carry links to other objects, e.g. a service instance.
+    The full list of supported links can be found :ref:`here <api_self_referencing_links>`.
 
     :param id: The id of the compile and its reports to fetch.
     """
@@ -1059,6 +1065,9 @@ def get_server_status() -> model.StatusResponse:
 def get_compile_queue(tid: uuid.UUID) -> list[model.CompileRun]:
     """
     Get the current compiler queue on the server, ordered by increasing `requested` timestamp.
+
+    The returned compile run object may carry links to other objects, e.g. a service instance. The full list of supported links
+    can be found :ref:`here <api_self_referencing_links>`.
 
     :param tid: The id of the environment for which to retrieve the compile queue.
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -875,6 +875,9 @@ def get_compile_reports(
     """
     Get the compile reports from an environment.
 
+    The returned compile object may carry links to other objects, e.g. a service instance. The full list of supported links
+    can be found :ref:`here <api_self_referencing_links>`.
+
     :param tid: The id of the environment
     :param limit: Limit the number of instances that are returned
     :param first_id: The id to use as a continuation token for paging, in combination with the 'start' value,
@@ -922,6 +925,9 @@ def get_compile_reports(
 )
 def compile_details(tid: uuid.UUID, id: uuid.UUID) -> model.CompileDetails:
     """
+    The returned compile object may carry links to other objects, e.g. a service instance. The full list of supported links
+    can be found :ref:`here <api_self_referencing_links>`.
+
     :param tid: The id of the environment in which the compilation process occurred.
     :param id: The id of the compile for which the details are being requested.
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -875,8 +875,8 @@ def get_compile_reports(
     """
     Get the compile reports from an environment.
 
-    The returned compile object may carry links to other objects, e.g. a service instance. The full list of supported links
-    can be found :ref:`here <api_self_referencing_links>`.
+    The returned compile report objects may carry links to other objects, e.g. a service instance.
+    The full list of supported links can be found :ref:`here <api_self_referencing_links>`.
 
     :param tid: The id of the environment
     :param limit: Limit the number of instances that are returned
@@ -925,8 +925,8 @@ def get_compile_reports(
 )
 def compile_details(tid: uuid.UUID, id: uuid.UUID) -> model.CompileDetails:
     """
-    The returned compile object may carry links to other objects, e.g. a service instance. The full list of supported links
-    can be found :ref:`here <api_self_referencing_links>`.
+    The returned compile details object may carry links to other objects, e.g. a service instance.
+    The full list of supported links can be found :ref:`here <api_self_referencing_links>`.
 
     :param tid: The id of the environment in which the compilation process occurred.
     :param id: The id of the compile for which the details are being requested.

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -729,6 +729,8 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             they contain resources that are being exported.
         :param mergeable_env_vars: a set of env vars that can be compacted over multiple compiles.
             If multiple values are compacted, they will be joined using spaces.
+        :param links: An object that contains relevant links to this compile.
+            Conforms with the json api: https://jsonapi.org/format/#document-links
         :return: the compile id of the requested compile and any warnings produced during the request
         """
         if in_db_transaction and not connection:
@@ -745,6 +747,8 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             env_vars = {}
         if mergeable_env_vars is None:
             mergeable_env_vars = {}
+        if links is None:
+            links = {}
 
         server_compile: bool = bool(await env.get(data.SERVER_COMPILE))
         if not server_compile:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -710,6 +710,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         connection: Optional[Connection] = None,
         soft_delete: bool = False,
         mergeable_env_vars: Optional[Mapping[str, str]] = None,
+        links: Optional[model.JsonApiLinks] = None,
     ) -> tuple[Optional[uuid.UUID], Warnings]:
         """
         Recompile an environment in a different thread and taking wait time into account.
@@ -774,6 +775,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             notify_failed_compile=notify_failed_compile,
             failed_compile_message=failed_compile_message,
             soft_delete=soft_delete,
+            links=links,
         )
         if not in_db_transaction:
             async with self._queue_count_cache_lock:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -729,7 +729,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             they contain resources that are being exported.
         :param mergeable_env_vars: a set of env vars that can be compacted over multiple compiles.
             If multiple values are compacted, they will be joined using spaces.
-        :param links: An object that contains relevant links to this compile.
+        :param links: An object that contains relevant links for this compile.
             Conforms with the json api: https://jsonapi.org/format/#document-links
         :return: the compile id of the requested compile and any warnings produced during the request
         """

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -710,7 +710,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         connection: Optional[Connection] = None,
         soft_delete: bool = False,
         mergeable_env_vars: Optional[Mapping[str, str]] = None,
-        links: Optional[model.JsonApiLinks] = None,
+        links: Optional[dict[str, list[str]]] = None,
     ) -> tuple[Optional[uuid.UUID], Warnings]:
         """
         Recompile an environment in a different thread and taking wait time into account.
@@ -729,8 +729,9 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             they contain resources that are being exported.
         :param mergeable_env_vars: a set of env vars that can be compacted over multiple compiles.
             If multiple values are compacted, they will be joined using spaces.
-        :param links: An object that contains relevant links for this compile.
-            Conforms with the json api: https://jsonapi.org/format/#document-links
+        :param links: An object that contains relevant links to this compile.
+            It is a dictionary where the key is something that identifies one or more links
+            and the value is a list of urls. i.e. {"instances": ["link-1',"link-2"], "compiles": ["link-3"]}
         :return: the compile id of the requested compile and any warnings produced during the request
         """
         if in_db_transaction and not connection:

--- a/tests/db/migration_tests/test_v202501140_to_v202504040.py
+++ b/tests/db/migration_tests/test_v202501140_to_v202504040.py
@@ -16,7 +16,6 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-
 import os
 import re
 from collections import abc

--- a/tests/db/migration_tests/test_v202501140_to_v202504040.py
+++ b/tests/db/migration_tests/test_v202501140_to_v202504040.py
@@ -16,23 +16,6 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-"""
-Copyright 2025 Inmanta
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Contact: code@inmanta.com
-"""
 
 import os
 import re

--- a/tests/db/migration_tests/test_v202501140_to_v202504040.py
+++ b/tests/db/migration_tests/test_v202501140_to_v202504040.py
@@ -41,6 +41,7 @@ from collections import abc
 import asyncpg
 import pytest
 
+from inmanta.data import Environment
 from inmanta.protocol import Client
 
 file_name_regex = re.compile("test_v([0-9]{9})_to_v[0-9]{9}")
@@ -55,8 +56,12 @@ async def test_add_column(
     # This migration script adds a column.
     await migrate_db_from()
 
+    env = await Environment.get_one(name="dev-1")
+    assert env
+
     client = Client("client")
-    result = await client.get()
-    assert len(result.result["environments"]) > 0
-    for env in result.result["environments"]:
-        assert env["is_marked_for_deletion"] is False
+
+    reports = await client.get_reports(env.id)
+    assert reports.code == 200
+    for report in reports.result["reports"]:
+        assert report["links"] == {}

--- a/tests/db/migration_tests/test_v202501140_to_v202504040.py
+++ b/tests/db/migration_tests/test_v202501140_to_v202504040.py
@@ -1,0 +1,62 @@
+"""
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+"""
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+import os
+import re
+from collections import abc
+
+import asyncpg
+import pytest
+
+from inmanta.protocol import Client
+
+file_name_regex = re.compile("test_v([0-9]{9})_to_v[0-9]{9}")
+part = file_name_regex.match(__name__)[1]
+
+
+@pytest.mark.db_restore_dump(os.path.join(os.path.dirname(__file__), f"dumps/v{part}.sql"))
+async def test_add_column(
+    postgresql_client: asyncpg.Connection,
+    migrate_db_from: abc.Callable[[], abc.Awaitable[None]],
+) -> None:
+    # This migration script adds a column.
+    await migrate_db_from()
+
+    client = Client("client")
+    result = await client.get()
+    assert len(result.result["environments"]) > 0
+    for env in result.result["environments"]:
+        assert env["is_marked_for_deletion"] is False

--- a/tests/server/test_compile_details.py
+++ b/tests/server/test_compile_details.py
@@ -23,6 +23,8 @@ import pytest
 
 from inmanta import data
 from inmanta.data import Report
+from inmanta.server import SLICE_COMPILER
+from inmanta.server.services.compilerservice import CompilerService
 from inmanta.util import parse_timestamp
 
 
@@ -57,6 +59,7 @@ async def env_with_compiles(client, environment):
             version=1,
             substitute_compile_id=None,
             compile_data={"errors": [{"type": "UnexpectedException", "message": "msg"}]} if i % 2 else None,
+            links={"self": f"my-link{i}", f"test-{i}": f"my-link{i}"},
         )
         compiles.append(compile)
     compiles[1].substitute_compile_id = compiles[0].id
@@ -104,6 +107,9 @@ async def test_compile_details(server, client, env_with_compiles):
     assert parse_timestamp(result.result["data"]["requested"]) == compile_requested_timestamps[0].astimezone(
         datetime.timezone.utc
     )
+    # Assert that the links are correct
+    links = result.result["data"]["links"]
+    assert links == {"self": "my-link0", "test-0": "my-link0"}
 
     # A compile that is 2 levels deep in substitutions: id2 -> id1 -> id0
     result = await client.compile_details(environment, ids[2])
@@ -115,12 +121,30 @@ async def test_compile_details(server, client, env_with_compiles):
     assert parse_timestamp(result.result["data"]["requested"]) == compile_requested_timestamps[2].astimezone(
         datetime.timezone.utc
     )
+    # Assert that the links of the substitutions are also present
+    # Assert that "self" is the link of the requested compile
+    links = result.result["data"]["links"]
+    assert links == {"self": "my-link2", "test-0": "my-link0", "test-1": "my-link1", "test-2": "my-link2"}
 
     # A compile that has no reports
     result = await client.compile_details(environment, ids[3])
     assert result.code == 200
     assert not result.result["data"]["reports"]
 
+    # Assert that even without a report, we still get the correct links
+    links = result.result["data"]["links"]
+    assert links == {"self": "my-link3", "test-3": "my-link3"}
+
     # An id that doesn't exist as a compile
     result = await client.compile_details(environment, uuid.uuid4())
     assert result.code == 404
+
+    # Test passing links via request_recompile
+    env = await data.Environment.get_by_id(environment)
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    compile_id, _ = await compilerslice.request_recompile(
+        env, force_update=False, do_export=False, remote_id=uuid.uuid4(), links={"example-link": "localhost:8888"}
+    )
+    result = await client.compile_details(environment, compile_id)
+    assert result.code == 200
+    assert result.result["data"]["links"] == {"example-link": "localhost:8888"}

--- a/tests/server/test_compilereport_list.py
+++ b/tests/server/test_compilereport_list.py
@@ -64,6 +64,7 @@ async def env_with_compile_reports(client, environment):
             version=i,
             substitute_compile_id=None,
             compile_data=None,
+            links={},
         ).insert()
     return environment, compile_requested_timestamps
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1009,6 +1009,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
         do_export=False,
         remote_id=remote_id1,
         env_vars={"my_unique_var": "1"},
+        links={"self": "my-link"},
     )
 
     # api should return one
@@ -1018,6 +1019,8 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     result = await client.get_compile_queue(environment)
     assert len(result.result["queue"]) == 1
     assert result.result["queue"][0]["remote_id"] == str(remote_id1)
+    # Assert that links are present in the compile queue
+    assert result.result["queue"][0]["links"] == {"self": "my-link"}
     assert result.code == 200
     # None in the queue, all running
     await retry_limited(lambda: compilerslice._queue_count_cache == 0, 10)
@@ -1056,12 +1059,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
 
     # request a compile with do_export=False -> expect merge with compile2
     remote_id4 = uuid.uuid4()
-    compile_id4, _ = await compilerslice.request_recompile(
-        env=env,
-        force_update=False,
-        do_export=False,
-        remote_id=remote_id4,
-    )
+    compile_id4, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=remote_id4)
 
     # Queue = [
     #   remote_id1 (Running),

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1004,7 +1004,11 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     # request a compile
     remote_id1 = uuid.uuid4()
     await compilerslice.request_recompile(
-        env=env, force_update=False, do_export=False, remote_id=remote_id1, env_vars={"my_unique_var": "1"}
+        env=env,
+        force_update=False,
+        do_export=False,
+        remote_id=remote_id1,
+        env_vars={"my_unique_var": "1"},
     )
 
     # api should return one
@@ -1052,7 +1056,12 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
 
     # request a compile with do_export=False -> expect merge with compile2
     remote_id4 = uuid.uuid4()
-    compile_id4, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=remote_id4)
+    compile_id4, _ = await compilerslice.request_recompile(
+        env=env,
+        force_update=False,
+        do_export=False,
+        remote_id=remote_id4,
+    )
 
     # Queue = [
     #   remote_id1 (Running),

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1009,7 +1009,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
         do_export=False,
         remote_id=remote_id1,
         env_vars={"my_unique_var": "1"},
-        links={"self": "my-link"},
+        links={"self": ["my-link"]},
     )
 
     # api should return one
@@ -1020,7 +1020,7 @@ async def test_compileservice_queue(mocked_compiler_service_block: queue.Queue, 
     assert len(result.result["queue"]) == 1
     assert result.result["queue"][0]["remote_id"] == str(remote_id1)
     # Assert that links are present in the compile queue
-    assert result.result["queue"][0]["links"] == {"self": "my-link"}
+    assert result.result["queue"][0]["links"] == {"self": ["my-link"]}
     assert result.code == 200
     # None in the queue, all running
     await retry_limited(lambda: compilerslice._queue_count_cache == 0, 10)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2254,7 +2254,7 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     await report12.insert()
 
     # Compile 2
-    compile2 = data.Compile(environment=env.id)
+    compile2 = data.Compile(environment=env.id, links={"self": "my-link"})
     await compile2.insert()
     report21 = data.Report(
         started=datetime.datetime.now(), completed=datetime.datetime.now(), command="cmd", name="test", compile=compile2.id
@@ -2274,6 +2274,8 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     report_of_compile = await data.Compile.get_report(compile2.id)
     reports = report_of_compile["reports"]
     assert len(reports) == 1
+    # Assert that links are passed to the CompileReport
+    assert report_of_compile["links"] == {"self": "my-link"}
 
 
 async def test_match_tables_in_db_against_table_definitions_in_orm(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2254,7 +2254,8 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     await report12.insert()
 
     # Compile 2
-    compile2 = data.Compile(environment=env.id, links={"self": "my-link"})
+    link_obj = {"href": "another-link", "describedby": "docs.inmanta.com", "title": "another link to this compile"}
+    compile2 = data.Compile(environment=env.id, links={"self": "my-link", "obj": link_obj})
     await compile2.insert()
     report21 = data.Report(
         started=datetime.datetime.now(), completed=datetime.datetime.now(), command="cmd", name="test", compile=compile2.id
@@ -2275,7 +2276,7 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     reports = report_of_compile["reports"]
     assert len(reports) == 1
     # Assert that links are passed to the CompileReport
-    assert report_of_compile["links"] == {"self": "my-link"}
+    assert report_of_compile["links"] == {"self": "my-link", "obj": link_obj}
 
 
 async def test_match_tables_in_db_against_table_definitions_in_orm(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2254,8 +2254,8 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     await report12.insert()
 
     # Compile 2
-    link_obj = {"href": "another-link", "describedby": "docs.inmanta.com", "title": "another link to this compile"}
-    compile2 = data.Compile(environment=env.id, links={"self": "my-link", "obj": link_obj})
+    links = {"self": ["link-1"], "instances": ["link-2", "link-3"]}
+    compile2 = data.Compile(environment=env.id, links=links)
     await compile2.insert()
     report21 = data.Report(
         started=datetime.datetime.now(), completed=datetime.datetime.now(), command="cmd", name="test", compile=compile2.id
@@ -2276,7 +2276,7 @@ async def test_compile_get_report(init_dataclasses_and_load_schema):
     reports = report_of_compile["reports"]
     assert len(reports) == 1
     # Assert that links are passed to the CompileReport
-    assert report_of_compile["links"] == {"self": "my-link", "obj": link_obj}
+    assert report_of_compile["links"] == links
 
 
 async def test_match_tables_in_db_against_table_definitions_in_orm(


### PR DESCRIPTION
# Description

Added `links` to compiles. We can see them on the compile details, report and queue.
We can add these links through `request_recompile` . I believe that is how lsm requests recompiles.

closes #7558

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
