### PR TITLE
Environment halt scheduler fix

### DIFF
--- a/changelogs/unreleased/environment-halt-scheduler-fix.yml
+++ b/changelogs/unreleased/environment-halt-scheduler-fix.yml
@@ -1,0 +1,5 @@
+description: stop scheduler on environment halt
+change-type: patch
+destination-branches:
+  - iso8
+  - master

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -111,6 +111,7 @@ class Agent(SessionEndpoint):
     async def start_working(self) -> None:
         """Start working, once we have a session"""
 
+        print("starting!!!!")
         if self.working:
             return
         self.working = True
@@ -173,6 +174,7 @@ class Agent(SessionEndpoint):
             cfg.agent_deploy_interval.set(agent_deploy_interval)
 
     async def on_reconnect(self) -> None:
+        # TODO: this returns False...
         result = await self._client.get_state(tid=self._env_id, sid=self.sessionid, agent=AGENT_SCHEDULER_ID)
         if result.code == 200 and result.result is not None:
             state = result.result

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -173,7 +173,6 @@ class Agent(SessionEndpoint):
             cfg.agent_deploy_interval.set(agent_deploy_interval)
 
     async def on_reconnect(self) -> None:
-        # TODO: this returns False...
         result = await self._client.get_state(tid=self._env_id, sid=self.sessionid, agent=AGENT_SCHEDULER_ID)
         if result.code == 200 and result.result is not None:
             state = result.result

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -111,7 +111,6 @@ class Agent(SessionEndpoint):
     async def start_working(self) -> None:
         """Start working, once we have a session"""
 
-        print("starting!!!!")
         if self.working:
             return
         self.working = True

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -274,17 +274,23 @@ class AgentManager(ServerSlice, SessionListener):
 
     async def halt_agents(self, env: data.Environment, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
-        Halts all agents for an environment. Persists prior paused state.
+        Halts all agents for an environment. Persists prior paused state. Also halts the scheduler "agent"
         """
         await data.Agent.persist_on_halt(env.id, connection=connection)
-        await self._pause_agent(env, connection=connection)
+        await self._pause_agent(env, connection=connection)  # excludes scheduler
+        await self._pause_agent(env, endpoint=const.AGENT_SCHEDULER_ID, connection=connection)
+        # TODO: don't think this is required
+        #await self._autostarted_agent_manager._stop_scheduler(env)
 
     async def resume_agents(self, env: data.Environment, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
-        Resumes after halting. Unpauses all agents that had been paused by halting.
+        Resumes after halting. Unpauses all agents that had been paused by halting, then restarts the scheduler.
         """
         to_unpause: list[str] = await data.Agent.persist_on_resume(env.id, connection=connection)
         await asyncio.gather(*[self._unpause_agent(env, agent, connection=connection) for agent in to_unpause])
+        await self._unpause_agent(env, endpoint=const.AGENT_SCHEDULER_ID, connection=connection)
+        # TODO: don't think this is required
+        #await self._autostarted_agent_manager._ensure_scheduler(env.id)
 
     @handle(methods_v2.all_agents_action, env="tid")
     async def all_agents_action(self, env: data.Environment, action: AgentAction) -> None:
@@ -334,6 +340,8 @@ class AgentManager(ServerSlice, SessionListener):
         """
         Helper method to pause / unpause a logical agent by pausing an active agent instance if it exists and notify the
         scheduler that something has changed.
+
+        If no endpoint provided, pauses all logical agents. This does not include the scheduler itself.
         """
         # We need this lock otherwise, we would have transaction conflict in DB
         async with self.session_lock:
@@ -348,6 +356,7 @@ class AgentManager(ServerSlice, SessionListener):
     ) -> None:
         """
         Pause a logical agent by pausing an active agent instance if it exists.
+        If no endpoint provided, pauses all logical agents. This does not include the scheduler itself.
         """
         await self._update_paused_status_agent(env=env, new_paused_status=True, endpoint=endpoint, connection=connection)
 
@@ -356,6 +365,7 @@ class AgentManager(ServerSlice, SessionListener):
     ) -> None:
         """
         Unpause a logical agent by pausing an active agent instance if it exists.
+        If no endpoint provided, pauses all logical agents. This does not include the scheduler itself.
         """
         await self._update_paused_status_agent(env=env, new_paused_status=False, endpoint=endpoint, connection=connection)
 
@@ -656,6 +666,7 @@ class AgentManager(ServerSlice, SessionListener):
                 else:
                     # This should never occur. An agent cannot have an active session while its paused,
                     # given the fact that this method executes under session_lock
