### PR TITLE
Issue/fix all schedulers use same state dir alt

### DIFF
--- a/changelogs/unreleased/bugfix-all-schedulers-use-same-state-dir.yml
+++ b/changelogs/unreleased/bugfix-all-schedulers-use-same-state-dir.yml
@@ -1,0 +1,6 @@
+---
+description: 'Fixed the bug where all the agents of the different environments used the same state directory. This bug can cause a "no such file or directory" error on the .inmanta_venv_status file of an agent which prevents resources from being deployed.'
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -982,7 +982,6 @@ src/inmanta/resources.py:0: error: Returning Any from function declared to retur
 src/inmanta/server/agentmanager.py:0: error: Call to untyped function "get_status" in typed context  [no-untyped-call]
 src/inmanta/server/agentmanager.py:0: error: Item "None" of "Sequence[Agent] | None" has no attribute "__iter__" (not iterable)  [union-attr]
 src/inmanta/server/agentmanager.py:0: error: Value of type "dict[str, Any] | None" is not indexable  [index]
-src/inmanta/server/agentmanager.py:0: error: Value of type variable "AnyStr" of "abspath" cannot be "str | None"  [type-var]
 src/inmanta/server/bootloader.py:0: error: Incompatible return value type (got "Iterator[ModuleInfo]", expected "Generator[ModuleInfo, None, None]")  [return-value]
 src/inmanta/server/config.py:0: error: Cannot infer value of type parameter "T" of "Option"  [misc]
 src/inmanta/server/config.py:0: error: Cannot infer value of type parameter "T" of "Option"  [misc]

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -579,7 +579,7 @@ def make_option_for_log_file(component_name: str) -> Option[str | None]:
 
 
 component_log_configs = {k: make_option_for_log_file(k) for k in ["server", "scheduler", "compiler"]}
-scheduler_log_config = component_log_configs["scheduler"]
+scheduler_log_config: Option[str | None] = component_log_configs["scheduler"]
 
 
 def get_executable() -> Optional[str]:

--- a/src/inmanta/config.py
+++ b/src/inmanta/config.py
@@ -241,16 +241,21 @@ class Config:
         name = normalize_name(name)
 
         option: Optional[Option[object]] = cls.validate_option_request(section, name, default_value)
-        return cls.get_for_option(option) if option is not None else cls._get_value(section, name, default_value)
+        return cls.get_for_option(option) if option is not None else cls.get_raw_value(section, name, default_value)
 
     @classmethod
     def get_for_option(cls, option: "Option[T]") -> T:
-        default_value = option.get_default_value()
-        raw_value: str | T = cls._get_value(option.section, option.name, default_value)
-        return option.validate(raw_value)
+        """
+        Returns the parsed and validated option. Unlike Option.get(), does not fall back to deprecated predecessor option.
+        """
+        return option.parse(cls.get_raw_value(option.section, option.name, None))
 
     @classmethod
-    def _get_value(cls, section: str, name: str, default_value: T) -> str | T:
+    def get_raw_value(cls, section: str, name: str, default_value: T) -> str | T:
+        """
+        Returns the option as the raw string as defined in the config file / env var, or default_value if it is not set.
+        To get the properly typed option value, with default value filled in, see get_for_option().
+        """
         cfg: ConfigParser = cls.get_instance()
         val: Optional[str] = _get_from_env(section, name)
         if val is not None:
@@ -435,7 +440,7 @@ class Option(Generic[T]):
     :param documentation: the documentation for this option
     :param validator: a function responsible for turning the string representation of the option into the correct type.
         Its docstring is used as representation for the type of the option.
-    :param predecessor_option: The Option that was deprecated in favour of this option.
+    :param predecessor_option: The Option that was deprecated in favour of this option. Should not be nested.
     """
 
     def __init__(
@@ -461,18 +466,31 @@ class Option(Generic[T]):
         """
         return f"{self.section}.{self.name}"
 
-    def get(self) -> T:
+    def get_raw(self) -> str | None:
+        """
+        Returns this option as the raw string as defined in the config file / env var, or None if it is not set.
+        """
         raw_config: ConfigParser = Config.get()
-        if self.predecessor_option:
-            has_deprecated_option = raw_config.has_option(self.predecessor_option.section, self.predecessor_option.name)
-            has_new_option = raw_config.has_option(self.section, self.name)
-            if has_deprecated_option and not has_new_option:
-                warnings.warn(
-                    f"Config option {self.predecessor_option.name} is deprecated. Use {self.name} instead.",
-                    category=DeprecationWarning,
-                )
-                return self.predecessor_option.get()
-        return Config.get_for_option(self)
+        result: str | None = Config.get_raw_value(self.section, self.name, None)
+        if result is not None or not self.predecessor_option:
+            return result
+        predecessor_result: str | None = self.predecessor_option.get_raw()
+        if predecessor_result is not None:
+            warnings.warn(
+                f"Config option {self.predecessor_option.name} is deprecated. Use {self.name} instead.",
+                category=DeprecationWarning,
+            )
+            return predecessor_result
+        return None
+
+    def parse(self, value: str | None) -> T:
+        """
+        Parses the raw string value by running it through validate, or returns default value if None.
+        """
+        return self.validate(value if value is not None else self.get_default_value())
+
+    def get(self) -> T:
+        return self.parse(self.get_raw())
 
     def get_type(self) -> Optional[str]:
         if callable(self.validator):

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -55,7 +55,7 @@ from inmanta.server import (
     SLICE_SERVER,
     SLICE_TRANSPORT,
 )
