### PR TITLE
Added the /health endpoint

### DIFF
--- a/changelogs/unreleased/added-health-endpoint.yml
+++ b/changelogs/unreleased/added-health-endpoint.yml
@@ -1,0 +1,4 @@
+---
+description: "Added the 'GET /api/v2/health' endpoint."
+change-type: patch
+destination-branches: [iso7]


### PR DESCRIPTION
# Description

**This PR just adds a dummy changelog entry. We are not going to add the health endpoint in iso7, because iso7 is missing the capability for a slice to report its status. It's also not required because the iso7 docker image doesn't have a health check either. Parent PR https://github.com/inmanta/inmanta-core/pull/9239.**

The `/health` endpoint provides a yes/no answer on whether the server is healthy or not. It doesn't require authentication in contrast to the /serverstatus endpoint.

Part of https://github.com/inmanta/inmanta-core/issues/9061

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
