### PR TITLE
Revert "Add ``Result.all()`` helper method to easily iterate over res…

### DIFF
--- a/changelogs/unreleased/8801-add-helper-method-to-use-paging-links.yml
+++ b/changelogs/unreleased/8801-add-helper-method-to-use-paging-links.yml
@@ -1,8 +1,0 @@
-description: >
-  Add ``Result.all()`` helper method to easily iterate over results returned by
-  v2 Rest API endpoints that support paging. See [documentation](helper_method_for_paging) for more information.
-issue-nr: 8801
-change-type: minor
-destination-branches: [iso8]
-sections:
-  minor-improvement: "{{description}}"

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -377,25 +377,7 @@ end and last_id
     These parameters define the upper limit for the page
     (only one of the (`start`, `first_id`), (`end`, `last_id`) pairs should be specified at the same time).
 
-
-.. _helper_method_for_paging:
-
-.. note::
-
-    The return value of these methods that support paging contains a ``links`` tag, with the urls of the ``next`` and
-    ``prev`` pages. To iterate over all the results, the client can follow these links, or alternatively call the
-    ``all()`` method on the result:
-
-    .. code-block:: python
-
-        # Iterate over all results by fetching pages of size 20
-
-        result = await client.resource_list(tid=env.id, limit=20)
-
-        async for item in result.all():
-            ...
-
-
+.. note:: The return value of these methods contain a `links` tag, with the urls of the `next` and `prev` pages, so for simply going through the pages a client only needs to follow these links.
 
 filter
     The `filter` parameter is used for filtering the result set.

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -1016,10 +1016,12 @@ src/inmanta/protocol/rest/client.py:0: error: Argument "result" to "Result" has 
 src/inmanta/protocol/rest/client.py:0: error: Argument "result" to "Result" has incompatible type "str"; expected "dict[str, Any] | None"  [arg-type]
 src/inmanta/protocol/rest/client.py:0: error: Argument "result" to "Result" has incompatible type "str"; expected "dict[str, Any] | None"  [arg-type]
 src/inmanta/protocol/rest/client.py:0: error: Function is missing a return type annotation  [no-untyped-def]
+src/inmanta/protocol/rest/client.py:0: error: Function is missing a return type annotation  [no-untyped-def]
 src/inmanta/protocol/rest/client.py:0: error: Incompatible types in assignment (expression has type "bytes | str", variable has type "dict[str, Any] | None")  [assignment]
 src/inmanta/protocol/rest/client.py:0: error: Incompatible types in assignment (expression has type "str | None", variable has type "str")  [assignment]
 src/inmanta/protocol/rest/client.py:0: error: Incompatible types in assignment (expression has type "str | int | None", variable has type "int")  [assignment]
 src/inmanta/protocol/rest/client.py:0: error: Incompatible types in assignment (expression has type "str | int | None", variable has type "int")  [assignment]
+src/inmanta/protocol/rest/client.py:0: error: Returning Any from function declared to return "Result"  [no-any-return]
 src/inmanta/protocol/rest/client.py:0: error: Value expression in dictionary comprehension has incompatible type "str"; expected type "bytes"  [misc]
 src/inmanta/protocol/rest/client.py:0: note: Use "-> None" if function does not return a value
 src/inmanta/protocol/rest/server.py:0: error: Argument 1 to "get_global_url_map" of "RESTServer" has incompatible type "Sequence[CallTarget]"; expected "list[CallTarget]"  [arg-type]

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -36,6 +36,7 @@ from inmanta.stable_api import stable_api
 from inmanta.types import Apireturn, JsonType
 
 LOGGER: logging.Logger = logging.getLogger(__name__)
+INMANTA_MT_HEADER = "X-Inmanta-tid"
 
 """
 

--- a/src/inmanta/protocol/rest/client.py
+++ b/src/inmanta/protocol/rest/client.py
@@ -27,7 +27,6 @@ from tornado.httpclient import AsyncHTTPClient, HTTPError, HTTPRequest, HTTPResp
 
 from inmanta import config as inmanta_config
 from inmanta import tracing
-from inmanta.const import INMANTA_MT_HEADER
 from inmanta.protocol import common
 from inmanta.protocol.rest import RESTBase
 
@@ -117,8 +116,6 @@ class RESTClient(RESTBase):
             if zipped:
                 headers["Content-Encoding"] = "gzip"
 
-        environment = headers.get(INMANTA_MT_HEADER, None)
-
         ca_certs = inmanta_config.Config.get(self.id, "ssl_ca_cert_file", None)
         LOGGER.debug("Calling server %s %s", properties.operation, url)
 
@@ -143,26 +140,23 @@ class RESTClient(RESTBase):
                     if length > 65000:
                         LOGGER.exception("Failed to send request, header is too long (estimated size %d)", length)
                         return common.Result(
-                            code=e.code,
-                            result={"message": f"{e.message} header is too long (estimated size {length})"},
-                            client=self,
-                            method_properties=properties,
+                            code=e.code, result={"message": f"{e.message} header is too long (estimated size {length})"}
                         )
                 if e.response is not None and e.response.body is not None and len(e.response.body) > 0:
                     try:
                         result = self._decode(e.response.body)
                     except ValueError:
                         result = {}
-                    return common.Result(code=e.code, result=result, client=self, method_properties=properties)
+                    return common.Result(code=e.code, result=result)
 
-                return common.Result(code=e.code, result={"message": str(e)}, client=self, method_properties=properties)
+                return common.Result(code=e.code, result={"message": str(e)})
             except CancelledError:
                 raise
             except Exception as e:
                 LOGGER.exception("Failed to send request")
-                return common.Result(code=500, result={"message": str(e)}, client=self, method_properties=properties)
+                return common.Result(code=500, result={"message": str(e)})
 
-        return self._decode_response(response, properties, environment)
+        return self._decode_response(response)
 
     def close(self):
         """