-from inmanta.server import config as opt
+from inmanta.server import config as server_config
 from inmanta.server import protocol
 from inmanta.server.protocol import ServerSlice
 from inmanta.server.server import Server
@@ -63,7 +63,6 @@ from inmanta.server.services import environmentservice
 from inmanta.types import Apireturn, ArgumentTypes, ResourceIdStr, ReturnTupple
 
 from ..data.dataview import AgentView
-from . import config as server_config
 from .validate_filter import InvalidFilter
 
 LOGGER = logging.getLogger(__name__)
@@ -120,7 +119,7 @@ class AgentManager(ServerSlice, websocket.SessionListener):
         super().__init__(SLICE_AGENT_MANAGER)
 
         if fact_back_off is None:
-            fact_back_off = opt.server_fact_resource_block.get()
+            fact_back_off = server_config.server_fact_resource_block.get()
 
         # back-off timer for fact requests
         self._fact_resource_block: int = fact_back_off
@@ -218,7 +217,7 @@ class AgentManager(ServerSlice, websocket.SessionListener):
             await self._expire_all_sessions_in_db()
 
         # Schedule cleanup of schedulersession table
-        agent_process_purge_interval = opt.agent_process_purge_interval.get()
+        agent_process_purge_interval = server_config.agent_process_purge_interval.get()
         if agent_process_purge_interval > 0:
             self.schedule(
                 self._purge_agent_processes, interval=agent_process_purge_interval, initial_delay=0, cancel_on_stop=False
@@ -483,7 +482,7 @@ class AgentManager(ServerSlice, websocket.SessionListener):
                     await data.SchedulerSession.expire_all(now=datetime.now().astimezone(), connection=connection)
 
     async def _purge_agent_processes(self) -> None:
-        agent_processes_to_keep = opt.agent_processes_to_keep.get()
+        agent_processes_to_keep = server_config.agent_processes_to_keep.get()
         await data.SchedulerSession.cleanup(nr_expired_records_to_keep=agent_processes_to_keep)
 
     def get_session_for(self, tid: uuid.UUID) -> Optional[websocket.Session]:
@@ -979,19 +978,18 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         """
         assert not assert_no_start_scheduler
 
-        config_options: str = await self._make_agent_config(env)
+        config_options: Mapping[inmanta.config.Option[object], str | None] = await self._get_agent_config(env)
 
         root_dir: str = self._server_storage["server"]
         config_dir = os.path.join(root_dir, str(env.id))
 
         os.makedirs(config_dir, exist_ok=True)
 
-        # TODO: clean up, move to config module
-        parser = global_config.LenientConfigParser(interpolation=configparser.Interpolation())
         section_dict: dict[str, dict[str, str]] = {}
         for option, value in config_options.items():
             if value is not None:
-                section_dict.setdefault(option.section, {})[option.name] = str(value)
+                section_dict.setdefault(option.section, {})[option.name] = value
+        parser = global_config.LenientConfigParser(interpolation=configparser.Interpolation())
         parser.read_dict(section_dict)
 
         config_path = os.path.join(config_dir, "scheduler.cfg")
@@ -1021,63 +1019,70 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         LOGGER.debug("Started new agent with PID %s", proc.pid)
         return ProcessDetails(process=proc, path_stdout=out, path_stderr=err)
 
-    async def _make_agent_config(
+    async def _get_agent_config(
         self,
         env: data.Environment,
-    ) -> dict[inmanta.config.Option[object], object | None]:
-        # TODO: return type. Also mention the None semantics
+    ) -> dict[inmanta.config.Option[object], str | None]:
         """
-        Generate the config file for the process that hosts the autostarted agents
+        Returns the config specific to this agent. All other config options should be inherited from the global config /
+        environment.
+
+        Returns all options that should be overridden for this agent. A None value signals that it should be left unset,
+        not inherited from the environment. Config values are returned as str to guarantee round-trip compatibility
+        (e.g. in cases where default != validate(str(default)), such as comma-separated lists).
 
         :param env: The environment for which to autostart agents
-        :return: A string that contains the config file content.
+        :return: A mapping of config options to their values
         """
         environment_id: str = str(env.id)
-        port: int = opt.server_bind_port.get()
 
-        privatestatedir: str = self._get_state_dir_for_agent_in_env(env.id)
-
-        agent_config_overrides: dict[inmanta.config.Option[object], object | None] = {
+        agent_config_overrides: Mapping[inmanta.config.Option[object], str | None] = {
             # global config overrides
-            global_config.state_dir: privatestatedir,
-            # TODO: redundant?
-            global_config.log_dir: global_config.log_dir.get(),
+            global_config.state_dir: self._get_state_dir_for_agent_in_env(env.id),
             # scheduler config
             agent_cfg.environment: environment_id,
-            # TODO: 2 redundant?
-            agent_cfg.agent_executor_cap: agent_cfg.agent_executor_cap.get(),
-            agent_cfg.agent_executor_retention_time: agent_cfg.agent_executor_retention_time.get(),
             # agent transport
-            agent_cfg.agent_transport.host: opt.internal_server_address.get(),
-            agent_cfg.agent_transport.port: port,
-            agent_cfg.agent_transport.ssl: server_config.server_ssl_key.get() is not None,
+            agent_cfg.agent_transport.host: server_config.internal_server_address.get(),
+            agent_cfg.agent_transport.port: str(server_config.server_bind_port.get()),
+            agent_cfg.agent_transport.ssl: str(server_config.server_ssl_key.get() is not None).lower(),
             agent_cfg.agent_transport.ssl_ca_cert_file: server_config.server_ssl_ca_cert.get(),
             agent_cfg.agent_transport.token: (
                 encode_token(["agent"], environment_id) if server_config.server_enable_auth.get() else None
             ),
         }
-        # TODO: add a comment: passthrough just in case until the follow-up ticket is fixed, though server
-        #       config is read by agent anyway
-        agent_config_passthrough: dict[inmanta.config.Option[object], object | None] = {
-            option: option.get()
+        # Best-effort approach to work around TODO: link ticket
+        # use get_raw() because it is guaranteed to be round-trip compatible
+        agent_config_passthrough: Mapping[inmanta.config.Option[object], str | None] = {
+            option: option.get_raw()
             for option in [
-                opt.db_wait_time,
-                opt.db_host,
-                opt.db_port,
-                opt.db_name,
-                opt.db_username,
-                opt.db_password,
+                global_config.log_dir,
+                scheduler_log_config,
+                agent_cfg.agent_reconnect_delay,
+                agent_cfg.server_timeout,
+                agent_cfg.agent_executor_cap,
+                agent_cfg.agent_executor_retention_time,
+                agent_cfg.executor_venv_retention_time,
+                agent_cfg.agent_cache_cleanup_tick_rate,
+                agent_cfg.agent_ws_ping_interval,
+                agent_cfg.agent_ws_ping_timeout,
+                agent_cfg.agent_transport.request_timeout,
+                agent_cfg.agent_transport.max_clients,
                 agent_cfg.scheduler_db_connection_pool_min_size,
                 agent_cfg.scheduler_db_connection_pool_max_size,
                 agent_cfg.scheduler_db_connection_timeout,
-                opt.influxdb_host,
-                opt.influxdb_port,
-                opt.influxdb_name,
-                opt.influxdb_username,
-                opt.influxdb_password,
-                opt.influxdb_interval,
-                opt.influxdb_tags,
-                scheduler_log_config,
+                server_config.db_wait_time,
+                server_config.db_host,
+                server_config.db_port,
+                server_config.db_name,
+                server_config.db_username,
+                server_config.db_password,
+                server_config.influxdb_host,
+                server_config.influxdb_port,
+                server_config.influxdb_name,
+                server_config.influxdb_username,
+                server_config.influxdb_password,
+                server_config.influxdb_interval,
+                server_config.influxdb_tags,
             ]
         }
 

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -17,6 +17,7 @@ Contact: code@inmanta.com
 """
 
 import asyncio
+import configparser
 import logging
 import os
 import shutil
@@ -961,7 +962,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
                     start_new_process = False
 
                 if start_new_process:
-                    self._agent_procs[env] = await self.__do_start_agent(refreshed_env, connection=connection)
+                    self._agent_procs[env] = await self.__do_start_agent(refreshed_env)
 
                 # Wait for the scheduler to come up
                 try:
@@ -970,9 +971,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
                     LOGGER.warning("Scheduler did not become active before the timeout expired")
                 return start_new_process
 
-    async def __do_start_agent(
-        self, env: data.Environment, *, connection: Optional[asyncpg.connection.Connection] = None
-    ) -> ProcessDetails:
+    async def __do_start_agent(self, env: data.Environment) -> ProcessDetails:
         """
         Start an autostarted agent process for the given environment. Should only be called if none is running yet.
 
@@ -980,19 +979,34 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         """
         assert not assert_no_start_scheduler
 
-        config: str = await self._make_agent_config(env, connection=connection)
+        config_options: str = await self._make_agent_config(env)
 
         root_dir: str = self._server_storage["server"]
         config_dir = os.path.join(root_dir, str(env.id))
 
         os.makedirs(config_dir, exist_ok=True)
 
+        # TODO: clean up, move to config module
+        parser = global_config.LenientConfigParser(interpolation=configparser.Interpolation())
+        section_dict: dict[str, dict[str, str]] = {}
+        for option, value in config_options.items():
+            if value is not None:
+                section_dict.setdefault(option.section, {})[option.name] = str(value)
+        parser.read_dict(section_dict)
+
         config_path = os.path.join(config_dir, "scheduler.cfg")
         with open(config_path, "w+", encoding="utf-8") as fd:
-            fd.write(config)
+            parser.write(fd)
 
         out: str = os.path.join(self._server_storage["logs"], "agent-%s.out" % env.id)
         err: str = os.path.join(self._server_storage["logs"], "agent-%s.err" % env.id)
+
+        env = os.environ.copy()
+        # TODO: clean up
+        for opt in config_options.keys():
+            env.pop(opt.get_environment_variable(), None)
+        # TODO: does this belong here or in fork_inmanta?
+        env.update(tracing.get_context())
 
         proc: subprocess.Process = await self._fork_inmanta(
             [
@@ -1005,6 +1019,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
             ],
             out,
             err,
+            env=env,
         )
 
         LOGGER.debug("Started new agent with PID %s", proc.pid)
@@ -1013,95 +1028,66 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
     async def _make_agent_config(
         self,
         env: data.Environment,
-        *,
-        connection: Optional[asyncpg.connection.Connection],
-    ) -> str:
+    ) -> dict[inmanta.config.Option[object], object | None]:
+        # TODO: return type. Also mention the None semantics
         """
         Generate the config file for the process that hosts the autostarted agents
 
         :param env: The environment for which to autostart agents
         :return: A string that contains the config file content.
         """
