### PR TITLE
Improve error message on login endpoint regarding invalid credentials

### DIFF
--- a/changelogs/unreleased/improve-msg-invalid-credentials.yml
+++ b/changelogs/unreleased/improve-msg-invalid-credentials.yml
@@ -1,0 +1,6 @@
+---
+description: Improve error message on login endpoint about invalid credentials.
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/protocol/exceptions.py
+++ b/src/inmanta/protocol/exceptions.py
@@ -65,6 +65,7 @@ class Forbidden(BaseHttpException):
 
         super().__init__(403, msg, details)
 
+
 class UnauthorizedException(BaseHttpException):
     """
     An exception raised when access to this resource is unauthorized

--- a/src/inmanta/protocol/exceptions.py
+++ b/src/inmanta/protocol/exceptions.py
@@ -65,17 +65,19 @@ class Forbidden(BaseHttpException):
 
         super().__init__(403, msg, details)
 
-
 class UnauthorizedException(BaseHttpException):
     """
     An exception raised when access to this resource is unauthorized
     """
 
-    def __init__(self, message: Optional[str] = None, details: Optional[JsonType] = None) -> None:
-        msg = "Access to this resource is unauthorized"
-        if message is not None:
-            msg += ": " + message
-
+    def __init__(self, message: Optional[str] = None, details: Optional[JsonType] = None, no_prefix: bool = False) -> None:
+        """
+        :param no_prefix: Don't add the 'Access to this resource is unauthorized: ' prefix to message if provided.
+        """
+        default_msg = "Access to this resource is unauthorized"
+        msg = default_msg if message is None else message
+        if message is not None and not no_prefix:
+            msg = f"{default_msg}: {msg}"
         super().__init__(401, msg, details)
 
 

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -115,11 +115,11 @@ class UserService(server_protocol.ServerSlice):
         invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
-            raise exceptions.UnauthorizedException(message=invalid_username_password_msg)
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix = True)
         try:
             nacl.pwhash.verify(user.password_hash.encode(), password.encode())
         except nacl.exceptions.InvalidkeyError:
-            raise exceptions.UnauthorizedException(message=invalid_username_password_msg)
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix = True)
 
         role_assignments: list[model.RoleAssignment] = await data.Role.get_roles_for_user(username)
         custom_claims: Mapping[str, str | list[str] | Mapping[str, str]] = {

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -115,11 +115,11 @@ class UserService(server_protocol.ServerSlice):
         invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
-            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix = True)
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
         try:
             nacl.pwhash.verify(user.password_hash.encode(), password.encode())
         except nacl.exceptions.InvalidkeyError:
-            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix = True)
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
 
         role_assignments: list[model.RoleAssignment] = await data.Role.get_roles_for_user(username)
         custom_claims: Mapping[str, str | list[str] | Mapping[str, str]] = {

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -112,13 +112,14 @@ class UserService(server_protocol.ServerSlice):
     async def login(self, username: str, password: str) -> common.ReturnValue[model.LoginReturn]:
         verify_authentication_enabled()
         # check if the user exists
+        invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
-            raise exceptions.UnauthorizedException()
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg)
         try:
             nacl.pwhash.verify(user.password_hash.encode(), password.encode())
         except nacl.exceptions.InvalidkeyError:
-            raise exceptions.UnauthorizedException()
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg)
 
         role_assignments: list[model.RoleAssignment] = await data.Role.get_roles_for_user(username)
         custom_claims: Mapping[str, str | list[str] | Mapping[str, str]] = {


### PR DESCRIPTION
# Description

Improve the error message given by the login endpoint when an invalid username/password combination is provided.

closes inmanta/inmanta-core#8972

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