+                    # TODO: test raises this warning
                     LOGGER.warning("Paused agent %s has an active session (sid=%s)", endpoint_name, session.id)
                     del self.tid_endpoint_to_session[key]
                     result.append((endpoint_name, None))

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -662,7 +662,6 @@ class AgentManager(ServerSlice, SessionListener):
                 else:
                     # This should never occur. An agent cannot have an active session while its paused,
                     # given the fact that this method executes under session_lock
-                    # TODO: test raises this warning
                     LOGGER.warning("Paused agent %s has an active session (sid=%s)", endpoint_name, session.id)
                     del self.tid_endpoint_to_session[key]
                     result.append((endpoint_name, None))

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -279,8 +279,6 @@ class AgentManager(ServerSlice, SessionListener):
         await data.Agent.persist_on_halt(env.id, connection=connection)
         await self._pause_agent(env, connection=connection)  # excludes scheduler
         await self._pause_agent(env, endpoint=const.AGENT_SCHEDULER_ID, connection=connection)
-        # TODO: don't think this is required
-        #await self._autostarted_agent_manager._stop_scheduler(env)
 
     async def resume_agents(self, env: data.Environment, connection: Optional[asyncpg.connection.Connection] = None) -> None:
         """
@@ -289,8 +287,6 @@ class AgentManager(ServerSlice, SessionListener):
         to_unpause: list[str] = await data.Agent.persist_on_resume(env.id, connection=connection)
         await asyncio.gather(*[self._unpause_agent(env, agent, connection=connection) for agent in to_unpause])
         await self._unpause_agent(env, endpoint=const.AGENT_SCHEDULER_ID, connection=connection)
-        # TODO: don't think this is required
-        #await self._autostarted_agent_manager._ensure_scheduler(env.id)
 
     @handle(methods_v2.all_agents_action, env="tid")
     async def all_agents_action(self, env: data.Environment, action: AgentAction) -> None:

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1099,9 +1099,7 @@ async def test_pause_all_agents_doesnt_pause_environment(server, environment, cl
     await agent_manager.ensure_agent_registered(env=env, nodename=agent.name)
 
     async def wait_for_state(*, active: bool) -> None:
-        await retry_limited(
-            lambda: len(autostarted_agent_manager._agent_procs) == (1 if active else 0), timeout=2
-        )
+        await retry_limited(lambda: len(autostarted_agent_manager._agent_procs) == (1 if active else 0), timeout=2)
 
     await wait_for_state(active=True)
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -29,7 +29,6 @@ from uuid import UUID, uuid4
 import pytest
 from tornado.httpclient import AsyncHTTPClient
 
-import inmanta.util
 from inmanta import config, const, data
 from inmanta.config import Config
 from inmanta.const import AgentAction, AgentStatus
@@ -1087,9 +1086,7 @@ async def test_heartbeat_different_session(server_pre_start, async_finalizer, ca
 
 
 @pytest.mark.parametrize("halt_environment", (True, False))
-async def test_pause_all_agents_doesnt_pause_environment(
-    server, environment, client, agent, halt_environment: bool, caplog
-) -> None:
+async def test_pause_all_agents_doesnt_pause_environment(server, environment, client, agent, halt_environment: bool) -> None:
     """
     Reproduces bug: https://github.com/inmanta/inmanta-core/issues/9081. Additionally verifies that halting the entire
     environment does halt the scheduler process.
@@ -1148,7 +1145,3 @@ async def test_pause_all_agents_doesnt_pause_environment(
     agent_dct = {agent.name: agent for agent in agents}
     assert not agent_dct[const.AGENT_SCHEDULER_ID].paused
     assert not agent_dct[agent.name].paused
-
-    import pprint
-    pprint.pprint(caplog.records)
-    assert False

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -1091,8 +1091,8 @@ async def test_pause_all_agents_doesnt_pause_environment(
     server, environment, client, agent, halt_environment: bool, caplog
 ) -> None:
     """
-    Reproduces bug: https://github.com/inmanta/inmanta-core/issues/9081. Additionally verifiest that halting the entire
-    environment does pause the scheduler "agent".
+    Reproduces bug: https://github.com/inmanta/inmanta-core/issues/9081. Additionally verifies that halting the entire
+    environment does halt the scheduler process.
     """
     env_id = UUID(environment)
     env = await data.Environment.get_by_id(env_id)


### PR DESCRIPTION
# Description

#9116 (not yet released) fixed a bug where "pause all agents" would also halt the scheduler. Apparently it also prevented scheduler halting when the environment is halted. This caused some flaky tests on inmanta-lsm.

This PR ensures that we do stop the scheduler process when the environment is halted, while retaining the fix from #9116 so that we don't stop the scheduler when all agents are paused.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