@@ -171,37 +165,15 @@ class RESTClient(RESTBase):
         if self.forced_instance:
             self.client.close()
 
-    def _decode_response(
-        self, response: HTTPResponse, properties: common.MethodProperties, environment: str | None
-    ) -> common.Result:
+    def _decode_response(self, response: HTTPResponse):
         content_type = response.headers.get(common.CONTENT_TYPE, None)
 
         if content_type is None or content_type == common.JSON_CONTENT:
-            return common.Result(
-                code=response.code,
-                result=self._decode(response.body),
-                client=self,
-                method_properties=properties,
-                environment=environment,
-            )
+            return common.Result(code=response.code, result=self._decode(response.body))
         elif content_type == common.HTML_CONTENT:
-            return common.Result(
-                code=response.code,
-                result=response.body.decode(common.HTML_ENCODING),
-                client=self,
-                method_properties=properties,
-                environment=environment,
-            )
+            return common.Result(code=response.code, result=response.body.decode(common.HTML_ENCODING))
         elif content_type == common.HTML_CONTENT_WITH_UTF8_CHARSET:
-            return common.Result(
-                code=response.code,
-                result=response.body.decode(common.UTF8_ENCODING),
-                client=self,
-                method_properties=properties,
-                environment=environment,
-            )
+            return common.Result(code=response.code, result=response.body.decode(common.UTF8_ENCODING))
         else:
             # Any other content-type will leave the encoding unchanged
-            return common.Result(
-                code=response.code, result=response.body, client=self, method_properties=properties, environment=environment
-            )
+            return common.Result(code=response.code, result=response.body)

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -95,19 +95,9 @@ class ReturnClient(Client):
                 else:
                     return_value = await self.session.put_call(call_spec, expect_reply=expect_reply)
             except asyncio.CancelledError:
-                return common.Result(
-                    code=500,
-                    result={"message": "Call timed out"},
-                    client=self._transport_instance,
-                    method_properties=method_properties,
-                )
+                return common.Result(code=500, result={"message": "Call timed out"})
 
-            return common.Result(
-                code=return_value["code"],
-                result=return_value["result"],
-                client=self._transport_instance,
-                method_properties=method_properties,
-            )
+            return common.Result(code=return_value["code"], result=return_value["result"])
 
 
 # Server Side
@@ -862,12 +852,4 @@ class LocalClient(TypedClient):
         spec = method_properties.build_call(args, kwargs)
         method_config = self._get_op_mapping(spec.url, spec.method)
         response = await self._server._transport._execute_call(method_config, spec.body, spec.headers)
-        return self._process_response(
-            method_properties,
-            common.Result(
-                code=response.status_code,
-                result=response.body,
-                client=self._transport_instance,
-                method_properties=method_properties,
-            ),
-        )
+        return self._process_response(method_properties, common.Result(code=response.status_code, result=response.body))

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -744,7 +744,7 @@ class ResourceService(protocol.ServerSlice, EnvironmentListener):
         try:
             handler = ResourceView(env, limit, first_id, last_id, start, end, filter, sort, deploy_summary)
 
-            out: ReturnValueWithMeta[Sequence[LatestReleasedResource]] = await handler.execute()
+            out = await handler.execute()
             if deploy_summary:
                 out.metadata["deploy_summary"] = await data.Resource.get_resource_deploy_summary(env.id)
             return out

--- a/tests/deploy/e2e/test_resource_handler.py
+++ b/tests/deploy/e2e/test_resource_handler.py
@@ -20,7 +20,6 @@ import base64
 import logging
 import typing
 from typing import TypeVar
-from unittest.mock import Mock
 
 import pytest
 
@@ -44,7 +43,7 @@ class MockSessionClient(SessionClient):
         content = b""
         if self.return_code != 404:
             content = base64.b64encode(self.content)
-        return common.Result(self.return_code, result={"content": content}, client=Mock(), method_properties=Mock())
+        return common.Result(self.return_code, result={"content": content})
 
 
 class MockGetFileResourceHandler(ResourceHandler):

