### PR TITLE
Improve resource action deploy log messages. (Issue #8812, PR #9369)

### DIFF
--- a/changelogs/unreleased/8812-improve-deploy-log-messages.yml
+++ b/changelogs/unreleased/8812-improve-deploy-log-messages.yml
@@ -1,0 +1,6 @@
+description: Improve resource action deploy log messages.
+issue-nr: 8812
+change-type: patch
+destination-branches: [iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -191,10 +191,10 @@ class Agent(SessionEndpoint):
 
         if incremental_deploy:
             LOGGER.info("%s got a trigger to run deploy in environment %s", agent_id, env)
-            await self.scheduler.deploy(reason="Deploy was triggered because user has requested a deploy", agent=agent)
+            await self.scheduler.deploy(reason="user requested a deploy", agent=agent)
         else:
             LOGGER.info("%s got a trigger to run repair in environment %s", agent_id, env)
-            await self.scheduler.repair(reason="Deploy was triggered because user has requested a repair", agent=agent)
+            await self.scheduler.repair(reason="user requested a repair", agent=agent)
         return 200
 
     @protocol.handle(methods.trigger_read_version, env="tid", agent="id")

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -155,7 +155,6 @@ class InProcessExecutor(executor.Executor, executor.AgentInstance):
     async def _execute(
         self,
         resource: Resource,
-        gid: uuid.UUID,
         ctx: handler.HandlerContext,
         requires: Mapping[ResourceIdStr, const.ResourceState],
     ) -> None:
@@ -163,13 +162,11 @@ class InProcessExecutor(executor.Executor, executor.AgentInstance):
         Get the handler for a given resource and run its ``deploy`` method.
 
         :param resource: The resource to deploy.
-        :param gid: Id of this deploy.
         :param ctx: The context to use during execution of this deploy.
         :param requires: A dictionary that maps each dependency of the resource to be deployed, to its latest resource
                          state that was not `deploying'.
         """
         # setup provider
-        ctx.debug("Start deploy %(deploy_id)s of resource %(resource_id)s", deploy_id=gid, resource_id=resource.id)
 
         provider: Optional[HandlerAPI[Any]] = None
         try:
@@ -240,16 +237,15 @@ class InProcessExecutor(executor.Executor, executor.AgentInstance):
         ctx = handler.HandlerContext(resource, action_id=action_id, logger=self.resource_action_logger)
 
         ctx.debug(
-            "Start run for resource %(resource)s because %(reason)s",
-            resource=str(resource_details.rvid),
-            deploy_id=gid,
-            agent=self.name,
+            "Start run because %(reason)s.",
             reason=reason,
+            deploy_id=gid,
+            resource=resource_details.id,
         )
 
         async with self.activity_lock:
             with self._cache:
-                await self._execute(resource, gid=gid, ctx=ctx, requires=requires)
+                await self._execute(resource, ctx=ctx, requires=requires)
 
         ctx.debug(
             "End run for resource %(r_id)s in deploy %(deploy_id)s",

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -493,7 +493,7 @@ class ResourceScheduler(TaskManager):
                 if self._state.version == restored_version:
                     # no new version was present. Simply trigger a deploy for everything that's not in a known good state
                     await self.deploy(
-                        reason="Deploy was triggered because the resource scheduler was started",
+                        reason="the resource scheduler was started",
                         priority=TaskPriority.INTERVAL_DEPLOY,
                     )
             else:
@@ -537,7 +537,7 @@ class ResourceScheduler(TaskManager):
             [model],
             up_to_date_resources=up_to_date_resources,
             last_deploy_time=last_deploy_time,
-            reason="Deploy was triggered because the scheduler was started",
+            reason="the scheduler was started",
             connection=connection,
         )
 
@@ -730,7 +730,7 @@ class ResourceScheduler(TaskManager):
 
             await self._new_version(
                 new_versions,
-                reason="Deploy was triggered because a new version has been released",
+                reason="a new version was released",
                 connection=con,
             )
 
@@ -842,7 +842,7 @@ class ResourceScheduler(TaskManager):
         *,
         up_to_date_resources: Optional[Set[ResourceIdStr]] = None,
         last_deploy_time: Mapping[ResourceIdStr, datetime.datetime] | None = None,
-        reason: str = "Deploy was triggered because a new version has been released",
+        reason: str = "a new version was released",
         connection: Optional[asyncpg.connection.Connection] = None,
     ) -> None:
         """
@@ -1369,9 +1369,9 @@ class ResourceScheduler(TaskManager):
             self._work.deploy_with_context(
                 all_listeners,
                 reason=(
-                    f"Deploying because a recovery event was received from {resource_id}"
+                    f"a recovery event was received from {resource_id}"
                     if recovered_from_failure
-                    else f"Deploying because an event was received from {resource_id}"
+                    else f"an event was received from {resource_id}"
                 ),
                 priority=priority,
                 deploying=self._deploying_latest,

--- a/src/inmanta/deploy/timers.py
+++ b/src/inmanta/deploy/timers.py
@@ -262,7 +262,7 @@ class TimerManager:
 
         async def _action() -> None:
             await self._resource_scheduler.deploy(
-                reason=f"Global deploy triggered because of cron expression for deploy interval: '{cron_expression}'",
+                reason="a global deploy was triggered by a cron expression",
                 priority=TaskPriority.INTERVAL_DEPLOY,
             )
 
@@ -281,7 +281,7 @@ class TimerManager:
 
         async def _action() -> None:
             await self._resource_scheduler.repair(
-                reason=f"Global repair triggered because of cron expression for repair interval: '{cron_expression}'",
+                reason="a global repair was triggered by a cron expression",
                 priority=TaskPriority.INTERVAL_REPAIR,
             )
 
@@ -337,20 +337,14 @@ class TimerManager:
         def _setup_repair(repair_interval: int) -> None:
             self.resource_timers[resource].set_timer(
                 when=(last_deployed + timedelta(seconds=repair_interval)),
-                reason=(
-                    f"Individual repair triggered for resource {resource} because last "
-                    f"repair happened more than {repair_interval}s ago."
-                ),
+                reason=f"previous repair happened more than {repair_interval}s ago",
                 priority=(TaskPriority.INTERVAL_REPAIR),
             )
 
         def _setup_deploy(deploy_interval: int) -> None:
             self.resource_timers[resource].set_timer(
                 when=(last_deployed + timedelta(seconds=deploy_interval)),
-                reason=(
-                    f"Individual deploy triggered for resource {resource} because last "
-                    f"deploy happened more than {deploy_interval}s ago."
-                ),
+                reason=f"previous deploy happened more than {deploy_interval}s ago",
                 priority=(TaskPriority.INTERVAL_DEPLOY),
             )
 

--- a/src/inmanta/deploy/work.py
+++ b/src/inmanta/deploy/work.py
@@ -415,6 +415,7 @@ class ScheduledWork:
 
         :param resources: Set of resources that should be deployed. Adds a deploy task to the scheduled work for each
             of these, unless it is already scheduled.
+        :param reason: The reason for this deploy.
         :param priority: The priority of this deploy.
         :param deploying: Set of resources for which a non-stale deploy is in progress, i.e. the scheduler does not need to
             take action to deploy the latest intent for any of these resources because that deploy is already in progress

--- a/tests/deploy/scheduler_mocks.py
+++ b/tests/deploy/scheduler_mocks.py
@@ -75,9 +75,7 @@ class DummyExecutor(executor.Executor):
         requires: Mapping[ResourceIdStr, const.HandlerResourceState],
     ) -> DeployReport:
         assert reason
-        # Actual reason or test reason
-        # The actual reasons are of the form `action because of reason`
-        assert ("because" in reason) or ("Test" in reason)
+
         self.execute_count += 1
         result = (
             const.HandlerResourceState.failed

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -1244,7 +1244,7 @@ async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal)
     # verify that rid3 got the event and is waiting for rid2
     assert agent.scheduler._work._waiting.keys() == {rid3}
     assert agent.scheduler._work._waiting[rid3].blocked_on == {rid2}
-    assert agent.scheduler._work._waiting[rid3].reason == f"Deploying because an event was received from {rid1}"
+    assert agent.scheduler._work._waiting[rid3].reason == f"an event was received from {rid1}"
 
     # finish rid2 deploy, assert end condition
     executor2.deploys[rid2].set_result(const.HandlerResourceState.deployed)


### PR DESCRIPTION
ISO8 PR for https://github.com/inmanta/inmanta-core/pull/9369

minor conflict  in `_recover_scheduler_state_using_increments_calculation` in `scheduler.py`

closes https://github.com/inmanta/inmanta-core/issues/8812

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)

# Description

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
