### PR TITLE
Add psutil dep

### DIFF
--- a/changelogs/unreleased/psutil-dep.yml
+++ b/changelogs/unreleased/psutil-dep.yml
@@ -1,0 +1,5 @@
+description: added psutil dev dependency
+change-type: patch
+destination-branches:
+  - master
+  - iso8

--- a/changelogs/unreleased/psutil-dep.yml
+++ b/changelogs/unreleased/psutil-dep.yml
@@ -3,3 +3,4 @@ change-type: patch
 destination-branches:
   - master
   - iso8
+  - iso7

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ packaging==25.0
 pip==25.1
 pip2pi==0.8.2
 ply==3.11
+psutil==7.0.0
 pydantic==2.11.3
 pyformance==0.4
 PyJWT==2.10.1

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
             "openapi_spec_validator",
             "pep8-naming",
             "pip2pi",
+            "psutil",
             "time-machine",
             # types
             "types-python-dateutil",


### PR DESCRIPTION
I noticed that we had an import for `psutil` while it was only a transitive dev dependency. This PR makes it a direct one.