### PR TITLE
Issue/8621 cleanup agent setting loading

### DIFF
--- a/changelogs/unreleased/8621-clean-up-agent-settings-loading.yml
+++ b/changelogs/unreleased/8621-clean-up-agent-settings-loading.yml
@@ -1,0 +1,4 @@
+description: Clean up agent settings loading
+issue-nr: 8621
+change-type: minor
+destination-branches: [master, iso8]

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -114,7 +114,6 @@ class Agent(SessionEndpoint):
         if self.working:
             return
         self.working = True
-        await self.load_environment_settings()
         await self.executor_manager.start()
         await self.scheduler.start()
         LOGGER.info("Scheduler started for environment %s", self.environment)
@@ -156,25 +155,6 @@ class Agent(SessionEndpoint):
             else:
                 await self.scheduler.refresh_agent_state_from_db(name=agent)
                 return 200, f"Agent `{agent}` has been notified!"
-
-    async def load_environment_settings(self) -> None:
-        """
-        Load environment settings into local settings
-        """
-        # Called
-        # - on @protocol.handle(methods.set_state)
-        # - on on_reconnect (e.g. in heartbeat)
-        # - on @protocol.handle(methods_v2.notify_timer_update, ...)
-        async with data.Environment.get_connection() as connection:
-            assert self.environment is not None
-            environment = await data.Environment.get_by_id(self.environment, connection=connection)
-            assert environment is not None
-            agent_deploy_interval = await environment.get(data.AUTOSTART_AGENT_DEPLOY_INTERVAL, connection=connection)
-            assert agent_deploy_interval is not None and isinstance(agent_deploy_interval, str)  # make mypy happy
-            agent_repair_interval = await environment.get(data.AUTOSTART_AGENT_REPAIR_INTERVAL, connection=connection)
-            assert agent_repair_interval is not None and isinstance(agent_repair_interval, str)  # make mypy happy
-            cfg.agent_repair_interval.set(agent_repair_interval)
-            cfg.agent_deploy_interval.set(agent_deploy_interval)
 
     async def on_reconnect(self) -> None:
         result = await self._client.get_state(tid=self._env_id, sid=self.sessionid, agent=AGENT_SCHEDULER_ID)
@@ -260,7 +240,6 @@ class Agent(SessionEndpoint):
     @protocol.handle(methods_v2.notify_timer_update, env="tid")
     async def notify_timer_update(self, env: data.Environment) -> None:
         assert env == self.environment
-        await self.load_environment_settings()
         await self.scheduler.load_timer_settings()
 
     @protocol.handle(methods_v2.get_db_status)

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -161,6 +161,10 @@ class Agent(SessionEndpoint):
         """
         Load environment settings into local settings
         """
+        # Called
+        # - on @protocol.handle(methods.set_state)
+        # - on on_reconnect (e.g. in heartbeat)
+        # - on @protocol.handle(methods_v2.notify_timer_update, ...)
         async with data.Environment.get_connection() as connection:
             assert self.environment is not None
             environment = await data.Environment.get_by_id(self.environment, connection=connection)

--- a/src/inmanta/deploy/timers.py
+++ b/src/inmanta/deploy/timers.py
@@ -25,8 +25,7 @@ from collections.abc import Collection
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
-from inmanta import util
-from inmanta.agent import config as agent_config
+from inmanta import util, data
 from inmanta.deploy.state import Blocked, Compliance, ResourceState
 from inmanta.deploy.work import TaskPriority
 from inmanta.types import ResourceIdStr
@@ -172,22 +171,32 @@ class TimerManager:
         await self.reload_config()
 
     async def reload_config(self) -> None:
-        deploy_timer: int | str = agent_config.agent_deploy_interval.get()
-        repair_timer: int | str = agent_config.agent_repair_interval.get()
 
-        if isinstance(deploy_timer, str):
-            new_deploy_cron: str | None = deploy_timer
-            new_periodic_deploy_interval: int | None = None
-        else:
+        async with data.Environment.get_connection() as connection:
+            assert self._resource_scheduler.environment is not None
+            environment = await data.Environment.get_by_id(self._resource_scheduler.environment, connection=connection)
+            assert environment is not None
+            deploy_timer: int | str = await environment.get(data.AUTOSTART_AGENT_DEPLOY_INTERVAL, connection=connection)
+            assert deploy_timer is not None  # make mypy happy
+            repair_timer: int | str = await environment.get(data.AUTOSTART_AGENT_REPAIR_INTERVAL, connection=connection)
+            assert repair_timer is not None  # make mypy happy
+
+        try:
+            deploy_timer = int(deploy_timer)
             new_deploy_cron = None
             new_periodic_deploy_interval = deploy_timer if deploy_timer > 0 else None
+        except ValueError:
+            new_deploy_cron: str | None = deploy_timer
+            new_periodic_deploy_interval: int | None = None
 
-        if isinstance(repair_timer, str):
-            new_repair_cron: str | None = repair_timer
-            new_periodic_repair_interval: int | None = None
-        else:
+        try:
+            repair_timer = int(repair_timer)
             new_repair_cron = None
             new_periodic_repair_interval = repair_timer if repair_timer > 0 else None
+        except ValueError:
+            new_repair_cron: str | None = repair_timer
+            new_periodic_repair_interval: int | None = None
+
 
         if not new_periodic_repair_interval and not new_periodic_deploy_interval:
             self.periodic_repair_interval = new_periodic_repair_interval

--- a/tests/deploy/scheduler_mocks.py
+++ b/tests/deploy/scheduler_mocks.py
@@ -372,9 +372,6 @@ class TestAgent(Agent):
         self.executor_manager = DummyManager()
         self.scheduler = TestScheduler(self.scheduler.environment, self.executor_manager, self.scheduler.client)
 
-    async def load_environment_settings(self) -> None:
-        pass
-
 
 class DummyDatabaseConnection:
 

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -2485,9 +2485,6 @@ class BadTestAgent(Agent):
         self.executor_manager = BrokenDummyManager()
         self.scheduler = TestScheduler(self.scheduler.environment, self.executor_manager, self.scheduler.client)
 
-    async def load_environment_settings(self) -> None:
-        pass
-
 
 @pytest.fixture
 async def bad_agent(environment, config):


### PR DESCRIPTION
# Description

# Part 1/2 for https://github.com/inmanta/inmanta-core/issues/8621:

Remove one level of indirection for the repair/deploy timers for the scheduler: read these values directly from the DB instead of relying on the values from the config file set by the AutoStartedAgentManager.

# Part 2/2 will make sure the AutoStartedAgentManager no longer sets these values.


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