-        environment_id = str(env.id)
+        environment_id: str = str(env.id)
         port: int = opt.server_bind_port.get()
 
         privatestatedir: str = self._get_state_dir_for_agent_in_env(env.id)
 
-        # generate config file
-        config = f"""[config]
-state-dir=%(statedir)s
-log-dir={global_config.log_dir.get()}
+        agent_config_overrides: dict[inmanta.config.Option[object], object | None] = {
+            # global config overrides
+            global_config.state_dir: privatestatedir,
+            # TODO: redundant?
+            global_config.log_dir: global_config.log_dir.get(),
 
-environment=%(env_id)s
+            # scheduler config
+            agent_cfg.environment: environment_id,
+            # TODO: 2 redundant?
+            agent_cfg.agent_executor_cap: agent_cfg.agent_executor_cap.get(),
+            agent_cfg.agent_executor_retention_time: agent_cfg.agent_executor_retention_time.get(),
 
-[agent]
-executor-cap={agent_cfg.agent_executor_cap.get()}
-executor-retention-time={agent_cfg.agent_executor_retention_time.get()}
-
-[agent_rest_transport]
-port=%(port)s
-host={opt.internal_server_address.get()}
-""" % {
-            "env_id": environment_id,
-            "port": port,
-            "statedir": privatestatedir,
+            # agent transport
+            agent_cfg.agent_transport.host: opt.internal_server_address.get(),
+            agent_cfg.agent_transport.port: port,
+            agent_cfg.agent_transport.ssl: server_config.server_ssl_key.get() is not None,
+            agent_cfg.agent_transport.ssl_ca_cert_file: server_config.server_ssl_ca_cert.get(),
+            agent_cfg.agent_transport.token: encode_token(["agent"], environment_id) if server_config.server_enable_auth.get() else None,
+        }
+        # TODO: add a comment: passthrough just in case until the follow-up ticket is fixed, though server config is read by agent anyway
+        agent_config_passthrough: dict[inmanta.config.Option[object], object | None] = {
+            option: option.get()
+            for option in [
+                opt.db_wait_time,
+                opt.db_host,
+                opt.db_port,
+                opt.db_name,
+                opt.db_username,
+                opt.db_password,
+                agent_cfg.scheduler_db_connection_pool_min_size,
+                agent_cfg.scheduler_db_connection_pool_max_size,
+                agent_cfg.scheduler_db_connection_timeout,
+                opt.influxdb_host,
+                opt.influxdb_port,
+                opt.influxdb_name,
+                opt.influxdb_username,
+                opt.influxdb_password,
+                opt.influxdb_interval,
+                opt.influxdb_tags,
+                scheduler_log_config,
+            ]
         }
 
