### PR TITLE
Disallow commas on agent name

### DIFF
--- a/changelogs/unreleased/10342-fix-agent-comma.yml
+++ b/changelogs/unreleased/10342-fix-agent-comma.yml
@@ -1,0 +1,6 @@
+description: Disallow commas in agent name.
+issue-nr: 10342
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/10342-fix-agent-comma.yml
+++ b/changelogs/unreleased/10342-fix-agent-comma.yml
@@ -3,4 +3,4 @@ issue-nr: 10342
 change-type: patch
 destination-branches: [master, iso9]
 sections:
-  bugfix: "{{description}}"
+  bugfix: "Raise a clear error message instead of failing cryptically for invalid agent names"

--- a/changelogs/unreleased/10342-fix-agent-comma.yml
+++ b/changelogs/unreleased/10342-fix-agent-comma.yml
@@ -1,6 +1,6 @@
-description: Disallow commas in agent name.
+description: Raise a clear error when resource id components contain invalid characters.
 issue-nr: 10342
 change-type: patch
 destination-branches: [master, iso9]
 sections:
-  bugfix: "Raise a clear error message instead of failing cryptically for invalid agent names"
+  bugfix: "{{description}}"

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -779,8 +779,14 @@ class Id:
         :attr attribute_value: The corresponding value for this key attribute.
         :attr version: The version number for this resource.
         """
-        if "," in agent_name:
-            raise ValueError(f"Agent name '{agent_name}' is not valid. Agent names cannot contain commas.")
+        for value, label, forbidden in (
+            (agent_name, "agent name", [","]),
+            (attribute, "attribute name", [",", "="]),
+            (attribute_value, "attribute value", ["]"]),
+        ):
+            for char in forbidden:
+                if char in value:
+                    raise ValueError(f"Invalid {label} '{value}': cannot contain '{char}'.")
 
         self._entity_type = entity_type
         self._agent_name = agent_name

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -781,10 +781,7 @@ class Id:
         """
         if "," in agent_name:
             raise ResourceException(f"Agent name '{agent_name}' is not valid. Agent names cannot contain commas.")
-        # if "]" in attribute_value:
-        #     raise ResourceException(
-        #         f"Attribute value '{attribute_value}' is not valid. Attribute values cannot contain ']'."
-        #     )
+
         self._entity_type = entity_type
         self._agent_name = agent_name
         self._attribute = attribute

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -772,13 +772,19 @@ class Id:
 
     def __init__(self, entity_type: str, agent_name: str, attribute: str, attribute_value: str, version: int = 0) -> None:
         """
-        :attr entity_type: The resource type, as defined in the configuration model.
+        :param entity_type: The resource type, as defined in the configuration model.
             For example :inmanta:entity:`std::testing::NullResource`.
-        :attr agent_name: The agent responsible for this resource.
-        :attr attribute: The key attribute that uniquely identifies this resource on the agent
-        :attr attribute_value: The corresponding value for this key attribute.
-        :attr version: The version number for this resource.
+        :param agent_name: The agent responsible for this resource.
+        :param attribute: The key attribute that uniquely identifies this resource on the agent
+        :param attribute_value: The corresponding value for this key attribute.
+        :param version: The version number for this resource.
         """
+        if "," in agent_name:
+            raise ResourceException(f"Agent name '{agent_name}' is not valid. Agent names cannot contain commas.")
+        # if "]" in attribute_value:
+        #     raise ResourceException(
+        #         f"Attribute value '{attribute_value}' is not valid. Attribute values cannot contain ']'."
+        #     )
         self._entity_type = entity_type
         self._agent_name = agent_name
         self._attribute = attribute

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -772,15 +772,15 @@ class Id:
 
     def __init__(self, entity_type: str, agent_name: str, attribute: str, attribute_value: str, version: int = 0) -> None:
         """
-        :param entity_type: The resource type, as defined in the configuration model.
+        :attr entity_type: The resource type, as defined in the configuration model.
             For example :inmanta:entity:`std::testing::NullResource`.
-        :param agent_name: The agent responsible for this resource.
-        :param attribute: The key attribute that uniquely identifies this resource on the agent
-        :param attribute_value: The corresponding value for this key attribute.
-        :param version: The version number for this resource.
+        :attr agent_name: The agent responsible for this resource.
+        :attr attribute: The key attribute that uniquely identifies this resource on the agent
+        :attr attribute_value: The corresponding value for this key attribute.
+        :attr version: The version number for this resource.
         """
         if "," in agent_name:
-            raise ResourceException(f"Agent name '{agent_name}' is not valid. Agent names cannot contain commas.")
+            raise ValueError(f"Agent name '{agent_name}' is not valid. Agent names cannot contain commas.")
 
         self._entity_type = entity_type
         self._agent_name = agent_name

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -387,10 +387,38 @@ def test_parse_rvid_regex():
     assert result is None
 
 
