### PR TITLE
Issue/disable module version check in partial exports

### DIFF
--- a/changelogs/unreleased/disable-partial-module-version-check.yml
+++ b/changelogs/unreleased/disable-partial-module-version-check.yml
@@ -1,0 +1,3 @@
+description: Temporarily disable module version check during partial exports.
+change-type: patch
+destination-branches: [master]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -2,6 +2,7 @@ src/inmanta/agent/cache.py:0: error: Function is missing a type annotation for o
 src/inmanta/agent/forking_executor.py:0: error: Argument 1 of "connection_made" is incompatible with supertype "BaseProtocol"; supertype defines the argument type as "BaseTransport"  [override]
 src/inmanta/agent/forking_executor.py:0: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
 src/inmanta/agent/forking_executor.py:0: note: This violates the Liskov substitution principle
+src/inmanta/agent/handler.py:0: error: Argument 2 to "chain_future" has incompatible type "concurrent.futures._base.Future[T]"; expected "_asyncio.Future[Any]"  [arg-type]
 src/inmanta/agent/handler.py:0: error: Argument 3 to "log" of "LogLine" has incompatible type "**dict[str, object]"; expected "datetime | None"  [arg-type]
 src/inmanta/agent/handler.py:0: error: Returning Any from function declared to return "bool"  [no-any-return]
 src/inmanta/agent/reporting.py:0: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