-        if server_config.server_enable_auth.get():
-            token = encode_token(["agent"], environment_id)
-            config += """
-token=%s
-    """ % (token)
-
-        ssl_cert: Optional[str] = server_config.server_ssl_key.get()
-        ssl_ca: Optional[str] = server_config.server_ssl_ca_cert.get()
-
-        if ssl_ca is not None and ssl_cert is not None:
-            # override CA
-            config += """
-ssl=True
-ssl_ca_cert_file=%s
-    """ % (ssl_ca)
-        elif ssl_cert is not None:
-            # system CA
-            config += """
-ssl=True
-    """
-        config += f"""
-[database]
-wait_time={opt.db_wait_time.get()}
-host={opt.db_host.get()}
-port={opt.db_port.get()}
-name={opt.db_name.get()}
-username={opt.db_username.get()}
-password={opt.db_password.get()}
-
-[scheduler]
-db-connection-pool-min-size={agent_cfg.scheduler_db_connection_pool_min_size.get()}
-db-connection-pool-max-size={agent_cfg.scheduler_db_connection_pool_max_size.get()}
-db-connection-timeout={agent_cfg.scheduler_db_connection_timeout.get()}
-
-[influxdb]
-host = {opt.influxdb_host.get()}
-port = {opt.influxdb_port.get()}
-name = {opt.influxdb_name.get()}
-username = {opt.influxdb_username.get()}
-password = {opt.influxdb_password.get()}
-interval = {opt.influxdb_interval.get()}
-tags = {config_map_to_str(opt.influxdb_tags.get())}
-"""
-
-        if scheduler_log_config.get():
-            config += f"""
-
-[logging]
-scheduler = {os.path.abspath(scheduler_log_config.get())}
-"""
-
-        return config
+        return agent_config_overrides | agent_config_passthrough
 
     async def _fork_inmanta(
-        self, args: list[str], outfile: Optional[str], errfile: Optional[str], cwd: Optional[str] = None
+        self, args: list[str], outfile: Optional[str], errfile: Optional[str], cwd: Optional[str] = None, *, env: Mapping[str, object] | None = None
     ) -> subprocess.Process:
         """
         Fork an inmanta process from the same code base as the current code
@@ -1116,8 +1102,6 @@ scheduler = {os.path.abspath(scheduler_log_config.get())}
             if errfile is not None:
                 errhandle = open(errfile, "wb+")
 
-            env = os.environ.copy()
-            env.update(tracing.get_context())
             return await asyncio.create_subprocess_exec(
                 sys.executable, *full_args, cwd=cwd, env=env, stdout=outhandle, stderr=errhandle
             )

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -784,7 +784,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         preserver = server.get_slice(SLICE_SERVER)
         assert isinstance(preserver, Server)
         self._server: Server = preserver
-        self._server_storage: dict[str, str] = self._server._server_storage
+        self._server_storage: Mapping[str, str] = self._server._server_storage
 
         agent_manager = server.get_slice(SLICE_AGENT_MANAGER)
         assert isinstance(agent_manager, AgentManager)

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -1051,7 +1051,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
             ),
         }
 
-        # Best-effort approach to work around TODO: link ticket
+        # Best-effort approach to work around #10421
         agent_config_passthrough: Sequence[inmanta.config.Option[typing.Any]] = [
             global_config.log_dir,
             scheduler_log_config,

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -41,7 +41,7 @@ from inmanta import const, data
 from inmanta import logging as inmanta_logging
 from inmanta import tracing
 from inmanta.agent import config as agent_cfg
-from inmanta.config import Config, config_map_to_str, scheduler_log_config
+from inmanta.config import Config, scheduler_log_config
 from inmanta.const import AgentAction, AgentStatus, AllAgentAction
 from inmanta.data import APILIMIT, Environment, InvalidSort, model
 from inmanta.data.model import DataBaseReport
@@ -1001,12 +1001,8 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         out: str = os.path.join(self._server_storage["logs"], "agent-%s.out" % env.id)
         err: str = os.path.join(self._server_storage["logs"], "agent-%s.err" % env.id)
 
-        env = os.environ.copy()
-        # TODO: clean up
-        for opt in config_options.keys():
-            env.pop(opt.get_environment_variable(), None)
-        # TODO: does this belong here or in fork_inmanta?
-        env.update(tracing.get_context())
+        shadowed_config_env_vars: Set[str] = {option.get_environment_variable() for option in config_options.keys()}
+        env = {k: v for k, v in os.environ.items() if k not in shadowed_config_env_vars}
 
         proc: subprocess.Process = await self._fork_inmanta(
             [
@@ -1046,21 +1042,22 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
             global_config.state_dir: privatestatedir,
             # TODO: redundant?
             global_config.log_dir: global_config.log_dir.get(),
-
             # scheduler config
             agent_cfg.environment: environment_id,
             # TODO: 2 redundant?
             agent_cfg.agent_executor_cap: agent_cfg.agent_executor_cap.get(),
             agent_cfg.agent_executor_retention_time: agent_cfg.agent_executor_retention_time.get(),
-
             # agent transport
             agent_cfg.agent_transport.host: opt.internal_server_address.get(),
             agent_cfg.agent_transport.port: port,
             agent_cfg.agent_transport.ssl: server_config.server_ssl_key.get() is not None,
             agent_cfg.agent_transport.ssl_ca_cert_file: server_config.server_ssl_ca_cert.get(),
-            agent_cfg.agent_transport.token: encode_token(["agent"], environment_id) if server_config.server_enable_auth.get() else None,
+            agent_cfg.agent_transport.token: (
+                encode_token(["agent"], environment_id) if server_config.server_enable_auth.get() else None
+            ),
         }
-        # TODO: add a comment: passthrough just in case until the follow-up ticket is fixed, though server config is read by agent anyway
+        # TODO: add a comment: passthrough just in case until the follow-up ticket is fixed, though server
+        #       config is read by agent anyway
         agent_config_passthrough: dict[inmanta.config.Option[object], object | None] = {
             option: option.get()
             for option in [
@@ -1087,11 +1084,20 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         return agent_config_overrides | agent_config_passthrough
 
     async def _fork_inmanta(
-        self, args: list[str], outfile: Optional[str], errfile: Optional[str], cwd: Optional[str] = None, *, env: Mapping[str, object] | None = None
+        self,
+        args: list[str],
+        outfile: Optional[str],
+        errfile: Optional[str],
+        cwd: Optional[str] = None,
+        *,
+        env: Mapping[str, object] | None = None,
     ) -> subprocess.Process:
         """
         Fork an inmanta process from the same code base as the current code
         """
+        env = env if env is not None else os.environ.copy()
+        env.update(tracing.get_context())
+
         full_args = ["-m", "inmanta.app", *args]
         # handles can be closed, owned by child process,...
         outhandle = None

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -979,7 +979,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         """
         assert not assert_no_start_scheduler
 
