### PR TITLE
Support fetching active configuration (iso8)

### DIFF
--- a/changelogs/unreleased/support-collecting-full-active-configuration.yml
+++ b/changelogs/unreleased/support-collecting-full-active-configuration.yml
@@ -1,0 +1,8 @@
+---
+description: "Added support to the configuration framework to get the full active configuration."
+issue-nr: 960
+issue-repo: inmanta-support
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/support-collecting-full-active-configuration.yml
+++ b/changelogs/unreleased/support-collecting-full-active-configuration.yml
@@ -3,6 +3,6 @@ description: "Added support to the configuration framework to get the full activ
 issue-nr: 960
 issue-repo: inmanta-support
 change-type: patch
-destination-branches: [master, iso9, iso8]
+destination-branches: [iso8]
 sections:
   minor-improvement: "{{description}}"

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -35,7 +35,10 @@ LOGGER = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def _normalize_name(name: str) -> str:
+def normalize_name(name: str) -> str:
+    """
+    Normalize the name of a configuration option.
+    """
     return name.replace("_", "-")
 
 
@@ -64,7 +67,10 @@ def _get_from_env(section: str, name: str) -> Optional[str]:
 
 class LenientConfigParser(ConfigParser):
     def optionxform(self, name: str) -> str:
-        name = _normalize_name(name)
+        """
+        This method transforms option names on every get or set operation.
+        """
+        name = normalize_name(name)
         return super().optionxform(name)
 
     def _validate_value_types(self, *, section: str = "", option: str = "", value: str = "") -> None:
@@ -148,9 +154,39 @@ class Config:
     def config_as_dict(cls) -> typing.Mapping[str, typing.Mapping[str, typing.Any]]:
         """
         Return the config as a dict, to be used with load_config_from_dict
+
+        This method only returns the configuration options that were actively
+        set by the user using a configuration file. This means:
+            * Configuration options set using environment variables are not included in the result.
+            * Configuration options that are left to their default values are not included in the result.
         """
         assert cls.__instance is not None
         return dict(cls.__instance.items())
+
+    @classmethod
+    def get_active_configuration_as_dict(cls) -> typing.Mapping[str, typing.Mapping[str, object]]:
+        """
+        Returns the values of the configuration options that are currently used (active configuration).
+
+        :returns: A dictionary that maps the configuration section name to a dictionary that maps
+                  the name of a configuration option to its value. This dictionary contains the
+                  active configuration exhaustively, i.e. values that were not explicitly set
+                  will be present in this dictionary using their default value.
+        """
+        from inmanta.protocol.auth import auth
+
+        # Collect the configuration for options that were defined using an instance of the Option class.
+        config_definitions: dict[str, dict[str, Option[object]]] = cls.get_config_options()
+        result = {
+            section: {config_name: option.get() for config_name, option in options.items()}
+            for section, options in config_definitions.items()
+        }
+        # Collect the JWT configuration. Those configuration options have a more free format and
+        # don't have an associated instance of the Option class.
+        jwt_configuration: dict[str, auth.AuthJWTConfig] = auth.AuthJWTConfig.get_all()
+        for section_name, jwt_config in jwt_configuration.items():
+            result[f"{auth.AUTH_JWT_PREFIX}{section_name}"] = jwt_config.get_as_dict()
+        return result
 
     @classmethod
     def _get_instance(cls) -> ConfigParser:
@@ -201,7 +237,7 @@ class Config:
             return cls.get_instance()
 
         assert name is not None
-        name = _normalize_name(name)
+        name = normalize_name(name)
 
         option: Optional[Option[object]] = cls.validate_option_request(section, name, default_value)
         return cls.get_for_option(option) if option is not None else cls._get_value(section, name, default_value)
@@ -243,7 +279,7 @@ class Config:
         """
         Override a value
         """
-        name = _normalize_name(name)
+        name = normalize_name(name)
 
         if section not in cls.get_instance():
             cls.get_instance().add_section(section)
@@ -411,7 +447,7 @@ class Option(Generic[T]):
         predecessor_option: Optional["Option"] = None,
     ) -> None:
         self.section = section
