### PR TITLE
Make schedulers ignore config options set using environment variables

### DIFF
--- a/changelogs/unreleased/bugfix-all-schedulers-use-same-state-dir.yml
+++ b/changelogs/unreleased/bugfix-all-schedulers-use-same-state-dir.yml
@@ -1,0 +1,6 @@
+---
+description: 'Fixed the bug where all the schedulers of the different environments used the same state directory. This bug can cause a "no such file or directory" error on the .inmanta_venv_status file of an agent which prevents resources from being deployed.'
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -546,7 +546,7 @@ def mp_worker_entrypoint(
     logger = logging.getLogger(f"{LOGGER_NAME_EXECUTOR}.{name}")
 
     # Load config
-    inmanta.config.Config.load_config_from_dict(config)
+    inmanta.config.Config.load_config_from_dict(config, ignore_env_vars=True)
 
     # Make sure logfire is configured correctly
     tracing.configure_logfire("executor")

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -1045,8 +1045,16 @@ def app() -> None:
     if options.config_file and not os.path.exists(options.config_file):
         LOGGER.warning("Config file %s doesn't exist", options.config_file)
 
+    component: str | None = options.component if hasattr(options, "component") else None
+
     # Load the configuration
-    Config.load_config(min_c_config_file=options.config_file, config_dir=options.config_dir)
+    Config.load_config(
+        min_c_config_file=options.config_file,
+        config_dir=options.config_dir,
+        # The scheduler gets all its configuration using a configuration file that is generated
+        # by the server. Configuration options set using environment variables must be ignored.
+        ignore_env_vars=(component == "scheduler"),
+    )
 
     # Collect potential log context
     log_context: dict[str, str] = {}
@@ -1059,7 +1067,6 @@ def app() -> None:
         log_context[LOG_CONTEXT_VAR_ENVIRONMENT] = env
 
     # Log config
-    component = options.component if hasattr(options, "component") else None
     log_config.apply_options(options, component=component, context=log_context)
     logging.captureWarnings(True)
 

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -228,8 +228,8 @@ class Config:
         cls.__instance = None
         cls._config_dir = None
         cls._min_c_config_file = None
-        cls._config_updated()
         cls._ignore_env_vars = False
+        cls._config_updated()
 
     @classmethod
     def _config_updated(cls) -> None:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -169,8 +169,8 @@ class Config:
         cls.__instance = config
         cls._config_dir = config_dir
         cls._min_c_config_file = min_c_config_file
-        cls._config_updated()
         cls._ignore_env_vars = ignore_env_vars
+        cls._config_updated()
 
     @classmethod
     def config_as_dict(cls) -> typing.Mapping[str, typing.Mapping[str, typing.Any]]:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -91,6 +91,7 @@ class Config:
     _config_dir: Optional[str] = None  # The directory this config was loaded from
     _min_c_config_file: Optional[str] = None  # Config file
     __config_definition: dict[str, dict[str, "Option"]] = defaultdict(dict)
+    _ignore_env_vars: bool = False
 
     @classmethod
     def get_config_options(cls) -> dict[str, dict[str, "Option"]]:
@@ -102,9 +103,13 @@ class Config:
         min_c_config_file: Optional[str] = None,
         config_dir: Optional[str] = None,
         main_cfg_file: str = "/etc/inmanta/inmanta.cfg",
+        ignore_env_vars: bool = False,
     ) -> None:
         """
         Load the configuration file
+
+        :param ignore_env_vars: True iff configuration options set using environment variables
+                                must be ignored.
         """
         cfg_files_in_config_dir: list[str]
         if config_dir and os.path.isdir(config_dir):
@@ -127,29 +132,38 @@ class Config:
         config = LenientConfigParser(interpolation=Interpolation())
         loaded_files = config.read(files)
         LOGGER.debug("Configuration files loaded: %s", loaded_files)
-        cls._save_loaded_config(config, config_dir, min_c_config_file)
+        cls._save_loaded_config(config, config_dir, min_c_config_file, ignore_env_vars=ignore_env_vars)
 
     @classmethod
     def load_config_from_dict(
         cls,
         input_config: typing.Mapping[str, typing.Mapping[str, typing.Any]],
+        ignore_env_vars: bool = False,
     ) -> None:
         """
         Load the configuration from a dict, used to copy config.
         Replaces all existing config.
+
+        :param ignore_env_vars: True iff configuration options set using environment variables
+                                must be ignored.
         """
         config = LenientConfigParser(interpolation=Interpolation())
         config.read_dict(input_config)
