### PR TITLE
Fixed escaping

### DIFF
--- a/changelogs/unreleased/references_7.yml
+++ b/changelogs/unreleased/references_7.yml
@@ -1,0 +1,3 @@
+description: Fix dictpath escaping
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -30,6 +30,7 @@ from inmanta.ast import CompilerException, ExplicitPluginException, ExternalExce
 from inmanta.execute import proxy, util
 from inmanta.stable_api import stable_api
 from inmanta.types import JsonType, ResourceIdStr, ResourceVersionIdStr
+from inmanta.util import dict_path
 
 if TYPE_CHECKING:
     from inmanta import export
@@ -245,7 +246,10 @@ def collect_references(value_reference_collector: ReferenceCollector | None, val
             ]
 
         case dict() | proxy.DictProxy():
-            return {key: collect_references(value_reference_collector, value, f"{path}.{key}") for key, value in value.items()}
+            return {
+                key: collect_references(value_reference_collector, value, f"{path}.{dict_path.NormalValue(key).escape()}")
+                for key, value in value.items()
+            }
 
         case references.Reference():
             if value_reference_collector is None:

--- a/tests/data/modules_v2/refs/inmanta_plugins/refs/__init__.py
+++ b/tests/data/modules_v2/refs/inmanta_plugins/refs/__init__.py
@@ -143,7 +143,8 @@ class Deep(ManagedResource, PurgeableResource):
 
     @classmethod
     def get_value(cls, _, resource) -> dict[str, object]:
-        return {"inner": resource.value}
+        # use a . to ensure proper escaping
+        return {"inner.something": resource.value}
 
 
 @provider("refs::DeepResource", name="null")

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -181,6 +181,9 @@ async def test_deploy_end_to_end(
     assert result.code == 200
     details = ReleasedResourceDetails(**result.result["data"])
     assert details.status == ReleasedResourceState.deployed
+    result = await client.resource_logs(environment, "refs::DeepResource[test,name=test3]")
+    assert result.code == 200
+    assert [msg for msg in result.result["data"] if "Observed value: {'inner.something': 'testx'}" in msg["msg"]]
 
 
 def test_reference_cycle(snippetcompiler: "SnippetCompilationTest", modules_v2_dir: str) -> None:

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -162,7 +162,7 @@ def test_wild_null_path() -> None:
 
 @pytest.mark.parametrize(
     "escaped, unescaped",
-    [(r"a\.b\=\[\\\*", r"a.b=[\*"), ("a\.\.\.b", "a...b")],
+    [(r"a\.b\=\[\\\*", r"a.b=[\*"), (r"a\.\.\.b", "a...b")],
 )
 def test_escape_and_un_escape(escaped: str, unescaped: str) -> None:
     """

--- a/tests/util/test_dict_path.py
+++ b/tests/util/test_dict_path.py
@@ -162,7 +162,7 @@ def test_wild_null_path() -> None:
 
 @pytest.mark.parametrize(
     "escaped, unescaped",
-    [(r"a\.b\=\[\\\*", r"a.b=[\*")],
+    [(r"a\.b\=\[\\\*", r"a.b=[\*"), ("a\.\.\.b", "a...b")],
 )
 def test_escape_and_un_escape(escaped: str, unescaped: str) -> None:
     """


### PR DESCRIPTION
# Description

Fix issue where dictpaths are not correctly escaped 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