-def test_id_agent_name_with_comma() -> None:
-    """Verify that agent names with commas are rejected"""
-    with pytest.raises(ResourceException, match="cannot contain a comma"):
+def test_invalid_id_parameters() -> None:
+    with pytest.raises(ValueError, match="Invalid agent name 'foo,bar': cannot contain ','."):
         Id("test::Resource", "foo,bar", "key", "val")
+    with pytest.raises(ValueError, match="Invalid attribute name 'ke,y': cannot contain ','."):
+        Id("test::Resource", "agent", "ke,y", "val")
+    with pytest.raises(ValueError, match="Invalid attribute name 'ke=y': cannot contain '='."):
+        Id("test::Resource", "agent", "ke=y", "val")
+    with pytest.raises(ValueError, match="Invalid attribute value 'va]l': cannot contain ']'."):
+        Id("test::Resource", "agent", "key", "va]l")
+
+@pytest.mark.parametrize(
+    "entity_type,agent_name,attribute,attribute_value",
+    [
+        ("test::Resource", "agent", "key", "val"),
+        ("test::Resource", "agent=with=equals", "key", "val"),
+        ("test::Resource", "agent[with]brackets", "key", "val"),
+        ("test::Resource", "agent with spaces", "key", "val"),
+        ("test::Resource", "agent", "key]with[brackets", "val"),
+        ("test::Resource", "agent", "key with spaces", "val"),
+        ("test::Resource", "agent", "key", "value=with=equals"),
+        ("test::Resource", "agent", "key", "value[with[brackets"),
+        ("test::Resource", "agent", "key", "value with spaces"),
+        ("test::Resource", "agent", "key", "value,with,commas"),
+    ],
+)
+def test_id_roundtrip(entity_type: str, agent_name: str, attribute: str, attribute_value: str) -> None:
+    id_obj = Id(entity_type, agent_name, attribute, attribute_value)
+    parsed = Id.parse_id(id_obj.resource_str())
+    assert parsed.entity_type == entity_type
+    assert parsed.agent_name == agent_name
+    assert parsed.attribute == attribute
+    assert parsed.attribute_value == attribute_value
 
 
 def test_resource_deserialize_backward_compatibility() -> None:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -387,6 +387,12 @@ def test_parse_rvid_regex():
     assert result is None
 
 
+def test_id_agent_name_with_comma() -> None:
+    """Verify that agent names with commas are rejected"""
+    with pytest.raises(ResourceException, match="cannot contain a comma"):
+        Id("test::Resource", "foo,bar", "key", "val")
+
+
 def test_resource_deserialize_backward_compatibility() -> None:
     """
     Verify backward compatibiltiy of resource deserialization. This is important because we store resources in serialized form

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -387,15 +387,22 @@ def test_parse_rvid_regex():
     assert result is None
 
 
-def test_invalid_id_parameters() -> None:
-    with pytest.raises(ValueError, match="Invalid agent name 'foo,bar': cannot contain ','."):
-        Id("test::Resource", "foo,bar", "key", "val")
-    with pytest.raises(ValueError, match="Invalid attribute name 'ke,y': cannot contain ','."):
-        Id("test::Resource", "agent", "ke,y", "val")
-    with pytest.raises(ValueError, match="Invalid attribute name 'ke=y': cannot contain '='."):
-        Id("test::Resource", "agent", "ke=y", "val")
-    with pytest.raises(ValueError, match="Invalid attribute value 'va]l': cannot contain ']'."):
-        Id("test::Resource", "agent", "key", "va]l")
+@pytest.mark.parametrize(
+    "args,match",
+    [
+        (("test::Resource", "foo,bar", "key", "val"), "Invalid agent name 'foo,bar': cannot contain ','."),
+        (("test::Resource", "agent", "ke,y", "val"), "Invalid attribute name 'ke,y': cannot contain ','."),
+        (("test::Resource", "agent", "ke=y", "val"), "Invalid attribute name 'ke=y': cannot contain '='."),
+        (("test::Resource", "agent", "key", "va]l"), "Invalid attribute value 'va]l': cannot contain ']'."),
+    ],
+)
+def test_invalid_id_parameters(args: tuple[str, ...], match: str) -> None:
+    """
+    Test that invalid input is rejected from the Id constructor.
+    """
+    with pytest.raises(ValueError, match=match):
+        Id(*args)
+
 
 @pytest.mark.parametrize(
     "entity_type,agent_name,attribute,attribute_value",
@@ -413,6 +420,9 @@ def test_invalid_id_parameters() -> None:
     ],
 )
 def test_id_roundtrip(entity_type: str, agent_name: str, attribute: str, attribute_value: str) -> None:
+    """
+    Test that what we input on the Id constructor is the same that we get after calling Id.parse_id(id_obj.resource_str())
+    """
     id_obj = Id(entity_type, agent_name, attribute, attribute_value)
     parsed = Id.parse_id(id_obj.resource_str())
     assert parsed.entity_type == entity_type


### PR DESCRIPTION
# Description

Disallow commas on agent name, fixing roundtrip issue.

Iso8 deploy works but there are some inconsistencies between the agent as seen on the resource_id and the agent seen on the db column.

Still not sure on how to proceed regarding iso8

closes #10342 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
