### PR TITLE
Fix bug where isExpertMode field of graphql endpoint always returne False

### DIFF
--- a/changelogs/unreleased/fix-bug-is-expert-mode-graphql.yml
+++ b/changelogs/unreleased/fix-bug-is-expert-mode-graphql.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix bug where isExpertMode field of graphql endpoint always returns False."
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -18,8 +18,7 @@ import uuid
 
 import inmanta.data.sqlalchemy as models
 import strawberry
-from inmanta.data import model
-from inmanta.data import get_session, get_session_factory
+from inmanta.data import get_session, get_session_factory, model
 from inmanta.server.services.compilerservice import CompilerService
 from sqlalchemy import Select, asc, desc, select
 from strawberry import relay

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -16,6 +16,7 @@ import dataclasses
 import typing
 import uuid
 
+from typing import cast
 import inmanta.data.sqlalchemy as models
 import strawberry
 from inmanta.data import get_session, get_session_factory, model
@@ -158,7 +159,7 @@ def get_expert_mode(root: "Environment") -> bool:
     assert hasattr(root, "settings")  # Make mypy happy
     if "enable_lsm_expert_mode" not in root.settings["settings"]:
         return False
-    return root.settings["settings"]["enable_lsm_expert_mode"]["value"]
+    return cast(bool, root.settings["settings"]["enable_lsm_expert_mode"]["value"])
 
 
 def get_is_compiling(root: "Environment", info: strawberry.Info) -> bool:

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -15,8 +15,8 @@ Contact: code@inmanta.com
 import dataclasses
 import typing
 import uuid
-
 from typing import cast
+
 import inmanta.data.sqlalchemy as models
 import strawberry
 from inmanta.data import get_session, get_session_factory, model

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -18,6 +18,7 @@ import uuid
 
 import inmanta.data.sqlalchemy as models
 import strawberry
+from inmanta.data import model
 from inmanta.data import get_session, get_session_factory
 from inmanta.server.services.compilerservice import CompilerService
 from sqlalchemy import Select, asc, desc, select
@@ -156,10 +157,9 @@ def get_expert_mode(root: "Environment") -> bool:
     Checks settings of environment to figure out if expert mode is enabled or not
     """
     assert hasattr(root, "settings")  # Make mypy happy
-    is_expert_mode = root.settings.get("enable_lsm_expert_mode", False)
-    if isinstance(is_expert_mode, str) and is_expert_mode.lower() == "false":
+    if "enable_lsm_expert_mode" not in root.settings["settings"]:
         return False
-    return bool(is_expert_mode)
+    return root.settings["settings"]["enable_lsm_expert_mode"]["value"]
 
 
 def get_is_compiling(root: "Environment", info: strawberry.Info) -> bool:


### PR DESCRIPTION
# Description

* Fix bug where `isExpertMode` field of graphql endpoint always returns False.
* Move `test_query_is_expert_mode` test case to lsm extension repository.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
