### PR TITLE
Bump cryptography from 47.0.0 to 48.0.0 (#10349)

### DIFF
--- a/changelogs/unreleased/10349-dependabot.yml
+++ b/changelogs/unreleased/10349-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump cryptography from 47.0.0 to 48.0.0
+destination-branches:
+- master
+- iso9
+sections: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click-plugins==1.1.1.2
 colorlog==6.10.1
 cookiecutter==2.7.1
 crontab==1.0.5
-cryptography==47.0.0
+cryptography==48.0.0
 docstring-parser==0.18.0
 # documentation
 email-validator==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = [
     "colorlog~=6.4",
     "cookiecutter>=1,<3",
     "crontab>=0.23,<2.0",
-    "cryptography>=36,<48",
+    "cryptography>=36,<49",
     # docstring-parser has been known to publish non-backwards compatible minors in the past
     "docstring-parser>=0.10,<0.19",
     "email-validator>=1,<3",


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #10349