### PR TITLE
Fix generation of tokens attempt 2

### DIFF
--- a/changelogs/unreleased/8962-fix-token-generation-endpoint.yml
+++ b/changelogs/unreleased/8962-fix-token-generation-endpoint.yml
@@ -1,0 +1,8 @@
+---
+description: "Fix bug where the POST /api/v2/environment_auth endpoint returns a 400 if the server.auth=true config option was set using an environment variable."
+issue-nr: 8962
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -18,7 +18,6 @@ src/inmanta/warnings.py:0: error: Function is missing a type annotation for one 
 src/inmanta/config.py:0: error: "_validate_value_types" undefined in superclass  [misc]
 src/inmanta/config.py:0: error: Missing type parameters for generic type "Option"  [type-arg]
 src/inmanta/config.py:0: error: Missing type parameters for generic type "Option"  [type-arg]
-src/inmanta/config.py:0: error: Argument "fallback" to "getboolean" of "RawConfigParser" has incompatible type "bool | None"; expected "bool"  [arg-type]
 src/inmanta/config.py:0: error: Missing type parameters for generic type "Option"  [type-arg]
 src/inmanta/config.py:0: error: Argument 1 to "CronTab" has incompatible type "str | int"; expected "str"  [arg-type]
 src/inmanta/config.py:0: error: Incompatible default for argument "validator" (default has type "Callable[[str], str]", argument has type "Callable[[str | T], T]")  [assignment]

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -201,7 +201,7 @@ class Config:
         cfg: ConfigParser = cls.get_instance()
         val: Optional[str] = _get_from_env(section, name)
         if val is not None:
-            LOGGER.debug(f"Setting {section}:{name} was set using an environment variable")
+            LOGGER.debug("Setting %s:%s was set using an environment variable", section, name)
             return val
         # Typing of this method in the sdk is not entirely accurate
         # It just returns the fallback, whatever its type
@@ -213,12 +213,14 @@ class Config:
         return section in cls.get_instance() and name in cls.get_instance()[section]
 
     @classmethod
-    def getboolean(cls, section: str, name: str, default_value: Optional[bool] = None) -> bool:
+    def getboolean(cls, section: str, name: str, default_value: bool = None) -> bool:
         """
         Return a boolean from the configuration
         """
-        cls.validate_option_request(section, name, default_value)
-        return cls.get_instance().getboolean(section, name, fallback=default_value)
+        value = cls.get(section, name, default_value)
+        if value is None:
+            raise ValueError(f"Expected boolean value. Found: {value}")
+        return is_bool(value)
 
     @classmethod
     def set(cls, section: str, name: str, value: str) -> None:
@@ -238,7 +240,7 @@ class Config:
     @classmethod
     def validate_option_request(cls, section: str, name: str, default_value: Optional[T]) -> Optional["Option[T]"]:
         if section not in cls.__config_definition:
-            LOGGER.warning("Config section %s not defined" % (section))
+            LOGGER.warning("Config section %s not defined", section)
             # raise Exception("Config section %s not defined" % (section))
             return None
         if name not in cls.__config_definition[section]:
@@ -248,8 +250,8 @@ class Config:
         opt = cls.__config_definition[section][name]
         if default_value is not None and opt.get_default_value() != default_value:
             LOGGER.warning(
-                "Inconsistent default value for option %s.%s: defined as %s, got %s"
-                % (section, name, opt.default, default_value)
+                "Inconsistent default value for option %s.%s: defined as %s, got %s",
+                section, name, opt.default, default_value
             )
 
         return opt

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -250,8 +250,7 @@ class Config:
         opt = cls.__config_definition[section][name]
         if default_value is not None and opt.get_default_value() != default_value:
             LOGGER.warning(
-                "Inconsistent default value for option %s.%s: defined as %s, got %s",
-                section, name, opt.default, default_value
+                "Inconsistent default value for option %s.%s: defined as %s, got %s", section, name, opt.default, default_value
             )
 
         return opt

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -213,7 +213,7 @@ class Config:
         return section in cls.get_instance() and name in cls.get_instance()[section]
 
     @classmethod
-    def getboolean(cls, section: str, name: str, default_value: bool = None) -> bool:
+    def getboolean(cls, section: str, name: str, default_value: Optional[bool] = None) -> bool:
         """
         Return a boolean from the configuration
         """

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -18,7 +18,9 @@ Contact: code@inmanta.com
 
 import pytest
 
-from inmanta import config, const
+import nacl.pwhash
+from inmanta import config, const, data
+from inmanta.data.model import AuthMethod
 from inmanta.protocol import auth, endpoints
 from inmanta.server import SLICE_USER, protocol
 
@@ -152,3 +154,37 @@ async def test_set_password(server: protocol.Server, auth_client: endpoints.Clie
 
     response = await auth_client.login("admin", new_pw)
     assert response.code == 200
+
+
+async def test_environment_create_token(server: protocol.Server, auth_client: endpoints.Client, monkeypatch) -> None:
+    """
+    Verify that the environment_create_token endpoint works correctly when the server.auth=true
+    option is set via an environment variable.
+    Reproduction of bug: https://github.com/inmanta/inmanta-core/issues/8962
+    """
+    config.Config.set("server", "auth", "false")
+    monkeypatch.setenv("INMANTA_SERVER_AUTH", "true")
+    user = data.User(
+        username="admin",
+        password_hash=nacl.pwhash.str("adminadmin".encode()).decode(),
+        auth_method=AuthMethod.database,
+    )
+    await user.insert()
+
+    response = await auth_client.login("admin", "adminadmin")
+    assert response.code == 200
+    token = response.result["data"]["token"]
+    config.Config.set("client_rest_transport", "token", token)
+    auth_client = protocol.Client("client")
+
+    response = await auth_client.project_create(name="test")
+    assert response.code == 200
+    project_id = response.result["data"]["id"]
+
+    response = await auth_client.environment_create(project_id=project_id, name="test")
+    assert response.code == 200
+    env_id = response.result["data"]["id"]
+
+    response = await auth_client.environment_create_token(tid=env_id, client_types=["api"])
+    assert response.code == 200
+    assert response.result["data"]


### PR DESCRIPTION
# Description

Fix bug where the POST /api/v2/environment_auth endpoint returns a 400 if the server.auth=true config option was set using an environment variable.

closes #8962 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
