### PR TITLE
Fix bug in venv cleanup test

### DIFF
--- a/changelogs/unreleased/fix-bug-venv-cleanup-test.yml
+++ b/changelogs/unreleased/fix-bug-venv-cleanup-test.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix bug in test_executor_creation_and_venv_usage test case."
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/forking_agent/test_agent_executor.py
+++ b/tests/forking_agent/test_agent_executor.py
@@ -442,7 +442,7 @@ def test():
         assert all(not e.running for e in executors)
 
         def did_executor_server_stop() -> bool:
-            return executor_blueprint in mpmanager_light.process_pool.pool
+            return executor_blueprint not in mpmanager_light.process_pool.pool
 
         # Also wait until the executor server has stopped, because that one refreshes the .inmanta_venv_status file.
         await retry_limited(did_executor_server_stop, timeout=10)


### PR DESCRIPTION
# Description

Fix bug in test_executor_creation_and_venv_usage test case.

This might be causing the following error in the test suite:

```
11:54:35  ____________________ test_executor_creation_and_venv_usage _____________________
11:54:35  
11:54:35  server_config = <module 'inmanta.config' from '/home/jenkins/workspace/62-fix-generation-of-tokens-iso8/env/lib64/python3.12/site-packages/inmanta/config.py'>
11:54:35  pip_index = PipIndex(artifact_dir='/tmp/pytest-of-jenkins/pytest-5717/pip_index0')
11:54:35  mpmanager_light = <inmanta.agent.forking_executor.MPManager object at 0x7fd782573050>
11:54:35  
11:54:35      @with_timeout(30)
11:54:35      @trace_error_26
11:54:35      async def test_executor_creation_and_venv_usage(
11:54:35          server_config, pip_index: PipIndex, mpmanager_light: forking_executor.MPManager
11:54:35      ) -> None:
11:54:35          """
11:54:35          This test verifies the creation and reuse of executors based on their blueprints. It checks whether
11:54:35          the concurrency aspects and the locking mechanisms work as intended.
11:54:35          """
11:54:35          env_id = uuid.uuid4()
11:54:35          mpmanager_light.process_pool.venv_checkup_interval = 0.1  # Renew the timestamp of the venv status file every 100 ms
11:54:35          requirements1 = ()
11:54:35          requirements2 = ("pkg1",)
11:54:35          requirements3 = ("pkg2",)
11:54:35          pip_config = PipConfig(index_url=pip_index.url)
11:54:35      
11:54:35          # Prepare a source module and its hash
11:54:35          code = """
11:54:35      def test():
11:54:35          return 10
11:54:35          """.encode()
11:54:35          sha1sum = hashlib.new("sha1")
11:54:35          sha1sum.update(code)
11:54:35          hv: str = sha1sum.hexdigest()
11:54:35          module_source1 = ModuleSource(
11:54:35              name="inmanta_plugins.test",
11:54:35              hash_value=hv,
11:54:35              is_byte_code=False,
11:54:35              source=code,
11:54:35          )
11:54:35          sources1 = ()
11:54:35          sources2 = (module_source1,)
11:54:35          sources3 = (module_source1,)
11:54:35      
11:54:35          initial_version: tuple[int, int] = (3, 11)
11:54:35      
11:54:35          blueprint1 = executor.ExecutorBlueprint(
11:54:35              environment_id=env_id,
11:54:35              pip_config=pip_config,
11:54:35              requirements=requirements1,
11:54:35              sources=sources1,
11:54:35              python_version=initial_version,
11:54:35          )
11:54:35          blueprint2 = executor.ExecutorBlueprint(
11:54:35              environment_id=env_id,
11:54:35              pip_config=pip_config,
11:54:35              requirements=requirements2,
11:54:35              sources=sources2,
11:54:35              python_version=initial_version,
11:54:35          )
11:54:35          blueprint3 = executor.ExecutorBlueprint(
11:54:35              environment_id=env_id,
11:54:35              pip_config=pip_config,
11:54:35              requirements=requirements3,
11:54:35              sources=sources3,
11:54:35              python_version=initial_version,
11:54:35          )
11:54:35      
11:54:35          executor_manager = mpmanager_light
11:54:35          executor_1, executor_2, executor_3 = await asyncio.gather(
11:54:35              executor_manager.get_executor("agent1", "local:", code_for(blueprint1)),
11:54:35              executor_manager.get_executor("agent2", "local:", code_for(blueprint2)),
11:54:35              executor_manager.get_executor("agent3", "local:", code_for(blueprint3)),
11:54:35          )
11:54:35      
11:54:35          executor_1_venv_status_file = (
11:54:35              pathlib.Path(executor_1.process.executor_virtual_env.env_path) / const.INMANTA_VENV_STATUS_FILENAME
11:54:35          )
11:54:35          executor_2_venv_status_file = (
11:54:35              pathlib.Path(executor_2.process.executor_virtual_env.env_path) / const.INMANTA_VENV_STATUS_FILENAME
11:54:35          )
11:54:35          executor_3_venv_status_file = (
11:54:35              pathlib.Path(executor_3.process.executor_virtual_env.env_path) / const.INMANTA_VENV_STATUS_FILENAME
11:54:35          )
11:54:35      
11:54:35          logger.warning("Touching %s now", executor_2_venv_status_file)
11:54:35          old_datetime = datetime.datetime(year=2022, month=9, day=22, hour=12, minute=51, second=42)
11:54:35          # This part of the test is a bit subtle because we rely on the fact that there is no context switching between the
11:54:35          # modification override of the inmanta file and the retrieval of the last modification of the file
11:54:35          os.utime(
11:54:35              executor_2_venv_status_file,
11:54:35              (datetime.datetime.now().timestamp(), old_datetime.timestamp()),
11:54:35          )
11:54:35      
11:54:35          old_check_executor1 = executor_1.process.executor_virtual_env.last_used
11:54:35          old_check_executor2 = executor_2.process.executor_virtual_env.last_used
11:54:35      
11:54:35          # We wait for the refresh of the venv status files
11:54:35          await asyncio.sleep(0.2)
11:54:35          logger.warning("Sleeping done")
11:54:35      
11:54:35          new_check_executor1 = executor_1.process.executor_virtual_env.last_used
11:54:35          new_check_executor2 = executor_2.process.executor_virtual_env.last_used
11:54:35      
11:54:35          assert new_check_executor1 > old_check_executor1
11:54:35          assert new_check_executor2 > old_check_executor2
11:54:35          assert (datetime.datetime.now().astimezone() - new_check_executor2).seconds <= 2
11:54:35      
11:54:35          async def stop_executor_and_wait_for_executor_server_to_stop(
11:54:35              executor_name: str, executor_blueprint: executor.ExecutorBlueprint
11:54:35          ) -> None:
11:54:35              # Stop the executor
11:54:35              executors = await executor_manager.stop_for_agent(executor_name)
11:54:35              await asyncio.gather(*(e.join() for e in executors))
11:54:35              assert all(not e.running for e in executors)
11:54:35      
11:54:35              def did_executor_server_stop() -> bool:
11:54:35                  return executor_blueprint in mpmanager_light.process_pool.pool
11:54:35      
11:54:35              # Also wait until the executor server has stopped, because that one refreshes the .inmanta_venv_status file.
11:54:35              await retry_limited(did_executor_server_stop, timeout=10)
11:54:35      
11:54:35          # Now we want to check if the cleanup is working correctly
11:54:35          await stop_executor_and_wait_for_executor_server_to_stop(executor_name="agent1", executor_blueprint=blueprint1)
11:54:35          # First we want to override the modification date of the `inmanta_venv_status` file
11:54:35          os.utime(
11:54:35              executor_1_venv_status_file, (datetime.datetime.now().astimezone().timestamp(), old_datetime.astimezone().timestamp())
11:54:35          )
11:54:35          environment_manager = mpmanager_light.process_pool.environment_manager
11:54:35          venv_dir = pathlib.Path(environment_manager.envs_dir)
11:54:35          assert len([e for e in venv_dir.iterdir()]) == 3, "We should have two Virtual Environments for our 2 executors!"
11:54:35          # We remove the old VirtualEnvironment
11:54:35          logger.debug("Calling cleanup_virtual_environments")
11:54:35          await environment_manager.cleanup_inactive_pool_members()
11:54:35          logger.debug("cleanup_virtual_environments ended")
11:54:35      
11:54:35          venvs = {str(e) for e in venv_dir.iterdir()}
11:54:35          assert len(venvs) == 2, "Only two Virtual Environment should exist!"  # Venv one is gone
11:54:35          assert {executor_2.process.executor_virtual_env.env_path, executor_3.process.executor_virtual_env.env_path} == venvs
11:54:35      
11:54:35          # Let's stop the other agent and pretend that the venv is broken
11:54:35          await stop_executor_and_wait_for_executor_server_to_stop(executor_name="agent2", executor_blueprint=blueprint2)
11:54:35          executor_2_venv_status_file.unlink()
11:54:35      
11:54:35          await environment_manager.cleanup_inactive_pool_members()
11:54:35          venvs = [str(e) for e in venv_dir.iterdir()]
11:54:35  >       assert len(venvs) == 1, "Only one Virtual Environment should exist!"  # Only nr 3
11:54:35  E       AssertionError: Only one Virtual Environment should exist!
11:54:35  E       assert 2 == 1
11:54:35  E        +  where 2 = len(['/tmp/pytest-of-jenkins/pytest-5717/test_executor_creation_and_ven0/executors/venvs/b7beb0bfbc6ab2daaa29f33e62ae5fed', '/tmp/pytest-of-jenkins/pytest-5717/test_executor_creation_and_ven0/executors/venvs/d43b23a6aa7aad1620c675875ee414f7'])
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
