### PR TITLE
Fix deletion of resource sets

### DIFF
--- a/changelogs/unreleased/fix-deleteion-of-resource-sets.yml
+++ b/changelogs/unreleased/fix-deleteion-of-resource-sets.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix deletion of resource sets"
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5284,8 +5284,9 @@ class ResourceSet(BaseDocument):
                 FROM resource_set_configuration_model AS rscm
                 WHERE rscm.environment=rs.environment
                 AND rscm.resource_set_id=rs.id
-            )
+            ) AND rs.environment=$1
             """,
+            environment,
             connection=connection,
         )
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5284,7 +5284,7 @@ class ResourceSet(BaseDocument):
                 FROM resource_set_configuration_model AS rscm
                 WHERE environment=$1
                 AND rscm.resource_set_id=rs.id
-            )
+            ) AND environment=$1
             """,
             environment,
             connection=connection,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5284,9 +5284,8 @@ class ResourceSet(BaseDocument):
                 FROM resource_set_configuration_model AS rscm
                 WHERE rscm.environment=rs.environment
                 AND rscm.resource_set_id=rs.id
-            ) AND rs.environment=$1
+            )
             """,
-            environment,
             connection=connection,
         )
 

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5282,11 +5282,10 @@ class ResourceSet(BaseDocument):
             WHERE NOT EXISTS (
                 SELECT 1
                 FROM resource_set_configuration_model AS rscm
-                WHERE environment=$1
+                WHERE rscm.environment=rs.environment
                 AND rscm.resource_set_id=rs.id
-            ) AND environment=$1
+            )
             """,
-            environment,
             connection=connection,
         )
 

--- a/src/inmanta/db/versions/v202509100.py
+++ b/src/inmanta/db/versions/v202509100.py
@@ -24,6 +24,15 @@ async def update(connection: Connection) -> None:
     Add 'created' column to ResourcePersistentState
     """
     schema = """
+    -- Remove dangling resource_sets (resources are deleted with cascade)
+    DELETE FROM resource_set AS rs
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM resource_set_configuration_model AS rscm
+        WHERE rscm.environment=rs.environment
+        AND rscm.resource_set_id=rs.id
+    );
+
     ALTER TABLE public.resource_persistent_state
         ADD COLUMN created TIMESTAMP WITH TIME ZONE;
 


### PR DESCRIPTION
# Description

Fixes the deletion of resource sets.
Updates the migration query to delete dangling resource sets

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
