### PR TITLE
Fixed bug in environment metrics

### DIFF
--- a/changelogs/unreleased/fix-environment-metrics.yml
+++ b/changelogs/unreleased/fix-environment-metrics.yml
@@ -1,0 +1,4 @@
+description: Fix bug in environment metrics
+change-type: patch
+destination-branches:
+  - master

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -865,7 +865,6 @@ src/inmanta/protocol/methods.py:0: error: Function is missing a return type anno
 src/inmanta/protocol/methods.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/inmanta/protocol/methods.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/inmanta/protocol/methods.py:0: error: Function is missing a return type annotation  [no-untyped-def]
-src/inmanta/protocol/methods.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/inmanta/protocol/methods.py:0: error: Incompatible return value type (got "UUID", expected "Environment")  [return-value]
 src/inmanta/protocol/methods.py:0: error: Incompatible types in assignment (expression has type "Environment | None", variable has type "UUID")  [assignment]
 src/inmanta/protocol/methods.py:0: error: Missing return statement  [empty-body]

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -36,7 +36,6 @@ from inmanta.data import (
     Environment,
     EnvironmentMetricsGauge,
     EnvironmentMetricsTimer,
-    Resource,
     Setting,
 )
 from inmanta.data.model import EnvironmentMetricsResult
@@ -438,11 +437,9 @@ class ResourceCountMetricsCollector(MetricsCollector):
     ) -> Sequence[MetricValue]:
         query: str = f"""
             WITH resource_statuses AS (
-                SELECT r.environment,
+                SELECT rps.environment,
                 {const.SQL_RESOURCE_STATUS_SELECTOR} AS status
-                FROM {Resource.table_name()} AS r
-                INNER JOIN public.resource_persistent_state AS rps
-                    ON r.resource_id = rps.resource_id AND r.environment = rps.environment
+                FROM public.resource_persistent_state AS rps
                 WHERE NOT rps.is_orphan
             ),
             nonzero_statuses AS (


### PR DESCRIPTION
# Description

Fixed bug in environment metrics. It was fetching every version of each resource that was not orphaned


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
