### PR TITLE
Fix backwards compatibility problem when auth is enabled

### DIFF
--- a/changelogs/unreleased/fix-backwards-compatibility-problem-authorization.yml
+++ b/changelogs/unreleased/fix-backwards-compatibility-problem-authorization.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix issue where the server tries to start a policy engine even if enforce_access_policy config option is disabled."
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -571,16 +571,13 @@ class CallArguments:
         if not auth_enabled:
             return
 
-        if not server_config.enforce_access_policy.get():
-            return
-
         if self._auth_token is None:
             if self._config.properties.enforce_auth:
                 # We only need a valid token when the endpoint enforces authentication and auth is enabled
                 raise exceptions.UnauthorizedException()
             return None
 
-        if self._is_service_token():
+        if self._is_service_token() or not server_config.enforce_access_policy.get():
             self._authorize_service_token()
         else:
             if policy_engine is None:

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -286,7 +286,7 @@ class RESTServer(RESTBase):
         """
         Start the server on the current ioloop
         """
-        if self.is_auth_enabled():
+        if self.is_auth_enabled() and server_config.enforce_access_policy.get():
             self._policy_engine = policy_engine.PolicyEngine()
             await self._policy_engine.start()
 


### PR DESCRIPTION
# Description

* Fix issue where the server tries to start a policy engine even if `server.enforce_access_policy` config option is disabled.
* Fix issue where we don't fall back to legacy mode token validation when `server.enforce_access_policy` is disabled.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
