### PR TITLE
references change entries

### DIFF
--- a/changelogs/unreleased/dataclass-union-bugfix.yml
+++ b/changelogs/unreleased/dataclass-union-bugfix.yml
@@ -1,0 +1,8 @@
+description: Various improvements and bugfixes on references
+issue-nr: 8946
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+sections:
+  bugfix: "Compiler: fixed bug where compiler would crash under specific circumstances on calling a plugin that takes a union involving a dataclass as parameter."

--- a/changelogs/unreleased/dataclasses-inheritance.yml
+++ b/changelogs/unreleased/dataclasses-inheritance.yml
@@ -1,0 +1,8 @@
+description: Various improvements and bugfixes on references
+issue-nr: 8946
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+sections:
+  minor-improvement: "Compiler: support inheritance for dataclass entities."

--- a/changelogs/unreleased/references-error-reporting.yml
+++ b/changelogs/unreleased/references-error-reporting.yml
@@ -1,0 +1,8 @@
+description: Various improvements and bugfixes on references
+issue-nr: 8946
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+sections:
+  bugfix: "Compiler: improved clarity of error reporting related to references"

--- a/changelogs/unreleased/references-guards.yml
+++ b/changelogs/unreleased/references-guards.yml
@@ -1,0 +1,9 @@
+description: Various improvements and bugfixes on references
+issue-nr: 8946
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+sections:
+  bugfix: "Compiler: implemented more thorough checks for references passed into plugins, and accessed by traversing the model from plugins, so they don't show up where they may not be expected. For more details, see the documentation."
+  minor-improvement: "Compiler: added the ``inmanta.plugins.allow_reference_values`` function to explicitly allow access to reference values by traversing the model from a plugin."

--- a/changelogs/unreleased/references-in-dict.yml
+++ b/changelogs/unreleased/references-in-dict.yml
@@ -1,0 +1,8 @@
+description: Various improvements and bugfixes on references
+issue-nr: 8946
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+sections:
+  minor-improvement: "Compiler: allow references in dict attributes."

--- a/changelogs/unreleased/references-proxy.yml
+++ b/changelogs/unreleased/references-proxy.yml
@@ -1,0 +1,8 @@
+description: Various improvements and bugfixes on references
+issue-nr: 8946
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+sections:
+  bugfix: "Compiler: reference values passed into or accessed from plugins, when explicitly declared, are now passed as proper ``Reference`` objects instead of being wrapped in a ``DynamicProxy``."

--- a/changelogs/unreleased/references-string-format.yml
+++ b/changelogs/unreleased/references-string-format.yml
@@ -1,0 +1,8 @@
+description: Various improvements and bugfixes on references
+issue-nr: 8946
+change-type: patch
+destination-branches:
+  - master
+  - iso8
+sections:
+  bugfix: "Compiler: made sure f-strings and old-style string format expressions raise a clear error when attempting to substitute a reference value."


### PR DESCRIPTION
# Description

Added change entries for changes merged in #8946. I didn't mention all bullet points listed in #9262 explicitly, as I think that would be too fine grained. There are already enough entries as it is now.

Documentation PR will follow and when it does I'll update the change entry that mentions documentation to link there.

Part of #9262

I'll merge this by hand (merge tool can not handle more than one change entry)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
