### PR TITLE
Fix bug: JWT config not cleared (iso7)

### DIFF
--- a/changelogs/unreleased/fix-bug-clear-jwt-config.yml
+++ b/changelogs/unreleased/fix-bug-clear-jwt-config.yml
@@ -1,4 +1,4 @@
 ---
 description: Fix bug where the JWT configuration is not cleared after reloading the configuration files.
 change-type: patch
-destination-branches: [master, iso8, iso7]
+destination-branches: [iso7]

--- a/changelogs/unreleased/fix-bug-clear-jwt-config.yml
+++ b/changelogs/unreleased/fix-bug-clear-jwt-config.yml
@@ -1,0 +1,4 @@
+---
+description: Fix bug where the JWT configuration is not cleared after reloading the configuration files.
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -120,9 +120,7 @@ class Config:
         cls._save_loaded_config(config, config_dir)
 
     @classmethod
-    def _save_loaded_config(
-        cls, config: LenientConfigParser, config_dir: Optional[str]
-    ) -> None:
+    def _save_loaded_config(cls, config: LenientConfigParser, config_dir: Optional[str]) -> None:
         cls.__instance = config
         cls._config_dir = config_dir
         cls._config_updated()

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -117,15 +117,14 @@ class Config:
 
         config = LenientConfigParser(interpolation=Interpolation())
         config.read(files)
-        cls._save_loaded_config(config, config_dir, min_c_config_file)
+        cls._save_loaded_config(config, config_dir)
 
     @classmethod
     def _save_loaded_config(
-        cls, config: LenientConfigParser, config_dir: Optional[str], min_c_config_file: Optional[str]
+        cls, config: LenientConfigParser, config_dir: Optional[str]
     ) -> None:
         cls.__instance = config
         cls._config_dir = config_dir
-        cls._min_c_config_file = min_c_config_file
         cls._config_updated()
 
     @classmethod
@@ -152,7 +151,7 @@ class Config:
         """
         This method must be called every time the configuration is updated.
         """
-        from inmanta.protocol.auth import auth
+        from inmanta.protocol import auth
 
         # Clear the cached JWT config. It might have become out of sync with
         # the configuration in this class.

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -98,7 +98,6 @@ class Config:
         """
         Load the configuration file
         """
-
         cfg_files_in_config_dir: list[str]
         if config_dir and os.path.isdir(config_dir):
             cfg_files_in_config_dir = sorted(
@@ -118,8 +117,16 @@ class Config:
 
         config = LenientConfigParser(interpolation=Interpolation())
         config.read(files)
+        cls._save_loaded_config(config, config_dir, min_c_config_file)
+
+    @classmethod
+    def _save_loaded_config(
+        cls, config: LenientConfigParser, config_dir: Optional[str], min_c_config_file: Optional[str]
+    ) -> None:
         cls.__instance = config
         cls._config_dir = config_dir
+        cls._min_c_config_file = min_c_config_file
+        cls._config_updated()
 
     @classmethod
     def _get_instance(cls) -> ConfigParser:
@@ -138,6 +145,18 @@ class Config:
     def _reset(cls) -> None:
         cls.__instance = None
         cls._config_dir = None
+        cls._config_updated()
+
+    @classmethod
+    def _config_updated(cls) -> None:
+        """
+        This method must be called every time the configuration is updated.
+        """
+        from inmanta.protocol.auth import auth
+
+        # Clear the cached JWT config. It might have become out of sync with
+        # the configuration in this class.
+        auth.AuthJWTConfig.reset()
 
     @overload
     @classmethod
@@ -203,6 +222,7 @@ class Config:
         if section not in cls.get_instance():
             cls.get_instance().add_section(section)
         cls.get_instance().set(section, name, value)
+        cls._config_updated()
 
     @classmethod
     def register_option(cls, option: "Option") -> None:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -119,8 +119,6 @@ validate_cert=false
             )
         )
 
-    # Make sure the config starts from a clean slate
-    auth.AuthJWTConfig.reset()
     config.Config.load_config(config_file)
 
     cfg_list = await asyncio.get_event_loop().run_in_executor(None, auth.AuthJWTConfig.list)
@@ -168,8 +166,6 @@ validate_cert=false
             )
         )
 
-    # Make sure the config starts from a clean slate
-    auth.AuthJWTConfig.reset()
     config.Config.load_config(config_file)
     with pytest.raises(ValueError):
         await asyncio.get_event_loop().run_in_executor(None, partial(auth.AuthJWTConfig.get, "auth_jwt_keycloak"))


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/9094 but applied on the iso7 branch due to a merge conflict.**

The `AuthJWTConfig` class keeps a cache with the JWT configuration. This configuration is derived on the configuration in the Config class. If the Config class is updated, the AuthJWTConfig class should be reset so that it picks up the new configuration. This reset didn't happen, which mainly caused issues for the test suite. This PR fixes that problems. 

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
