### PR TITLE
Use os._exit() in compile command to skip expensive GC shutdown

### DIFF
--- a/changelogs/unreleased/fast-compile-exit.yml
+++ b/changelogs/unreleased/fast-compile-exit.yml
@@ -1,0 +1,9 @@
+change-type: patch
+description: >-
+  Improved compile command exit performance by using os._exit() to skip Python's interpreter shutdown.
+  The garbage collector would otherwise spend significant time tearing down the compiler's large cyclic
+  object graph (Namespace trees, Entity hierarchies, Instance/ResultVariable webs), which is unnecessary
+  since the process is terminating.
+destination-branches:
+- master
+sections: {}

--- a/changelogs/unreleased/fast-compile-exit.yml
+++ b/changelogs/unreleased/fast-compile-exit.yml
@@ -1,0 +1,11 @@
+change-type: minor
+description: >-
+  Improved compile command exit performance by using os._exit() to skip Python's interpreter shutdown.
+  The garbage collector would otherwise spend significant time tearing down the compiler's large cyclic
+  object graph (Namespace trees, Entity hierarchies, Instance/ResultVariable webs), which is unnecessary
+  since the process is terminating. Atexit hooks, which cover log and telemetry flushing, still run
+  and the stdout/stderr buffers are flushed explicitly before exiting.
+destination-branches:
+- master
+- iso9
+sections: {}

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -810,9 +810,15 @@ class CompileSummaryReporter:
     def print_summary_and_exit(self, show_stack_traces: bool) -> None:
         """
         Print the compile summary and exit with a 0 status code in case of success or 1 in case of failure.
+
+        Uses os._exit() to skip Python's interpreter shutdown, which would otherwise spend significant time
+        running the garbage collector over the compiler's large cyclic object graph (Namespace trees, Entity
+        hierarchies, Instance/ResultVariable webs). Since the process is terminating, this GC work is unnecessary.
         """
         self.print_summary(show_stack_traces)
-        exit(1 if self.is_failure() else 0)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1 if self.is_failure() else 0)
 
 
 def cmd_parser() -> argparse.ArgumentParser:

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -32,6 +32,7 @@ Entry points
 
 import argparse
 import asyncio
+import atexit
 import contextlib
 import dataclasses
 import enum
@@ -810,9 +811,30 @@ class CompileSummaryReporter:
     def print_summary_and_exit(self, show_stack_traces: bool) -> None:
         """
         Print the compile summary and exit with a 0 status code in case of success or 1 in case of failure.
+
+        Exits with os._exit() to skip Python's interpreter shutdown. The compiler leaves behind a large
+        cyclic object graph (Namespace trees, Entity hierarchies, Instance/ResultVariable webs) and the
+        garbage collector spends seconds tearing it down on shutdown, which is pointless work for a
+        process that is terminating anyway.
+
+        os._exit() skips the cleanup a normal exit performs, so the parts of it that must still happen
+        are done explicitly first:
+
+        - atexit hooks are run via atexit._run_exitfuncs(): the stdlib (logging), the telemetry stack
+          (opentelemetry registers the tracer provider shutdown there and logfire its open-span cleanup)
+          and modules' plugin code (e.g. remote session cleanup) register work there that must not be
+          lost. Hooks run LIFO exactly as on a normal exit, an exception in a hook is printed and
+          ignored, and the hook list is cleared afterwards so hooks cannot run a second time.
+        - the stdout/stderr buffers are flushed
+
+        What remains skipped, by design: __del__ finalizers (the object teardown this method avoids) and
+        joining non-daemon threads.
         """
         self.print_summary(show_stack_traces)
-        exit(1 if self.is_failure() else 0)
+        atexit._run_exitfuncs()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1 if self.is_failure() else 0)
 
 
 def cmd_parser() -> argparse.ArgumentParser:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import atexit
 import json
 import logging
 import os