--- a/tests/server/test_agents_api.py
+++ b/tests/server/test_agents_api.py
@@ -231,19 +231,6 @@ async def test_agents_paging(server, client, env_with_agents: None, environment:
     }
     assert result.result["metadata"] == {"total": 2, "before": 2, "after": 0, "page_size": 1}
 
-    result = await client.get_agents(environment)
-    assert result.code == 200
-    all_agents = result.result["data"]
-    assert len(all_agents) == 9
-
-    result = await client.get_agents(environment)
-
-    idx = 0
-    async for item in result.all():
-        assert item == all_agents[idx]
-        idx += 1
-    assert idx == len(all_agents)
-
 
 async def test_sorting_validation(client, environment: str, env_with_agents: None) -> None:
     sort_status_map = {

--- a/tests/server/test_resource_history.py
+++ b/tests/server/test_resource_history.py
@@ -19,7 +19,6 @@ Contact: code@inmanta.com
 import datetime
 import itertools
 import json
-import logging
 import uuid
 from collections import defaultdict
 from operator import itemgetter
@@ -33,8 +32,6 @@ from inmanta.const import ResourceState
 from inmanta.server import config
 from inmanta.types import ResourceVersionIdStr
 from inmanta.util import parse_timestamp
-
-LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 class ResourceFactory:
@@ -468,19 +465,6 @@ async def test_resource_history_paging(server, client, order_by_column, order, e
     assert attribute_hashes(result.result["data"]) == all_resource_ids_in_expected_order
 
     assert result.result["metadata"] == {"total": 5, "before": 0, "after": 0, "page_size": 5}
-
-    result = await client.resource_history(env.id, resource_with_long_history, sort=f"{order_by_column}.{order}")
-    assert result.code == 200
-    full_history = result.result["data"]
-
-    result = await client.resource_history(env.id, resource_with_long_history, sort=f"{order_by_column}.{order}", limit=2)
-
-    idx = 0
-    async for item in result.all():
-        assert item == full_history[idx]
-        idx += 1
-
-    assert idx == len(full_history)
 
 
 async def test_history_not_continuous_versions(server, client, environment):

--- a/tests/server/test_resource_list.py
+++ b/tests/server/test_resource_list.py
@@ -43,8 +43,6 @@ from inmanta.deploy.state import DeployResult
 from inmanta.server import config
 from inmanta.types import ResourceIdStr, ResourceVersionIdStr
 
-LOGGER: logging.Logger = logging.getLogger(__name__)
-
 
 async def test_resource_list_no_released_version(server, client):
     """Test that if there are no released versions of a resource, the result set is empty"""
@@ -600,22 +598,6 @@ async def test_none_resources_paging(server, client, env_with_resources):
     assert len(actual_result_asc_next.result["data"]) == 2
 
 
-async def test_client_all_pages(server, client, env_with_resources):
-    env = env_with_resources
-    result = await client.resource_list(tid=env.id)
-    assert result.code == 200
-    all_resources = result.result["data"]
-    assert len(all_resources) == 6
-
-    result = await client.resource_list(tid=env.id, limit=2)
-
-    idx = 0
-    async for item in result.all():
-        assert item == all_resources[idx]
-        idx += 1
-    assert idx == len(all_resources)
-
-
 @pytest.mark.parametrize(
     "sort, expected_status",
     [
@@ -851,7 +833,7 @@ async def very_big_env(server, client, environment, clienthelper, null_agent, in
     for iteration in [0, 1]:
         for tenant in range(instances):
             await make_resource_set(tenant, iteration)
-            LOGGER.warning("deploys: %d, tenant: %d, iteration: %d", deploy_counter, tenant, iteration)
+            logging.getLogger(__name__).warning("deploys: %d, tenant: %d, iteration: %d", deploy_counter, tenant, iteration)
 
     return instances
 
@@ -946,4 +928,6 @@ async def test_resources_paging_performance(client, environment, very_big_env: i
             latency_page2, links = await time_page(links, "next")
             latency_page3, links = await time_page(links, "next")
 
-            LOGGER.warning("Timings %s %s %d %d %d", filter, order, latency_page1, latency_page2, latency_page3)
+            logging.getLogger(__name__).warning(
+                "Timings %s %s %d %d %d", filter, order, latency_page1, latency_page2, latency_page3
+            )

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -71,9 +71,7 @@ async def api_call_future(*args, **kwargs) -> Result:
     """
     Mock implementation of Client methods
     """
-    client = Mock()
-    method_properties = Mock()
-    return Result(200, "X", client=client, method_properties=method_properties)
+    return Result(200, "X")
 
 
 class MockSession:


### PR DESCRIPTION
…ults returned by v2 Rest API endpoints that support paging. See [documentation](helper_method_for_paging) for more information."

This reverts commit 88cbc1fac3689a59a45ee99cc6812501c798d3da.

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
