### PR TITLE
Improve error message on login endpoint regarding invalid credentials (iso8 + iso7)

### DIFF
--- a/changelogs/unreleased/improve-msg-invalid-credentials.yml
+++ b/changelogs/unreleased/improve-msg-invalid-credentials.yml
@@ -1,0 +1,6 @@
+---
+description: Improve error message on login endpoint about invalid credentials.
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/improve-msg-invalid-credentials.yml
+++ b/changelogs/unreleased/improve-msg-invalid-credentials.yml
@@ -1,6 +1,7 @@
 ---
 description: Improve error message on login endpoint about invalid credentials.
 change-type: patch
-destination-branches: [master, iso8, iso7]
+destination-branches: [iso8, iso7]
 sections:
   minor-improvement: "{{description}}"
+

--- a/src/inmanta/protocol/exceptions.py
+++ b/src/inmanta/protocol/exceptions.py
@@ -71,11 +71,14 @@ class UnauthorizedException(BaseHttpException):
     An exception raised when access to this resource is unauthorized
     """
 
-    def __init__(self, message: Optional[str] = None, details: Optional[JsonType] = None) -> None:
-        msg = "Access to this resource is unauthorized"
-        if message is not None:
-            msg += ": " + message
-
+    def __init__(self, message: Optional[str] = None, details: Optional[JsonType] = None, no_prefix: bool = False) -> None:
+        """
+        :param no_prefix: Don't add the 'Access to this resource is unauthorized: ' prefix to message if provided.
+        """
+        default_msg = "Access to this resource is unauthorized"
+        msg = default_msg if message is None else message
+        if message is not None and not no_prefix:
+            msg = f"{default_msg}: {msg}"
         super().__init__(401, msg, details)
 
 

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -109,13 +109,14 @@ class UserService(server_protocol.ServerSlice):
     async def login(self, username: str, password: str) -> common.ReturnValue[model.LoginReturn]:
         verify_authentication_enabled()
         # check if the user exists
+        invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
-            raise exceptions.UnauthorizedException()
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
         try:
             nacl.pwhash.verify(user.password_hash.encode(), password.encode())
         except nacl.exceptions.InvalidkeyError:
-            raise exceptions.UnauthorizedException()
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
 
         token = auth.encode_token([str(const.ClientType.api.value)], expire=None, custom_claims={"sub": username})
         return common.ReturnValue(

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -105,3 +105,26 @@ async def test_provide_token_as_parameter(server: protocol.Server, client) -> No
 
     result = await client.get_api_docs(token=token)
     assert result.code == 200
+
+
+async def test_login_failed(server, client) -> None:
+    """
+    Ensure that a meaningful error message is returned when incorrect
+    credentials are provided to the login endpoint.
+    """
+    user = data.User(
+        username="admin",
+        password_hash=nacl.pwhash.str("admin".encode()).decode(),
+        auth_method=AuthMethod.database,
+    )
+    await user.insert()
+
+    # Invalid username
+    result = await client.login(username="test", password="test")
+    assert result.code == 401
+    assert "Invalid username or password" == result.result["message"]
+
+    # Invalid password
+    result = await client.login(username="admin", password="test")
+    assert result.code == 401
+    assert "Invalid username or password" == result.result["message"]


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/9218 but applied on the iso8 branch due to a merge conflict.**

Improve the error message given by the login endpoint when an invalid username/password combination is provided.

closes inmanta/inmanta-core#8972

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
