### PR TITLE
fix lsm docs snippets

### DIFF
--- a/changelogs/unreleased/lsm-docs-align.yml
+++ b/changelogs/unreleased/lsm-docs-align.yml
@@ -1,0 +1,5 @@
+description: Fixed docs alinment with isort run on lsm module
+change-type: patch
+destination-branches:
+  - master
+  - iso8

--- a/docs/lsm/allocation/allocation_sources/allocation_v2/allocation_v2_native.py
+++ b/docs/lsm/allocation/allocation_sources/allocation_v2/allocation_v2_native.py
@@ -7,6 +7,7 @@ Inmanta LSM
 """
 
 from inmanta.util import dict_path
+
 from inmanta_plugins.lsm.allocation import AllocationSpecV2
 from inmanta_plugins.lsm.allocation_v2.framework import AllocatorV2, ContextV2, ForEach
 

--- a/docs/lsm/allocation/allocation_sources/allocation_v2/allocation_v2_track_delete.py
+++ b/docs/lsm/allocation/allocation_sources/allocation_v2/allocation_v2_track_delete.py
@@ -7,6 +7,7 @@ Inmanta LSM
 """
 
 from inmanta.util import dict_path
+
 from inmanta_plugins.lsm.allocation import AllocationSpecV2
 from inmanta_plugins.lsm.allocation_v2.framework import (
     AllocatorV2,

--- a/docs/lsm/allocation/allocation_sources/allocation_v2/allocation_v2_with_context_v2_wrapper.py
+++ b/docs/lsm/allocation/allocation_sources/allocation_v2/allocation_v2_with_context_v2_wrapper.py
@@ -7,6 +7,7 @@ Inmanta LSM
 """
 
 from inmanta.util import dict_path
+
 from inmanta_plugins.lsm.allocation import AllocationSpecV2
 from inmanta_plugins.lsm.allocation_v2.framework import (
     AllocatorV2,

--- a/docs/lsm/allocation/allocation_sources/deallocation.py
+++ b/docs/lsm/allocation/allocation_sources/deallocation.py
@@ -15,8 +15,9 @@ from inmanta.agent import handler
 from inmanta.agent.handler import CRUDHandlerGeneric as CRUDHandler
 from inmanta.agent.handler import ResourcePurged, provider
 from inmanta.resources import PurgeableResource, resource
-from inmanta_plugins.lsm.allocation import AllocationSpec, ExternalServiceIdAllocator
 from psycopg2.extensions import ISOLATION_LEVEL_SERIALIZABLE
+
+from inmanta_plugins.lsm.allocation import AllocationSpec, ExternalServiceIdAllocator
 
 
 class PGServiceIdAllocator(ExternalServiceIdAllocator[int]):

--- a/docs/lsm/allocation/allocation_sources/pg_attr_example.py
+++ b/docs/lsm/allocation/allocation_sources/pg_attr_example.py
@@ -9,10 +9,11 @@ Inmanta LSM
 import os
 from typing import Any, Optional
 
-import inmanta_plugins.lsm.allocation as lsm
 import psycopg2
-from inmanta_plugins.lsm.allocation import ExternalAttributeAllocator, T
 from psycopg2.extensions import ISOLATION_LEVEL_SERIALIZABLE
+
+import inmanta_plugins.lsm.allocation as lsm
+from inmanta_plugins.lsm.allocation import ExternalAttributeAllocator, T
 
 
 class PGAttributeAllocator(ExternalAttributeAllocator[T]):

--- a/docs/lsm/allocation/allocation_sources/pg_id_example.py
+++ b/docs/lsm/allocation/allocation_sources/pg_id_example.py
@@ -10,10 +10,11 @@ import os
 from typing import Optional
 from uuid import UUID
 
-import inmanta_plugins.lsm.allocation as lsm
 import psycopg2
-from inmanta_plugins.lsm.allocation import ExternalServiceIdAllocator, T
 from psycopg2.extensions import ISOLATION_LEVEL_SERIALIZABLE
+
+import inmanta_plugins.lsm.allocation as lsm
+from inmanta_plugins.lsm.allocation import ExternalServiceIdAllocator, T
 
 
 class PGServiceIdAllocator(ExternalServiceIdAllocator[T]):

--- a/docs/lsm/allocation/allocation_sources/pg_lookup_example.py
+++ b/docs/lsm/allocation/allocation_sources/pg_lookup_example.py
@@ -9,14 +9,15 @@ Inmanta LSM
 import os
 from typing import Any, Optional
 
-import inmanta_plugins.lsm.allocation as lsm
 import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+import inmanta_plugins.lsm.allocation as lsm
 from inmanta_plugins.lsm.allocation import (
     AllocationContext,
     ExternalAttributeAllocator,
     T,
 )
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 
 class PGRouterResolver(ExternalAttributeAllocator[T]):


### PR DESCRIPTION
# Description

`isort` was run on the lsm module after converting it to v2. This moved around some imports. This PR aligns the docs snippets in core with those changes.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
