### PR TITLE
Document token parameter of documentation endpoint

### DIFF
--- a/changelogs/unreleased/add-doc-token-param.yml
+++ b/changelogs/unreleased/add-doc-token-param.yml
@@ -1,0 +1,4 @@
+---
+description: "Make sure the token parameter of the GET /api/v2/docs endpoint is properly documented."
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -415,6 +415,7 @@ def get_api_docs(
     Get the OpenAPI definition of the API
 
     :param format: Use 'openapi' to get the schema in json format, leave empty or use 'swagger' to get the Swagger-UI view
+    :param token: If provided, use this token to authorize the request instead of the value from the authorization header.
     """
 
 


### PR DESCRIPTION
# Description

Make sure the token parameter of the `GET /api/v2/docs` endpoint is properly documented.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
