### PR TITLE
use std v2 for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ graphviz==0.20.3
 importlib_metadata==8.5.0
 flake8-junit-report==2.1.0
 inmanta-dev-dependencies==2.146.0
+inmanta-module-std<5.3
 inmanta-sphinx==2.3.0
 jinja2==3.1.5
 more-itertools==10.6.0

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
             "bumpversion",
             "flake8-junit-report",
             "inmanta-dev-dependencies[pytest,async,core]",
+            "inmanta-module_std",
             "openapi_spec_validator",
             "pip2pi",
             "psutil",


### PR DESCRIPTION
# Description

Use std v2 for tests. Achieved this by adding it as a dev dependency, because this is already the case on master and iso8 anyway. Motivation is twofold:
- v1 master is no longer compatible with 3.11 and adding a constraint on the v2 is easier than on the v1
- very soon std will be converted to native v2. At that point we can't use it as v1 anymore anyway.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
