### PR TITLE
Added the /health endpoint

### DIFF
--- a/changelogs/unreleased/added-health-endpoint.yml
+++ b/changelogs/unreleased/added-health-endpoint.yml
@@ -1,0 +1,6 @@
+---
+description: "Added the 'GET /api/v2/health' endpoint."
+change-type: patch
+destination-branches: [iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -956,6 +956,7 @@ src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-bo
 src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
 src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
 src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
+src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
 src/inmanta/protocol/methods_v2.py:0: error: Module "inmanta.protocol.methods" does not explicitly export attribute "ArgOption"  [attr-defined]
 src/inmanta/protocol/methods_v2.py:0: error: Module "inmanta.protocol.methods" does not explicitly export attribute "ArgOption"  [attr-defined]
 src/inmanta/protocol/openapi/converter.py:0: error: "object" has no attribute "__iter__"; maybe "__dir__" or "__str__"? (not iterable)  [attr-defined]

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1618,3 +1618,14 @@ def discovered_resources_get_batch(
     :raise NotFound: This exception is raised when the referenced environment is not found
     :raise BadRequest: When the parameters used for filtering, sorting or paging are not valid
     """
+
+
+@typedmethod(path="/health", operation="GET", client_types=[ClientType.api], enforce_auth=False, api_version=2)
+def health() -> ReturnValue[None]:
+    """
+    Returns a 200 response code if the server is healthy
+    or a 500 if the server is not healthy.
+
+    In contrast to the 'GET /api/v1/serverstatus' endpoint, this endpoint does not require authentication.
+    """
+    pass

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -148,6 +148,11 @@ class Server(protocol.ServerSlice):
 
         return response
 
+    @handle(methods_v2.health)
+    async def health(self) -> ReturnValue[None]:
+        status = await self.get_server_status()
+        return ReturnValue(status_code=(200 if status.status == ReportedStatus.OK else 500))
+
     @handle(methods_v2.get_api_docs)
     async def get_api_docs(
         self, format: Optional[ApiDocsFormat] = ApiDocsFormat.swagger, token: str | None = None

--- a/tests/server/test_server_status.py
+++ b/tests/server/test_server_status.py
@@ -74,6 +74,9 @@ async def test_server_status_timeout(server, client, monkeypatch):
     assert result.code == 200
     assert result.result["data"]["status"] == ReportedStatus.OK
 
+    result = await client.health()
+    assert result.code == 200
+
     monkeypatch.setattr(CompilerService, "GET_SLICE_STATUS_TIMEOUT", 0.1)
 
     async def hang(self):
@@ -92,6 +95,9 @@ async def test_server_status_timeout(server, client, monkeypatch):
             compiler_slice = slice
     assert compiler_slice
     assert "error" in compiler_slice["status"]
+
+    result = await client.health()
+    assert result.code == 500
 
 
 @pytest.mark.parametrize("auto_start_agent", [True])


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/9239 but applied on the iso8 branch due to a merge conflict.**

The `/health` endpoint provides a yes/no answer on whether the server is healthy or not. It doesn't require authentication in contrast to the /serverstatus endpoint.

Part of https://github.com/inmanta/inmanta-core/issues/9061

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
