### PR TITLE
Fix discovered resources dataview bug

### DIFF
--- a/changelogs/unreleased/fix-discovered-resources-dataview-bug.yml
+++ b/changelogs/unreleased/fix-discovered-resources-dataview-bug.yml
@@ -1,0 +1,5 @@
+---
+description: >
+  Fix bug where the discovered_resources_get_batch endpoint would crash if the discovery_resource_id was not managed
+change-type: patch
+destination-branches: [master]

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -1359,17 +1359,13 @@ class DiscoveredResourceView(DataView[DiscoveredResourceOrder, model.DiscoveredR
                     dr.resource_id_value,
                     dr.values,
                     (rps_1.resource_id IS NOT NULL) AS managed,
-                    rps_2.resource_id AS discovery_resource_id
+                    dr.discovery_resource_id
 
                 FROM {data.DiscoveredResource.table_name()} as dr
 
                 -- Retrieve the corresponding managed resource id (if any)
                 LEFT JOIN {data.ResourcePersistentState.table_name()} rps_1
                 ON dr.environment=rps_1.environment AND dr.discovered_resource_id = rps_1.resource_id
-
-                -- Retrieve the id of the resource responsible for discovering this resource
-                LEFT JOIN {data.ResourcePersistentState.table_name()} rps_2
-                ON dr.environment=rps_2.environment AND dr.discovery_resource_id = rps_2.resource_id
 
                 WHERE dr.environment = $1
             )
@@ -1392,7 +1388,7 @@ class DiscoveredResourceView(DataView[DiscoveredResourceOrder, model.DiscoveredR
                     if res["managed"]
                     else None
                 ),
-                discovery_resource_id=res["discovery_resource_id"] if res["discovery_resource_id"] else None,
+                discovery_resource_id=res["discovery_resource_id"],
             ).model_dump()
             for rid, res in ((Id.parse_id(res["discovered_resource_id"]), res) for res in records)
         ]

--- a/tests/deploy/e2e/test_discovered_resources.py
+++ b/tests/deploy/e2e/test_discovered_resources.py
@@ -104,6 +104,11 @@ async def test_discovered_resource_batch(server, client, agent, environment):
     result = await agent._client.discovered_resource_create_batch(environment, resources)
     assert result.code == 200
 
+    # checks for a bug where this endpoint would crash if the discovery_resource_id was not managed (as is this case)
+    result = await client.discovered_resources_get_batch(environment)
+    assert result.code == 200
+    assert len(result.result["data"]) == 3
+
     for res in resources:
         result = await client.discovered_resources_get(environment, res["discovered_resource_id"])
         assert result.code == 200


### PR DESCRIPTION
# Description

Related to this discussion: https://inmanta.slack.com/archives/CKRF0C8R3/p1765961266631349

The discovered resources tab was crashing when we had discovery resources that were not managed (i.e. not on the RPS table)

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
