### PR TITLE
Issue/8962 Fix environment_auth endpoint returns 400 (iso7)

### DIFF
--- a/changelogs/unreleased/8962-fix-token-generation-endpoint.yml
+++ b/changelogs/unreleased/8962-fix-token-generation-endpoint.yml
@@ -1,0 +1,8 @@
+---
+description: "Fix bug where the POST /api/v2/environment_auth endpoint returns a 400 if the server.auth=true config option was set using an environment variable."
+issue-nr: 8962
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [iso7]
+sections:
+  bugfix: "{{description}}"

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -275,7 +275,6 @@ src/inmanta/compiler/help/explainer.py:0: error: Item "None" of "Reference | Non
 src/inmanta/compiler/help/explainer.py:0: error: Item "None" of "RelationAttribute | None" has no attribute "get_name"  [union-attr]
 src/inmanta/compiler/help/explainer.py:0: error: Missing return statement  [return]
 src/inmanta/config.py:0: error: "_validate_value_types" undefined in superclass  [misc]
-src/inmanta/config.py:0: error: Argument "fallback" to "getboolean" of "RawConfigParser" has incompatible type "bool | None"; expected "bool"  [arg-type]
 src/inmanta/config.py:0: error: Argument 1 to "CronTab" has incompatible type "str | int"; expected "str"  [arg-type]
 src/inmanta/config.py:0: error: Cannot infer type argument 1 of "Option"  [misc]
 src/inmanta/config.py:0: error: Cannot infer type argument 1 of "Option"  [misc]

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -172,7 +172,7 @@ class Config:
         cfg: ConfigParser = cls.get_instance()
         val: Optional[str] = _get_from_env(section, name)
         if val is not None:
-            LOGGER.debug(f"Setting {section}:{name} was set using an environment variable")
+            LOGGER.debug("Setting %s:%s was set using an environment variable", section, name)
             return val
         # Typing of this method in the sdk is not entirely accurate
         # It just returns the fallback, whatever its type
@@ -184,12 +184,14 @@ class Config:
         return section in cls.get_instance() and name in cls.get_instance()[section]
 
     @classmethod
-    def getboolean(cls, section: str, name: str, default_value: Optional[bool] = None) -> bool:
+    def getboolean(cls, section: str, name: str, default_value: bool) -> bool:
         """
         Return a boolean from the configuration
         """
-        cls.validate_option_request(section, name, default_value)
-        return cls.get_instance().getboolean(section, name, fallback=default_value)
+        val = cls.get(section, name, default_value)
+        if val is None:
+            raise ValueError(f"Expected boolean value. Found: {val}")
+        return is_bool(val)
 
     @classmethod
     def set(cls, section: str, name: str, value: str) -> None:
@@ -209,7 +211,7 @@ class Config:
     @classmethod
     def validate_option_request(cls, section: str, name: str, default_value: Optional[T]) -> Optional["Option[T]"]:
         if section not in cls.__config_definition:
-            LOGGER.warning("Config section %s not defined" % (section))
+            LOGGER.warning("Config section %s not defined", section)
             # raise Exception("Config section %s not defined" % (section))
             return None
         if name not in cls.__config_definition[section]:
@@ -219,8 +221,7 @@ class Config:
         opt = cls.__config_definition[section][name]
         if default_value is not None and opt.get_default_value() != default_value:
             LOGGER.warning(
-                "Inconsistent default value for option %s.%s: defined as %s, got %s"
-                % (section, name, opt.default, default_value)
+                "Inconsistent default value for option %s.%s: defined as %s, got %s", section, name, opt.default, default_value
             )
 
         return opt


### PR DESCRIPTION
# Description

Fix bug where the POST /api/v2/environment_auth endpoint returns a 400 if the server.auth=true config option was set using an environment variable.

closes #8962 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