-        cls._save_loaded_config(config, config_dir=None, min_c_config_file=None)
+        cls._save_loaded_config(config, config_dir=None, min_c_config_file=None, ignore_env_vars=ignore_env_vars)
 
     @classmethod
     def _save_loaded_config(
-        cls, config: LenientConfigParser, config_dir: Optional[str], min_c_config_file: Optional[str]
+        cls,
+        config: LenientConfigParser,
+        config_dir: Optional[str],
+        min_c_config_file: Optional[str],
+        ignore_env_vars: bool,
     ) -> None:
         cls.__instance = config
         cls._config_dir = config_dir
         cls._min_c_config_file = min_c_config_file
         cls._config_updated()
+        cls._ignore_env_vars = ignore_env_vars
 
     @classmethod
     def config_as_dict(cls) -> typing.Mapping[str, typing.Mapping[str, typing.Any]]:
@@ -208,6 +222,7 @@ class Config:
         cls._config_dir = None
         cls._min_c_config_file = None
         cls._config_updated()
+        cls._ignore_env_vars = False
 
     @classmethod
     def _config_updated(cls) -> None:
@@ -252,10 +267,11 @@ class Config:
     @classmethod
     def _get_value(cls, section: str, name: str, default_value: T) -> str | T:
         cfg: ConfigParser = cls.get_instance()
-        val: Optional[str] = _get_from_env(section, name)
-        if val is not None:
-            LOGGER.debug("Setting %s:%s was set using an environment variable", section, name)
-            return val
+        if not cls._ignore_env_vars:
+            val: Optional[str] = _get_from_env(section, name)
+            if val is not None:
+                LOGGER.debug("Setting %s:%s was set using an environment variable", section, name)
+                return val
         # Typing of this method in the sdk is not entirely accurate
         # It just returns the fallback, whatever its type
         return cfg.get(section, name, fallback=default_value)

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -98,6 +98,13 @@ class Config:
         return cls.__config_definition
 
     @classmethod
+    def is_ignoring_env_vars(cls) -> bool:
+        """
+        Return True iff config options set using environment variables must be ignored.
+        """
+        return cls._ignore_env_vars
+
+    @classmethod
     def load_config(
         cls,
         min_c_config_file: Optional[str] = None,

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -202,6 +202,8 @@ class AuthJWTConfig:
     @classmethod
     def _load_config_from_environment_variables(cls) -> dict[str, dict[str, str]]:
         env_config: dict[str, dict[str, str]] = defaultdict(dict[str, str])
+        if config.Config.is_ignoring_env_vars():
+            return env_config
         for name, value in os.environ.items():
             match: re.Match[str] | None = ENV_AUTH_JWT_SETTING_REGEX.match(name)
             if match:

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -326,5 +326,6 @@ async def test_executor_ignores_env_vars(monkeypatch, mpmanager_light: MPManager
         code=[executor.ModuleInstallSpec(module_name="test", module_version="123456", blueprint=blueprint)],
     )
 
-    state_dir_in_worker = await exe.call(GetConfig("config", "state_dir"))
-    assert state_dir_in_worker != fake_state_dir
+    state_dir_in_executor = await exe.call(GetConfig("config", "state_dir"))
+    monkeypatch.delenv("INMANTA_CONFIG_STATE_DIR")
+    assert state_dir_in_executor == inmanta.config.state_dir.get()

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -301,3 +301,30 @@ def test_hash_with_duplicates():
     )
     assert duplicated == simple
     assert duplicated.blueprint_hash() == simple.blueprint_hash()
