### PR TITLE
allow invisible warnings in inmanta --version test case

### DIFF
--- a/changelogs/unreleased/test-version-command-allow-hidden-warnings.yml
+++ b/changelogs/unreleased/test-version-command-allow-hidden-warnings.yml
@@ -1,0 +1,5 @@
+description: 'Allow invisible warnings in the inmanta --version test case'
+change-type: patch
+destination-branches:
+  - master
+  - iso8

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -150,25 +150,16 @@ def run_without_tty(
     env: typing.Optional[dict[str, str]] = None,
     killtime: int = 15,
     termtime: int = 10,
-    *,
-    treat_warnings_as_errors: bool = False,
 ) -> tuple[str, str, int]:
     """Run the given command without a tty"""
-    if treat_warnings_as_errors:
-        if env is None:
-            env = {}
-        env["PYTHONWARNINGS"] = "error"
-
     process = do_run(args, env)
     return do_kill(process, killtime, termtime)
 
 
-def run_with_tty(args, killtime=4, termtime=3, *, treat_warnings_as_errors: bool = False):
+def run_with_tty(args, killtime=4, termtime=3):
     """Could not get code for actual tty to run stable in docker, so we are faking it"""
     env = {const.ENVIRON_FORCE_TTY: "true"}
-    return run_without_tty(
-        args, env=env, killtime=killtime, termtime=termtime, treat_warnings_as_errors=treat_warnings_as_errors
-    )
+    return run_without_tty(args, env=env, killtime=killtime, termtime=termtime)
 
 
 def is_colorama_package_available():
@@ -279,9 +270,9 @@ def test_version_command(tmpdir, with_tty: bool, regexes_required_lines: list[st
 
     (args, log_dir) = get_command(tmpdir, command="--version")
     if with_tty:
-        (stdout, stderr, return_code) = run_with_tty(args, treat_warnings_as_errors=True)
+        (stdout, stderr, return_code) = run_with_tty(args)
     else:
-        (stdout, stderr, return_code) = run_without_tty(args, treat_warnings_as_errors=True)
+        (stdout, stderr, return_code) = run_without_tty(args)
 
     if return_code != 0 or stderr:
         e = Exception("An unexpected error occurred or warnings were logged while running 'inmanta --version'")


### PR DESCRIPTION
# Description

The test for `inmanta --version` was failing because of a warning outside of our control (between `strawberry-graphql` and `strawberry-sqlalchemy-mapper`). This PR relaxes the test conditions slightly: instead of failing on *any* warning, we only fail on *visible* warnings.

This test case was initially introduced in #9253

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