-        self.name = _normalize_name(name)
+        self.name = normalize_name(name)
         self.validator = validator
         self.documentation = documentation
         self.default = default

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -173,7 +173,7 @@ class Config:
                   active configuration exhaustively, i.e. values that were not explicitly set
                   will be present in this dictionary using their default value.
         """
-        from inmanta.protocol.auth import auth
+        from inmanta.protocol import auth
 
         # Collect the configuration for options that were defined using an instance of the Option class.
         config_definitions: dict[str, dict[str, Option[object]]] = cls.get_config_options()

--- a/src/inmanta/protocol/auth.py
+++ b/src/inmanta/protocol/auth.py
@@ -22,6 +22,7 @@ import configparser
 import dataclasses
 import json
 import logging
+import os
 import re
 import ssl
 import threading
@@ -319,7 +320,7 @@ class AuthJWTConfig:
             sign_true_found: int = 0
             sign_value_context: list[str] = []
             for section_name, section in cls.sections.items():
-                sign_value_context.append(f"auth_jwt_{section_name} -> sign={section.sign}")
+                sign_value_context.append(f"{AUTH_JWT_PREFIX}{section_name} -> sign={section.sign}")
                 if section.sign:
                     sign_true_found += 1
             if sign_true_found > 1:
@@ -358,6 +359,17 @@ class AuthJWTConfig:
             return None
 
     @classmethod
+    def get_all(cls) -> dict[str, "AuthJWTConfig"]:
+        """
+        Returns all the AuthJWTConfig configured on the server.
+        A dictionary is returned that maps the name of the configuration section
+        (without prefix) to the corresponding AuthJWTConfig object.
+        """
+        with cls._lock:
+            cls._load_config_and_validate()
+            return dict(cls.sections)
+
+    @classmethod
     def get_sign_config(cls) -> Optional["AuthJWTConfig"]:
         """
         Get the configuration with sign is true
@@ -394,6 +406,7 @@ class AuthJWTConfig:
         self.sign: bool = False
         self.issuer: str = "https://localhost:8888/"
         self.audience: str
+        self.client_types: list[str]
 
         if "algorithm" not in config:
             raise ValueError("algorithm is required in %s section" % self.section)
@@ -407,6 +420,30 @@ class AuthJWTConfig:
             self.validate_rs265()
         else:
             raise ValueError(f"Algorithm {self.algo} in {self.section} is not support ")
