### PR TITLE
fixed two instances of pydantic dict->model_dump

### DIFF
--- a/changelogs/unreleased/pydantic-model-dump.yml
+++ b/changelogs/unreleased/pydantic-model-dump.yml
@@ -1,0 +1,5 @@
+description: 'fixed two instances of pydantic dict->model-dump'
+change-type: patch
+destination-branches:
+  - master
+  - iso8

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1239,7 +1239,7 @@ class ModuleV1Metadata(ModuleMetadata, MetadataFieldRequires):
         return packaging.version.Version(self.version)
 
     def to_v2(self) -> "ModuleV2Metadata":
-        values = self.dict()
+        values = self.model_dump()
         if values["description"] is not None:
             values["description"] = values["description"].replace("\n", " ")
         del values["compiler_version"]
@@ -1357,7 +1357,7 @@ class ModuleV2Metadata(ModuleMetadata):
 
         if not out.has_section("metadata"):
             out.add_section("metadata")
-        for k, v in self.dict(exclude_none=True, exclude={"install_requires", "version_tag"}).items():
+        for k, v in self.model_dump(exclude_none=True, exclude={"install_requires", "version_tag"}).items():
             out.set("metadata", k, str(v))
 
         if self.version_tag:


### PR DESCRIPTION
# Description

I got warnings about these when I ran `v1tov2` so I fixed them.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
