### PR TITLE
Fix export to json without server

### DIFF
--- a/changelogs/unreleased/fix-export-to-json-without-server.yml
+++ b/changelogs/unreleased/fix-export-to-json-without-server.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix bug where the export command requires a server to be present even when an export to json was requested."
+change-type: patch
+destination-branches: [master, iso8]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -630,6 +630,7 @@ src/inmanta/export.py:0: error: Argument 2 to "add" of "Exporter" has incompatib
 src/inmanta/export.py:0: error: Argument 3 to "create_from_model" of "Resource" has incompatible type "str | tuple[object, ...] | int | float | DynamicProxy | Reference[str | float | int | bool | DataclassInstance | None] | None"; expected "DynamicProxy"  [arg-type]
 src/inmanta/export.py:0: error: Cannot infer type argument 1 of "Option"  [misc]
 src/inmanta/export.py:0: error: Incompatible return value type (got "int | None", expected "int")  [return-value]
+src/inmanta/export.py:0: error: Item "None" of "Namespace | None" has no attribute "json"  [union-attr]
 src/inmanta/export.py:0: error: List comprehension has incompatible type List[str | tuple[object, ...] | int | float | DynamicProxy | Reference[str | float | int | bool | DataclassInstance | None] | None]; expected List[dict[str, Sequence[str | tuple[Any, ...] | int | float | bool | DynamicProxy]]]  [misc]
 src/inmanta/export.py:0: error: Missing type parameters for generic type "tuple"  [type-arg]
 src/inmanta/export.py:0: error: Returning Any from function declared to return "int"  [no-any-return]

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -424,7 +424,7 @@ class Exporter:
 
         resources = self.resources_to_list()
 
-        export_to_json = (self.options and self.options.json)
+        export_to_json = self.options and self.options.json
 
         # Update the environment settings, mentioned in the project.yml file, on the server.
         if not self.failed and not no_commit and export_env_var_settings and not export_to_json:

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -424,8 +424,10 @@ class Exporter:
 
         resources = self.resources_to_list()
 
+        export_to_json = (self.options and self.options.json)
+
         # Update the environment settings, mentioned in the project.yml file, on the server.
-        if not self.failed and not no_commit and export_env_var_settings:
+        if not self.failed and not no_commit and export_env_var_settings and not export_to_json:
             result = self.client.protected_environment_settings_set_batch(
                 tid=self._get_env_id(),
                 settings=project.metadata.environment_settings or {},
@@ -440,7 +442,7 @@ class Exporter:
         if len(self._resources) == 0:
             LOGGER.warning("Empty deployment model.")
 
-        if self.options and self.options.json:
+        if export_to_json:
             with open(self.options.json, "wb+") as fd:
                 fd.write(protocol.json_encode(resources).encode("utf-8"))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -424,6 +424,20 @@ caused by:
     exec(*cl_export)
 
 
+def test_export_no_server(snippetcompiler):
+    """
+    Make sure that export to json works if no server is present.
+    """
+    snippetcompiler.setup_for_snippet(
+        """
+        """,
+        autostd=True,
+    )
+    process = do_run([sys.executable, "-m", "inmanta.app", "export", "-j", "out.json"], cwd=snippetcompiler.project_dir)
+    stdout, stderr = process.communicate(timeout=30)
+    assert process.returncode == 0, f"{stdout}\n\n{stderr}"
+
+
 @pytest.mark.timeout(15)
 @pytest.mark.parametrize_any(
     "cmd", [(["-X", "compile"]), (["compile", "-X"]), (["compile"]), (["export", "-X"]), (["-X", "export"]), (["export"])]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -428,11 +428,7 @@ def test_export_no_server(snippetcompiler):
     """
     Make sure that export to json works if no server is present.
     """
-    snippetcompiler.setup_for_snippet(
-        """
-        """,
-        autostd=True,
-    )
+    snippetcompiler.setup_for_snippet("")
     process = do_run([sys.executable, "-m", "inmanta.app", "export", "-j", "out.json"], cwd=snippetcompiler.project_dir)
     stdout, stderr = process.communicate(timeout=30)
     assert process.returncode == 0, f"{stdout}\n\n{stderr}"


### PR DESCRIPTION
# Description

Fix bug where the export command requires a server to be present even when an export to json was requested.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
