### PR TITLE
Added the inmanta module download command

### DIFF
--- a/changelogs/unreleased/add-inmanta-module-download-cmd.yml
+++ b/changelogs/unreleased/add-inmanta-module-download-cmd.yml
@@ -1,0 +1,8 @@
+---
+description: "Added the `inmanta module download` command, that allows downloading Inmanta modules in their source format from a Python package repository."
+issue-nr: 7820
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso8]
+sections:
+  feature: "{{description}}"

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -364,7 +364,7 @@ class PipCommandBuilder:
         cls, python_path: str, pkg_requirement: inmanta.util.CanonicalRequirement, no_deps: bool, no_binary: str | None
     ) -> list[str]:
         """
-        Returns the pip command to download a module as a python package.
+        Returns the pip command to download a python package.
         """
         command = [python_path, "-m", "pip", "download"]
         if no_deps:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -629,7 +629,8 @@ When a development release is done using the \--dev option, this command:
         release.add_argument("-a", "--all", dest="commit_all", help="Use commit -a", action="store_true")
         download = subparser.add_parser(
             "download",
-            help="Download an Inmanta module from a Python package repository and convert it to its source format.",
+            help="Download the source distribution of an Inmanta module from a Python package repository,"
+                 " extract it and convert it to its source format.",
             parents=parent_parsers,
         )
         download.add_argument(

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -676,17 +676,16 @@ When a development release is done using the \--dev option, this command:
             assert len(files_extract_dir) == 1
             path_extracted_pkg = os.path.join(extract_dir, files_extract_dir[0])
             # Convert to source format
-            model_dir = os.path.join(path_extracted_pkg, "inmanta_plugins", module_name, "model")
-            templates_dir = os.path.join(path_extracted_pkg, "inmanta_plugins", module_name, "templates")
-            files_dir = os.path.join(path_extracted_pkg, "inmanta_plugins", module_name, "files")
-            setup_cfg_file = os.path.join(path_extracted_pkg, "inmanta_plugins", module_name, "setup.cfg")
             try:
+                # Remove this file as it will be replace by the one present in the inmanta_plugins/<mod-name> directory.
                 os.remove(os.path.join(path_extracted_pkg, "setup.cfg"))
             except FileNotFoundError:
                 pass
-            for file_or_dir in [model_dir, templates_dir, files_dir, setup_cfg_file]:
-                if os.path.exists(file_or_dir):
-                    shutil.move(src=file_or_dir, dst=path_extracted_pkg)
+            files_and_dirs_to_move = ["model", "templates", "files", "setup.cfg"]
+            for file_or_dir in files_and_dirs_to_move:
+                fq_path = os.path.join(path_extracted_pkg, "inmanta_plugins", module_name, file_or_dir)
+                if os.path.exists(fq_path):
+                    shutil.move(src=fq_path, dst=path_extracted_pkg)
             # Move to desired output directory
             destination_dir = os.path.join(directory, module_name)
             shutil.copytree(src=path_extracted_pkg, dst=destination_dir)

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -20,6 +20,7 @@ import argparse
 import configparser
 import datetime
 import enum
+import gzip
 import inspect
 import itertools
 import logging
@@ -31,7 +32,6 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import gzip
 import tempfile
 import zipfile
 from argparse import ArgumentParser, RawTextHelpFormatter

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -630,7 +630,7 @@ When a development release is done using the \--dev option, this command:
         download = subparser.add_parser(
             "download",
             help="Download the source distribution of an Inmanta module from a Python package repository,"
-                 " extract it and convert it to its source format.",
+            " extract it and convert it to its source format.",
             parents=parent_parsers,
         )
         download.add_argument(

--- a/tests/data/modules_v2/elaboratev2module/tests/test_test.py
+++ b/tests/data/modules_v2/elaboratev2module/tests/test_test.py
@@ -1,0 +1,2 @@
+def test_test():
+    pass

--- a/tests/moduletool/test_download.py
+++ b/tests/moduletool/test_download.py
@@ -1,0 +1,196 @@
+"""
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+import pytest
+import os
+import shutil
+from packaging import version
+import packaging.utils
+from libpip2pi.commands import dir2pi
+import sys
+import subprocess
+import tempfile
+
+from inmanta import moduletool, module, env
+
+from utils import module_from_template
+
+@pytest.fixture(scope="session")
+def pip_index(modules_v2_dir: str) -> str:
+    """
+    Returns the path to a pip index that contains several version for the same python package.
+    """
+    with tempfile.TemporaryDirectory() as root_dir:
+        source_dir = os.path.join(root_dir, "source")
+        build_dir = os.path.join(root_dir, "build")
+        index_dir = os.path.join(build_dir, "simple")
+
+        modules_to_build = [
+            ("elaboratev2module", version.Version("1.2.3"), False),
+            ("elaboratev2module", version.Version("2.3.4"), False),
+            ("elaboratev2module", version.Version("2.3.5"), True),
+            ("minimalv2module", version.Version("1.1.1"), False),
+        ]
+
+        for module_name, mod_version, is_prerelease in modules_to_build:
+            template_dir = os.path.join(modules_v2_dir, module_name)
+            module_dir = os.path.join(source_dir, module_name)
+            module_from_template(
+                source_dir=template_dir,
+                dest_dir=module_dir,
+                new_version=mod_version,
+            )
+            moduletool.ModuleTool().build(
+                path=module_dir,
+                output_dir=build_dir,
+                dev_build=is_prerelease,
+                wheel=True,
+                sdist=True,
+            )
+            shutil.rmtree(module_dir)
+
+        # The setuptools and wheel packages are required by `pip download`
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "download", "setuptools", "wheel"], cwd=build_dir
+        )
+        dir2pi(argv=["dir2pi", build_dir])
+        yield index_dir
+
+
+def execute_inmanta_download(module_req: str, install: bool, download_dir: str | None) -> str:
+    """
+    Execute the `inmanta download` command and returns the ModuleV2 object for the downloaded module.
+    This method assumes that the downloaded package is elaboratev2module.
+    """
+    if download_dir is None:
+        download_dir = os.getcwd()
+    module_name: str = module.InmantaModuleRequirement.parse(module_req).name
+    assert not os.listdir(download_dir)
+    m = moduletool.ModuleTool()
+    m.download(module_req=module_req, install=install, directory=download_dir)
+    files = os.listdir(download_dir)
+    assert len(files) == 1
+    assert files[0] == module_name
+    return module.ModuleV2(project=None, path=os.path.join(download_dir, module_name))
+
+
+def assert_files_in_module(
+    module_dir: str, module_name: str, has_files_dir: bool, has_templates_dir: bool, has_tests_dir: bool
+) -> None:
+    """
+    Verify that the directory structure of the extracted python package is correct.
+
+    :param has_files_dir: True iff the given module has a files directory.
+    :param has_templates_dir: True iff the given module has a templates directory.
+    :param has_tests_dir: True iff the given module has a tests directory.
+    """
+    assert os.path.exists(os.path.join(module_dir, "inmanta_plugins"))
+    for file_or_dir, must_exist_in_root_dir in [
+        ("tests", has_tests_dir),
+        ("files", has_files_dir),
+        ("templates", has_templates_dir),
+        ("setup.cfg", True),
+    ]:
+        assert not os.path.exists(
+            os.path.join(module_dir, "inmanta_plugins", module_name, file_or_dir)
+        )
+        assert os.path.exists(os.path.join(module_dir, file_or_dir)) == must_exist_in_root_dir
+
+
+def test_module_download_no_optional_files(tmpdir, monkeypatch, tmpvenv_active, pip_index: str):
+    """
+    Test the `inmanta module download` command on a module that doesn't have any of the optional
+    files/directories (e.g. templates, files, tests).
+    """
+    monkeypatch.setenv("PIP_INDEX_URL", pip_index)
+    monkeypatch.setenv("PIP_PRE", "false")
+    download_dir = os.path.join(tmpdir, "download")
+
+    os.mkdir(download_dir)
+    mod: ModuleV2 = execute_inmanta_download(module_req="minimalv2module", install=False, download_dir=download_dir)
+    assert_files_in_module(
+        module_dir=mod.path, module_name="elaboratev2module", has_files_dir=False, has_templates_dir=False, has_tests_dir=False
+    )
+    assert mod.version == version.Version("1.1.1")
+
+
+def test_download_module_req(tmpdir, monkeypatch, tmpvenv_active, pip_index: str):
+    monkeypatch.setenv("PIP_INDEX_URL", pip_index)
+    monkeypatch.setenv("PIP_PRE", "false")
+    download_dir = os.path.join(tmpdir, "download")
+
+    # Test download package without constraint
+    os.mkdir(download_dir)
+    mod: ModuleV2 = execute_inmanta_download(module_req="elaboratev2module", install=False, download_dir=download_dir)
+    assert_files_in_module(
+        module_dir=mod.path, module_name="elaboratev2module", has_files_dir=True, has_templates_dir=True, has_tests_dir=True
+    )
+    assert mod.version == version.Version("2.3.4")
+    shutil.rmtree(download_dir)
+
+    # Test download package with constraint
+    os.mkdir(download_dir)
+    mod: ModuleV2 = execute_inmanta_download(module_req="elaboratev2module~=1.2.0", install=False, download_dir=download_dir)
+    assert_files_in_module(
+        module_dir=mod.path, module_name="elaboratev2module", has_files_dir=True, has_templates_dir=True, has_tests_dir=True
+    )
+    assert mod.version == version.Version("1.2.3")
+    shutil.rmtree(download_dir)
+
+    # Test download package with --pre
+    os.mkdir(download_dir)
+    monkeypatch.setenv("PIP_PRE", "true")
+    mod: ModuleV2 = execute_inmanta_download(module_req="elaboratev2module", install=False, download_dir=download_dir)
+    assert_files_in_module(
+        module_dir=mod.path, module_name="elaboratev2module", has_files_dir=True, has_templates_dir=True, has_tests_dir=True
+    )
+    assert mod.version.base_version == "2.3.5"
+    assert mod.version.is_prerelease
+
+
+def test_download_cwd(tmpdir, monkeypatch, tmpvenv_active, pip_index: str):
+    """
+    Test the `inmanta module download` command when downloading to the current working directory.
+    """
+    monkeypatch.setenv("PIP_INDEX_URL", pip_index)
+    monkeypatch.setenv("PIP_PRE", "false")
+    download_dir = os.path.join(tmpdir, "download")
+    os.mkdir(download_dir)
+    monkeypatch.chdir(download_dir)
+    mod: ModuleV2 = execute_inmanta_download(module_req="elaboratev2module", install=False, download_dir=None)
+    assert_files_in_module(
+        module_dir=mod.path, module_name="elaboratev2module", has_files_dir=True, has_templates_dir=True, has_tests_dir=True
+    )
+
+def test_download_install(tmpdir, monkeypatch, tmpvenv_active, pip_index: str):
+    """
+    Test the install option of the `inmanta module download` command.
+    """
+    monkeypatch.setenv("PIP_INDEX_URL", pip_index)
+    monkeypatch.setenv("PIP_PRE", "false")
+    download_dir = os.path.join(tmpdir, "download")
+    pkg_name = "inmanta-module-minimalv2module"
+
+    os.mkdir(download_dir)
+    pkgs_installed_in_editable_mode: dict[packaging.utils.NormalizedName, version.Version]
+    pkgs_installed_in_editable_mode = env.process_env.get_installed_packages(only_editable=True)
+    assert pkg_name not in pkgs_installed_in_editable_mode
+    mod: ModuleV2 = execute_inmanta_download(module_req="minimalv2module", install=True, download_dir=download_dir)
+    pkgs_installed_in_editable_mode = env.process_env.get_installed_packages(only_editable=True)
+    assert pkg_name in pkgs_installed_in_editable_mode
+    assert pkgs_installed_in_editable_mode[pkg_name] == version.Version("1.1.1")
+


### PR DESCRIPTION
# Description

Added the `inmanta module download` command, that allows downloading Inmanta modules in their source format from a Python package repository.

closes #7820

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
