### PR TITLE
relax constraints for stable-depth-first interface

### DIFF
--- a/changelogs/unreleased/stable-depth-first-relax-interface.yml
+++ b/changelogs/unreleased/stable-depth-first-relax-interface.yml
@@ -1,0 +1,5 @@
+description: Relax interface for stable-depth-first util method
+change-type: patch
+destination-branches:
+  - master
+  - iso8

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -39,12 +39,12 @@ import warnings
 from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop, CancelledError, Lock, Task, ensure_future, gather
 from collections import abc, defaultdict
-from collections.abc import Awaitable, Coroutine, Iterable, Iterator
+from collections.abc import Awaitable, Callable, Collection, Coroutine, Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from logging import Logger
 from types import TracebackType
-from typing import TYPE_CHECKING, BinaryIO, Callable, Generic, Mapping, Optional, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, BinaryIO, Generic, Optional, TypeVar, Union
 
 import asyncpg
 import click
@@ -703,7 +703,7 @@ class CycleException(Exception):
                 self.done = True
 
 
-def stable_depth_first(nodes: list[str], edges: dict[str, list[str]]) -> list[str]:
+def stable_depth_first(nodes: Collection[str], edges: Mapping[str, Collection[str]]) -> list[str]:
     """Creates a linear sequence based on a set of "comes after" edges, same graph yields the same solution,
     independent of order given to this function"""
     nodes = sorted(nodes)


### PR DESCRIPTION
This function declares that it needs a list and dict as input respectively, but it really only needs a collection and a mapping.