### PR TITLE
updated sqlalchemy schema to prevent conflicts

### DIFF
--- a/changelogs/unreleased/sqlalchemy-warnings.yml
+++ b/changelogs/unreleased/sqlalchemy-warnings.yml
@@ -1,0 +1,4 @@
+description: updated sqlalchemy schema to prevent conflicts
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -410,7 +410,7 @@ class Environment(Base):
     resource_persistent_state: Mapped[List["ResourcePersistentState"]] = relationship(
         "ResourcePersistentState", back_populates="environment_"
     )
-    unknownparameter: Mapped[List["UnknownParameter"]] = relationship("UnknownParameter", back_populates="environment_")
+    unknownparameter: Mapped[List["UnknownParameter"]] = relationship("UnknownParameter", viewonly=True)
     agent: Mapped[List["Agent"]] = relationship("Agent", back_populates="environment_")
 
 
@@ -878,7 +878,7 @@ class UnknownParameter(Base):
     resolved: Mapped[Optional[bool]] = mapped_column(Boolean, server_default=text("false"))
 
     configurationmodel: Mapped["ConfigurationModel"] = relationship("ConfigurationModel", back_populates="unknownparameter")
-    environment_: Mapped["Environment"] = relationship("Environment", back_populates="unknownparameter")
+    environment_: Mapped["Environment"] = relationship("Environment", viewonly=True)
 
 
 class Agent(Base):


### PR DESCRIPTION
# Description

I believe this is the appropriate change to get rid of the warnings. While unknown parameters are part of an environment, they are really always created in the context of a configuration model. Therefore, they should never be set via the `environment` "relation", or the `Environment.unknownparameter` relation, but always via the `configurationmodel` relation or the `ConfigurationModel.unknownparameter` relation.

I will make sure to request Joao's hindsight review when he's back.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
