### PR TITLE
Fix path_policy_engine_executable fixture

### DIFF
--- a/changelogs/unreleased/fix-path-policy-engine-executable-fixture.yml
+++ b/changelogs/unreleased/fix-path-policy-engine-executable-fixture.yml
@@ -1,0 +1,4 @@
+---
+description: Fix path_policy_engine_executable fixture.
+change-type: patch
+destination-branches: [master]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -717,7 +717,7 @@ async def access_policy() -> str:
     """
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 async def path_policy_engine_executable() -> str:
     """
     Returns the path to the Open Policy Agent executable.


### PR DESCRIPTION
# Description

The `path_policy_engine_executable` somehow breaks the tests of the support extension. Changing the scope somehow resolves the issue. I would like to merge this in like this and investigate tomorrow why this fixes the issue. Otherwise I have to revert all the authorization-related PRs which is a lot of work. Since the issue is only present in the test suite, it should be fine.

# Self Check

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
