### PR TITLE
Improve docstring configurationmodel table

### DIFF
--- a/changelogs/unreleased/improve-docstring-configurationmodel-table.yml
+++ b/changelogs/unreleased/improve-docstring-configurationmodel-table.yml
@@ -1,0 +1,4 @@
+---
+description: "Improve the docstring of the undeployable and skipped_for_undeployable columns of the configurationmodel database table."
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/changelogs/unreleased/improve-docstring-configurationmodel-table.yml
+++ b/changelogs/unreleased/improve-docstring-configurationmodel-table.yml
@@ -1,4 +1,4 @@
 ---
 description: "Improve the docstring of the undeployable and skipped_for_undeployable columns of the configurationmodel database table."
 change-type: patch
-destination-branches: [master, iso9, iso8]
+destination-branches: [master, iso9]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -6359,8 +6359,17 @@ class ConfigurationModel(BaseDocument):
     :param is_suitable_for_partial_compiles: This boolean indicates whether the model can later on be updated using a
                                              partial compile. In other words, the value is True iff no cross resource set
                                              dependencies exist between the resources.
-    :param undeployable: List of resource ids that are undeployable
-    :param skipped_for_undeployable: List of resource ids that are skipped because of undeployable dependencies
+    :param undeployable: List of all the resource ids across the entire configurationmodel that are undeployable (undefined).
+                         This field is only used by the dryrun feature. The scheduler determines the undeployable resouces
+                         using the is_undefined column of the resource table.
+    :param skipped_for_undeployable: List of resource ids that are skipped because of undeployable (undefined) dependencies.
+                                     If this configurationmodel was created using a partial compile, this column does not
+                                     include skipped_for_undeployable resources for resources in resource sets that were
+                                     not part of the partial compile. This is not intentional, but a bug:
+                                     https://github.com/inmanta/inmanta-core/issues/10277. This column is only used by
+                                     the dryrun feature. The scheduler calculates the skipped_for_undeployable resources
+                                     by relying on the is_undefined column of the resource table and the fact that it has
+                                     a full view on the states of all the resources in the configurationmodel.
     :param pip_config: The pip configuration for this version
     :param project_constraints: The project constraints for this version
     """


### PR DESCRIPTION
# Description

Improve the docstring of the undeployable and skipped_for_undeployable columns of the configurationmodel database table.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~