### PR TITLE
Prevent infinite recursion if a resource inherits from the resource decorator

### DIFF
--- a/changelogs/unreleased/resource-inherits-from-resource-decorator.yml
+++ b/changelogs/unreleased/resource-inherits-from-resource-decorator.yml
@@ -1,0 +1,8 @@
+---
+description: "Log a clear error message if a Resource accidentally inherits from the resource decorator instead of the Resource class."
+issue-nr: 8817
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/tests/data/modules_v2/invalid-resource-def/MANIFEST.in
+++ b/tests/data/modules_v2/invalid-resource-def/MANIFEST.in
@@ -1,0 +1,2 @@
+include inmanta_plugins/invalid_resource_def/setup.cfg
+recursive-include inmanta_plugins/invalid_resource_def/model *.cf

--- a/tests/data/modules_v2/invalid-resource-def/inmanta_plugins/invalid_resource_def/__init__.py
+++ b/tests/data/modules_v2/invalid-resource-def/inmanta_plugins/invalid_resource_def/__init__.py
@@ -1,0 +1,24 @@
+"""
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+from inmanta.resources import resource
+
+
+@resource("invalid_resource_def::Test", agent="agent1", id_attribute="id")
+class Test(resource):
+    pass

--- a/tests/data/modules_v2/invalid-resource-def/model/_init.cf
+++ b/tests/data/modules_v2/invalid-resource-def/model/_init.cf
@@ -1,0 +1,17 @@
+"""
+    Copyright 2025 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""

--- a/tests/data/modules_v2/invalid-resource-def/pyproject.toml
+++ b/tests/data/modules_v2/invalid-resource-def/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/data/modules_v2/invalid-resource-def/setup.cfg
+++ b/tests/data/modules_v2/invalid-resource-def/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = inmanta-module-invalid-resource-def
+version = 0.0.1
+description = 
+author = Inmanta
+author_email = code@inmanta.com
+license = ASL 2.0
+copyright = 2025 Inmanta
+
+[options]
+zip_safe=False
+include_package_data=True
+packages=find_namespace:
+install_requires =
+    inmanta-module-std
+
+[options.packages.find]
+include = inmanta_plugins*

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -866,5 +866,5 @@ async def test_resource_inherits_from_decorator(snippetcompiler, local_module_pa
 
     assert (
         "Resource inmanta_plugins.invalid_resource_def.Test is inheriting from the inmanta.resources.resource decorator."
-        " Did you intent to inherit from inmanta.resources.Resource instead?"
+        " Did you intend to inherit from inmanta.resources.Resource instead?"
     ) in str(exc.value)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -26,10 +26,11 @@ import pytest
 
 import inmanta.resources
 from inmanta import config, const, module
-from inmanta.ast import CompilerException, ExternalException
+from inmanta.ast import CompilerException, ExternalException, RuntimeException
 from inmanta.const import ResourceState
 from inmanta.data import Environment, Resource
 from inmanta.export import DependencyCycleException
+from inmanta.module import InmantaModuleRequirement
 from inmanta.server import SLICE_RESOURCE
 from inmanta.server.server import Server
 from utils import LogSequence
@@ -844,3 +845,26 @@ async def test_export_duplicate(resource_container, snippetcompiler):
         snippetcompiler.do_export()
 
     assert "exists more than once in the configuration model" in str(exc.value)
+
+
+async def test_resource_inherits_from_decorator(snippetcompiler, local_module_package_index):
+    """
+    Verify that a clear error message is shown to the user if a resource inherits
+    from the resource decorator instead of the Resource class.
+    """
+    requirement = InmantaModuleRequirement.parse("invalid_resource_def")
+    snippetcompiler.setup_for_snippet(
+        "import invalid_resource_def",
+        install_project=True,
+        index_url=local_module_package_index,
+        python_requires=[requirement.get_python_package_requirement()],
+        autostd=False,
+    )
+
+    with pytest.raises(RuntimeException) as exc:
+        snippetcompiler.do_export()
+
+    assert (
+        "Resource inmanta_plugins.invalid_resource_def.Test is inheriting from the inmanta.resources.resource decorator."
+        " Did you intent to inherit from inmanta.resources.Resource instead?"
+    ) in str(exc.value)


### PR DESCRIPTION
# Description

Log a clear error message if a Resource accidentally inherits from the resource decorator instead of the Resource class.

closes #8817 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
