### PR TITLE
hold back sphinx 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,9 @@ updates:
       update-types: ["version-update:semver-major"]
     - dependency-name: "execnet"
       update-types: ["version-update:semver-major"]
+    - dependency-name: "sphinx"
+      # blocked on https://github.com/executablebooks/MyST-Parser/pull/1076
+      versions: [">=9"]
 - target-branch: iso8
   package-ecosystem: pip
   directory: "/"


### PR DESCRIPTION
# Description

Holding back sphinx for now because we have incompatible dependencies. I'm creating a ticket to unblock it, hopefully before the iso9 release.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
