### PR TITLE
fixed broken cycle detection in stable dfs

### DIFF
--- a/changelogs/unreleased/bugfix-stable-dfs.yml
+++ b/changelogs/unreleased/bugfix-stable-dfs.yml
@@ -1,0 +1,7 @@
+description: "Bugfix in util.stable_depth_first"
+change-type: patch
+sections:
+  bugfix: "Fixed broken cycle detection in inmanta.util.stable_depth_first function."
+destination-branches:
+  - master
+  - iso8

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -718,7 +718,7 @@ def stable_depth_first(nodes: list[str], edges: dict[str, list[str]]) -> list[st
         try:
             if node in edges:
                 for edge in edges[node]:
-                    dfs(edge, seen | set(node))
+                    dfs(edge, seen | {node})
             out.append(node)
         except CycleException as e:
             e.add(node)

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -415,48 +415,48 @@ def test_stable_dfs():
     graph = expand_graph(
         """
     e: f
-    a: b c
+    ab: b c
     b: c d
     h: i
     0:
     """
     )
     seq = stable_depth_first(*graph)
-    assert seq == ["0", "c", "d", "b", "a", "f", "e", "i", "h"]
+    assert seq == ["0", "c", "d", "b", "ab", "f", "e", "i", "h"]
 
     graph = expand_graph(
         """
         e: f
         b: c d
-        a: c b
+        ab: c b
         h: i
         0:
         """
     )
     seq = stable_depth_first(*graph)
-    assert seq == ["0", "c", "d", "b", "a", "f", "e", "i", "h"]
+    assert seq == ["0", "c", "d", "b", "ab", "f", "e", "i", "h"]
 
     with pytest.raises(CycleException) as e:
-        stable_depth_first(*expand_graph("a: a"))
+        stable_depth_first(*expand_graph("ab: ab"))
 
-    assert e.value.nodes == ["a"]
+    assert e.value.nodes == ["ab"]
 
     with pytest.raises(CycleException) as e:
         stable_depth_first(
             *expand_graph(
-                """a: b
-        b: a"""
+                """ab: b
+        b: ab"""
             )
         )
 
-    assert e.value.nodes == ["b", "a"]
+    assert e.value.nodes == ["b", "ab"]
 
     # missing nodes
-    graph, edges = expand_graph("""a: b""")
+    graph, edges = expand_graph("""ab: b""")
     graph.remove("b")
 
     seq = stable_depth_first(graph, edges)
-    assert seq == ["b", "a"]
+    assert seq == ["b", "ab"]
 
 
 def test_is_sub_dict():


### PR DESCRIPTION
# Description

Turns out our cycle detection was almost completely broken (as far as I can tell). We would keep track of "seen" nodes as a set of characters rather than a set of words (`{"n", "o", "d", "e", "1", "2"}` instead of `{"node1", "node2"}`. This could cause false positives in case of single-character node names (the change I made to the test) as well as false negatives for all other cases.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