@@ -568,6 +569,33 @@ def test_compiler_summary_reporter(monkeypatch, capsys) -> None:
     summary_reporter.print_summary(show_stack_traces=True)
     output = capsys.readouterr().err
     assert re.match(r"\n=+ EXCEPTION TRACE =+\n(.|\n)*\n=+ EXPORT FAILURE =+\nError: This is an export failure\n", output)
+
+
+def test_print_summary_and_exit_runs_hooks_before_exit(monkeypatch) -> None:
+    """
+    print_summary_and_exit uses os._exit, which skips the normal exit cleanup. Verify it explicitly
+    runs the atexit hooks (which cover log and telemetry flushing) before exiting, and preserves the
+    exit code semantics.
+
+    atexit._run_exitfuncs is replaced here because really invoking it would run and clear the atexit
+    hooks of the test process itself.
+    """
+    calls: list[object] = []
+    monkeypatch.setattr(atexit, "_run_exitfuncs", lambda: calls.append("atexit"))
+    monkeypatch.setattr(os, "_exit", lambda code: calls.append(("exit", code)))
+
+    summary_reporter = CompileSummaryReporter()
+    with summary_reporter.compiler_exception.capture():
+        pass
+    summary_reporter.print_summary_and_exit(show_stack_traces=False)
+    assert calls == ["atexit", ("exit", 0)]
+
+    calls.clear()
+    summary_reporter = CompileSummaryReporter()
+    with summary_reporter.compiler_exception.capture():
+        raise Exception("This is a compilation failure")
+    summary_reporter.print_summary_and_exit(show_stack_traces=False)
+    assert calls == ["atexit", ("exit", 1)]
 
 
 def test_validate_logging_config(tmpdir, monkeypatch):


### PR DESCRIPTION
## Summary

- Uses `os._exit()` instead of `exit()` in `CompileSummaryReporter.print_summary_and_exit()` to skip Python's interpreter shutdown after the compile summary is printed.
- The compiler builds large cyclic object graphs (Namespace trees, Entity hierarchies, Instance/ResultVariable webs). Python's GC spends significant time tearing these down on shutdown, which is unnecessary since the process is terminating.
- The parts of a normal exit that must still happen are performed explicitly before `os._exit()`:
  - all atexit hooks are run via `atexit._run_exitfuncs()`: the stdlib (logging), the telemetry stack (opentelemetry registers the tracer provider shutdown there, logfire its open-span cleanup) and modules' plugin code register flushing and remote-session cleanup there. Hooks run LIFO exactly as on a normal exit, an exception in a hook is printed and ignored, and the hook list is cleared afterwards so hooks cannot run twice. Measured cost: under 0.1ms.
  - the stdout/stderr buffers are flushed
- No telemetry-specific code is needed: logfire and opentelemetry flush through their own atexit hooks, and logfire additionally patches `os._exit` itself to force-flush as a safety net (pydantic/logfire#779).
- The only behavior skipped relative to a normal exit is by design: `__del__` finalizers (the object teardown this change avoids) and joining non-daemon threads. A survey of core, lsm and all module plugin code found no compile-path reliance on either.

## Measurements

- CLI (`inmanta compile`, juniper-mx v23, 16803 .cf files): see benchmark comment below; 27-50% of user wall clock time.
- Server-side compiles in the orchestrator (`service-orchestrator:dev` nightly, 218 .cf file model, warm parse cache): the "Recompiling configuration model" stage drops from ~9.8s to ~4.1s; the post-export teardown segment collapses from ~6s to 33ms. Teardown time grows with AST heap size, so the absolute win grows with model size.

## Testing

- `tests/test_app.py`: 43 passed, including a new test asserting the exit path runs the atexit hooks before `os._exit` and preserves the exit code 0/1 semantics.
- Existing subprocess tests cover that compile/export output is fully written and exit codes are correct through the new exit path.
- End-to-end in an orchestrator container: LSM lifecycle transfers, exports and deploys behave normally; a failing validation compile still propagates exit code 1 (instance ends up rejected).
- black/isort/flake8 clean; mypy reports no new violations relative to master with the same toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)