### PR TITLE
revert __str__ guard for references

### DIFF
--- a/src/inmanta/references.py
+++ b/src/inmanta/references.py
@@ -77,7 +77,7 @@ class ReferenceCycleException(Exception):
         self.references.append(element)
 
     def get_message(self) -> str:
-        trace = " -> ".join([str(x) for x in self.references])
+        trace = " -> ".join([repr(x) for x in self.references])
         return "Reference cycle detected: %s" % (trace)
 
     def __str__(self) -> str:
@@ -452,7 +452,7 @@ class Reference(ReferenceLike, Generic[T]):
             self._reference_value_cached = True
 
         else:
-            logger.debug("Using cached value for reference %(reference)s", reference=str(self))
+            logger.debug("Using cached value for reference %(reference)s", reference=repr(self))
         return self._reference_value
 
     def serialize(self) -> ReferenceModel:

--- a/src/inmanta/references.py
+++ b/src/inmanta/references.py
@@ -474,12 +474,6 @@ class Reference(ReferenceLike, Generic[T]):
     def __bool__(self) -> Never:
         raise NotImplementedError(f"{self!r} is an inmanta reference, not a boolean.")
 
-    def __str__(self) -> Never:
-        raise NotImplementedError(
-            f"{self!r} This is an inmanta reference. Its string conversion is disabled so it can't be accidentally used where a"
-            " concrete value is expected. Use `repr()` if you truly want it as a string."
-        )
-
 
 class reference:
     """This decorator registers a reference under a specific name"""

--- a/tests/data/modules_v2/refs/inmanta_plugins/refs/__init__.py
+++ b/tests/data/modules_v2/refs/inmanta_plugins/refs/__init__.py
@@ -22,8 +22,8 @@ class BoolReference(Reference[bool]):
         """Resolve the reference"""
         return False
 
-    def __str__(self) -> str:
-        return f"BoolReference {self.name}"
+    def __repr__(self) -> str:
+        return f"BoolReference({self.name!r})"
 
 
 @reference("refs::Int")
@@ -40,8 +40,8 @@ class IntReference(Reference[int]):
         """Resolve the reference"""
         return 42
 
-    def __str__(self) -> str:
-        return f"IntReference {self.name}"
+    def __repr__(self) -> str:
+        return f"IntReference({self.name!r})"
 
 
 @reference("refs::String")
@@ -59,8 +59,8 @@ class StringReference(Reference[str]):
         """Resolve the reference"""
         return self.resolve_other(self.name, logger)
 
-    def __str__(self) -> str:
-        return f"StringReference"
+    def __repr__(self) -> str:
+        return f"StringReference()"
 
 
 @plugin
@@ -122,8 +122,8 @@ class BadReference(Reference[str]):
         """Resolve the reference"""
         raise Exception("BAD")
 
-    def __str__(self) -> str:
-        return f"BadReference"
+    def __repr__(self) -> str:
+        return f"BadReference({self.name!r})"
 
 
 @plugin
@@ -146,8 +146,8 @@ class DictMade(Reference[str]):
         """Resolve the reference"""
         return self.resolve_other(self.name["name"], logger)
 
-    def __str__(self) -> str:
-        return f"DictMade"
+    def __repr__(self) -> str:
+        return f"DictMade({self.name!r})"
 
 
 @plugin

--- a/tests/data/modules_v2/refs/inmanta_plugins/refs/dc.py
+++ b/tests/data/modules_v2/refs/inmanta_plugins/refs/dc.py
@@ -33,8 +33,8 @@ class NoRefsDataclassReference(Reference[NoRefsDataclass]):
     def resolve(self, logger: LoggerABC) -> NoRefsDataclass:
         return NoRefsDataclassReference()
 
-    def __str__(self):
-        return "NoRefsDataclassReference"
+    def __repr__(self) -> str:
+        return f"NoRefsDataclassReference()"
 
 
 class AllRefsDataclassReferenceABC[D: AllRefsDataclass](Reference[D]):
@@ -46,8 +46,8 @@ class AllRefsDataclassReferenceABC[D: AllRefsDataclass](Reference[D]):
     def resolve(self, logger: LoggerABC) -> D:
         return self._dc_type(maybe_ref_value=self.resolve_other(self.maybe_ref_value, logger))
 
-    def __str__(self):
-        return f"{self._dc_type.__name__}Reference {self.maybe_ref_value}"
+    def __repr__(self):
+        return f"{self._dc_type.__name__}Reference({self.maybe_ref_value!r})"
 
 
 @reference("refs::dc::AllRefsDataclassReference")


### PR DESCRIPTION
# Description

Some part of the code use string conversion instead of the repr

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
