### PR TITLE
Prevent infinite recursion if a resource inherits from the resource decorator (iso7)

### DIFF
--- a/changelogs/unreleased/resource-inherits-from-resource-decorator.yml
+++ b/changelogs/unreleased/resource-inherits-from-resource-decorator.yml
@@ -3,6 +3,6 @@ description: "Log a clear error message if a Resource accidentally inherits from
 issue-nr: 8817
 issue-repo: inmanta-core
 change-type: patch
-destination-branches: [master, iso8, iso7]
+destination-branches: [iso7]
 sections:
   minor-improvement: "{{description}}"

--- a/changelogs/unreleased/resource-inherits-from-resource-decorator.yml
+++ b/changelogs/unreleased/resource-inherits-from-resource-decorator.yml
@@ -1,0 +1,8 @@
+---
+description: "Log a clear error message if a Resource accidentally inherits from the resource decorator instead of the Resource class."
+issue-nr: 8817
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -24,9 +24,8 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, cast
 
 import inmanta.util
 from inmanta import plugins
-from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
-from inmanta import const, references, plugins
 from inmanta.ast import CompilerException, ExplicitPluginException, ExternalException, RuntimeException
+from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
 from inmanta.execute import proxy, util
 from inmanta.stable_api import stable_api
 from inmanta.types import JsonType

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -24,8 +24,9 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, cast
 
 import inmanta.util
 from inmanta import plugins
-from inmanta.ast import CompilerException, ExplicitPluginException, ExternalException
 from inmanta.data.model import ResourceIdStr, ResourceVersionIdStr
+from inmanta import const, references, plugins
+from inmanta.ast import CompilerException, ExplicitPluginException, ExternalException, RuntimeException
 from inmanta.execute import proxy, util
 from inmanta.stable_api import stable_api
 from inmanta.types import JsonType
@@ -83,7 +84,20 @@ class resource:  # noqa: N801
 
     @classmethod
     def validate(cls) -> None:
+        fq_name_resource_decorator = f"{cls.__module__}.{cls.__name__}"
+        fq_name_resource_class = f"{Resource.__module__}.{Resource.__name__}"
         for resource, _ in cls._resources.values():
+            if issubclass(resource, cls):
+                # If a Resource inherits from the resource decorator, the server goes into an infinite recursion.
+                # Here we make sure the user gets a clear error message (https://github.com/inmanta/inmanta-core/issues/8817).
+                fq_name_current_resource = f"{resource.__module__}.{resource.__name__}"
+                raise RuntimeException(
+                    stmt=None,
+                    msg=(
+                        f"Resource {fq_name_current_resource} is inheriting from the {fq_name_resource_decorator} decorator."
+                        f" Did you intend to inherit from {fq_name_resource_class} instead?"
+                    ),
+                )
             resource.validate()
 
     @classmethod

--- a/tests/data/modules_v2/invalid-resource-def/MANIFEST.in
+++ b/tests/data/modules_v2/invalid-resource-def/MANIFEST.in
@@ -1,0 +1,2 @@
+include inmanta_plugins/invalid_resource_def/setup.cfg
+recursive-include inmanta_plugins/invalid_resource_def/model *.cf

--- a/tests/data/modules_v2/invalid-resource-def/inmanta_plugins/invalid_resource_def/__init__.py
+++ b/tests/data/modules_v2/invalid-resource-def/inmanta_plugins/invalid_resource_def/__init__.py
@@ -1,0 +1,24 @@
+"""
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+from inmanta.resources import resource
+
+
+@resource("invalid_resource_def::Test", agent="agent1", id_attribute="id")
+class Test(resource):
+    pass

--- a/tests/data/modules_v2/invalid-resource-def/model/_init.cf
+++ b/tests/data/modules_v2/invalid-resource-def/model/_init.cf
@@ -1,0 +1,17 @@
+"""
+    Copyright 2025 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""

--- a/tests/data/modules_v2/invalid-resource-def/pyproject.toml
+++ b/tests/data/modules_v2/invalid-resource-def/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/data/modules_v2/invalid-resource-def/setup.cfg
+++ b/tests/data/modules_v2/invalid-resource-def/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = inmanta-module-invalid-resource-def
+version = 0.0.1
+description = 
+author = Inmanta
+author_email = code@inmanta.com
+license = ASL 2.0
+copyright = 2025 Inmanta
+
+[options]
+zip_safe=False
+include_package_data=True
+packages=find_namespace:
+install_requires =
+    inmanta-module-std
+
+[options.packages.find]
+include = inmanta_plugins*

--- a/tests/data/modules_v2/invalid-resource-def/setup.cfg
+++ b/tests/data/modules_v2/invalid-resource-def/setup.cfg
@@ -11,8 +11,6 @@ copyright = 2025 Inmanta
 zip_safe=False
 include_package_data=True
 packages=find_namespace:
-install_requires =
-    inmanta-module-std
 
 [options.packages.find]
 include = inmanta_plugins*

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -24,7 +24,7 @@ from typing import Optional
 import pytest
 
 import inmanta.resources
-from inmanta import config, const, module
+from inmanta import config, const
 from inmanta.ast import CompilerException, ExternalException, RuntimeException
 from inmanta.const import ResourceState
 from inmanta.data import Environment, Resource
@@ -797,4 +797,3 @@ async def test_resource_inherits_from_decorator(snippetcompiler, local_module_pa
         "Resource inmanta_plugins.invalid_resource_def.Test is inheriting from the inmanta.resources.resource decorator."
         " Did you intend to inherit from inmanta.resources.Resource instead?"
     ) in str(exc.value)
-


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/9124 but applied on the iso7 branch due to a merge conflict.**

Log a clear error message if a Resource accidentally inherits from the resource decorator instead of the Resource class.

closes #8817 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
