### PR TITLE
create sphinx dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,18 @@ updates:
       patterns:
         - "logfire"
         - "opentelemetry*"
+    sphinx:
+      patterns:
+        - "sphinx"
+        - "furo"
   cooldown:
     include:
-      # these two packages are tied together very strongly, but there is an occasional small delay between there releases,
+      # these two packages are tied together very strongly, but there is an occasional small delay between their releases,
       # causing CI failures
       - "logfire"
       - "opentelemetry*"
+      # wait for furo to bump their upper bound on sphinx
+      - "sphinx"
     default-days: 1
   ignore:
     # #6668
@@ -45,12 +51,18 @@ updates:
       patterns:
         - "logfire"
         - "opentelemetry*"
+    sphinx:
+      patterns:
+        - "sphinx"
+        - "furo"
   cooldown:
     include:
-      # these two packages are tied together very strongly, but there is an occasional small delay between there releases,
+      # these two packages are tied together very strongly, but there is an occasional small delay between their releases,
       # causing CI failures
       - "logfire"
       - "opentelemetry*"
+      # wait for furo to bump their upper bound on sphinx
+      - "sphinx"
     default-days: 1
   ignore:
     # #6668

--- a/changelogs/unreleased/sphinx-dependabot-group.yml
+++ b/changelogs/unreleased/sphinx-dependabot-group.yml
@@ -1,0 +1,4 @@
+description: created sphinx dependabot group
+change-type: patch
+destination-branches:
+  - master


### PR DESCRIPTION
# Description

Sphinx 9 was released yeterday. Furo has an upper bound on it. There is a PR for it at pradyunsg/furo#914. I think it would be wise to group sphinx and furo version bumps together, and to delay sphinx PRs for a day.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
