### PR TITLE
Issue/fix warning pkg resources deprecated

### DIFF
--- a/changelogs/unreleased/warning-pkg-resources-deprecated.yml
+++ b/changelogs/unreleased/warning-pkg-resources-deprecated.yml
@@ -1,0 +1,4 @@
+---
+description: Fix test that failed because of warning pkg_resources being deprecated.
+change-type: patch
+destination-branches: [master, iso8]

--- a/tests/server/test_workon.py
+++ b/tests/server/test_workon.py
@@ -578,7 +578,9 @@ async def assert_workon_state(
     assert (python == str(os.path.realpath(expected_dir.join(".env", "bin", "python")))) != invert_python_assert
     assert ps1_prefix == ("" if invert_ps1_assert else f"({arg}) ")
     assert empty == ""
-    assert result.stderr.strip() == expect_stderr.strip()
+    # Ignore the warning about pkg_resources being deprecated until pyformance doesn't use it anymore.
+    stderr = "\n".join([r for r in result.stderr.strip().split("\n") if "pkg_resources" not in r])
+    assert stderr == expect_stderr.strip()
 
 
 @pytest.mark.slowtest


### PR DESCRIPTION
# Description

`pkg_resources` is deprecated as an API.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