-        config_options: Mapping[inmanta.config.Option[object], str | None] = await self._get_agent_config(env)
+        config_options: Mapping[inmanta.config.Option[object], str | None] = self._get_agent_config(env)
 
         root_dir: str = self._server_storage["server"]
         config_dir = os.path.join(root_dir, str(env.id))
@@ -1019,7 +1019,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         LOGGER.debug("Started new agent with PID %s", proc.pid)
         return ProcessDetails(process=proc, path_stdout=out, path_stderr=err)
 
-    async def _get_agent_config(
+    def _get_agent_config(
         self,
         env: data.Environment,
     ) -> dict[inmanta.config.Option[object], str | None]:
@@ -1035,6 +1035,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         :return: A mapping of config options to their values
         """
         environment_id: str = str(env.id)
+        scheduler_log_config_value: str | None = scheduler_log_config.get()
 
         agent_config_overrides: dict[inmanta.config.Option[typing.Any], str | None] = {
             # global config overrides
@@ -1049,12 +1050,14 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
             agent_cfg.agent_transport.token: (
                 encode_token(["agent"], environment_id) if server_config.server_enable_auth.get() else None
             ),
+            scheduler_log_config: (
+                os.path.abspath(scheduler_log_config_value) if scheduler_log_config_value is not None else None
+            ),
         }
 
         # Best-effort approach to work around #10421
         agent_config_passthrough: Sequence[inmanta.config.Option[typing.Any]] = [
             global_config.log_dir,
-            scheduler_log_config,
             agent_cfg.agent_reconnect_delay,
             agent_cfg.server_timeout,
             agent_cfg.agent_executor_cap,

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import sys
 import time
+import typing
 import uuid
 from asyncio import subprocess
 from collections.abc import Iterable, Mapping, Sequence, Set
@@ -1000,7 +1001,6 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         err: str = os.path.join(self._server_storage["logs"], "agent-%s.err" % env.id)
 
         shadowed_config_env_vars: Set[str] = {option.get_environment_variable() for option in config_options.keys()}
-        env = {k: v for k, v in os.environ.items() if k not in shadowed_config_env_vars}
 
         proc: subprocess.Process = await self._fork_inmanta(
             [
@@ -1013,7 +1013,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
             ],
             out,
             err,
-            env=env,
+            env={k: v for k, v in os.environ.items() if k not in shadowed_config_env_vars},
         )
 
         LOGGER.debug("Started new agent with PID %s", proc.pid)
@@ -1036,7 +1036,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         """
         environment_id: str = str(env.id)
 
-        agent_config_overrides: Mapping[inmanta.config.Option[object], str | None] = {
+        agent_config_overrides: dict[inmanta.config.Option[typing.Any], str | None] = {
             # global config overrides
             global_config.state_dir: self._get_state_dir_for_agent_in_env(env.id),
             # scheduler config
@@ -1050,43 +1050,40 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
                 encode_token(["agent"], environment_id) if server_config.server_enable_auth.get() else None
             ),
         }
-        # Best-effort approach to work around TODO: link ticket
-        # use get_raw() because it is guaranteed to be round-trip compatible
-        agent_config_passthrough: Mapping[inmanta.config.Option[object], str | None] = {
-            option: option.get_raw()
-            for option in [
-                global_config.log_dir,
-                scheduler_log_config,
-                agent_cfg.agent_reconnect_delay,
-                agent_cfg.server_timeout,
-                agent_cfg.agent_executor_cap,
-                agent_cfg.agent_executor_retention_time,
-                agent_cfg.executor_venv_retention_time,
-                agent_cfg.agent_cache_cleanup_tick_rate,
-                agent_cfg.agent_ws_ping_interval,
-                agent_cfg.agent_ws_ping_timeout,
-                agent_cfg.agent_transport.request_timeout,
-                agent_cfg.agent_transport.max_clients,
-                agent_cfg.scheduler_db_connection_pool_min_size,
-                agent_cfg.scheduler_db_connection_pool_max_size,
-                agent_cfg.scheduler_db_connection_timeout,
-                server_config.db_wait_time,
-                server_config.db_host,
-                server_config.db_port,
-                server_config.db_name,
-                server_config.db_username,
-                server_config.db_password,
-                server_config.influxdb_host,
-                server_config.influxdb_port,
-                server_config.influxdb_name,
-                server_config.influxdb_username,
-                server_config.influxdb_password,
-                server_config.influxdb_interval,
-                server_config.influxdb_tags,
-            ]
-        }
 
-        return agent_config_overrides | agent_config_passthrough
+        # Best-effort approach to work around TODO: link ticket
+        agent_config_passthrough: Sequence[inmanta.config.Option[typing.Any]] = [
+            global_config.log_dir,
+            scheduler_log_config,
+            agent_cfg.agent_reconnect_delay,
+            agent_cfg.server_timeout,
+            agent_cfg.agent_executor_cap,
+            agent_cfg.agent_executor_retention_time,
+            agent_cfg.executor_venv_retention_time,
+            agent_cfg.agent_cache_cleanup_tick_rate,
+            agent_cfg.agent_ws_ping_interval,
+            agent_cfg.agent_ws_ping_timeout,
+            agent_cfg.agent_transport.request_timeout,
+            agent_cfg.agent_transport.max_clients,
+            agent_cfg.scheduler_db_connection_pool_min_size,
+            agent_cfg.scheduler_db_connection_pool_max_size,
+            agent_cfg.scheduler_db_connection_timeout,
+            server_config.db_wait_time,
+            server_config.db_host,
+            server_config.db_port,
+            server_config.db_name,
+            server_config.db_username,
+            server_config.db_password,
+            server_config.influxdb_host,
+            server_config.influxdb_port,
+            server_config.influxdb_name,
+            server_config.influxdb_username,
+            server_config.influxdb_password,
+            server_config.influxdb_interval,
+            server_config.influxdb_tags,
+        ]
+
+        return agent_config_overrides | {option: option.get_raw() for option in agent_config_passthrough}
 
     async def _fork_inmanta(
         self,
@@ -1095,13 +1092,15 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         errfile: Optional[str],
         cwd: Optional[str] = None,
         *,
-        env: Mapping[str, object] | None = None,
+        env: Mapping[str, str] | None = None,
     ) -> subprocess.Process:
         """
         Fork an inmanta process from the same code base as the current code
         """
-        env = env if env is not None else os.environ.copy()
-        env.update(tracing.get_context())
+        full_env = {
+            **(env if env is not None else os.environ),
+            **tracing.get_context(),
+        }
 
         full_args = ["-m", "inmanta.app", *args]
         # handles can be closed, owned by child process,...
@@ -1114,7 +1113,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
                 errhandle = open(errfile, "wb+")
 
             return await asyncio.create_subprocess_exec(
-                sys.executable, *full_args, cwd=cwd, env=env, stdout=outhandle, stderr=errhandle
+                sys.executable, *full_args, cwd=cwd, env=full_env, stdout=outhandle, stderr=errhandle
             )
         finally:
             if outhandle is not None:

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -821,7 +821,7 @@ async def test_do_start_agent_clears_shadowed_settings_env_vars(server_config, m
     assert environment_env_var not in captured_env
     # Verify that other settings still reach the agent process.
     # For now, this is mostly relevant as an additional safeguard in case we missed a relevant agent setting in the workaround
-    # for TODO.
+    # for #10421.
     # Once that issue has been addressed, this mechanism will ensure we properly inherit most of the agent config from the
     # global one.
     assert captured_env.get(logging_config_env_var) == str(tmp_path / "logging_config")

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -22,8 +22,8 @@ import logging
 import os
 import typing
 import uuid
-from collections.abc import Iterator, Mapping
 from asyncio import subprocess
+from collections.abc import Iterator
 from typing import Optional
 from unittest.mock import Mock
 from uuid import UUID, uuid4

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -19,8 +19,10 @@ Contact: code@inmanta.com
 import asyncio
 import datetime
 import logging
+import os
 import typing
 import uuid
+from collections.abc import Iterator, Mapping
 from asyncio import subprocess
 from typing import Optional
 from unittest.mock import Mock
@@ -28,6 +30,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+import inmanta.agent.config
 from inmanta import config, const, data
 from inmanta.config import Config
 from inmanta.const import AgentAction, AgentStatus
@@ -622,6 +625,40 @@ async def test_process_already_terminated(server, environment):
     await autostarted_agent_manager._terminate_agents()
 
 
+@pytest.fixture
+def set_state_dir_using_env_var(monkeypatch, tmp_path) -> Iterator[str]:
+    """
+    Fixture that creates a temporary directory and configures it as the state directory
+    of the server using the INMANTA_CONFIG_STATE_DIR environment variable.
+    """
+    state_dir = str(tmp_path / "state_dir")
+    os.mkdir(state_dir)
+    monkeypatch.setenv(config.state_dir.get_environment_variable(), state_dir)
+    yield state_dir
+
+
+@pytest.mark.parametrize("auto_start_agent", [True])
+async def test_scheduler_ignores_env_var_state_dir(set_state_dir_using_env_var: str, server, environment):
+    """
+    Verify that the scheduler is using the state dir configured in its scheduler.cfg file
+    and ignores the state directory configured using an environment variable.
+    """
+    server_state_dir: str = set_state_dir_using_env_var
+
+    autostarted_agent_manager = server.get_slice(SLICE_AUTOSTARTED_AGENT_MANAGER)
+    await autostarted_agent_manager._ensure_scheduler(env=uuid.UUID(environment))
+    assert len(autostarted_agent_manager._agent_procs) == 1
+
+    # The AutostartedAgentManager configures the state dir of the scheduler as:
+    # <server_state_dir>/server/<env_id> in the scheduler.cfg file. The scheduler
+    # creates the executors subdirectory.
+    await retry_limited(
+        lambda: os.path.exists(os.path.join(server_state_dir, "server", environment, "executors")),
+        timeout=10,
+    )
+    assert not os.path.exists(os.path.join(server_state_dir, "executors"))
+
+
 async def test_error_handling_agent_fork(server, environment, monkeypatch):
     """
     Verifies resolution of issue: inmanta/inmanta-core#2777
@@ -629,7 +666,7 @@ async def test_error_handling_agent_fork(server, environment, monkeypatch):
     exception_message = "The start of the agent failed"
 
     async def _dummy_fork_inmanta(
-        self, args: list[str], outfile: Optional[str], errfile: Optional[str], cwd: Optional[str] = None
+        self, args: list[str], outfile: Optional[str], errfile: Optional[str], cwd: Optional[str] = None, *, env=None
     ) -> subprocess.Process:
         raise Exception(exception_message)
 
@@ -736,3 +773,52 @@ async def test_pause_all_agents_doesnt_pause_environment(server, environment, cl
     agent_dct = {agent.name: agent for agent in agents}
     assert not agent_dct[const.AGENT_SCHEDULER_ID].paused
     assert not agent_dct["agent1"].paused
+
+
+async def test_do_start_agent_clears_shadowed_settings_env_vars(server_config, monkeypatch, tmp_path):
+    """
+    Verify that the __do_start_agent method properly clears environment variables for shadowed / overridden config settings.
+
+    Related e2e test in test_scheduler_ignores_env_var_state_dir.
+    """
+    state_dir_env_var: str = config.state_dir.get_environment_variable()
+    environment_env_var: str = inmanta.agent.config.environment.get_environment_variable()
+    executor_venv_retention_time_env_var: str = inmanta.agent.config.executor_venv_retention_time.get_environment_variable()
+
+    monkeypatch.setenv(state_dir_env_var, str(tmp_path / "state_dir"))
+    monkeypatch.setenv(environment_env_var, "00000000-0000-0000-0000-000000000000")
+    monkeypatch.setenv(executor_venv_retention_time_env_var, "42")
+
+    captured_env: dict[str, str] = {}
+
+    async def mock_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return Mock(pid=0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", mock_create_subprocess_exec)
+
+    server_dir = tmp_path / "server"
+    logs_dir = tmp_path / "logs"
+    server_dir.mkdir()
+    logs_dir.mkdir()
+
+    class ServerlessAgentManager(AutostartedAgentManager):
+        """
+        Mock agent manager that skips large parts of the setup that require interaction with the server.
+        """
+
+        def __init__(self) -> None:
+            self._server_storage = {"server": str(server_dir), "logs": str(logs_dir)}
+
+    agent_manager = ServerlessAgentManager()
+    env_mock = Mock()
+    env_mock.id = uuid4()
+
+    await agent_manager._AutostartedAgentManager__do_start_agent(env_mock)
+
+    # verify that overridden settings are properly trimmed from the environment
+    assert state_dir_env_var not in captured_env
+    assert environment_env_var not in captured_env
+    # verify that other settings still reach the agent process
+    assert "PATH" in captured_env
+    assert captured_env.get(executor_venv_retention_time_env_var) == "42"

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -783,11 +783,11 @@ async def test_do_start_agent_clears_shadowed_settings_env_vars(server_config, m
     """
     state_dir_env_var: str = config.state_dir.get_environment_variable()
     environment_env_var: str = inmanta.agent.config.environment.get_environment_variable()
-    executor_venv_retention_time_env_var: str = inmanta.agent.config.executor_venv_retention_time.get_environment_variable()
+    logging_config_env_var: str = config.logging_config.get_environment_variable()
 
     monkeypatch.setenv(state_dir_env_var, str(tmp_path / "state_dir"))
     monkeypatch.setenv(environment_env_var, "00000000-0000-0000-0000-000000000000")
-    monkeypatch.setenv(executor_venv_retention_time_env_var, "42")
+    monkeypatch.setenv(logging_config_env_var, str(tmp_path / "logging_config"))
 
     captured_env: dict[str, str] = {}
 
@@ -819,6 +819,9 @@ async def test_do_start_agent_clears_shadowed_settings_env_vars(server_config, m
     # verify that overridden settings are properly trimmed from the environment
     assert state_dir_env_var not in captured_env
     assert environment_env_var not in captured_env
-    # verify that other settings still reach the agent process
-    assert "PATH" in captured_env
-    assert captured_env.get(executor_venv_retention_time_env_var) == "42"
+    # Verify that other settings still reach the agent process.
+    # For now, this is mostly relevant as an additional safeguard in case we missed a relevant agent setting in the workaround
+    # for TODO.
+    # Once that issue has been addressed, this mechanism will ensure we properly inherit most of the agent config from the
+    # global one.
+    assert captured_env.get(logging_config_env_var) == str(tmp_path / "logging_config")


### PR DESCRIPTION
# Description

Follow-up PR of #10404, proposing a different solution that covers all use cases.

# Background

The server spawns a scheduler subprocess for each environment and generates a dedicated `scheduler.cfg` for it. Two requirements must hold:

  1. A few options must be explicitly controlled by the server — state-dir, environment, transport settings, auth token. These are written into scheduler.cfg
  with environment-specific values.
  2. All other config options should be inherited from the server one way or the other (e.g. agent_ws_ping_interval, executor_venv_retention_time).

# The bug

  The inmanta container sets `INMANTA_CONFIG_STATE_DIR=/var/lib/inmanta` as an environment variable. Because the scheduler is a subprocess of the server,
  it inherits this env var. Since environment variables take higher priority than config file values, INMANTA_CONFIG_STATE_DIR was overriding the
  per-environment state directory written into scheduler.cfg, causing all schedulers to share the same state directory and race on venv files.

#10404 attempted to fix this by ignoring all config from env vars in the scheduler process. However, this could lead to other relevant config being ignored. Notably, in #10404, `agent_ws_ping_interval` and some others would be ignored if configured through env variables.

# This PR

The approach proposed in this PR is simple:
1. for the options that are explicitly controlled by the server, unset the associated environment variables for the scheduler subprocess
2. let all other options be inherited naturally, either through the environment, or by the scheduler process reading the server's main config files (already in place).

There is however one caveat (#10421): if the server is started with an explicit `--config`, it might contain agent-relevant settings that are then not inherited by the scheduler process. This PR works around it, but the proper fix was deemed out of scope. For the workaround, we add a third step:

3. additionally, hardcode the list of all options in `inmanta.agent.config`, and explicitly control them from the server as well, setting them to the value as read by the server config. The previous implementation seemed to have something similar in place, but it was not kept up to date, which highlights the importance of the general approach proposed in this PR. This workaround can be removed once #10421 has been resolved, since it is only required in the very rare case where the server is started with a custom `--config`.

# Implementation

The best place to start is probably `inmanta.server.agentmanager._get_agent_config`.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~
- [x] ~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~
