### PR TITLE
fixed unknown evaluation in implement conditions

### DIFF
--- a/changelogs/unreleased/8672-compiler-bugfix-unknown-implement-condition.yml
+++ b/changelogs/unreleased/8672-compiler-bugfix-unknown-implement-condition.yml
@@ -1,0 +1,6 @@
+description: 'Compiler: fixed bug where implement conditions evaluated Unknown values as true, deviating from how they are evaluated in if statement conditions'
+change-type: patch
+sections:
+  bugfix: "{{description}}"
+destination-branches:
+  - master

--- a/src/inmanta/ast/statements/generator.py
+++ b/src/inmanta/ast/statements/generator.py
@@ -142,7 +142,7 @@ class SubConstructor(RequiresEmitStatement):
                 % condition
             )
             raise e
-        if not condition:
+        if isinstance(condition, Unknown) or not condition:
             return None
 
         implementations = self.implements.implementations

--- a/tests/compiler/test_implement.py
+++ b/tests/compiler/test_implement.py
@@ -88,3 +88,25 @@ x = Child()
         """,
         "Conditional implementation with parents not allowed (reported in Implement(Child) ({dir}/main.cf:10:11))",
     )
+
+
+def test_implement_unknown_condition(snippetcompiler):
+    snippetcompiler.setup_for_snippet(
+        """\
+        import std
+        import tests
+
+        entity A: end
+        implement A using std::none
+        implement A using contradiction when tests::unknown()
+
+        implementation contradiction for std::Entity:
+            x = 0
+            x = 1
+        end
+
+        A()
+        """
+    )
+
+    compiler.do_compile()


### PR DESCRIPTION
# Description

Fixed bug where implement conditions evaluated Unknown values as true, deviating from how they are evaluated in if statement conditions

closes #8672 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
