### PR TITLE
Show python and postgresql version

### DIFF
--- a/changelogs/unreleased/8150-show-python-and-postgres-version.yml
+++ b/changelogs/unreleased/8150-show-python-and-postgres-version.yml
@@ -1,0 +1,6 @@
+---
+description: Show Python and PostgreSQL version in serverstatus endpoint
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/8150-show-python-and-postgres-version.yml
+++ b/changelogs/unreleased/8150-show-python-and-postgres-version.yml
@@ -1,6 +1,6 @@
 ---
 description: Show Python and PostgreSQL version in serverstatus endpoint
-change-type: patch
+change-type: minor
 destination-branches: [master, iso8]
 sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -103,6 +103,8 @@ class StatusResponse(BaseModel):
     slices: list[SliceStatus]
     features: list[FeatureStatus]
     status: ReportedStatus
+    python_version: str
+    postgresql_version: str | None
 
 
 @stable_api

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -103,7 +103,10 @@ class StatusResponse(BaseModel):
     slices: list[SliceStatus]
     features: list[FeatureStatus]
     status: ReportedStatus
+    # The python version used by the server
     python_version: str
+    # The postgresql version used by the database slice
+    # None if it is not initialized or an error occurred with the database slice
     postgresql_version: str | None
 
 

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -93,6 +93,18 @@ class FeatureStatus(BaseModel):
 class StatusResponse(BaseModel):
     """
     Response for the status method call
+
+    :param product: The name of the product.
+    :param edition: The edition of the product.
+    :param version: The version of the product.
+    :param license: The license used by the product.
+    :param extensions: The status of the extensions of the server
+    :param slices: The status of the slices of the server.
+    :param features: The status of the features offered by the slices of the server.
+    :param status: The overall status of the server
+    :param python_version: The python version used by the server.
+    :param postgresql_version: The postgresql version used by the database slice
+        None if it is not initialized or an error occurred with the database slice.
     """
 
     product: str
@@ -103,10 +115,7 @@ class StatusResponse(BaseModel):
     slices: list[SliceStatus]
     features: list[FeatureStatus]
     status: ReportedStatus
-    # The python version used by the server
     python_version: str
-    # The postgresql version used by the database slice
-    # None if it is not initialized or an error occurred with the database slice
     postgresql_version: str | None
 
 

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -157,7 +157,7 @@ class Server(protocol.ServerSlice):
                 for feature in self.feature_manager.get_features()
             ],
             status=max(ReportedStatus(slice.reported_status) for slice in slices),
-            python_version=sys.version,
+            python_version=".".join(map(str, sys.version_info[:3])),
             postgresql_version=postgresql_version,
         )
 

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import pathlib
+import sys
 import uuid
 from typing import TYPE_CHECKING, Optional, Union, cast
 
@@ -34,6 +35,7 @@ from inmanta.protocol.common import HTML_CONTENT_WITH_UTF8_CHARSET, ReturnValue,
 from inmanta.protocol.openapi.converter import OpenApiConverter
 from inmanta.protocol.openapi.model import OpenAPI
 from inmanta.server import SLICE_COMPILER, SLICE_DATABASE, SLICE_SERVER, SLICE_TRANSPORT, protocol
+from inmanta.server.services.databaseservice import DatabaseService
 from inmanta.types import Apireturn, JsonType, Warnings
 from inmanta.util import ensure_directory_exist
 
@@ -141,6 +143,8 @@ class Server(protocol.ServerSlice):
 
         slices = await asyncio.gather(*(slice.get_slice_status() for slice in self._server.get_slices().values()))
 
+        db_slice: "DatabaseService" = cast("DatabaseService", self._server.get_slice(SLICE_DATABASE))
+        postgresql_version = await db_slice.get_postgresql_version()
         response = StatusResponse(
             product=product_metadata.product,
             edition=product_metadata.edition,
@@ -153,6 +157,8 @@ class Server(protocol.ServerSlice):
                 for feature in self.feature_manager.get_features()
             ],
             status=max(ReportedStatus(slice.reported_status) for slice in slices),
+            python_version=sys.version,
+            postgresql_version=postgresql_version,
         )
 
         return response

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -249,14 +249,15 @@ class DatabaseService(protocol.ServerSlice):
         return (await self._db_monitor.get_status()).model_dump(mode="json")
 
     async def get_postgresql_version(self) -> str | None:
-        """Get the Postgres version of the database connection"""
-        assert self._db_monitor
+        """Get the Postgres version of the database connection.
+        Return None if the database is not connected"""
+        if self._db_monitor is None or self._pool is None:
+            return None
         status = await self._db_monitor.get_status()
         if not status.connected:
             return None
-        assert self._pool is not None
         async with self._pool.acquire() as connection:
-            return await connection.fetchval("SELECT version();")
+            return await connection.fetchval("SHOW server_version;")
 
 
 async def initialize_database_connection_pool(

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -248,6 +248,16 @@ class DatabaseService(protocol.ServerSlice):
         assert self._db_monitor is not None  # make mypy happy
         return (await self._db_monitor.get_status()).model_dump(mode="json")
 
+    async def get_postgresql_version(self) -> str | None:
+        """Get the Postgres version of the database connection"""
+        assert self._db_monitor
+        status = await self._db_monitor.get_status()
+        if not status.connected:
+            return None
+        assert self._pool is not None
+        async with self._pool.acquire() as connection:
+            return await connection.fetchval("SELECT version();")
+
 
 async def initialize_database_connection_pool(
     database_host: str,

--- a/tests/server/test_server_status.py
+++ b/tests/server/test_server_status.py
@@ -54,10 +54,13 @@ async def test_server_status(server, client, agent, environment, postgresql_clie
     assert "features" in status
     assert len(status["features"]) > 0
 
-    assert status["python_version"] == sys.version
-    postgresql_version = await postgresql_client.fetchval("SELECT version();")
-    # Assert that the output is `PostgreSQL X.Y[.Z] ...`
-    assert re.match(r"^(PostgreSQL \d+(?:\.\d+)+)", postgresql_version)
+    assert status["python_version"] == ".".join(map(str, sys.version_info[:3]))
+    regex_major_minor_patch = r"(\d+\.\d+(?:\.\d+)?)"
+    # Assert that the output is `X.Y[.Z]`
+    assert re.match(regex_major_minor_patch, status["python_version"])
+    postgresql_version = await postgresql_client.fetchval("SHOW server_version;")
+    # Assert that the output is `X.Y[.Z]`
+    assert re.match(regex_major_minor_patch, postgresql_version)
     assert status["postgresql_version"] == postgresql_version
 
 


### PR DESCRIPTION
# Description

Show python and postgresql version in /serverstatus

I made postgresql version optional in case the database is not connected

closes #8150


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
