### PR TITLE
Disallow role related endpoints when auth is disabled

### DIFF
--- a/changelogs/unreleased/disallow-role-related-endpoints-auth-disabled.yml
+++ b/changelogs/unreleased/disallow-role-related-endpoints-auth-disabled.yml
@@ -1,4 +1,4 @@
 ---
-description: Refuse calling any role-related endpoints when auth is disabled.
+description: Refuse calls to any role-related endpoints when auth is disabled.
 change-type: patch
 destination-branches: [master]

--- a/changelogs/unreleased/disallow-role-related-endpoints-auth-disabled.yml
+++ b/changelogs/unreleased/disallow-role-related-endpoints-auth-disabled.yml
@@ -1,0 +1,4 @@
+---
+description: Refuse calling any role-related endpoints when auth is disabled.
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1574,6 +1574,7 @@ def set_is_admin(username: str, is_admin: bool) -> None:
 
     :param username: The username of the user for which the admin status has to be updated.
     :param is_admin: True iff the given user should be an admin user.
+    :raises BadRequest: Raised when server authentication is not enabled
     """
 
 
@@ -1592,6 +1593,7 @@ def create_role(name: str) -> None:
     Create a new role.
 
     :param name: The name of the role to create.
+    :raises BadRequest: Raised when server authentication is not enabled
     """
 
 
@@ -1602,6 +1604,7 @@ def delete_role(name: str) -> None:
     Delete a role.
 
     :param name: The name of the role to delete.
+    :raises BadRequest: Raised when server authentication is not enabled
     """
 
 
@@ -1624,6 +1627,7 @@ def assign_role(username: str, environment: uuid.UUID, role: str) -> None:
     :param username: The name of the user the role will be assigned to.
     :param environment: The environment scope of the role.
     :param role: The name of the role that should be assigned to the user.
+    :raises BadRequest: Raised when server authentication is not enabled
     """
 
 
@@ -1637,6 +1641,7 @@ def unassign_role(username: str, environment: uuid.UUID, role: str) -> None:
     :param environment: The environment scope of the role.
     :param role: The name of the role that should be unassigned from the user.
     :raise BadRequest: If the user with the given username doesn't have the given role assigned.
+    :raises BadRequest: Raised when server authentication is not enabled
     """
 
 

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -154,6 +154,7 @@ class UserService(server_protocol.ServerSlice):
 
     @protocol.handle(protocol.methods_v2.create_role)
     async def create_role(self, name: str) -> None:
+        verify_authentication_enabled()
         try:
             await data.Role(id=uuid.uuid4(), name=name).insert()
         except asyncpg.UniqueViolationError:
@@ -161,6 +162,7 @@ class UserService(server_protocol.ServerSlice):
 
     @protocol.handle(protocol.methods_v2.delete_role)
     async def delete_role(self, name: str) -> None:
+        verify_authentication_enabled()
         try:
             await data.Role.delete_role(name=name)
         except data.RoleStillAssignedException:
@@ -174,6 +176,7 @@ class UserService(server_protocol.ServerSlice):
 
     @protocol.handle(protocol.methods_v2.assign_role)
     async def assign_role(self, username: str, environment: uuid.UUID, role: str) -> None:
+        verify_authentication_enabled()
         try:
             await data.Role.assign_role_to_user(username, model.RoleAssignment(environment=environment, role=role))
         except data.CannotAssignRoleException:
@@ -184,6 +187,7 @@ class UserService(server_protocol.ServerSlice):
 
     @protocol.handle(protocol.methods_v2.unassign_role)
     async def unassign_role(self, username: str, environment: uuid.UUID, role: str) -> None:
+        verify_authentication_enabled()
         try:
             await data.Role.unassign_role_from_user(username, model.RoleAssignment(environment=environment, role=role))
         except KeyError:
@@ -191,6 +195,7 @@ class UserService(server_protocol.ServerSlice):
 
     @protocol.handle(protocol.methods_v2.set_is_admin)
     async def set_is_admin(self, username: str, is_admin: bool) -> None:
+        verify_authentication_enabled()
         try:
             await data.User.set_is_admin(username=username, is_admin=is_admin)
         except KeyError:


### PR DESCRIPTION
# Description

Refuse calls to any role-related endpoints when auth is disabled.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~