### PR TITLE
Bump types-python-dateutil from 2.9.0.20260408 to 2.9.0.20260508 (#10363)

### DIFF
--- a/changelogs/unreleased/10363-dependabot.yml
+++ b/changelogs/unreleased/10363-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Bump types-python-dateutil from 2.9.0.20260408 to 2.9.0.20260508
+destination-branches:
+- master
+- iso9
+sections: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ texttable==1.7.0
 time-machine==3.2.0
 toml==0.10.2
 tornado==6.5.5
-types-python-dateutil==2.9.0.20260408
+types-python-dateutil==2.9.0.20260508
 types-toml==0.10.8.20260408
 types-PyYAML==6.0.12.20260408
 typing_inspect==0.9.0


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #10363