### PR TITLE
Test file names db migration scripts

### DIFF
--- a/changelogs/unreleased/check-format-db-migration-scripts.yml
+++ b/changelogs/unreleased/check-format-db-migration-scripts.yml
@@ -1,4 +1,4 @@
 ---
 description: Added test to validate the filenames of the database migration scripts.
 change-type: patch
-destination-branches: [master, iso8, iso7]
+destination-branches: [iso7]

--- a/changelogs/unreleased/check-format-db-migration-scripts.yml
+++ b/changelogs/unreleased/check-format-db-migration-scripts.yml
@@ -1,0 +1,4 @@
+---
+description: Added test to validate the filenames of the database migration scripts.
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/tests/db/test_migration_check.py
+++ b/tests/db/test_migration_check.py
@@ -18,6 +18,8 @@
 
 from pathlib import Path
 
+import utils
+
 
 def test_migration_check():
     """
@@ -61,3 +63,13 @@ def test_migration_check():
         )
     migration_test: Path = migration_tests[-1]
     assert migration_test.is_file()
+
+
+async def test_filenames_migration_scripts() -> None:
+    """
+    Validate that the version numbers of the database migration scripts have the correct format.
+    Migration scripts must have the format vYYYYMMDDN.py
+    """
+    inmanta_dir: Path = Path(__file__).parent.parent.parent.absolute()
+    versions_folder: Path = inmanta_dir / "src" / "inmanta" / "db" / "versions"
+    utils.validate_version_numbers_migration_scripts(versions_folder)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,9 @@ import functools
 import json
 import logging
 import os
+import pathlib
 import random
+import re
 import shutil
 import uuid
 from collections import abc
@@ -771,3 +773,23 @@ def make_random_file(size: int = 0) -> tuple[str, bytes, str]:
     body = base64.b64encode(content).decode("ascii")
 
     return hash, content, body
+
+
+def validate_version_numbers_migration_scripts(versions_folder: pathlib.Path) -> None:
+    """
+    Validate whether the names of the database migration scripts in the given directory
+    are compliant with the schema. Migration scripts must have the format vYYYYMMDDN.py
+    """
+    v1_found = False
+    for path in versions_folder.iterdir():
+        file_name = path.name
+        if not file_name.endswith(".py"):
+            continue
+        if file_name == "__init__.py":
+            continue
+        if file_name == "v1.py":
+            v1_found = True
+            continue
+        if not re.fullmatch(r"v([0-9]{9})\.py", file_name):
+            raise Exception(f"Database migration script {file_name} has invalid format.")
+    assert v1_found


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/8991, but on the iso7 branch due to a merge conflict.**

Added test to validate the filenames of the database migration scripts.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
