### PR TITLE
bugfix: dataclass null conversion

### DIFF
--- a/changelogs/unreleased/bugfix-dataclasses-null-conversion.yml
+++ b/changelogs/unreleased/bugfix-dataclasses-null-conversion.yml
@@ -1,0 +1,7 @@
+description: Convert NoneValue to None in dataclass fields on plugin boundary.
+change-type: patch
+sections:
+  bugfix: "Compiler: in dataclass fields, properly convert internal ``null`` value to Python ``None`` value."
+destination-branches:
+  - master
+  - iso8

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -428,7 +428,7 @@ class Compiler:
         Exports compiler data if the option has been set.
         """
         with open(compiler_config.export_compile_data_file.get(), "w") as file:
-            file.write("%s\n" % self._data.export().json())
+            file.write("%s\n" % self._data.export().model_dump_json())
 
     def handle_exception(self, exception: CompilerException) -> None:
         try:

--- a/tests/compiler/test_dataclasses.py
+++ b/tests/compiler/test_dataclasses.py
@@ -288,3 +288,25 @@ def test_docs(snippetcompiler):
 
     run_for_example("1")
     run_for_example("2")
+
+
+def test_dataclass_plugin_boundary_null(snippetcompiler):
+    """
+    Verify null conversion for dataclass fields on the plugin boundary.
+    """
+    snippetcompiler.setup_for_snippet(
+        """\
+import dataclasses
+
+x = dataclasses::NullableDC(n=1)
+y = dataclasses::NullableDC(n=null)
+z = dataclasses::CollectionDC(l=[1, null, 3], d={"one": 1, "null": null})
+
+dataclasses::takes_nullable_dc(x)
+dataclasses::takes_nullable_dc(y)
+dataclasses::takes_collection_dc(z)
+        """,
+        ministd=True,
+    )
+
+    compiler.do_compile()

--- a/tests/data/modules/dataclasses/model/_init.cf
+++ b/tests/data/modules/dataclasses/model/_init.cf
@@ -17,3 +17,14 @@ entity SimpleDC extends DataclassABC:
     int n
 end
 implement SimpleDC using std::none
+
+entity NullableDC extends DataclassABC:
+    int? n
+end
+implement NullableDC using std::none
+
+entity CollectionDC extends DataclassABC:
+    list l
+    dict d
+end
+implement CollectionDC using std::none

--- a/tests/data/modules/dataclasses/plugins/__init__.py
+++ b/tests/data/modules/dataclasses/plugins/__init__.py
@@ -17,10 +17,12 @@ Contact: code@inmanta.com
 """
 
 import dataclasses
-from collections.abc import Sequence
+import itertools
+from collections.abc import Mapping, Sequence
 from typing import Annotated
 
 from inmanta.execute.proxy import DynamicProxy
+from inmanta.execute.util import NoneValue
 from inmanta.plugins import plugin, ModelType
 
 
@@ -31,6 +33,17 @@ class DataclassABC: ...
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class SimpleDC(DataclassABC):
     n: int
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class NullableDC(DataclassABC):
+    n: int | None
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CollectionDC(DataclassABC):
+    l: Sequence[object]
+    d: Mapping[str, object]
 
 
 @plugin
@@ -123,3 +136,13 @@ def dc_union(value: int | Virtualmachine) -> None:
     A plugin that takes a union with a dataclass. Could just as well (more realistic) be a union between two dataclasses.
     """
     ...
+
+
+@plugin
+def takes_nullable_dc(v: NullableDC) -> None:
+    assert v.n is None or isinstance(v.n, int), v.n
+
+
+@plugin
+def takes_collection_dc(v: CollectionDC) -> None:
+    assert not any(isinstance(x, NoneValue) for x in itertools.chain(v.l, v.d.values()))


### PR DESCRIPTION
# Description

When converting a DSL dataclass isntance to a Python one, make sure to convert `NoneValue()` (internal representation of `null` DSL value) to `None`.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
