### PR TITLE
Fix race condition in test_compilerservice_halt test case

### DIFF
--- a/changelogs/unreleased/fix-race-test-compilerservice-halt.yml
+++ b/changelogs/unreleased/fix-race-test-compilerservice-halt.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix race condition in the test_compilerservice_halt test case"
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -1248,12 +1248,18 @@ async def test_compilerservice_halt(
 ) -> None:
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
 
+    # Wait until the compiler service is ready to process compiles.
+    # As long as the compiler service is not fully ready,
+    # is_compiling() will always return False.
+    await retry_limited(lambda: compilerslice.fully_ready, timeout=10)
+
     result = await client.get_compile_queue(environment)
     assert result.code == 200
     assert len(result.result["queue"]) == 0
     assert compilerslice._queue_count_cache == 0
 
-    await client.halt_environment(environment)
+    result = await client.halt_environment(environment)
+    assert result.code == 200
 
     env = await data.Environment.get_by_id(environment)
     assert env is not None
@@ -1267,7 +1273,8 @@ async def test_compilerservice_halt(
     result = await client.is_compiling(environment)
     assert result.code == 204
 
-    await client.resume_environment(environment)
+    result = await client.resume_environment(environment)
+    assert result.code == 200
     result = await client.is_compiling(environment)
     assert result.code == 200
 


### PR DESCRIPTION
# Description

If the compilerservice is not fully_ready, the is_compiling() API endpoint will return False. As such, the last assertion of the test case will fail in the situation where the compilerservice is not fully ready by the time it's called.

```
02:58:06  _______________________ test_compilerservice_halt[True] ________________________
02:58:06  
02:58:06  mocked_compiler_service_block = <queue.Queue object at 0x7f2463833e00>
02:58:06  server = <inmanta.server.protocol.Server object at 0x7f24686d80e0>
02:58:06  client = <inmanta.protocol.endpoints.Client object at 0x7f2463830f20>
02:58:06  environment = 'ca4beb25-0198-4d61-b4cc-13a793e8fcf8', no_agent = True
02:58:06  
02:58:06      @pytest.mark.parametrize("no_agent", [True])
02:58:06      async def test_compilerservice_halt(
02:58:06          mocked_compiler_service_block, server, client, environment: uuid.UUID, no_agent: bool
02:58:06      ) -> None:
02:58:06          compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
02:58:06      
02:58:06          result = await client.get_compile_queue(environment)
02:58:06          assert result.code == 200
02:58:06          assert len(result.result["queue"]) == 0
02:58:06          assert compilerslice._queue_count_cache == 0
02:58:06      
02:58:06          await client.halt_environment(environment)
02:58:06      
02:58:06          env = await data.Environment.get_by_id(environment)
02:58:06          assert env is not None
02:58:06          await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
02:58:06      
02:58:06          result = await client.get_compile_queue(environment)
02:58:06          assert result.code == 200
02:58:06          assert len(result.result["queue"]) == 1
02:58:06          assert compilerslice._queue_count_cache == 1
02:58:06      
02:58:06          result = await client.is_compiling(environment)
02:58:06          assert result.code == 204
02:58:06      
02:58:06          await client.resume_environment(environment)
02:58:06          result = await client.is_compiling(environment)
02:58:06  >       assert result.code == 200
02:58:06  E       assert 204 == 200
02:58:06  E        +  where 204 = <inmanta.protocol.common.Result object at 0x7f2468d298e0>.code
02:58:06  
02:58:06  tests/server/test_compilerservice.py:1299: AssertionError
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