+
+    def get_as_dict(self) -> dict[str, object]:
+        """
+        Returns this AuthJWTConfig object in dictionary form.
+        The keys in the dictionary represent the config options
+        and the values the associated configuration values.
+        """
+        result = {
+            "algorithm": self.algo,
+            "sign": self.sign,
+            "client-types": list(self.client_types),
+            "issuer": self.issuer,
+            "audience": self.audience,
+            "jwt-username-claim": self.jwt_username_claim,
+        }
+        if self.sign:
+            result["expire"] = self.expire
+        if self.algo.lower() == "hs256":
+            result["key"] = self.base64_encoded_key
+        else:
+            result["jwks-uri"] = self.jwks_uri
+            result["validate-cert"] = self.validate_cert
+            result["jwks-request-timeout"] = self.jwks_timeout
+        return result
 
     def validate_generic(self) -> None:
         """
@@ -437,10 +474,10 @@ class AuthJWTConfig:
         if "claims" in self._config:
             self.parse_claim_matching(self._config["claims"])
 
-        if "jwt-username-claim" in self._config:
+        if "jwt_username_claim" in self._config:
             if self.sign:
                 raise ValueError(f"auth config {self.section} used for signing cannot use a custom claim.")
-            self.jwt_username_claim = self._config["jwt-username-claim"]
+            self.jwt_username_claim = self._config["jwt_username_claim"]
 
     def parse_claim_matching(self, claim_conf: str) -> None:
         """Parse claim matching expressions"""
@@ -461,7 +498,8 @@ class AuthJWTConfig:
         if "key" not in self._config:
             raise ValueError(f"key is required in {self.section} for algorithm {self.algo}")
 
-        self.key = base64.urlsafe_b64decode((self._config["key"] + "==").encode("ascii"))
+        self.base64_encoded_key = self._config["key"]
+        self.key = base64.urlsafe_b64decode((self.base64_encoded_key + "==").encode("ascii"))
         if len(self.key) < 32:
             raise ValueError("HS256 requires a key of 32 bytes (256 bits) or longer in " + self.section)
 
@@ -501,9 +539,9 @@ class AuthJWTConfig:
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
-        jwks_timeout = self._config.getfloat("jwks_request_timeout", 30.0)
+        self.jwks_timeout = self._config.getfloat("jwks_request_timeout", 30.0)
         try:
-            with request.urlopen(self.jwks_uri, timeout=jwks_timeout, context=ctx) as response:
+            with request.urlopen(self.jwks_uri, timeout=self.jwks_timeout, context=ctx) as response:
                 key_data = json.loads(response.read().decode("utf-8"))
         except error.URLError as e:
             # HTTPError is raised for non-200 responses; the response

--- a/src/inmanta/protocol/auth.py
+++ b/src/inmanta/protocol/auth.py
@@ -22,7 +22,6 @@ import configparser
 import dataclasses
 import json
 import logging
-import os
 import re
 import ssl
 import threading
@@ -434,6 +433,7 @@ class AuthJWTConfig:
             "issuer": self.issuer,
             "audience": self.audience,
             "jwt-username-claim": self.jwt_username_claim,
+            "claims": [str(c) for c in self.claims],
         }
         if self.sign:
             result["expire"] = self.expire

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -178,8 +178,24 @@ db-connection-pool-max-size=5
     assert Config.get("influxdb", "tags")["tag2"] == "value2"
     assert Config.get("database", "username") == "non-default-name-2"
     assert Config.get("server", "db_connection_pool_max_size") == 5
-    assert Config.get("server", "auth")
+    assert Config.get("server", "auth") is True
     assert Config.get("server", "agent-timeout") == 60
+
+    active_config = Config.get_active_configuration_as_dict()
+    assert active_config["config"]["log-dir"] == "/log"
+    assert active_config["database"]["host"] == "host3"
+    assert active_config["database"]["name"] == "db2"
+    assert active_config["database"]["port"] == 5678
+    assert active_config["influxdb"]["host"] == "host3"
+    assert active_config["influxdb"]["interval"] == 20
+    assert active_config["influxdb"]["tags"]["tag2"] == "value2"
+    assert active_config["database"]["username"] == "non-default-name-2"
+    assert active_config["server"]["db-connection-pool-max-size"] == 5
+    assert active_config["server"]["auth"] is True
+    assert active_config["server"]["agent-timeout"] == 60
+    # Verify that active_config also contains the configuration that
+    # was not explicitly set by the user.
+    assert active_config["compiler"]["cache"] is True
 
 
 async def test_bind_address_ipv4(async_finalizer):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -232,10 +232,37 @@ jwt_username_claim=name
 
     # load and parse
     cfg = auth.AuthJWTConfig.get("test")
-    assert cfg
+    auth_jwt_test_dct = {
+        "algorithm": "HS256",
+        "sign": True,
+        "client-types": ["agent", "compiler"],
+        "key": "eciwliGyqECVmXtIkNpfVrtBLutZiITZKSKYhogeHMM",
+        "expire": 0,
+        "issuer": "https://localhost:8888/",
+        "audience": "https://localhost:8888/",
+        "claims": [],
+        "jwt-username-claim": "sub",
+    }
+    assert auth_jwt_test_dct == cfg.get_as_dict()
 
     cfg = auth.AuthJWTConfig.get("name")
-    assert cfg
+    auth_jwt_name_dct = {
+        "algorithm": "HS256",
+        "sign": False,
+        "client-types": ["agent", "compiler"],
+        "key": "eciwliGyqECVmXtIkNpfVrtBLutZiITZKSKYhogeHMM",
+        "issuer": "https://example.com:8888/",
+        "audience": "abcdef",
+        "claims": [],
+        "jwt-username-claim": "name",
+    }
+    assert auth_jwt_name_dct == cfg.get_as_dict()
+
+    active_config = config.Config.get_active_configuration_as_dict()
+    assert "auth_jwt_name" in active_config
+    assert active_config["auth_jwt_name"] == auth_jwt_name_dct
+    assert "auth_jwt_test" in active_config
+    assert active_config["auth_jwt_test"] == auth_jwt_test_dct
 
     # Test authentication with custom token header
     payload: dict[str, object] = {


### PR DESCRIPTION
# Description

Added support to the configuration framework to get the full active configuration. This feature is required by https://github.com/inmanta/inmanta-support/pull/971

closes inmanta/inmanta-support#960

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
