### PR TITLE
Improve performance populate_for_version

### DIFF
--- a/changelogs/unreleased/improve-performance-populate-for-version.yml
+++ b/changelogs/unreleased/improve-performance-populate-for-version.yml
@@ -1,0 +1,4 @@
+---
+description: "Improve the performance of the `populate_for_version` query."
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -4612,11 +4612,8 @@ class ResourcePersistentState(BaseDocument):
                     ELSE 'NOT_BLOCKED'
                 END
             FROM {Resource.table_name()} AS r
-            WHERE r.environment=$1 AND r.model=$2 AND NOT EXISTS(
-                SELECT *
-                FROM {cls.table_name()} AS rps
-                WHERE rps.environment=r.environment AND rps.resource_id=r.resource_id
-            )
+            WHERE r.environment=$1 AND r.model=$2
+            ON CONFLICT DO NOTHING
             """,
             environment,
             model_version,


### PR DESCRIPTION
# Description

Improve the performance of the query done by the `ResourcePersistentState.populate_for_version` method.

Query plan old query:

```
 Insert on resource_persistent_state  (cost=520.05..993.57 rows=0 width=0) (actual time=0.047..0.049 rows=0 loops=1)
   ->  Hash Anti Join  (cost=520.05..993.57 rows=8 width=342) (actual time=0.046..0.047 rows=0 loops=1)
         Hash Cond: ((r.resource_id)::text = (rps.resource_id)::text)
         ->  Index Scan using resource_environment_model_resource_set_idx on resource r  (cost=0.42..472.93 rows=235 width=215) (actual time=0.044..0.045 rows=0 loops=1)
               Index Cond: ((environment = 'f81be80b-8582-499f-b002-7cdd2f2df98a'::uuid) AND (model = 13))
         ->  Hash  (cost=426.45..426.45 rows=7454 width=102) (never executed)
               ->  Seq Scan on resource_persistent_state rps  (cost=0.00..426.45 rows=7454 width=102) (never executed)
                     Filter: (environment = 'f81be80b-8582-499f-b002-7cdd2f2df98a'::uuid)
 Planning Time: 3.151 ms
 Execution Time: 0.191 ms
(10 rows)
```
Query plan new query:

```
 Insert on resource_persistent_state  (cost=0.42..474.69 rows=0 width=0) (actual time=0.042..0.043 rows=0 loops=1)
   Conflict Resolution: NOTHING
   Tuples Inserted: 0
   Conflicting Tuples: 0
   ->  Index Scan using resource_environment_model_resource_set_idx on resource r  (cost=0.42..474.69 rows=235 width=342) (actual time=0.041..0.041 rows=0 loops=1)
         Index Cond: ((environment = 'f81be80b-8582-499f-b002-7cdd2f2df98a'::uuid) AND (model = 13))
 Planning Time: 1.552 ms
 Execution Time: 0.111 ms
```

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
