### PR TITLE
Fix scheduler state check in agent_factory fixture (iso8)

### DIFF
--- a/changelogs/unreleased/fix-state-check-agent-factory.yml
+++ b/changelogs/unreleased/fix-state-check-agent-factory.yml
@@ -1,0 +1,4 @@
+---
+description: "Make sure that no deploy actions can be done while the agent_factory fixture is running the scheduler state check"
+change-type: patch
+destination-branches: [master, iso8]

--- a/changelogs/unreleased/fix-state-check-agent-factory.yml
+++ b/changelogs/unreleased/fix-state-check-agent-factory.yml
@@ -1,4 +1,4 @@
 ---
 description: "Make sure that no deploy actions can be done while the agent_factory fixture is running the scheduler state check"
 change-type: patch
-destination-branches: [master, iso8]
+destination-branches: [iso8]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -890,6 +890,12 @@ async def agent_factory(server, monkeypatch) -> AsyncIterator[Callable[[uuid.UUI
     global DISABLE_STATE_CHECK
     try:
         if not DISABLE_STATE_CHECK:
+            all_environments = {agent.environment for agent in agents}
+            for environment in all_environments:
+                # Make sure that the scheduler doesn't deploy anything anymore, because this would alter
+                # the last_deploy timestamp in the resource_state.
+                result = await client.all_agents_action(tid=environment, action=const.AgentAction.pause.value)
+                assert result.code == 200
             for agent in agents:
                 await agent.stop_working()
                 the_state = copy.deepcopy(dict(agent.scheduler._state.resource_state))


### PR DESCRIPTION
# Description

**Same type of change as https://github.com/inmanta/inmanta-core/pull/9418 but applied on the iso8 branch due to a merge conflict.**

When a deploy operation happens while the agent_factory fixture is running its scheduler state check, a mismatch happens on the last_deploy timestamp. This PR fixes that issue by pausing all environments.

<details>
<summary>Output test case</summary>
<pre>
05:33:01  ==================================== ERRORS ====================================
05:33:01  _________________ ERROR at teardown of test_deploy_end_to_end __________________
05:33:01  
05:33:01      def finalizer() -> None:
05:33:01          """Yield again, to finalize."""
05:33:01      
05:33:01          async def async_finalizer() -> None:
05:33:01              try:
05:33:01                  await gen_obj.__anext__()  # type: ignore[union-attr]
05:33:01              except StopAsyncIteration:
05:33:01                  pass
05:33:01              else:
05:33:01                  msg = "Async generator fixture didn't stop."
05:33:01                  msg += "Yield only once."
05:33:01                  raise ValueError(msg)
05:33:01      
05:33:01  >       runner.run(async_finalizer(), context=context)
05:33:01  
05:33:01  ../../env/lib64/python3.12/site-packages/pytest_asyncio/plugin.py:289: 
05:33:01  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:33:01  /usr/lib64/python3.12/asyncio/runners.py:118: in run
05:33:01      return self._loop.run_until_complete(task)
05:33:01             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
05:33:01  /usr/lib64/python3.12/asyncio/base_events.py:691: in run_until_complete
05:33:01      return future.result()
05:33:01             ^^^^^^^^^^^^^^^
05:33:01  ../../env/lib64/python3.12/site-packages/pytest_asyncio/plugin.py:281: in async_finalizer
05:33:01      await gen_obj.__anext__()  # type: ignore[union-attr]
05:33:01      ^^^^^^^^^^^^^^^^^^^^^^^^^
05:33:01  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
05:33:01  
05:33:01  server = <inmanta.server.protocol.Server object at 0x7f04b78d3c20>
05:33:01  client = <inmanta.protocol.endpoints.Client object at 0x7f04b79a5520>
05:33:01  monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f04b5ff0770>
05:33:01  
05:33:01      @pytest.fixture(scope="function")
05:33:01      async def agent_factory(server, client, monkeypatch) -> AsyncIterator[Callable[[uuid.UUID], Awaitable[Agent]]]:
05:33:01          agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
05:33:01          agents: list[Agent] = []
05:33:01      
05:33:01          async def create(environment: uuid.UUID) -> Agent:
05:33:01              # Mock scheduler state-dir: outside of tests this happens
05:33:01              # when the scheduler config is loaded, before starting the scheduler
05:33:01              server_state_dir = config.Config.get("config", "state-dir")
05:33:01              scheduler_state_dir = pathlib.Path(server_state_dir) / "server" / str(environment)
05:33:01              scheduler_state_dir.mkdir(exist_ok=True)
05:33:01              config.Config.set("config", "state-dir", str(scheduler_state_dir))
05:33:01              a = Agent(environment)
05:33:01              agents.append(a)
05:33:01              # Restore state-dir
05:33:01              config.Config.set("config", "state-dir", str(server_state_dir))
05:33:01      
05:33:01              executor = InProcessExecutorManager(
05:33:01                  environment,
05:33:01                  a._client,
05:33:01                  asyncio.get_running_loop(),
05:33:01                  logger,
05:33:01                  a.thread_pool,
05:33:01                  str(pathlib.Path(a._storage["executors"]) / "code"),
05:33:01                  str(pathlib.Path(a._storage["executors"]) / "venvs"),
05:33:01                  False,
05:33:01              )
05:33:01      
05:33:01              executor = WriteBarierExecutorManager(executor)
05:33:01      
05:33:01              a.executor_manager = executor
05:33:01              a.scheduler.executor_manager = executor
05:33:01              a.scheduler.code_manager = utils.DummyCodeManager()
05:33:01              await a.start()
05:33:01              await utils.retry_limited(
05:33:01                  lambda: agentmanager.get_agent_client(tid=environment, endpoint=const.AGENT_SCHEDULER_ID, live_agent_only=True)
05:33:01                  is not None,
05:33:01                  timeout=10,
05:33:01              )
05:33:01              return a
05:33:01      
05:33:01          yield create
05:33:01      
05:33:01          global DISABLE_STATE_CHECK
05:33:01          try:
05:33:01              if not DISABLE_STATE_CHECK:
05:33:01                  # Set data.RESET_DEPLOY_PROGRESS_ON_START back to False in all of the environments of the created agents
05:33:01                  # Because this teardown asserts that the state is correct on restart and this setting breaks that assertion
05:33:01                  all_environments = {agent.environment for agent in agents}
05:33:01                  for environment in all_environments:
05:33:01                      await client.set_setting(environment, data.RESET_DEPLOY_PROGRESS_ON_START, False)
05:33:01                  for agent in agents:
05:33:01                      await agent.stop_working()
05:33:01                      the_state = copy.deepcopy(dict(agent.scheduler._state.resource_state))
05:33:01                      for r, state in the_state.items():
05:33:01                          if state.blocked is inmanta.deploy.state.Blocked.TEMPORARILY_BLOCKED:
05:33:01                              # TODO[#8541]: also persist TEMPORARILY_BLOCKED in database
05:33:01                              state.blocked = inmanta.deploy.state.Blocked.NOT_BLOCKED
05:33:01                          print(r, state)
05:33:01                      monkeypatch.setattr(agent.scheduler._work.agent_queues, "_new_agent_notify", lambda x: x)
05:33:01                      await agent.start_working()
05:33:01                      new_state = copy.deepcopy(dict(agent.scheduler._state.resource_state))
05:33:01  >                   assert the_state == new_state
05:33:01  E                   AssertionError: assert {'std::testing::NullResource[test,name=test]': ResourceState(compliance=<Compliance.NON_COMPLIANT: 'non_compliant'>, last_deploy_result=<DeployResult.FAILED: 'failed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 241336, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST'))), 'std::testing::NullResource[test,name=test2]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 225851, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST'))), 'refs::DeepResource[test,name=test3]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 253604, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST'))), 'refs::DictResource[test,name=test4]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 263583, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST'))), 'refs::DeepResource[test,name=test4]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 278102, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')))} == {'refs::DeepResource[test,name=test3]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 253604, tzinfo=datetime.timezone.utc)), 'refs::DeepResource[test,name=test4]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 278102, tzinfo=datetime.timezone.utc)), 'refs::DictResource[test,name=test4]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 263583, tzinfo=datetime.timezone.utc)), 'std::testing::NullResource[test,name=test2]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>, last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 225851, tzinfo=datetime.timezone.utc)), 'std::testing::NullResource[test,name=test]': ResourceState(compliance=<Compliance.NON_COMPLIANT: 'non_compliant'>, last_deploy_result=<DeployResult.FAILED: 'failed'>, blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>, last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 433308, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')))}
05:33:01  E                     
05:33:01  E                     Common items:
05:33:01  E                     {'refs::DeepResource[test,name=test3]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                                                                           last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                                                                           blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                                                                           last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 253604, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST'))),
05:33:01  E                      'refs::DeepResource[test,name=test4]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                                                                           last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                                                                           blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                                                                           last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 278102, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST'))),
05:33:01  E                      'refs::DictResource[test,name=test4]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                                                                           last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                                                                           blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                                                                           last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 263583, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST'))),
05:33:01  E                      'std::testing::NullResource[test,name=test2]': ResourceState(compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                                                                                   last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                                                                                   blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                                                                                   last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 225851, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')))}
05:33:01  E                     Differing items:
05:33:01  E                     {'std::testing::NullResource[test,name=test]': ResourceState(compliance=<Compliance.NON_COMPLIANT: 'non_compliant'>, l...=datetime.datetime(2025, 8, 6, 5, 27, 53, 241336, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')))} != {'std::testing::NullResource[test,name=test]': ResourceState(compliance=<Compliance.NON_COMPLIANT: 'non_compliant'>, l...=datetime.datetime(2025, 8, 6, 5, 27, 53, 433308, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')))}
05:33:01  E                     
05:33:01  E                     Full diff:
05:33:01  E                       {
05:33:01  E                           'refs::DeepResource[test,name=test3]': ResourceState(
05:33:01  E                               compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                               last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                               blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                     -         last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 253604, tzinfo=datetime.timezone.utc),
05:33:01  E                     ?                                                     ^                                           -
05:33:01  E                     +         last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 253604, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),
05:33:01  E                     ?                                                     ^                                          +++++++++  +++++++++++ +++++++++  ++++++++++
05:33:01  E                           ),
05:33:01  E                           'refs::DeepResource[test,name=test4]': ResourceState(
05:33:01  E                               compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                               last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                               blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                     -         last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 278102, tzinfo=datetime.timezone.utc),
05:33:01  E                     ?                                                     ^                                           -
05:33:01  E                     +         last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 278102, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),
05:33:01  E                     ?                                                     ^                                          +++++++++  +++++++++++ +++++++++  ++++++++++
05:33:01  E                           ),
05:33:01  E                           'refs::DictResource[test,name=test4]': ResourceState(
05:33:01  E                               compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                               last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                               blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                     -         last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 263583, tzinfo=datetime.timezone.utc),
05:33:01  E                     ?                                                     ^                                           -
05:33:01  E                     +         last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 263583, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),
05:33:01  E                     ?                                                     ^                                          +++++++++  +++++++++++ +++++++++  ++++++++++
05:33:01  E                           ),
05:33:01  E                           'std::testing::NullResource[test,name=test2]': ResourceState(
05:33:01  E                               compliance=<Compliance.COMPLIANT: 'compliant'>,
05:33:01  E                               last_deploy_result=<DeployResult.DEPLOYED: 'deployed'>,
05:33:01  E                               blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                     -         last_deployed=datetime.datetime(2025, 8, 6, 3, 27, 53, 225851, tzinfo=datetime.timezone.utc),
05:33:01  E                     ?                                                     ^                                           -
05:33:01  E                     +         last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 225851, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),
05:33:01  E                     ?                                                     ^                                          +++++++++  +++++++++++ +++++++++  ++++++++++
05:33:01  E                           ),
05:33:01  E                           'std::testing::NullResource[test,name=test]': ResourceState(
05:33:01  E                               compliance=<Compliance.NON_COMPLIANT: 'non_compliant'>,
05:33:01  E                               last_deploy_result=<DeployResult.FAILED: 'failed'>,
05:33:01  E                               blocked=<Blocked.NOT_BLOCKED: 'not_blocked'>,
05:33:01  E                     -         last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 433308, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),
05:33:01  E                     ?                                                                   ^^^
05:33:01  E                     +         last_deployed=datetime.datetime(2025, 8, 6, 5, 27, 53, 241336, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), 'CEST')),
05:33:01  E                     ?                                                                + +  ^
05:33:01  E                           ),
05:33:01  E                       }
05:33:01  
05:33:01  tests/conftest.py:1017: AssertionError
</pre>
</details>

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x]  No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
