### PR TITLE
Small improvements related to the authorization framework

### DIFF
--- a/changelogs/unreleased/small-enhancements-authorization-framework.yml
+++ b/changelogs/unreleased/small-enhancements-authorization-framework.yml
@@ -1,0 +1,4 @@
+---
+description: Added small enhancements related to the authorization framework.
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/protocol/auth/policy_engine.py
+++ b/src/inmanta/protocol/auth/policy_engine.py
@@ -56,7 +56,11 @@ policy_engine_log_level = config.Option(
     is_opa_log_level,
 )
 path_opa_executable = config.Option(
-    "policy_engine", "executable", "/opt/inmanta/bin/opa", "Path to the executable that runs the Open Policy Agent.", config.is_str
+    "policy_engine",
+    "executable",
+    "/opt/inmanta/bin/opa",
+    "Path to the executable that runs the Open Policy Agent.",
+    config.is_str,
 )
 
 

--- a/src/inmanta/protocol/auth/policy_engine.py
+++ b/src/inmanta/protocol/auth/policy_engine.py
@@ -56,7 +56,7 @@ policy_engine_log_level = config.Option(
     is_opa_log_level,
 )
 path_opa_executable = config.Option(
-    "policy_engine", "executable", "", "Path to the executable that runs the Open Policy Agent.", config.is_str
+    "policy_engine", "executable", "/opt/inmanta/bin/opa", "Path to the executable that runs the Open Policy Agent.", config.is_str
 )
 
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -170,10 +170,20 @@ class AuthorizationProviderName(enum.Enum):
     legacy = "legacy"
     policy_engine = "policy-engine"
 
+    @classmethod
+    def get_valid_values_str(cls) -> str:
+        """
+        Returns a human readable string containing the valid values for
+        the server.authorization_provider config option.
+        """
+        valid_values = [e.value for e in cls]
+        assert len(valid_values) > 1
+        return ", ".join(valid_values[0:-1]) + " or " + valid_values[-1]
+
 
 def _is_authorization_provider(value: str) -> str:
     f"""
-    str, valid values: {', '.join(a.value for a in AuthorizationProviderName)}
+    str, valid values: {AuthorizationProviderName.get_valid_values_str()}
     """
     value = value.lower()
     try:
@@ -181,7 +191,7 @@ def _is_authorization_provider(value: str) -> str:
     except ValueError:
         raise ValueError(
             f"Invalid value for config option {authorization_provider.get_full_name()}: {value}."
-            f" Valid values: {', '.join(a.value for a in AuthorizationProviderName)}"
+            f" Valid values: {AuthorizationProviderName.get_valid_values_str()}"
         )
     else:
         return value
@@ -191,7 +201,7 @@ authorization_provider = Option(
     "server",
     "authorization-provider",
     AuthorizationProviderName.legacy.value,
-    "The authorization provider that should be used if authentication is enabled.",
+    f"The authorization provider that should be used if authentication is enabled: {AuthorizationProviderName.get_valid_values_str()}",
     _is_authorization_provider,
 )
 


### PR DESCRIPTION
# Description

Small improvements related to the authorization framework:

* Add default value to the `policy_engine.executable` config option.
* Show valid values for the `server.authorization-provider` config option to the documentation.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