@@ -1010,7 +1011,10 @@ src/inmanta/protocol/rest/client.py:0: error: Incompatible types in assignment (
 src/inmanta/protocol/rest/client.py:0: error: Returning Any from function declared to return "Result"  [no-any-return]
 src/inmanta/protocol/rest/client.py:0: error: Value expression in dictionary comprehension has incompatible type "str"; expected type "bytes"  [misc]
 src/inmanta/protocol/rest/client.py:0: note: Use "-> None" if function does not return a value
+src/inmanta/protocol/rest/server.py:0: error: Argument 1 to "Application" has incompatible type "list[Rule]"; expected "list[Rule | list[Any] | tuple[str | Matcher, Any] | tuple[str | Matcher, Any, dict[str, Any]] | tuple[str | Matcher, Any, dict[str, Any], str]] | None"  [arg-type]
 src/inmanta/protocol/rest/server.py:0: error: Argument 1 to "get_global_url_map" of "RESTServer" has incompatible type "Sequence[CallTarget]"; expected "list[CallTarget]"  [arg-type]
+src/inmanta/protocol/rest/server.py:0: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+src/inmanta/protocol/rest/server.py:0: note: Consider using "Sequence" instead, which is covariant
 src/inmanta/references.py:0: error: Parameter 1 of Literal[...] is invalid  [valid-type]
 src/inmanta/references.py:0: error: Returning Any from function declared to return "type[T] | None"  [no-any-return]
 src/inmanta/resources.py:0: error: "Resource" has no attribute "receive_events"; maybe "get_receive_events"?  [attr-defined]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -2,7 +2,6 @@ src/inmanta/agent/cache.py:0: error: Function is missing a type annotation for o
 src/inmanta/agent/forking_executor.py:0: error: Argument 1 of "connection_made" is incompatible with supertype "BaseProtocol"; supertype defines the argument type as "BaseTransport"  [override]
 src/inmanta/agent/forking_executor.py:0: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
 src/inmanta/agent/forking_executor.py:0: note: This violates the Liskov substitution principle
-src/inmanta/agent/handler.py:0: error: Argument 2 to "chain_future" has incompatible type "concurrent.futures._base.Future[T]"; expected "_asyncio.Future[Any]"  [arg-type]
 src/inmanta/agent/handler.py:0: error: Argument 3 to "log" of "LogLine" has incompatible type "**dict[str, object]"; expected "datetime | None"  [arg-type]
 src/inmanta/agent/handler.py:0: error: Returning Any from function declared to return "bool"  [no-any-return]
 src/inmanta/agent/reporting.py:0: error: Incompatible types in assignment (expression has type "None", variable has type Module)  [assignment]
@@ -1011,10 +1010,7 @@ src/inmanta/protocol/rest/client.py:0: error: Incompatible types in assignment (
 src/inmanta/protocol/rest/client.py:0: error: Returning Any from function declared to return "Result"  [no-any-return]
 src/inmanta/protocol/rest/client.py:0: error: Value expression in dictionary comprehension has incompatible type "str"; expected type "bytes"  [misc]
 src/inmanta/protocol/rest/client.py:0: note: Use "-> None" if function does not return a value
-src/inmanta/protocol/rest/server.py:0: error: Argument 1 to "Application" has incompatible type "list[Rule]"; expected "list[Rule | list[Any] | tuple[str | Matcher, Any] | tuple[str | Matcher, Any, dict[str, Any]] | tuple[str | Matcher, Any, dict[str, Any], str]] | None"  [arg-type]
 src/inmanta/protocol/rest/server.py:0: error: Argument 1 to "get_global_url_map" of "RESTServer" has incompatible type "Sequence[CallTarget]"; expected "list[CallTarget]"  [arg-type]
-src/inmanta/protocol/rest/server.py:0: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
-src/inmanta/protocol/rest/server.py:0: note: Consider using "Sequence" instead, which is covariant
 src/inmanta/references.py:0: error: Parameter 1 of Literal[...] is invalid  [valid-type]
 src/inmanta/references.py:0: error: Returning Any from function declared to return "type[T] | None"  [no-any-return]
 src/inmanta/resources.py:0: error: "Resource" has no attribute "receive_events"; maybe "get_receive_events"?  [attr-defined]

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -671,14 +671,14 @@ class OrchestrationService(protocol.ServerSlice):
         base_version_data: dict[tuple[str, str], list[str]] = await AgentModules.get_agents_per_module(
             model_version=partial_base_version, environment=environment, connection=connection
         )
-        for inmanta_module_name, module_data in module_version_info.items():
-            module_version = module_data.version
-            if (inmanta_module_name, module_version) not in base_version_data:
-                raise BadRequest(
-                    "Cannot perform partial export because of version mismatch for module %s." % inmanta_module_name
-                )
-
         return base_version_data
+        # for inmanta_module_name, module_data in module_version_info.items():
+        #     module_version = module_data.version
+        #     if (inmanta_module_name, module_version) not in base_version_data:
+        #         raise BadRequest(
+        #             "Cannot perform partial export because of version mismatch for module %s." % inmanta_module_name
+        #         )
+
 
     async def _register_agent_code(
         self,

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -671,14 +671,13 @@ class OrchestrationService(protocol.ServerSlice):
         base_version_data: dict[tuple[str, str], list[str]] = await AgentModules.get_agents_per_module(
             model_version=partial_base_version, environment=environment, connection=connection
         )
-        return base_version_data
         # for inmanta_module_name, module_data in module_version_info.items():
         #     module_version = module_data.version
         #     if (inmanta_module_name, module_version) not in base_version_data:
         #         raise BadRequest(
         #             "Cannot perform partial export because of version mismatch for module %s." % inmanta_module_name
         #         )
-
+        return base_version_data
 
     async def _register_agent_code(
         self,
@@ -706,10 +705,9 @@ class OrchestrationService(protocol.ServerSlice):
             base_version_info = await self._check_version_info(
                 partial_base_version, environment, module_version_info, connection
             )
-        else:
-            await InmantaModule.register_modules(
-                environment=environment, module_version_info=module_version_info, connection=connection
-            )
+        await InmantaModule.register_modules(
+            environment=environment, module_version_info=module_version_info, connection=connection
+        )
         await AgentModules.register_modules_for_agents(
             model_version=version,
             environment=environment,


### PR DESCRIPTION
# Description

Temporarily disable module version check during partial exports while [this bug](https://github.com/inmanta/inmanta-core/pull/9129#discussion_r2102783573) is being investigated

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
