### PR TITLE
Improvements for inmanta module/project download command

### DIFF
--- a/changelogs/unreleased/improvements-project-module-download.yml
+++ b/changelogs/unreleased/improvements-project-module-download.yml
@@ -1,0 +1,4 @@
+---
+description: "Improvements for the `inmanta module download` and `inmanta project download` command."
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1513,7 +1513,7 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
     :param environment_settings: The environment settings that need to be configured on the server for this project.
                                  The settings will be applied on the server when the `inmanta export` command is run.
                                  Environment settings specified here cannot be updated via the regular API endpoints
-                                 to update environment settings as long as they are in this list.
+                                 to update environment settings as long as they are in this dictionary.
     """
 
     _raw_parser: typing.ClassVar[type[YamlParser]] = YamlParser


### PR DESCRIPTION
# Description

Improvements for the `inmanta module download` and `inmanta project download` command:

* Performance improvement on `inmanta module download` command, by not using the two stage approach. There cannot by any version conflicts when downloading a single package.
* Override if the module already exists in the download directory.
* Fix in documentation.

Part of #7820

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~