### PR TITLE
Fix issue caused by renamed db migration script

### DIFF
--- a/changelogs/unreleased/fix-issue-renamed-db-migration-script.yml
+++ b/changelogs/unreleased/fix-issue-renamed-db-migration-script.yml
@@ -1,0 +1,4 @@
+---
+description: Fix the issue caused by the rename of a db migration script.
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/db/versions/v202504040.py
+++ b/src/inmanta/db/versions/v202504040.py
@@ -24,6 +24,6 @@ async def update(connection: Connection) -> None:
     Add links column to compile table
     """
     schema = """
-        ALTER TABLE public.compile ADD COLUMN links jsonb DEFAULT '{}' NOT NULL;
+        ALTER TABLE public.compile ADD COLUMN IF NOT EXISTS links jsonb DEFAULT '{}' NOT NULL;
     """
     await connection.execute(schema)


### PR DESCRIPTION
# Description

[This PR](https://github.com/inmanta/inmanta-core/pull/8961) renames a db migration script, which causes it to be applied twice. This results in errors. This PR fixes that issue.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~