### PR TITLE
Fix bug: JWT config not cleared

### DIFF
--- a/changelogs/unreleased/fix-bug-clear-jwt-config.yml
+++ b/changelogs/unreleased/fix-bug-clear-jwt-config.yml
@@ -1,0 +1,4 @@
+---
+description: Fix bug where the JWT configuration is not cleared after reloading the configuration files.
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -174,7 +174,7 @@ class Config:
     def _clear_jwt_config_cache(cls) -> None:
         """
         Clear the cached JWT config. This method must be called after (re)loading
-        the config, because it can cause the cache to become out of sync.
+        the config, because it can cause the cache to become stale.
         """
         from inmanta.protocol.auth import auth
 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -120,7 +120,7 @@ class Config:
 
         config = LenientConfigParser(interpolation=Interpolation())
         config.read(files)
-        cls._set_config(config, config_dir, min_c_config_file)
+        cls._save_loaded_config(config, config_dir, min_c_config_file)
 
     @classmethod
     def load_config_from_dict(
@@ -133,7 +133,16 @@ class Config:
         """
         config = LenientConfigParser(interpolation=Interpolation())
         config.read_dict(input_config)
-        cls._set_config(config, config_dir=None, min_c_config_file=None)
+        cls._save_loaded_config(config, config_dir=None, min_c_config_file=None)
+
+    @classmethod
+    def _save_loaded_config(
+        cls, config: LenientConfigParser, config_dir: Optional[str], min_c_config_file: Optional[str]
+    ) -> None:
+        cls.__instance = config
+        cls._config_dir = config_dir
+        cls._min_c_config_file = min_c_config_file
+        cls._config_updated()
 
     @classmethod
     def config_as_dict(cls) -> typing.Mapping[str, typing.Mapping[str, typing.Any]]:
@@ -157,27 +166,21 @@ class Config:
         return cls._get_instance()
 
     @classmethod
-    def _set_config(cls, config: LenientConfigParser, config_dir: Optional[str], min_c_config_file: Optional[str]) -> None:
-        cls.__instance = config
-        cls._config_dir = config_dir
-        cls._min_c_config_file = min_c_config_file
-        cls._clear_jwt_config_cache()
-
-    @classmethod
     def _reset(cls) -> None:
         cls.__instance = None
         cls._config_dir = None
         cls._min_c_config_file = None
-        cls._clear_jwt_config_cache()
+        cls._config_updated()
 
     @classmethod
-    def _clear_jwt_config_cache(cls) -> None:
+    def _config_updated(cls) -> None:
         """
-        Clear the cached JWT config. This method must be called after (re)loading
-        the config, because it can cause the cache to become stale.
+        This method must be called every time the configuration is updated.
         """
         from inmanta.protocol.auth import auth
 
+        # Clear the cached JWT config. It might have become out of sync with
+        # the configuration in this class.
         auth.AuthJWTConfig.reset()
 
     @overload
@@ -245,7 +248,7 @@ class Config:
         if section not in cls.get_instance():
             cls.get_instance().add_section(section)
         cls.get_instance().set(section, name, value)
-        cls._clear_jwt_config_cache()
+        cls._config_updated()
 
     @classmethod
     def register_option(cls, option: "Option") -> None:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -245,6 +245,7 @@ class Config:
         if section not in cls.get_instance():
             cls.get_instance().add_section(section)
         cls.get_instance().set(section, name, value)
+        cls._clear_jwt_config_cache()
 
     @classmethod
     def register_option(cls, option: "Option") -> None:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -119,8 +119,6 @@ validate_cert=false
             )
         )
 
-    # Make sure the config starts from a clean slate
-    auth.AuthJWTConfig.reset()
     config.Config.load_config(config_file)
 
     cfg_list = await asyncio.get_event_loop().run_in_executor(None, auth.AuthJWTConfig.list)
@@ -168,8 +166,6 @@ validate_cert=false
             )
         )
 
-    # Make sure the config starts from a clean slate
-    auth.AuthJWTConfig.reset()
     config.Config.load_config(config_file)
     with pytest.raises(ValueError):
         await asyncio.get_event_loop().run_in_executor(None, partial(auth.AuthJWTConfig.get, "auth_jwt_keycloak"))


### PR DESCRIPTION
# Description

The `AuthJWTConfig` class keeps a cache with the JWT configuration. This configuration is derived on the configuration in the Config class. If the Config class is updated, the AuthJWTConfig class should be reset so that it picks up the new configuration. This reset didn't happen, which mainly caused issues for the test suite. This PR fixes that problems. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
