### PR TITLE
Fix OpenAPI path parameter notation for openapi-spec-validator 0.8.4

### DIFF
--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -319,6 +319,14 @@ class UrlPath:
     def path(self) -> str:
         return self._path
 
+    @property
+    def openapi_path(self) -> str:
+        """Return the path with variables in OpenAPI {var} notation."""
+        path = self._path
+        for var in self._vars:
+            path = path.replace(f"<{var}>", f"{{{var}}}")
+        return path
+
     def generate_path(self, variables: dict[str, str]) -> str:
         """Create a path with all variables substituted"""
         path = self._path
@@ -929,6 +937,10 @@ class MethodProperties(Generic[R]):
         """
         return f"/{self._api_prefix}/v{self._api_version}{self._path.path}"
 
+    def get_openapi_path(self) -> str:
+        """Return the full path with OpenAPI {var} notation for path parameters."""
+        return f"/{self._api_prefix}/v{self._api_version}{self._path.openapi_path}"
+
     def get_call_url(self, msg: dict[str, str]) -> str:
         """
         Create a calling url for the client
@@ -1080,6 +1092,10 @@ class UrlMethod:
         Returns the path part of the URL. Parameters in this path are templated using the <param> notation.
         """
         return self._properties.get_full_path()
+
+    def get_openapi_path(self) -> str:
+        """Returns the path with OpenAPI {var} notation."""
+        return self._properties.get_openapi_path()
 
 
 # Util functions

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -96,7 +96,7 @@ class OpenApiConverter:
             api_methods = self._filter_api_methods(methods)
             if len(api_methods) > 0:
                 url_method: UrlMethod = next(iter(methods.values()))
-                parameterized_path: str = url_method.get_path()
+                parameterized_path: str = url_method.get_openapi_path()
                 path_item = self._extract_operations_from_methods(api_methods, parameterized_path)
                 paths[parameterized_path] = path_item
         security: list[dict[SecuritySchemeName, list[Scope]]] | None = (
@@ -354,7 +354,7 @@ class FunctionParameterHandler:
         self.non_path_and_non_header_params: dict[str, inspect.Parameter] = {}
 
         for param_name, param in self.all_params_dct.items():
-            if f"<{param_name}>" in self.path:
+            if f"{{{param_name}}}" in self.path:
                 self.path_params[param_name] = param
             elif (
                 param_name in self.method_properties.arg_options.keys()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -530,7 +530,7 @@ def test_post_operation(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(post, "/operation/<id>")
+    operation = operation_handler.handle_method(post, "/operation/{id}")
 
     # Asserts on request body
     expected_params = ["param", "non_header"]
@@ -621,7 +621,7 @@ def test_post_operation_no_docstring(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(post, "/operation/<id>")
+    operation = operation_handler.handle_method(post, "/operation/{id}")
 
     # Asserts on request body
     expected_params = ["param", "non_header"]
@@ -696,7 +696,7 @@ def test_post_operation_partial_documentation(api_methods_fixture):
     )
 
     operation_handler = OperationHandler(OpenApiTypeConverter(), ArgOptionHandler(OpenApiTypeConverter()))
-    operation = operation_handler.handle_method(post, "/operation/<id_doc>/<id_no_doc>")
+    operation = operation_handler.handle_method(post, "/operation/{id_doc}/{id_no_doc}")
 
     # Asserts on request body
     request_body_parameters = list(operation.requestBody.content["application/json"].schema_.properties.keys())


### PR DESCRIPTION
openapi-spec-validator 0.8.1+ validates that declared path parameters match the path template. Our converter was emitting paths with <param> (internal notation) instead of {param} (OpenAPI notation), causing UnresolvableParameterError for every endpoint with path parameters.

Add UrlPath.openapi_path property and MethodProperties.get_openapi_path() to produce {var} notation, and use it in the OpenAPI converter.
