### PR TITLE
Make config directory creation more robust

### DIFF
--- a/changelogs/unreleased/make-config-dir-creation-more-robust.yml
+++ b/changelogs/unreleased/make-config-dir-creation-more-robust.yml
@@ -1,0 +1,4 @@
+---
+description: "Make config directory creation code path more robust from AutostartedAgentManager"
+change-type: patch
+destination-branches: [iso7]

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -1164,8 +1164,7 @@ class AutostartedAgentManager(ServerSlice):
         config: str = await self._make_agent_config(env, connection=connection)
 
         config_dir = os.path.join(self._server_storage["agents"], str(env.id))
-        if not os.path.exists(config_dir):
-            os.mkdir(config_dir)
+        os.makedirs(config_dir, exist_ok=True)
 
         config_path = os.path.join(config_dir, "agent.cfg")
         with open(config_path, "w+", encoding="utf-8") as fd:


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/10000 but applied on the iso7 branch due to a merge conflict.**

This PR makes the code path that creates the config directory in the AutostartedAgentManager more robust. It will no longer raise an exception if the one of the parent directories does not exist. Normally this should never happen, but making it more robust doesn't hurt.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~