### PR TITLE
Update notation for parameters in path of URL in openapi documentation

### DIFF
--- a/changelogs/unreleased/update-template-marker-openapi-docs.yml
+++ b/changelogs/unreleased/update-template-marker-openapi-docs.yml
@@ -1,0 +1,6 @@
+---
+description: 'Mark parameters in the path of an endpoint using `<param>` instead of `{param}` in the openapi documentation.'
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -1018,6 +1018,12 @@ class UrlMethod:
     def get_operation(self) -> str:
         return self._properties.operation
 
+    def get_path(self) -> str:
+        """
+        Returns the path part of the URL. Parameters in this path are templated using the <param> notation.
+        """
+        return self._properties.get_full_path()
+
 
 # Util functions
 def custom_json_encoder(o: object, tz_aware: bool = True) -> Union[ReturnTypes, util.JSONSerializable]:

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -94,9 +94,10 @@ class OpenApiConverter:
         for path, methods in self.global_url_map.items():
             api_methods = self._filter_api_methods(methods)
             if len(api_methods) > 0:
-                path_in_openapi_format = self._format_path(path)
-                path_item = self._extract_operations_from_methods(api_methods, path_in_openapi_format)
-                paths[path_in_openapi_format] = path_item
+                url_method: UrlMethod = next(iter(methods.values()))
+                parameterized_path: str = url_method.get_path()
+                path_item = self._extract_operations_from_methods(api_methods, parameterized_path)
+                paths[parameterized_path] = path_item
         security: list[dict[SecuritySchemeName, list[Scope]]] | None = (
             # Set the security scheme globally for all endpoints.
             [{schema_name: []} for schema_name in self.type_converter.components.securitySchemes]
@@ -354,7 +355,7 @@ class FunctionParameterHandler:
         self.non_path_and_non_header_params: dict[str, inspect.Parameter] = {}
 
         for param_name, param in self.all_params_dct.items():
-            if f"{{{param_name}}}" in self.path:
+            if f"<{param_name}>" in self.path:
                 self.path_params[param_name] = param
             elif (
                 param_name in self.method_properties.arg_options.keys()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -529,7 +529,7 @@ def test_post_operation(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(post, "/operation/{id}")
+    operation = operation_handler.handle_method(post, "/operation/<id>")
 
     # Asserts on request body
     expected_params = ["param", "non_header"]
@@ -582,7 +582,7 @@ def test_get_operation(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(get, "/operation/{id}")
+    operation = operation_handler.handle_method(get, "/operation/<id>")
 
     # Asserts on request body
     assert operation.requestBody is None
@@ -620,7 +620,7 @@ def test_post_operation_no_docstring(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(post, "/operation/{id}")
+    operation = operation_handler.handle_method(post, "/operation/<id>")
 
     # Asserts on request body
     expected_params = ["param", "non_header"]
@@ -656,7 +656,7 @@ def test_get_operation_no_docstring(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(get, "/operation/{id}")
+    operation = operation_handler.handle_method(get, "/operation/<id>")
 
     # Asserts on request body
     assert operation.requestBody is None
@@ -695,7 +695,7 @@ def test_post_operation_partial_documentation(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(post, "/operation/{id_doc}/{id_no_doc}")
+    operation = operation_handler.handle_method(post, "/operation/<id_doc>/<id_no_doc>")
 
     # Asserts on request body
     request_body_parameters = list(operation.requestBody.content["application/json"].schema_.properties.keys())
@@ -739,7 +739,7 @@ def test_get_operation_partial_documentation(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(get, "/operation/{id_doc}/{id_no_doc}")
+    operation = operation_handler.handle_method(get, "/operation/<id_doc>/<id_no_doc>")
 
     # Asserts on request body
     assert operation.requestBody is None


### PR DESCRIPTION
# Description

Mark parameters in the path of an endpoint using `<param>` instead of `{param}` in the openapi documentation. This way the notation is consistent between the notation used in the code, in the access policy file and in the openapi documentation.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
