### PR TITLE
Make query compatible with postgres13

### DIFF
--- a/changelogs/unreleased/make-compatible-with-postgres13.yml
+++ b/changelogs/unreleased/make-compatible-with-postgres13.yml
@@ -1,0 +1,4 @@
+---
+description: "Make query compatible with postgres13"
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5680,7 +5680,7 @@ class Resource(BaseDocument):
         #       - resource_set_id: resource set id in the new version iff it differs from the previous version
         #           -> NULL iff resource set with this name was deleted in this version
         #       - <projection_fields> -> NULL iff LEFT join didn't match any resources => empty resource set
-        query = f"""\
+        query: typing.LiteralString = f"""\
         WITH
         -- `since` model iff it exists and has been released
         reference_model AS (

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5680,7 +5680,7 @@ class Resource(BaseDocument):
         #       - resource_set_id: resource set id in the new version iff it differs from the previous version
         #           -> NULL iff resource set with this name was deleted in this version
         #       - <projection_fields> -> NULL iff LEFT join didn't match any resources => empty resource set
-        query: typing.LiteralString = f"""\
+        query = f"""\
         WITH
         -- `since` model iff it exists and has been released
         reference_model AS (
@@ -5720,9 +5720,9 @@ class Resource(BaseDocument):
                 FROM models AS cm
                 WINDOW pairs AS (ORDER BY cm.version ROWS 1 PRECEDING)
                 ORDER BY cm.version
-            )
+            ) AS unfiltered_model_pairs
             -- drop first row where there is no PRECEDING for the window function
-            WHERE old != new
+            WHERE unfiltered_model_pairs.old != unfiltered_model_pairs.new
         )
         SELECT
             reference_model.exists,


### PR DESCRIPTION
# Description

Related to this error: https://jenkins.inmanta.com/job/integration-tests/job/pytest/branch=master,os=rocky9/2954/testReport/junit/rocky9_master.tests.deploy.e2e/test_deploy_trigger/test_spontaneous_repair_2_/

Not sure if it is solved, I haven't tested it. So not sure that this is the only place where it happens

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
