### PR TITLE
Fix clone

### DIFF
--- a/changelogs/unreleased/resource_clone.yml
+++ b/changelogs/unreleased/resource_clone.yml
@@ -1,0 +1,5 @@
+description: Fix bug in Resource.clone, where reference cache was not retained
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -678,6 +678,12 @@ class Resource(metaclass=ResourceMeta):
         for k, v in kwargs.items():
             setattr(res, k, v)
 
+        # Resources are copied in the hanlder, the cache has to be retained!
+        res._resolved = self._resolved
+        # In every case, share caches with child
+        res._references = self._references
+        res._references_model = self._references_model
+
         return res
 
     def serialize(self) -> JsonType:

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -74,7 +74,21 @@ def round_trip_resource(resource):
     serialized = resource.serialize()
     data = json.dumps(serialized, default=util.api_boundary_json_encoder)
     r = resources.Resource.deserialize(json.loads(data))
+
+    # Test cloning includes caches
+    clone = r.clone()
+    assert clone._references_model == r._references_model
+    assert clone._references == r._references
+    assert clone._resolved == r._resolved
     r.resolve_all_references(PythonLogger(logging.getLogger("test.refs")))
+    # old clone shares cache, but not resolved state, as it has not been mutated
+    assert clone._references_model == r._references_model
+    assert clone._references == r._references
+    assert clone._resolved != r._resolved
+    clone = r.clone()
+    assert clone._references_model == r._references_model
+    assert clone._references == r._references
+    assert clone._resolved == r._resolved
     return r
 
 
@@ -373,8 +387,20 @@ def test_decoding_legacy_resources(snippetcompiler, modules_v2_dir):
         """
 
     r = resources.Resource.deserialize(json.loads(old_resource))
+    # Test cloning includes caches
+    clone = r.clone()
+    assert clone._references_model == r._references_model
+    assert clone._references == r._references
+    assert clone._resolved == r._resolved
     r.resolve_all_references(PythonLogger(logging.getLogger("test.refs")))
-    return r
+    # old clone shares cache, but not resolved state, as it has not been mutated
+    assert clone._references_model == r._references_model
+    assert clone._references == r._references
+    assert clone._resolved != r._resolved
+    clone = r.clone()
+    assert clone._references_model == r._references_model
+    assert clone._references == r._references
+    assert clone._resolved == r._resolved
 
 
 def test_references_in_plugins(snippetcompiler: "SnippetCompilationTest", modules_v2_dir: str) -> None:


### PR DESCRIPTION
# Description

Fixes bug where resource reference cache is not cloned 



# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
