### PR TITLE
fix underline too short warning in docs

### DIFF
--- a/changelogs/unreleased/fix-underline-too-short-warning-in-docs.yml
+++ b/changelogs/unreleased/fix-underline-too-short-warning-in-docs.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix underline too short warning in docs"
+change-type: patch
+destination-branches: [master, iso9]

--- a/docs/install/2-install-postgresql-orchestrator.rst
+++ b/docs/install/2-install-postgresql-orchestrator.rst
@@ -6,7 +6,7 @@ Install PostgreSQL
 This page describes how to install PostgreSQL on RedHat Enterprise Linux or derivatives.
 
 Step 1: Install PostgreSQL |pg_version|
------------------------------
+---------------------------------------
 
 .. only:: oss
 


### PR DESCRIPTION
# Description

I fixed this already for iso8 in the previous cherry pick

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
