### PR TITLE
Bump compiler version to 2024.4.1 on iso7

### DIFF
--- a/changelogs/unreleased/bump-compiler-version-for-iso7-release.yml
+++ b/changelogs/unreleased/bump-compiler-version-for-iso7-release.yml
@@ -1,0 +1,3 @@
+description: Bump compiler version to 2024.4.1
+change-type: patch
+destination-branches: [iso7]

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -16,7 +16,7 @@
     Contact: code@inmanta.com
 """
 
-COMPILER_VERSION = "2024.4"
+COMPILER_VERSION = "2024.4.1"
 # This version is managed by bumpversion. Should you ever update it manually, make sure to consistently update it everywhere
 # (See the bumpversion.cfg file for relevant locations).
 __version__ = "11.5.1"


### PR DESCRIPTION
# Description

Bump compiler version to 2024.4.1 on iso7

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
