### PR TITLE
Allow resource to migrate between resource sets

### DIFF
--- a/changelogs/unreleased/9042_partial_migration.yml
+++ b/changelogs/unreleased/9042_partial_migration.yml
@@ -1,0 +1,6 @@
+description: For partial compile, allow resources to move between resource sets if both sets are being updated
+issue-nr: 9042
+change-type: minor
+destination-branches: [master, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -167,6 +167,7 @@ class PartialUpdateMerger:
         self.rids_in_partial_compile = rids_in_partial_compile
         self.updated_resource_sets = updated_resource_sets
         self.deleted_resource_sets = deleted_resource_sets
+        self.modified_resource_sets = updated_resource_sets | deleted_resource_sets
         self.updated_and_shared_resources_old = updated_and_shared_resources_old
         self.non_shared_resources_in_partial_update_old: abc.Mapping[ResourceIdStr, data.Resource] = {
             rid: r for rid, r in self.updated_and_shared_resources_old.items() if r.resource_set is not None
@@ -236,7 +237,9 @@ class PartialUpdateMerger:
         shared_resources = {r.resource_id: r for r in updated_and_shared_resources if r.resource_set is None}
         updated_resources = {r.resource_id: r for r in updated_and_shared_resources if r.resource_set is not None}
         shared_resources_merged = {r.resource_id: r for r in self._merge_shared_resources(shared_resources)}
-        result = {**updated_resources, **shared_resources_merged}
+        # Updated go last, so that in case of overlap, we get the updated one
+        # Validation on move is done later
+        result = {**shared_resources_merged, **updated_resources}
         self._validate_constraints(result)
         return result
 
@@ -252,7 +255,13 @@ class PartialUpdateMerger:
                 continue
             matching_resource_old_model = self.updated_and_shared_resources_old[res.resource_id]
 
-            if res.resource_set != matching_resource_old_model.resource_set:
+            if (
+                res.resource_set != matching_resource_old_model.resource_set
+                and matching_resource_old_model.resource_set not in self.modified_resource_sets
+            ):
+                # We can't move resource
+                # Unless between resource sets we are updating
+                # Shared set is never in modified_resource_sets, so no escape from there
                 raise BadRequest(
                     f"A partial compile cannot migrate resources: trying to move {res.resource_id} from resource set"
                     f" {matching_resource_old_model.resource_set} to {res.resource_set}."
@@ -863,7 +872,7 @@ class OrchestrationService(protocol.ServerSlice):
                             "a full compile is necessary for this process:\n"
                         )
                         msg += "\n".join(
-                            f"    {rid} moved from {rids_unchanged_resource_sets[rid]} to {resource_sets[rid]}"
+                            f"    {rid} moved from {rids_unchanged_resource_sets[rid]} to {resource_sets.get(rid)}"
                             for rid in resources_that_moved_resource_sets
                         )
 

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -66,6 +66,12 @@ PERFORM_CLEANUP: bool = True
 # Kill switch for cleanup, for use when working with historical data
 
 
+def get_printable_name_for_resource_set(native: str | None) -> str:
+    if native is None:
+        return "<SHARED>"
+    return native
+
+
 class CrossResourceSetDependencyError(Exception):
     def __init__(self, resource_id1: ResourceIdStr, resource_id2: ResourceIdStr) -> None:
         """
@@ -265,7 +271,8 @@ class PartialUpdateMerger:
                 raise BadRequest(
                     "A partial compile only migrate resources between resource set that are pushed together:"
                     f" trying to move {res.resource_id} from resource set "
-                    f"{matching_resource_old_model.resource_set} to {res.resource_set}."
+                    f"{get_printable_name_for_resource_set(matching_resource_old_model.resource_set)} "
+                    f"to {get_printable_name_for_resource_set(res.resource_set)}."
                 )
 
             if res.resource_set is None and res.attribute_hash != matching_resource_old_model.attribute_hash:
@@ -873,7 +880,8 @@ class OrchestrationService(protocol.ServerSlice):
                             "a full compile is necessary for this process:\n"
                         )
                         msg += "\n".join(
-                            f"    {rid} moved from {rids_unchanged_resource_sets[rid]} to {resource_sets.get(rid)}"
+                            f"    {rid} moved from {get_printable_name_for_resource_set(rids_unchanged_resource_sets[rid])} "
+                            f"to {get_printable_name_for_resource_set(resource_sets.get(rid))}"
                             for rid in resources_that_moved_resource_sets
                         )
 

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -263,8 +263,9 @@ class PartialUpdateMerger:
                 # Unless between resource sets we are updating
                 # Shared set is never in modified_resource_sets, so no escape from there
                 raise BadRequest(
-                    f"A partial compile cannot migrate resources: trying to move {res.resource_id} from resource set"
-                    f" {matching_resource_old_model.resource_set} to {res.resource_set}."
+                    "A partial compile only migrate resources between resource set that are pushed together:"
+                    f" trying to move {res.resource_id} from resource set "
+                    f"{matching_resource_old_model.resource_set} to {res.resource_set}."
                 )
 
             if res.resource_set is None and res.attribute_hash != matching_resource_old_model.attribute_hash:

--- a/tests/deploy/e2e/test_code_loading.py
+++ b/tests/deploy/e2e/test_code_loading.py
@@ -632,10 +632,7 @@ async def test_code_loading_after_partial(server, agent, client, environment, cl
         version_info={},
         compiler_version=get_compiler_version(),
         module_version_info=module_version_info,
-        resource_sets={
-            "test::ResType_A[agent_X,key=key1]": "set-a",
-            "test::ResType_A[agent_Y,key=key1]": "set-b"
-        }
+        resource_sets={"test::ResType_A[agent_X,key=key1]": "set-a", "test::ResType_A[agent_Y,key=key1]": "set-b"},
     )
 
     assert result.code == 200

--- a/tests/deploy/e2e/test_code_loading.py
+++ b/tests/deploy/e2e/test_code_loading.py
@@ -632,6 +632,10 @@ async def test_code_loading_after_partial(server, agent, client, environment, cl
         version_info={},
         compiler_version=get_compiler_version(),
         module_version_info=module_version_info,
+        resource_sets={
+            "test::ResType_A[agent_X,key=key1]": "set-a",
+            "test::ResType_A[agent_Y,key=key1]": "set-b"
+        }
     )
 
     assert result.code == 200

--- a/tests/deploy/e2e/test_resource_sets.py
+++ b/tests/deploy/e2e/test_resource_sets.py
@@ -600,7 +600,7 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
         "trying to move test::Resource[agent1,key=key2] from resource set <SHARED> to set-b-new." in result.result["message"]
     )
 
-    ### Reset for require provides test
+    # Reset for require provides test
     version = await clienthelper.get_version()
     resources = [
         {
@@ -633,7 +633,7 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
     )
     assert result.code == 200
 
-    ## Try to move on part of require-provide to new resource set, updating both sets
+    # Try to move on part of require-provide to new resource set, updating both sets
     version = 0
     resources = [
         {
@@ -669,7 +669,7 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
         "test::Resource[agent1,key=key1], but they belong to different resource sets." in result.result["message"]
     )
 
-    ## Try to move on part of require-provide updating only requires
+    # Try to move on part of require-provide updating only requires
     version = 0
     resources = [
         {

--- a/tests/deploy/e2e/test_resource_sets.py
+++ b/tests/deploy/e2e/test_resource_sets.py
@@ -565,7 +565,7 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
     assert result.code == 400, result.result
     assert (
         "Invalid request: A partial compile only migrate resources between resource set that are pushed together: "
-        "trying to move test::Resource[agent1,key=key2] from resource set None to set-b-new." in result.result["message"]
+        "trying to move test::Resource[agent1,key=key2] from resource set <SHARED> to set-b-new." in result.result["message"]
     )
 
     # Don't allow escape out of shared
@@ -597,7 +597,7 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
     assert result.code == 400, result.result
     assert (
         "A partial compile only migrate resources between resource set that are pushed together: "
-        "trying to move test::Resource[agent1,key=key2] from resource set None to set-b-new." in result.result["message"]
+        "trying to move test::Resource[agent1,key=key2] from resource set <SHARED> to set-b-new." in result.result["message"]
     )
 
 

--- a/tests/deploy/e2e/test_resource_sets.py
+++ b/tests/deploy/e2e/test_resource_sets.py
@@ -564,7 +564,7 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
     )
     assert result.code == 400, result.result
     assert (
-        "Invalid request: A partial compile cannot migrate resources: "
+        "Invalid request: A partial compile only migrate resources between resource set that are pushed together: "
         "trying to move test::Resource[agent1,key=key2] from resource set None to set-b-new." in result.result["message"]
     )
 
@@ -596,7 +596,7 @@ async def test_put_partial_migrate_resource_to_other_resource_set(server, client
     )
     assert result.code == 400, result.result
     assert (
-        "Invalid request: A partial compile cannot migrate resources: "
+        "A partial compile only migrate resources between resource set that are pushed together: "
         "trying to move test::Resource[agent1,key=key2] from resource set None to set-b-new." in result.result["message"]
     )
 


### PR DESCRIPTION
# Description

Allow resource to migrate between resource sets if both target and source set are in the increment

closes #9042 
# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
