### PR TITLE
downgrade psutil pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ packaging==24.2
 pip==24.3.1
 pip2pi==0.8.2
 ply==3.11
-psutil==7.0.0
+psutil==6.1.1
 pydantic==2.10.6
 pyformance==0.4
 PyJWT==2.10.1


### PR DESCRIPTION
Downgrade the psutil pin (applied yesterday) because it is not compatible with inmanta-license.