### PR TITLE
Fix bug scheduler paused when all agents are paused

### DIFF
--- a/changelogs/unreleased/9081-fix-bug-scheduler-paused-on-all-agents-pause.yml
+++ b/changelogs/unreleased/9081-fix-bug-scheduler-paused-on-all-agents-pause.yml
@@ -1,0 +1,8 @@
+---
+description: "Fix bug where the scheduler is paused by calling the `POST /api/v2/agents/pause` endpoint."
+issue-nr: 9081
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -3436,8 +3436,8 @@ class Agent(BaseDocument):
         :return A list of agent names that have been paused/unpaused by this method.
         """
         if endpoint is None:
-            query = f"UPDATE {cls.table_name()} SET paused=$1 WHERE environment=$2 RETURNING name"
-            values = [cls._get_value(paused), cls._get_value(env)]
+            query = f"UPDATE {cls.table_name()} SET paused=$1 WHERE environment=$2 AND name!=$3 RETURNING name"
+            values = [cls._get_value(paused), cls._get_value(env), const.AGENT_SCHEDULER_ID]
         else:
             query = f"UPDATE {cls.table_name()} SET paused=$1 WHERE environment=$2 AND name=$3 RETURNING name"
             values = [cls._get_value(paused), cls._get_value(env), cls._get_value(endpoint)]

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1082,3 +1082,20 @@ async def test_heartbeat_different_session(server_pre_start, async_finalizer, ca
     LOGGER.info("Heartbeat good, unlocking")
     hanglock.set()
     await hangers
+
+
+async def test_pause_all_agents_doesnt_pause_environment(server, environment, client, agent) -> None:
+    """
+    Reproduces bug: https://github.com/inmanta/inmanta-core/issues/9081
+    """
+    agents = await data.Agent.get_list()
+    assert len(agents) == 1
+    assert not agents[0].paused
+
+    result = await client.all_agents_action(environment, AgentAction.pause.value)
+    assert result.code == 200
+
+    agents = await data.Agent.get_list()
+    assert len(agents) == 1
+    assert not agents[0].paused
+

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1098,4 +1098,3 @@ async def test_pause_all_agents_doesnt_pause_environment(server, environment, cl
     agents = await data.Agent.get_list()
     assert len(agents) == 1
     assert not agents[0].paused
-

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -29,7 +29,7 @@ from uuid import UUID, uuid4
 import pytest
 from tornado.httpclient import AsyncHTTPClient
 
-from inmanta import config, data, const
+from inmanta import config, const, data
 from inmanta.config import Config
 from inmanta.const import AgentAction, AgentStatus
 from inmanta.protocol import Result, handle, typedmethod


### PR DESCRIPTION
# Description

Fix bug where the scheduler is paused by calling the `POST /api/v2/agents/pause` endpoint.

closes #9081

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
