### PR TITLE
Fix syntax errors in LSM attributes metadata docs

### DIFF
--- a/changelogs/unreleased/10231-fix-lsm-attributes-metadata-docs.yml
+++ b/changelogs/unreleased/10231-fix-lsm-attributes-metadata-docs.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix syntax errors in LSM attributes metadata documentation code examples"
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/docs/lsm/attributes_metadata/attributes_metadata.md
+++ b/docs/lsm/attributes_metadata/attributes_metadata.md
@@ -80,7 +80,8 @@ embedded entities in the same way.
 
 ```inmanta
 entity Interface extends lsm::ServiceEntity:
-    string interface_name dict __annotations = {"annotation": "value"}
+    string interface_name
+    dict __annotations = {"annotation": "value"}
 end
 ```
 
@@ -95,8 +96,8 @@ on simple attributes of embedded entities in the same way.
 
 ```inmanta
 entity Interface extends lsm::ServiceEntity:
-    string interface_name dict
-    interface_name__annotations = {"annotation": "value"}
+    string interface_name
+    dict interface_name__annotations = {"annotation": "value"}
 end
 ```
 


### PR DESCRIPTION
## Summary
- Fix code examples in `docs/lsm/attributes_metadata/attributes_metadata.md` where attributes were incorrectly placed on a single line instead of separate lines

## Destination branches
master, iso9, iso8
