### PR TITLE
Support removing executor venvs (iso8)

### DIFF
--- a/changelogs/unreleased/9260-rebuild-agent-venvs.yml
+++ b/changelogs/unreleased/9260-rebuild-agent-venvs.yml
@@ -1,0 +1,8 @@
+---
+description: Added an API endpoint to remove all the Python environments used by the agents in a certain environment.
+issue-nr: 9260
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master, iso8]
+sections:
+  feature: "{{description}}"

--- a/changelogs/unreleased/9260-rebuild-agent-venvs.yml
+++ b/changelogs/unreleased/9260-rebuild-agent-venvs.yml
@@ -3,6 +3,6 @@ description: Added an API endpoint to remove all the Python environments used by
 issue-nr: 9260
 issue-repo: inmanta-core
 change-type: minor
-destination-branches: [master, iso8]
+destination-branches: [iso8]
 sections:
   feature: "{{description}}"

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import datetime
 import logging
 import os
 import uuid
@@ -130,6 +131,58 @@ class Agent(SessionEndpoint):
         await self.executor_manager.join([], timeout=timeout)
         await self.scheduler.join()
         LOGGER.info("Scheduler stopped for environment %s", self.environment)
+
+    @protocol.handle(methods_v2.remove_executor_venvs)
+    async def remove_executor_venvs(self) -> None:
+        """
+        Remove all the venvs used by the executors of this agent.
+        """
+        try:
+            await data.Notification(
+                environment=self._env_id,
+                created=datetime.datetime.now().astimezone(),
+                title="Agent operations suspended",
+                message="Agent operations are temporarily suspended because the user requested to remove the agent venvs.",
+                severity=const.NotificationSeverity.info,
+            ).insert()
+            # Stop all deployments and stop all executors
+            await self.scheduler.suspend_deployments(reason="removing all agent venvs")
+            await self.executor_manager.stop_all_executors()
+            # Remove venvs
+            await self._remove_executor_venvs()
+        except Exception as e:
+            await data.Notification(
+                environment=self._env_id,
+                created=datetime.datetime.now().astimezone(),
+                title="Agent venv removal failed",
+                message=f"Failed to remove agent venvs: {e}",
+                severity=const.NotificationSeverity.error,
+            ).insert()
+        else:
+            await data.Notification(
+                environment=self._env_id,
+                created=datetime.datetime.now().astimezone(),
+                title="Agent venv removal finished",
+                message="The agent venvs were successfully removed. Resuming agent operations.",
+                severity=const.NotificationSeverity.info,
+            ).insert()
+        finally:
+            # Resume deployments again
+            await self.scheduler.resume_deployments()
+
+    async def _remove_executor_venvs(self) -> None:
+        """
+        This method was created to be able to monkeypatch it in testing.
+        """
+        environment_manager: executor.VirtualEnvironmentManager | None = self.executor_manager.get_environment_manager()
+        if not environment_manager:
+            raise Exception(
+                "Calling the remove_executor_venvs endpoint while running against an ExecutorManager that doesn't have"
+                " a VirtualEnvironmentManager. This can happen while running the test suite using"
+                " the agent fixture. In that case all executors run in the same process as the server."
+                " So there are no venvs to cleanup."
+            )
+        await environment_manager.remove_all_venvs()
 
     @protocol.handle(methods.set_state)
     async def set_state(self, agent: Optional[str], enabled: bool) -> Apireturn:

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -372,6 +372,12 @@ class ExecutorVirtualEnvironment(PythonEnvironment, resourcepool.PoolMember[str]
         This method must be called on a threadpool to not block the ioloop.
         """
         try:
+            # Remove the status file first. Like this we will rebuild the venv on use
+            # if the rmtree() call was interrupted because of a system failure.
+            os.remove(self.inmanta_venv_status_file)
+        except Exception:
+            pass
+        try:
             LOGGER.debug("Removing venv %s", self.env_path)
             shutil.rmtree(self.env_path)
         except Exception:
@@ -425,6 +431,34 @@ class VirtualEnvironmentManager(resourcepool.TimeBasedPoolManager[EnvBlueprint, 
 
     def get_lock_name_for(self, member_id: str) -> str:
         return member_id
+
+    async def remove_all_venvs(self) -> None:
+        """
+        Removes all the venvs from disk. It's the responsibility of the caller
+        to make sure the venvs are no longer used.
+        """
+        folders = [file for file in self.envs_dir.iterdir() if file.is_dir()]
+        for folder in folders:
+            if folder.name in self.pool:
+                # The ExecutorVirtualEnvironment is managed by this VirtualEnvironmentManager.
+                # Rely on the normal shutdown flow to clean up all datastructures correctly.
+                virtual_environment = self.pool[folder.name]
+                future: asyncio.Future[None] = asyncio.Future()
+
+                async def venv_cleanup_is_done(exec_virt_env: resourcepool.PoolMember[resourcepool.TPoolID]) -> None:
+                    future.set_result(None)
+
+                virtual_environment.termination_listeners.append(venv_cleanup_is_done)
+                await virtual_environment.request_shutdown()
+                await future
+            else:
+                # This should normally not happen, unless somebody added a directory manually
+                # to the venv directory while the server was running. Let's clean it up anyway.
+                fq_path = os.path.join(self.envs_dir, folder.name)
+                try:
+                    await asyncio.get_running_loop().run_in_executor(self.thread_pool, shutil.rmtree, fq_path)
+                except Exception:
+                    LOGGER.exception("An error occurred while removing the venv located %s", fq_path)
 
     async def init_environment_map(self) -> None:
         """
@@ -647,11 +681,26 @@ class ExecutorManager(abc.ABC, typing.Generic[E]):
         """
 
     @abc.abstractmethod
+    def get_environment_manager(self) -> VirtualEnvironmentManager | None:
+        """
+        Returns the VirtualEnvironmentManager used by this ExecutorManager or None if this
+        ExecutorManager doesn't have a VirtualEnvironmentManager.
+        """
+
+    @abc.abstractmethod
+    async def stop_all_executors(self) -> list[E]:
+        """
+        Stop all executors started by the ExecutorManager.
+        """
+        pass
+
+    @abc.abstractmethod
     async def stop_for_agent(self, agent_name: str) -> list[E]:
         """
         Indicate that all executors for this agent can be stopped.
 
-        This is considered to be a hint , the manager can choose to follow or not
+        Because multiple agents can run on the same executor, this method only stops the executor if no more
+        agents are running on it.
 
         If executors are stopped, they are returned
         """

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -98,6 +98,13 @@ import inmanta.util
 from inmanta import const, tracing
 from inmanta.agent import executor, resourcepool
 from inmanta.agent.executor import DeployReport, FailedInmantaModules, GetFactReport
+from inmanta.agent.executor import (
+    DeployReport,
+    FailedInmantaModules,
+    GetFactReport,
+    ModuleLoadingException,
+    VirtualEnvironmentManager,
+)
 from inmanta.agent.resourcepool import PoolManager, PoolMember
 from inmanta.const import LOGGER_NAME_EXECUTOR
 from inmanta.loader import get_inmanta_module_name
@@ -887,6 +894,12 @@ class MPPool(resourcepool.PoolManager[executor.ExecutorBlueprint, executor.Execu
     def get_lock_name_for(self, member_id: executor.ExecutorBlueprint) -> str:
         return member_id.blueprint_hash()
 
+    def get_environment_manager(self) -> VirtualEnvironmentManager:
+        """
+        Returns the VirtualEnvironmentManager used to create Python environments for the executors.
+        """
+        return self.environment_manager
+
     @classmethod
     def init_once(cls) -> None:
         try:
@@ -1029,6 +1042,12 @@ class MPManager(
         self.agent_map: collections.defaultdict[str, set[MPExecutor]] = collections.defaultdict(set)
         self.max_executors_per_agent = inmanta.agent.config.agent_executor_cap.get()
 
+    def get_environment_manager(self) -> VirtualEnvironmentManager:
+        """
+        Returns the VirtualEnvironmentManager used to create Python environments for the executors.
+        """
+        return self.process_pool.get_environment_manager()
+
     def get_lock_name_for(self, member_id: executor.ExecutorId) -> str:
         return member_id.identity()
 
@@ -1121,6 +1140,14 @@ class MPManager(
         # the last two parameters are there to glue the signatures of the join methods in the two super classes
         await super().join()
         await self.process_pool.join()
+
+    async def stop_all_executors(self) -> list[MPExecutor]:
+        """
+        Requests all executors to shutdown and returns these executors.
+        """
+        children = set().union(*(e for e in self.agent_map.values()))
+        await asyncio.gather(*(child.request_shutdown() for child in children))
+        return list(children)
 
     async def stop_for_agent(self, agent_name: str) -> list[MPExecutor]:
         children = list(self.agent_map[agent_name])

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -97,14 +97,7 @@ import inmanta.types
 import inmanta.util
 from inmanta import const, tracing
 from inmanta.agent import executor, resourcepool
-from inmanta.agent.executor import DeployReport, FailedInmantaModules, GetFactReport
-from inmanta.agent.executor import (
-    DeployReport,
-    FailedInmantaModules,
-    GetFactReport,
-    ModuleLoadingException,
-    VirtualEnvironmentManager,
-)
+from inmanta.agent.executor import DeployReport, FailedInmantaModules, GetFactReport, VirtualEnvironmentManager
 from inmanta.agent.resourcepool import PoolManager, PoolMember
 from inmanta.const import LOGGER_NAME_EXECUTOR
 from inmanta.loader import get_inmanta_module_name

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -530,6 +530,12 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
         self.executors.clear()
         self._running = True
 
+    def get_environment_manager(self) -> None:
+        return None
+
+    async def stop_all_executors(self) -> list[InProcessExecutor]:
+        raise NotImplementedError("Not used")
+
     async def stop_for_agent(self, agent_name: str) -> list[InProcessExecutor]:
         if agent_name in self.executors:
             out = self.executors[agent_name]

--- a/src/inmanta/agent/write_barier_executor.py
+++ b/src/inmanta/agent/write_barier_executor.py
@@ -92,6 +92,12 @@ class WriteBarierExecutorManager(executor.ExecutorManager[WriteBarierExecutor]):
             raise ValueError(f"{self.__class__.__name__}.get_executor() expects at least one resource install specification")
         return WriteBarierExecutor(await self.delegate.get_executor(agent_name, agent_uri, code))
 
+    def get_environment_manager(self) -> executor.VirtualEnvironmentManager | None:
+        return self.delegate.get_environment_manager()
+
+    async def stop_all_executors(self) -> list[WriteBarierExecutor]:
+        return [WriteBarierExecutor(e) for e in await self.delegate.stop_all_executors()]
+
     async def stop_for_agent(self, agent_name: str) -> list[WriteBarierExecutor]:
         return [WriteBarierExecutor(e) for e in await self.delegate.stop_for_agent(agent_name)]
 

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -302,6 +302,14 @@ class AgentAction(str, Enum):
     unpause_on_resume = "unpause_on_resume"
 
 
+class AllAgentAction(str, Enum):
+    pause = "pause"
+    unpause = "unpause"
+    keep_paused_on_resume = "keep_paused_on_resume"
+    unpause_on_resume = "unpause_on_resume"
+    remove_all_agent_venvs = "remove_all_agent_venvs"
+
+
 class AgentStatus(str, Enum):
     paused = "paused"
     up = "up"

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -234,12 +234,14 @@ class TaskRunner:
         self._scheduler = scheduler
         self._task: typing.Optional[asyncio.Task[None]] = None
         self._notify_tasks: dict[uuid.UUID, asyncio.Task[None]] = {}
+        # Lock to prevent race conditions on the running state of this TaskRunner
+        self._notify_lock = asyncio.Lock()
 
     async def start(self) -> None:
-        self.status = AgentStatus.STARTED
         assert (
             self._task is None or self._task.done()
         ), f"Task Runner {self.endpoint} is trying to start twice, this should not happen"
+        self.status = AgentStatus.STARTED
         self._task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
@@ -264,20 +266,23 @@ class TaskRunner:
         :param task_id: Is not None if this task was started using the `notify_sync()` method. It's used to clean up the
                         reference to the associated asyncio.Task object in `self._notify_tasks`. This value is None otherwise.
         """
-        should_be_running = await self._scheduler.should_be_running() and await self._scheduler.should_runner_be_running(
-            endpoint=self.endpoint
-        )
+        try:
+            async with self._notify_lock:
+                should_be_running = (
+                    await self._scheduler.should_be_running()
+                    and await self._scheduler.should_runner_be_running(endpoint=self.endpoint)
+                )
 
-        match self.status:
-            case AgentStatus.STARTED if not should_be_running:
-                await self.stop()
-            case AgentStatus.STOPPED if should_be_running:
-                await self.start()
-            case AgentStatus.STOPPING if should_be_running:
-                self.status = AgentStatus.STARTED
-
-        if task_id:
-            del self._notify_tasks[task_id]
+                match self.status:
+                    case AgentStatus.STARTED if not should_be_running:
+                        await self.stop()
+                    case AgentStatus.STOPPED if should_be_running:
+                        await self.start()
+                    case AgentStatus.STOPPING if should_be_running:
+                        self.status = AgentStatus.STARTED
+        finally:
+            if task_id:
+                del self._notify_tasks[task_id]
 
     def notify_sync(self) -> None:
         """
@@ -299,7 +304,6 @@ class TaskRunner:
                 LOGGER.exception(
                     "Task %s for agent %s has failed and the exception was not properly handled", work_item.task, self.endpoint
                 )
-
             self._scheduler._work.agent_queues.task_done(self.endpoint, work_item.task)
 
         self.status = AgentStatus.STOPPED
@@ -366,6 +370,8 @@ class ResourceScheduler(TaskManager):
         self.state_update_manager = ToDbUpdateManager(client, environment)
 
         self._timer_manager = timers.TimerManager(self)
+
+        self._deployment_suspended: bool = False
 
     async def _reset(self) -> None:
         """
@@ -1081,6 +1087,8 @@ class ResourceScheduler(TaskManager):
         :param endpoint: The name of the agent
         """
         await data.Agent.insert_if_not_exist(environment=self.environment, endpoint=endpoint)
+        if self._deployment_suspended:
+            return False
         current_agent = await data.Agent.get(env=self.environment, endpoint=endpoint)
         return not current_agent.paused
 
@@ -1628,3 +1636,21 @@ class ResourceScheduler(TaskManager):
                 resource_states=resource_states_in_db,
                 discrepancies=discrepancy_map,
             )
+
+    async def suspend_deployments(self, reason: str) -> None:
+        """
+        Suspend all agent operations. All other scheduler functionality remains active.
+        """
+        LOGGER.info("Suspending all deployment operations: %s", reason)
+        self._deployment_suspended = True
+        await asyncio.gather(*[worker.stop() for worker in self._workers.values()])
+        self._work.add_poison_pill_to_agent_queues(reason=reason)
+        await asyncio.gather(*[worker.join() for worker in self._workers.values()])
+
+    async def resume_deployments(self) -> None:
+        """
+        Resume all agent operations.
+        """
+        LOGGER.info("Resuming all deployment operations.")
+        self._deployment_suspended = False
+        await self.refresh_all_agent_states_from_db()

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -485,7 +485,6 @@ def remove_executor_venvs() -> None:
     """
 
 
-@auth(auth_label=const.CoreAuthorizationLabel.AGENT_PAUSE_RESUME, read_only=False, environment_param="tid")
 @typedmethod(
     path="/agent/<name>/<action>", operation="POST", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
 )

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -24,7 +24,8 @@ from collections.abc import Mapping, Sequence
 from typing import Literal, Optional, Union
 
 import inmanta.types
-from inmanta.const import AgentAction, ApiDocsFormat, Change, ClientType, ParameterSource, ResourceState
+from inmanta import const
+from inmanta.const import AgentAction, AllAgentAction, ApiDocsFormat, Change, ClientType, ParameterSource, ResourceState
 from inmanta.data import model
 from inmanta.data.model import DataBaseReport, LinkedDiscoveredResource, PipConfig
 from inmanta.protocol import methods
@@ -469,6 +470,23 @@ def notify_timer_update(tid: uuid.UUID) -> None:
 
 
 @typedmethod(
+    path="/executors/remove_venvs",
+    operation="DELETE",
+    server_agent=True,
+    timeout=5,
+    arg_options=methods.AGENT_ENV_OPTS,
+    client_types=[],
+    reply=False,
+    enforce_auth=False,
+)
+def remove_executor_venvs() -> None:
+    """
+    Remove all the Python virtual environments.
+    """
+
+
+@auth(auth_label=const.CoreAuthorizationLabel.AGENT_PAUSE_RESUME, read_only=False, environment_param="tid")
+@typedmethod(
     path="/agent/<name>/<action>", operation="POST", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
 )
 def agent_action(tid: uuid.UUID, name: str, action: AgentAction) -> None:
@@ -483,7 +501,7 @@ def agent_action(tid: uuid.UUID, name: str, action: AgentAction) -> None:
                     * pause: A paused agent cannot execute any deploy operations.
                     * unpause: A unpaused agent will be able to execute deploy operations.
                     * keep_paused_on_resume: The agent will still be paused when the environment is resumed
-                    * unpause_on_resume: The agent will be unpaused when the environment is resumed
+                    * unpause_on_resume: The agent will be unpaused when the environment is resumed.
 
     :raises Forbidden: The given environment has been halted and the action is pause/unpause,
                         or the environment is not halted and the action is related to the on_resume behavior
@@ -493,7 +511,7 @@ def agent_action(tid: uuid.UUID, name: str, action: AgentAction) -> None:
 @typedmethod(
     path="/agents/<action>", operation="POST", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
 )
-def all_agents_action(tid: uuid.UUID, action: AgentAction) -> None:
+def all_agents_action(tid: uuid.UUID, action: AllAgentAction) -> None:
     """
     Execute an action on all agents in the given environment.
 
@@ -505,6 +523,13 @@ def all_agents_action(tid: uuid.UUID, action: AgentAction) -> None:
                     * unpause: A unpaused agent will be able to execute deploy operations.
                     * keep_paused_on_resume: The agents will still be paused when the environment is resumed
                     * unpause_on_resume: The agents will be unpaused when the environment is resumed
+                    * remove_all_agent_venvs: Remove all agent venvs in the given environment. During this
+                                              process the agent operations in that environment are temporarily
+                                              suspended. The removal of the agent venvs will happen asynchronously
+                                              with respect to this API call. It might take a long time until the
+                                              venvs are actually removed, because all executing agent operations
+                                              will be allowed to finish first. As such, a long deploy operation
+                                              might delay the removal of the venvs considerably.
 
     :raises Forbidden: The given environment has been halted and the action is pause/unpause,
                         or the environment is not halted and the action is related to the on_resume behavior

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -24,7 +24,6 @@ from collections.abc import Mapping, Sequence
 from typing import Literal, Optional, Union
 
 import inmanta.types
-from inmanta import const
 from inmanta.const import AgentAction, AllAgentAction, ApiDocsFormat, Change, ClientType, ParameterSource, ResourceState
 from inmanta.data import model
 from inmanta.data.model import DataBaseReport, LinkedDiscoveredResource, PipConfig

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from functools import reduce
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union, assert_never, cast
 from uuid import UUID
 
 import asyncpg.connection
@@ -43,12 +43,12 @@ from inmanta import logging as inmanta_logging
 from inmanta import tracing
 from inmanta.agent import config as agent_cfg
 from inmanta.config import Config, config_map_to_str, scheduler_log_config
-from inmanta.const import AGENT_SCHEDULER_ID, UNDEPLOYABLE_NAMES, AgentAction, AgentStatus
+from inmanta.const import AGENT_SCHEDULER_ID, UNDEPLOYABLE_NAMES, AgentAction, AgentStatus, AllAgentAction
 from inmanta.data import APILIMIT, Environment, InvalidSort, model
 from inmanta.data.model import DataBaseReport
 from inmanta.protocol import encode_token, handle, methods, methods_v2
 from inmanta.protocol.common import ReturnValue
-from inmanta.protocol.exceptions import BadRequest, Forbidden, NotFound, ShutdownInProgress
+from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound, ShutdownInProgress
 from inmanta.server import (
     SLICE_AGENT_MANAGER,
     SLICE_AUTOSTARTED_AGENT_MANAGER,
@@ -291,21 +291,34 @@ class AgentManager(ServerSlice, SessionListener):
         await self._unpause_agent(env, endpoint=const.AGENT_SCHEDULER_ID, connection=connection)
 
     @handle(methods_v2.all_agents_action, env="tid")
-    async def all_agents_action(self, env: data.Environment, action: AgentAction) -> None:
-        if env.halted and action in {AgentAction.pause, AgentAction.unpause}:
+    async def all_agents_action(self, env: data.Environment, action: AllAgentAction) -> None:
+        if env.halted and action in {AllAgentAction.pause, AllAgentAction.unpause}:
             raise Forbidden("Can not pause or unpause agents when the environment has been halted.")
-        if not env.halted and action in {AgentAction.keep_paused_on_resume, AgentAction.unpause_on_resume}:
+        if not env.halted and action in {AllAgentAction.keep_paused_on_resume, AllAgentAction.unpause_on_resume}:
             raise Forbidden("Cannot set on_resume state of agents when the environment is not halted.")
-        if action is AgentAction.pause:
-            await self._pause_agent(env=env)
-        elif action is AgentAction.unpause:
-            await self._unpause_agent(env=env)
-        elif action is AgentAction.keep_paused_on_resume:
-            await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=False)
-        elif action is AgentAction.unpause_on_resume:
-            await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=True)
+        match action:
+            case AllAgentAction.pause:
+                await self._pause_agent(env=env)
+            case AllAgentAction.unpause:
+                await self._unpause_agent(env=env)
+            case AllAgentAction.keep_paused_on_resume:
+                await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=False)
+            case AllAgentAction.unpause_on_resume:
+                await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=True)
+            case AllAgentAction.remove_all_agent_venvs:
+                await self._remove_executor_venvs(env)
+            case _ as _never:
+                assert_never(_never)
+
+    async def _remove_executor_venvs(self, env: data.Environment) -> None:
+        """
+        Remove the venvs of the executors used by the given environment.
+        """
+        agent_client = self.get_agent_client(tid=env.id, endpoint=AGENT_SCHEDULER_ID, live_agent_only=False)
+        if agent_client:
+            self.add_background_task(agent_client.remove_executor_venvs())
         else:
-            raise BadRequest(f"Unknown agent action: {action.name}")
+            raise Conflict(f"No scheduler process is running for environment {env.id}")
 
     @handle(methods_v2.agent_action, env="tid")
     async def agent_action(self, env: data.Environment, name: str, action: AgentAction) -> None:
@@ -316,16 +329,17 @@ class AgentManager(ServerSlice, SessionListener):
             raise Forbidden("Can not pause or unpause agents when the environment has been halted.")
         if not env.halted and action in {AgentAction.keep_paused_on_resume, AgentAction.unpause_on_resume}:
             raise Forbidden("Cannot set on_resume state of agents when the environment is not halted.")
-        if action is AgentAction.pause:
-            await self._pause_agent(env, name)
-        elif action is AgentAction.unpause:
-            await self._unpause_agent(env, name)
-        elif action is AgentAction.keep_paused_on_resume:
-            await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=False, endpoint=name)
-        elif action is AgentAction.unpause_on_resume:
-            await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=True, endpoint=name)
-        else:
-            raise BadRequest(f"Unknown agent action: {action.name}")
+        match action:
+            case AgentAction.pause:
+                await self._pause_agent(env, name)
+            case AgentAction.unpause:
+                await self._unpause_agent(env, name)
+            case AgentAction.keep_paused_on_resume:
+                await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=False, endpoint=name)
+            case AgentAction.unpause_on_resume:
+                await self._set_unpause_on_resume(env, should_be_unpaused_on_resume=True, endpoint=name)
+            case _ as _never:
+                assert_never(_never)
 
     async def _update_paused_status_agent(
         self,

--- a/tests/deploy/scheduler_mocks.py
+++ b/tests/deploy/scheduler_mocks.py
@@ -182,6 +182,13 @@ class DummyManager(executor.ExecutorManager[executor.Executor]):
             self.executors[agent_name] = DummyExecutor()
         return self.executors[agent_name]
 
+    def get_environment_manager(self) -> None:
+        return None
+
+    async def stop_all_executors(self) -> list[DummyExecutor]:
+        for ex in self.executors.values():
+            await ex.stop()
+
     async def stop_for_agent(self, agent_name: str) -> list[DummyExecutor]:
         pass
 

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -18,6 +18,7 @@ Contact: code@inmanta.com
 This file is intended to contain test that use the agent/scheduler combination in isolation: no server, no executor
 """
 
+import asyncio
 import datetime
 import hashlib
 import itertools
@@ -33,7 +34,7 @@ import pytest
 
 import utils
 from deploy.scheduler_mocks import FAIL_DEPLOY, DummyExecutor, ManagedExecutor, TestAgent, TestScheduler
-from inmanta import const, util
+from inmanta import const, data, util
 from inmanta.agent import executor
 from inmanta.agent.agent_new import Agent
 from inmanta.agent.executor import ResourceDetails, ResourceInstallSpec
@@ -2452,6 +2453,71 @@ async def test_state_of_skipped_resources_for_dependencies(agent: TestAgent, mak
     )
 
 
+async def test_remove_agent_venvs(environment, agent: TestAgent, make_resource_minimal, monkeypatch):
+    """
+    Verify that a request to remove the agent venvs waits until all executing agent tasks are finished.
+    """
+    # Track whether the remove_executor_venvs method of the agent was called
+    # and block the call until the continue_remove_executor_venv_method future resolves.
+    _remove_executor_venvs_method_was_called = False
+    continue_remove_executor_venv_method = asyncio.get_running_loop().create_future()
+
+    async def _remove_executor_venvs_dummy() -> None:
+        nonlocal _remove_executor_venvs_method_was_called
+        _remove_executor_venvs_method_was_called = True
+        await continue_remove_executor_venv_method
+
+    monkeypatch.setattr(agent, "_remove_executor_venvs", _remove_executor_venvs_dummy)
+
+    # Mock the fact that we have no database and data.Notification().insert() would fail.
+    async def insert_dummy(connection):
+        pass
+
+    monkeypatch.setattr(data.Notification, "insert", insert_dummy)
+
+    # Push resources to the scheduler
+    rid1 = ResourceIdStr("test::Resource[agent1,name=1]")
+    rid2 = ResourceIdStr("test::Resource[agent1,name=2]")
+
+    executor1: ManagedExecutor = agent.executor_manager.register_managed_executor("agent1")
+
+    resources = {
+        rid1: make_resource_minimal(rid=rid1, values={"value": "r1_value"}, requires=[]),
+        rid2: make_resource_minimal(rid=rid2, values={"value": "r2_value"}, requires=[rid1]),
+    }
+    await agent.scheduler._new_version(
+        [ModelVersion(version=1, resources=resources, requires=make_requires(resources), undefined=set())]
+    )
+
+    # Wait until rid1 is deploying
+    await retry_limited_fast(lambda: rid1 in executor1.deploys, timeout=10)
+
+    # Request removal of all agent venvs.
+    # Assign task to a variable to prevent it from being garbage collected.
+    remove_executor_venvs_task = asyncio.create_task(agent.remove_executor_venvs())  # noqa: F841
+    await retry_limited_fast(lambda: agent.scheduler._deployment_suspended, timeout=10)
+
+    # Verify that we are waiting for the ongoing deployment to finish, before removing the venvs.
+    assert not _remove_executor_venvs_method_was_called
+
+    # Finish the deployment of rid1
+    executor1.deploys[rid1].set_result(const.HandlerResourceState.deployed)
+
+    ## Now the venv removal should start
+    await retry_limited_fast(lambda: _remove_executor_venvs_method_was_called, timeout=10)
+
+    ## As long as the removal is in progress, no new deployments should be started
+    assert not executor1.deploys
+
+    # Finish the venv_removal
+    continue_remove_executor_venv_method.set_result(None)
+
+    # Now the deployment of rid2 should start
+    await retry_limited_fast(lambda: rid2 in executor1.deploys, timeout=10)
+    # Finish the deployment of rid2
+    executor1.deploys[rid2].set_result(const.HandlerResourceState.deployed)
+
+
 class BrokenDummyManager(executor.ExecutorManager[executor.Executor]):
     """
     A broken dummy ExecutorManager that fails on get_executor to test failure paths
@@ -2463,6 +2529,12 @@ class BrokenDummyManager(executor.ExecutorManager[executor.Executor]):
         raise Exception()
 
     async def stop_for_agent(self, agent_name: str) -> list[DummyExecutor]:
+        pass
+
+    def get_environment_manager(self) -> None:
+        return None
+
+    async def stop_all_executors(self) -> list[DummyExecutor]:
         pass
 
     async def start(self) -> None:


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/9465 but on the iso8 branch due to a merge conflict.**

Added support to remove all the Python environments used by the agents in a certain environment.

closes #9260 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~