### PR TITLE
Added deprecation warning to v1 endpoint to fetch environment

### DIFF
--- a/changelogs/unreleased/deprecate-v1-environment-get.yml
+++ b/changelogs/unreleased/deprecate-v1-environment-get.yml
@@ -3,4 +3,4 @@ description: Deprecated the v1 endpoint to fetch an environment in favor of the 
 change-type: patch
 destination-branches: [iso8]
 sections:
-  deprecation-note: {{description}}
+  deprecation-note: "Deprecated the v1 endpoint to fetch an environment in favor of the v2 endpoint."

--- a/changelogs/unreleased/deprecate-v1-environment-get.yml
+++ b/changelogs/unreleased/deprecate-v1-environment-get.yml
@@ -1,0 +1,7 @@
+description: Deprecated the v1 endpoint to fetch an environment in favor of the v2 endpoint.
+change-type: patch
+destination-branches: [iso8]
+sections:
+  deprecation-note: {{description}}
+
+

--- a/changelogs/unreleased/deprecate-v1-environment-get.yml
+++ b/changelogs/unreleased/deprecate-v1-environment-get.yml
@@ -4,5 +4,3 @@ change-type: patch
 destination-branches: [iso8]
 sections:
   deprecation-note: {{description}}
-
-

--- a/changelogs/unreleased/deprecate-v1-environment-get.yml
+++ b/changelogs/unreleased/deprecate-v1-environment-get.yml
@@ -1,4 +1,5 @@
 description: Deprecated the v1 endpoint to fetch an environment in favor of the v2 endpoint.
+  Also deprecated Resource.get_resources_report as it was only used by this endpoint.
 change-type: patch
 destination-branches: [iso8]
 sections:

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5031,6 +5031,7 @@ class Resource(BaseDocument):
         return result
 
     @classmethod
+    @warnings.deprecated("To be removed in iso9")
     async def get_resources_report(cls, environment: uuid.UUID) -> list[JsonType]:
         """
         This method generates a report of all resources in the given environment,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5031,9 +5031,9 @@ class Resource(BaseDocument):
         return result
 
     @classmethod
-    @warnings.deprecated("To be removed in iso9")
     async def get_resources_report(cls, environment: uuid.UUID) -> list[JsonType]:
         """
+        [DEPRECATED] Only used in v1 get_environment endpoint
         This method generates a report of all resources in the given environment,
         with their latest version and when they are last deployed.
         """

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -175,6 +175,7 @@ def list_environments():
 )
 def get_environment(id: uuid.UUID, versions: Optional[int] = None, resources: Optional[int] = None):
     """
+    [DEPRECATED] Deprecated in favor of the v2 endpoint.
     Get an environment and all versions associated.
 
     :param id: The id of the environment to return.


### PR DESCRIPTION
# Description

Also deprecates Resource.get_resources_report

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
