### PR TITLE
Add filter on environment for the totalCount query

### DIFF
--- a/changelogs/unreleased/10352-fix-environment-filter-not-present-on-resource-count-query.yml
+++ b/changelogs/unreleased/10352-fix-environment-filter-not-present-on-resource-count-query.yml
@@ -1,0 +1,4 @@
+description: Fix bug where the totalCount field on the resources query of GraphQL was not filtering on environment.
+change-type: patch
+issue-nr: 10352
+destination-branches: [master, iso9]

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -980,16 +980,12 @@ def get_schema(context: GraphQLContext) -> strawberry.Schema:
 
             # Only fetch resources in their latest version
             # Logic based on src/inmanta/data/dataview.py::ResourceView
-            stmt = (
-                select(models.Resource)
-                .join(
-                    models.ResourcePersistentState,
-                    and_(
-                        models.Resource.resource_id == models.ResourcePersistentState.resource_id,
-                        models.Resource.environment == models.ResourcePersistentState.environment,
-                    ),
-                )
-                .where(models.ResourcePersistentState.environment == filter.environment)
+            stmt = select(models.Resource).join(
+                models.ResourcePersistentState,
+                and_(
+                    models.Resource.resource_id == models.ResourcePersistentState.resource_id,
+                    models.Resource.environment == models.ResourcePersistentState.environment,
+                ),
             )
 
             # CTE that fetches the latest scheduled version

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -730,6 +730,8 @@ class ResourceFilter(StrawberryFilter):
             attr = getattr(self, key)
             if attr is not None and attr is not strawberry.UNSET:
                 stmt = attr.apply_filter(stmt, self.rps_model, key)
+        if self.environment is not None and self.environment is not strawberry.UNSET:
+            stmt = stmt.filter(models.ResourcePersistentState.environment == self.environment)
         if self.purged is not None and self.purged is not strawberry.UNSET:
             stmt = stmt.filter(models.Resource.attributes["purged"].astext.cast(Boolean).is_(self.purged))
         if self.is_deploying is not None and self.is_deploying is not strawberry.UNSET:

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -738,7 +738,13 @@ async def test_notifications(server, client, setup_database):
         previous_time = created
 
 
-async def test_query_resources(server, client, environment, mixed_resource_generator):
+async def test_query_resources(server, client, environment, setup_database, mixed_resource_generator):
+    """
+    Test if different filters on the resource query are behaving as expected.
+
+    We include setup_database to have some resources in other envs
+    to make sure that we are not leaking resources from other envs on totalCount with different filters
+    """
     def is_subset_dict(expected: dict, actual: dict) -> bool:
         """
         Checks if a dict is a subset of another dict.

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -745,6 +745,7 @@ async def test_query_resources(server, client, environment, setup_database, mixe
     We include setup_database to have some resources in other envs
     to make sure that we are not leaking resources from other envs on totalCount with different filters
     """
+
     def is_subset_dict(expected: dict, actual: dict) -> bool:
         """
         Checks if a dict is a subset of another dict.


### PR DESCRIPTION
# Description

Fix bug where the totalCount field on the resources query of GraphQL was not filtering on environment.

I did not add `environment` to `ResourceOrder.key_to_model` because we are never ordering on environment, since we are always filter on one specific environment.

closes #10352 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
