### PR TITLE
addressed re.split deprecation warning

### DIFF
--- a/changelogs/unreleased/re-maxsplit.yml
+++ b/changelogs/unreleased/re-maxsplit.yml
@@ -1,0 +1,5 @@
+description: "Addressed re.split deprecation warning"
+change-type: patch
+destination-branches:
+  - master
+  - iso8

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -339,7 +339,7 @@ def is_map(map_in: str | typing.Mapping[str, str]) -> typing.Mapping[str, str]:
         mappings = map_in.split(",")
 
         for mapping in mappings:
-            parts = re.split("=", mapping.strip(), 1)
+            parts = re.split("=", mapping.strip(), maxsplit=1)
             if len(parts) == 2:
                 key = parts[0].strip()
                 value = parts[1].strip()


### PR DESCRIPTION
I noticed this in the output of the dump-tool.
```
16:27:57.674 WARNING /home/sander/documents/projects/inmanta/inmanta-core/src/inmanta/config.py:342: DeprecationWarning: 'maxsplit' is passed as positional argument
  parts = re.split("=", mapping.strip(), 1)
```