+
+
+async def test_executor_ignores_env_vars(monkeypatch, mpmanager_light: MPManager, tmp_path) -> None:
+    """
+    Verify that executor workers ignore config options set via environment variables.
+    """
+    fake_state_dir = str(tmp_path / "fake_state_dir")
+    monkeypatch.setenv("INMANTA_CONFIG_STATE_DIR", fake_state_dir)
+
+    manager = mpmanager_light
+    await manager.start()
+
+    blueprint = executor.ExecutorBlueprint(
+        environment_id=uuid.uuid4(),
+        pip_config=inmanta.data.PipConfig(),
+        requirements=[],
+        sources=[],
+        python_version=sys.version_info[:2],
+    )
+    exe = await manager.get_executor(
+        agent_name="agent1",
+        agent_uri="local:",
+        code=[executor.ModuleInstallSpec(module_name="test", module_version="123456", blueprint=blueprint)],
+    )
+
+    state_dir_in_worker = await exe.call(GetConfig("config", "state_dir"))
+    assert state_dir_in_worker != fake_state_dir

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -648,10 +648,13 @@ async def test_state_dir_scheduler(set_state_dir_using_env_var: str, server, env
     assert len(autostarted_agent_manager._agent_procs) == 1
 
     # The AutostartedAgentManager configures the state dir of the scheduler as:
-    # <server_state_dir>/servers/<env_id> in the scheduler.cfg file. The scheduler
+    # <server_state_dir>/server/<env_id> in the scheduler.cfg file. The scheduler
     # creates the executors subdirectory.
+    await retry_limited(
+        lambda: os.path.exists(os.path.join(server_state_dir, "server", environment, "executors")),
+        timeout=10,
+    )
     assert not os.path.exists(os.path.join(server_state_dir, "executors"))
-    assert os.path.exists(os.path.join(server_state_dir, "server", environment, "executors"))
 
 
 async def test_error_handling_agent_fork(server, environment, monkeypatch):

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -638,8 +638,8 @@ def set_state_dir_using_env_var(monkeypatch, tmpdir) -> str:
 @pytest.mark.parametrize("auto_start_agent", [True])
 async def test_state_dir_scheduler(set_state_dir_using_env_var: str, server, environment):
     """
-    Verify that the scheduler is using the state dir configured in its scheduler.cfg file.
-    It must ignore configuration options set using environment variables.
+    Verify that the scheduler is using the state dir configured in its scheduler.cfg file
+    and ignores the state directory configured using an environment variable.
     """
     server_state_dir: str = set_state_dir_using_env_var
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -648,8 +648,8 @@ async def test_state_dir_scheduler(set_state_dir_using_env_var: str, server, env
     assert len(autostarted_agent_manager._agent_procs) == 1
 
     # The AutostartedAgentManager configures the state dir of the scheduler as:
-    # <server_state_dir>/servers/<env_id>. The scheduler creates the executors
-    # subdirectory in it.
+    # <server_state_dir>/servers/<env_id> in the scheduler.cfg file. The scheduler
+    # creates the executors subdirectory.
     assert not os.path.exists(os.path.join(server_state_dir, "executors"))
     assert os.path.exists(os.path.join(server_state_dir, "server", environment, "executors"))
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -23,7 +23,7 @@ import os
 import typing
 import uuid
 from asyncio import subprocess
-from typing import Optional
+from typing import Iterator, Optional
 from unittest.mock import Mock
 from uuid import UUID, uuid4
 
@@ -624,7 +624,7 @@ async def test_process_already_terminated(server, environment):
 
 
 @pytest.fixture
-def set_state_dir_using_env_var(monkeypatch, tmpdir) -> str:
+def set_state_dir_using_env_var(monkeypatch, tmpdir) -> Iterator[str]:
     """
     Fixture that creates a temporary directory and configures it as the state directory
     of the server using the INMANTA_CONFIG_STATE_DIR environment variable.

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -624,12 +624,12 @@ async def test_process_already_terminated(server, environment):
 
 
 @pytest.fixture
-def set_state_dir_using_env_var(monkeypatch, tmpdir) -> Iterator[str]:
+def set_state_dir_using_env_var(monkeypatch, tmp_path) -> Iterator[str]:
     """
     Fixture that creates a temporary directory and configures it as the state directory
     of the server using the INMANTA_CONFIG_STATE_DIR environment variable.
     """
-    state_dir = os.path.join(tmpdir, "state_dir")
+    state_dir = str(tmp_path / "state_dir")
     os.mkdir(state_dir)
     monkeypatch.setenv("INMANTA_CONFIG_STATE_DIR", state_dir)
     yield state_dir

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import os
 import asyncio
 import datetime
 import logging
@@ -621,6 +622,34 @@ async def test_process_already_terminated(server, environment):
     # This call shouldn't raise an exception
     await autostarted_agent_manager._terminate_agents()
 
+@pytest.fixture
+def set_state_dir_using_env_var(monkeypatch, tmpdir) -> str:
+    """
+    Fixture that creates a temporary directory and configures it as the state directory
+    of the server using the INMANTA_CONFIG_STATE_DIR environment variable.
+    """
+    state_dir = os.path.join(tmpdir, "state_dir")
+    os.mkdir(state_dir)
+    monkeypatch.setenv("INMANTA_CONFIG_STATE_DIR", state_dir)
+    yield state_dir
+
+@pytest.mark.parametrize("auto_start_agent", [True])
+async def test_state_dir_scheduler(set_state_dir_using_env_var: str, server, environment):
+    """
+    Verify that the scheduler is using the state dir configured in its scheduler.cfg file.
+    It must ignore configuration options set using environment variables.
+    """
+    server_state_dir: str = set_state_dir_using_env_var
+
+    autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
+    await autostarted_agent_manager._ensure_scheduler(env=uuid.UUID(environment))
+    assert len(autostarted_agent_manager._agent_procs) == 1
+
+    # The AutostartedAgentManager configures the state dir of the scheduler as:
+    # <server_state_dir>/servers/<env_id>. The scheduler creates the executors
+    # subdirectory in it.
+    assert not os.path.exists(os.path.join(server_state_dir, "executors"))
+    assert os.path.exists(os.path.join(server_state_dir, "server", environment, "executors"))
 
 async def test_error_handling_agent_fork(server, environment, monkeypatch):
     """

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -636,7 +636,7 @@ def set_state_dir_using_env_var(monkeypatch, tmpdir) -> str:
 
 
 @pytest.mark.parametrize("auto_start_agent", [True])
-async def test_state_dir_scheduler(set_state_dir_using_env_var: str, server, environment):
+async def test_scheduler_ignores_env_var_state_dir(set_state_dir_using_env_var: str, server, environment):
     """
     Verify that the scheduler is using the state dir configured in its scheduler.cfg file
     and ignores the state directory configured using an environment variable.

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -16,10 +16,10 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-import os
 import asyncio
 import datetime
 import logging
+import os
 import typing
 import uuid
 from asyncio import subprocess
@@ -622,6 +622,7 @@ async def test_process_already_terminated(server, environment):
     # This call shouldn't raise an exception
     await autostarted_agent_manager._terminate_agents()
 
+
 @pytest.fixture
 def set_state_dir_using_env_var(monkeypatch, tmpdir) -> str:
     """
@@ -632,6 +633,7 @@ def set_state_dir_using_env_var(monkeypatch, tmpdir) -> str:
     os.mkdir(state_dir)
     monkeypatch.setenv("INMANTA_CONFIG_STATE_DIR", state_dir)
     yield state_dir
+
 
 @pytest.mark.parametrize("auto_start_agent", [True])
 async def test_state_dir_scheduler(set_state_dir_using_env_var: str, server, environment):
@@ -650,6 +652,7 @@ async def test_state_dir_scheduler(set_state_dir_using_env_var: str, server, env
     # subdirectory in it.
     assert not os.path.exists(os.path.join(server_state_dir, "executors"))
     assert os.path.exists(os.path.join(server_state_dir, "server", environment, "executors"))
+
 
 async def test_error_handling_agent_fork(server, environment, monkeypatch):
     """

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -376,6 +376,10 @@ def test_auth_jwt_env_vars_ignored_with_load_config(tmp_path, monkeypatch):
     Verify that when Config.load_config() is called with ignore_env_vars=True,
     AuthJWTConfig does not pick up JWT configuration from environment variables.
     """
+    # This environment variable overrides the client_types config option
+    # from the config file.
+    monkeypatch.setenv(f"{auth.ENV_AUTH_JWT_PREFIX}DEFAULT_CLIENT_TYPES", "api")
+
     config_file = os.path.join(tmp_path, "auth.cfg")
     with open(config_file, "w", encoding="utf-8") as fd:
         fd.write("""
@@ -391,10 +395,6 @@ audience=https://localhost:8888/
 
     config.Config.load_config(config_file, ignore_env_vars=True)
 
-    # This environment variable overrides the client_types config option
-    # from the config file.
-    monkeypatch.setenv(f"{auth.ENV_AUTH_JWT_PREFIX}DEFAULT_CLIENT_TYPES", "api")
-
     cfg_list = auth.AuthJWTConfig.list()
     assert cfg_list == ["default"]
 
@@ -407,6 +407,10 @@ def test_auth_jwt_env_vars_ignored_with_load_config_from_dict(monkeypatch):
     Verify that when Config.load_config_from_dict() is called with ignore_env_vars=True,
     AuthJWTConfig does not pick up JWT configuration from environment variables.
     """
+    # This environment variable overrides the client_types config option
+    # from the config dictionary.
+    monkeypatch.setenv(f"{auth.ENV_AUTH_JWT_PREFIX}DEFAULT_CLIENT_TYPES", "api")
+
     config.Config.load_config_from_dict(
         {
             "auth_jwt_default": {
@@ -421,10 +425,6 @@ def test_auth_jwt_env_vars_ignored_with_load_config_from_dict(monkeypatch):
         },
         ignore_env_vars=True,
     )
-
-    # This environment variable overrides the client_types config option
-    # from the config dictionary.
-    monkeypatch.setenv(f"{auth.ENV_AUTH_JWT_PREFIX}DEFAULT_CLIENT_TYPES", "api")
 
     cfg_list = auth.AuthJWTConfig.list()
     assert cfg_list == ["default"]

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -369,3 +369,65 @@ def test_authjwtconfig_thread_safe(inmanta_config):
         raise Exception(f"Some threads didn't stop after a timeout: {[(t.name, t.is_alive()) for t in threads]}")
 
     assert not errors, errors
+
+
+def test_auth_jwt_env_vars_ignored_with_load_config(tmp_path, monkeypatch):
+    """
+    Verify that when Config.load_config() is called with ignore_env_vars=True,
+    AuthJWTConfig does not pick up JWT configuration from environment variables.
+    """
+    config_file = os.path.join(tmp_path, "auth.cfg")
+    with open(config_file, "w", encoding="utf-8") as fd:
+        fd.write("""
+[auth_jwt_default]
+algorithm=HS256
+sign=true
+client_types=agent,compiler
+key=eciwliGyqECVmXtIkNpfVrtBLutZiITZKSKYhogeHMM
+expire=0
+issuer=https://localhost:8888/
+audience=https://localhost:8888/
+""")
+
+    config.Config.load_config(config_file, ignore_env_vars=True)
+
+    # This environment variable overrides the client_types config option
+    # from the config file.
+    monkeypatch.setenv(f"{auth.ENV_AUTH_JWT_PREFIX}DEFAULT_CLIENT_TYPES", "api")
+
+    cfg_list = auth.AuthJWTConfig.list()
+    assert cfg_list == ["default"]
+
+    cfg = auth.AuthJWTConfig.get("default")
+    assert sorted(cfg.client_types) == sorted(["agent", "compiler"])
+
+
+def test_auth_jwt_env_vars_ignored_with_load_config_from_dict(monkeypatch):
+    """
+    Verify that when Config.load_config_from_dict() is called with ignore_env_vars=True,
+    AuthJWTConfig does not pick up JWT configuration from environment variables.
+    """
+    config.Config.load_config_from_dict(
+        {
+            "auth_jwt_default": {
+                "algorithm": "HS256",
+                "sign": "true",
+                "client_types": "agent,compiler",
+                "key": "eciwliGyqECVmXtIkNpfVrtBLutZiITZKSKYhogeHMM",
+                "expire": "0",
+                "issuer": "https://localhost:8888/",
+                "audience": "https://localhost:8888/",
+            }
+        },
+        ignore_env_vars=True,
+    )
+
+    # This environment variable overrides the client_types config option
+    # from the config dictionary.
+    monkeypatch.setenv(f"{auth.ENV_AUTH_JWT_PREFIX}DEFAULT_CLIENT_TYPES", "api")
+
+    cfg_list = auth.AuthJWTConfig.list()
+    assert cfg_list == ["default"]
+
+    cfg = auth.AuthJWTConfig.get("default")
+    assert sorted(cfg.client_types) == sorted(["agent", "compiler"])


### PR DESCRIPTION
# Description

This PR fixes the bug where environment variables, set on the server, are taken into account by schedulers started by that server. The sever generates a configuration file for each scheduler and only the configuration options in that file should be taken into account. Any configuration option set using an environment variable must be ignored.

The concrete issue we faced is that the Inmanta docker container sets the state_dir directory as a environment variable by default. Hence, all schedulers use the same state directory and not the state directory configured in the scheduler.cfg file. As such, all schedulers would store their venv directories in the same location. This caused race conditions where one scheduler would cleanup a venv that was created by another process.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~