### PR TITLE
Define roles in the default policy

### DIFF
--- a/changelogs/unreleased/define-roles-in-default-policy.yml
+++ b/changelogs/unreleased/define-roles-in-default-policy.yml
@@ -1,0 +1,4 @@
+---
+description: Define roles in the default policy.
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/protocol/auth/default_policy.rego
+++ b/src/inmanta/protocol/auth/default_policy.rego
@@ -1,5 +1,8 @@
 package policy
 
+# Define roles
+roles := ["read-only", "noc", "operator", "environment-admin", "environment-expert-admin"]
+
 # Write the information about the endpoint into a variable
 # to make the policy easier to read.
 endpoint_data := data.endpoints[input.request.endpoint_id]

--- a/tests/test_default_policy.py
+++ b/tests/test_default_policy.py
@@ -57,6 +57,11 @@ async def test_default_policy(server, client, role: str | None, is_admin: bool, 
     """
     Test the behavior of the default policy.
     """
+    # Verify default roles, defined in the policy, are synchronized to the database.
+    result = await client.list_roles()
+    assert result.code == 200
+    assert result.result["data"] == sorted(["read-only", "noc", "operator", "environment-admin", "environment-expert-admin"])
+
     # Create a user
     user = data.User(
         username="user",


### PR DESCRIPTION
# Description

Define roles in the default policy.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
