### PR TITLE
Plugin annotated type fix

### DIFF
--- a/changelogs/unreleased/plugin-annotated-type-fix.yml
+++ b/changelogs/unreleased/plugin-annotated-type-fix.yml
@@ -3,4 +3,3 @@ change-type: patch
 destination-branches:
   - master
   - iso8
-  - iso7

--- a/changelogs/unreleased/plugin-annotated-type-fix.yml
+++ b/changelogs/unreleased/plugin-annotated-type-fix.yml
@@ -1,0 +1,6 @@
+description: "Bugfix for annotated plugin types: look up model type in builtin types dict"
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+  - iso7

--- a/changelogs/unreleased/plugin-annotated-type-fix.yml
+++ b/changelogs/unreleased/plugin-annotated-type-fix.yml
@@ -1,4 +1,4 @@
-description: "Bugfix for annotated plugin types: look up model type in builtin types dict"
+description: "Bugfix for annotated plugin types: look up model type in special types dict"
 change-type: patch
 destination-branches:
   - master

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -310,6 +310,8 @@ class ModelType:
 
 
 def parse_dsl_type(dsl_type: str, location: Range, resolver: Namespace) -> inmanta_type.Type:
+    if dsl_type in PLUGIN_TYPES:
+        return PLUGIN_TYPES[dsl_type]
     locatable_type: LocatableString = LocatableString(dsl_type, location, 0, resolver)
     return inmanta_type.resolve_type(locatable_type, resolver)
 

--- a/tests/compiler/test_plugin_types.py
+++ b/tests/compiler/test_plugin_types.py
@@ -44,6 +44,9 @@ def test_conversion(caplog):
     assert inmanta_type.NullableType(inmanta_type.Integer()) == to_dsl_type_simple(Annotated[int | None, "something"])
     # Union type should be ignored in favor of our ModelType
     assert inmanta_type.TypedDict(inmanta_type.Any()) == to_dsl_type_simple(Annotated[dict[str, int], ModelType["dict"]])
+    assert inmanta_type.Any() == to_dsl_type_simple(Annotated[dict[str, int], ModelType["any"]])
+    assert inmanta_type.TypedDict(inmanta_type.Any()) == to_dsl_type_simple(dict[str, Annotated[int, ModelType["any"]]])
+
     assert inmanta_type.Integer() == to_dsl_type_simple(int)
     assert inmanta_type.Float() == to_dsl_type_simple(float)
     assert inmanta_type.NullableType(inmanta_type.Float()) == to_dsl_type_simple(float | None)


### PR DESCRIPTION
# Description

Small bugfix in annotated plugin type implementation: special model types like "any" and "null" didn't work because we didn't look up in the `PLUGIN_TYPES` dict, only in the namespace.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
