### PR TITLE
Add glibc version to env hash

### DIFF
--- a/changelogs/unreleased/add-glibc-to-hash-venv.yml
+++ b/changelogs/unreleased/add-glibc-to-hash-venv.yml
@@ -1,5 +1,5 @@
 ---
-description: "Add the glibc version to the hash function of an executor venv."
+description: "Recreate the executor venvs when the version of glibc on the host has changed."
 change-type: patch
 destination-branches: [master, iso9, iso8]
 sections:

--- a/changelogs/unreleased/add-glibc-to-hash-venv.yml
+++ b/changelogs/unreleased/add-glibc-to-hash-venv.yml
@@ -1,0 +1,6 @@
+---
+description: "Add the glibc version to the hash function of an executor venv."
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -16,7 +16,6 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-import platform
 import abc
 import asyncio
 import concurrent.futures
@@ -27,6 +26,7 @@ import json
 import logging
 import os
 import pathlib
+import platform
 import shutil
 import typing
 import uuid
@@ -114,11 +114,15 @@ class EnvBlueprint:
     _hash_cache: str | None = dataclasses.field(default=None, init=False, repr=False)
     python_version: tuple[int, int]
     project_constraints: str | None = dataclasses.field(default=None, kw_only=True)
-    platform: str = platform.platform()
+    # This instance variable contains the glibc version. This version determines which
+    # python packages are compatible with the machine they run on. If this version is
+    # updated, pip might select different packages.
+    platform_details: str
 
     def __post_init__(self) -> None:
         # remove duplicates and make uniform
         self.requirements = sorted(set(self.requirements))
+        self.platform_details = platform.platform()
 
     def blueprint_hash(self) -> str:
         """
@@ -134,7 +138,7 @@ class EnvBlueprint:
                 "requirements": self.requirements,
                 "python_version": self.python_version,
                 "project_constraints": self.project_constraints,
-                "platform": self.platform,
+                "platform_details": self.platform_details,
             }
 
             # Serialize the blueprint dictionary to a JSON string, ensuring consistent ordering
@@ -154,14 +158,14 @@ class EnvBlueprint:
             set(self.requirements),
             self.python_version,
             self.project_constraints,
-            self.platform,
+            self.platform_details,
         ) == (
             other.environment_id,
             other.pip_config,
             set(other.requirements),
             other.python_version,
             other.project_constraints,
-            other.platform,
+            other.platform_details,
         )
 
     def __hash__(self) -> int:
@@ -173,7 +177,7 @@ class EnvBlueprint:
         return (
             f"EnvBlueprint(environment_id={self.environment_id}, requirements=[{str(req)}], "
             f"constraints=[{constraints}], pip={self.pip_config}, python_version={self.python_version}, "
-            f"platform={self.platform})"
+            f"platform_details={self.platform_details})"
         )
 
 
@@ -250,6 +254,7 @@ class ExecutorBlueprint(EnvBlueprint):
                 ],
                 "python_version": self.python_version,
                 "project_constraints": self.project_constraints,
+                "platform_details": self.platform_details,
             }
 
             # Serialize the extended blueprint dictionary to a JSON string, ensuring consistent ordering
@@ -270,6 +275,7 @@ class ExecutorBlueprint(EnvBlueprint):
             requirements=self.requirements,
             python_version=self.python_version,
             project_constraints=self.project_constraints,
+            platform_details=self.platform_details,
         )
 
     def __eq__(self, other: object) -> bool:
@@ -282,6 +288,7 @@ class ExecutorBlueprint(EnvBlueprint):
             self.sources,
             self.python_version,
             self.project_constraints,
+            self.platform_details,
         ) == (
             other.environment_id,
             other.pip_config,
@@ -289,6 +296,7 @@ class ExecutorBlueprint(EnvBlueprint):
             other.sources,
             other.python_version,
             other.project_constraints,
+            other.platform_details,
         )
 
     def __hash__(self) -> int:

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -26,7 +26,7 @@ import json
 import logging
 import os
 import pathlib
-import platform as platform_mod
+import platform
 import shutil
 import typing
 import uuid
@@ -114,10 +114,21 @@ class EnvBlueprint:
     _hash_cache: str | None = dataclasses.field(default=None, init=False, repr=False)
     python_version: tuple[int, int]
     project_constraints: str | None = dataclasses.field(default=None, kw_only=True)
-    # This instance variable contains the glibc version. This version determines which
-    # python packages are compatible with the machine they run on. If this version is
-    # updated, pip might select different packages.
-    platform: str = dataclasses.field(default_factory=platform_mod.platform, kw_only=True)
+    # The libc version determines which python packages are compatible with the machine they run on.
+    # If this version is updated, pip might select different packages.
+    libc_version: str = dataclasses.field(default_factory=_get_libc_version, kw_only=True)
+
+    @staticmethod
+    def _get_libc_version() -> str:
+        """
+        Return a string of the form "{lib}:{version}", where lib is the name
+        of the c library and the version its version number. An exception is raised
+        if we cannot determine the version of the c library.
+        """
+        lib, version = platform.libc_ver()
+        if not lib or not version:
+            raise Exception("Failed to determine libc version")
+        return f"{lib}:{version}"
 
     def __post_init__(self) -> None:
         # remove duplicates and make uniform
@@ -137,7 +148,7 @@ class EnvBlueprint:
                 "requirements": self.requirements,
                 "python_version": self.python_version,
                 "project_constraints": self.project_constraints,
-                "platform": self.platform,
+                "libc_version": self.libc_version,
             }
 
             # Serialize the blueprint dictionary to a JSON string, ensuring consistent ordering
@@ -157,14 +168,14 @@ class EnvBlueprint:
             set(self.requirements),
             self.python_version,
             self.project_constraints,
-            self.platform,
+            self.libc_version,
         ) == (
             other.environment_id,
             other.pip_config,
             set(other.requirements),
             other.python_version,
             other.project_constraints,
-            other.platform,
+            other.libc_version,
         )
 
     def __hash__(self) -> int:
@@ -176,7 +187,7 @@ class EnvBlueprint:
         return (
             f"EnvBlueprint(environment_id={self.environment_id}, requirements=[{str(req)}], "
             f"constraints=[{constraints}], pip={self.pip_config}, python_version={self.python_version}, "
-            f"platform={self.platform})"
+            f"libc_version={self.libc_version})"
         )
 
 
@@ -253,7 +264,7 @@ class ExecutorBlueprint(EnvBlueprint):
                 ],
                 "python_version": self.python_version,
                 "project_constraints": self.project_constraints,
-                "platform": self.platform,
+                "libc_version": self.libc_version,
             }
 
             # Serialize the extended blueprint dictionary to a JSON string, ensuring consistent ordering
@@ -274,7 +285,7 @@ class ExecutorBlueprint(EnvBlueprint):
             requirements=self.requirements,
             python_version=self.python_version,
             project_constraints=self.project_constraints,
-            platform=self.platform,
+            libc_version=self.libc_version,
         )
 
     def __eq__(self, other: object) -> bool:
@@ -287,7 +298,7 @@ class ExecutorBlueprint(EnvBlueprint):
             self.sources,
             self.python_version,
             self.project_constraints,
-            self.platform,
+            self.libc_version,
         ) == (
             other.environment_id,
             other.pip_config,
@@ -295,7 +306,7 @@ class ExecutorBlueprint(EnvBlueprint):
             other.sources,
             other.python_version,
             other.project_constraints,
-            other.platform,
+            other.libc_ver,
         )
 
     def __hash__(self) -> int:

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -106,12 +106,13 @@ class ResourceDetails:
 def get_libc_version() -> str:
     """
     Return a string of the form "{lib}:{version}", where lib is the name
-    of the c library and the version its version number. An exception is raised
-    if we cannot determine the version of the c library.
+    of the c library and the version its version number. Return an empty
+    string if the libc version cannot be determined. That can happen on
+    operating systems that are not Linux-based.
     """
     lib, version = platform.libc_ver()
     if not lib or not version:
-        raise Exception("Failed to determine libc version")
+        return ""
     return f"{lib}:{version}"
 
 

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -103,6 +103,18 @@ class ResourceDetails:
         return ResourceDetails(resource_dict["id"], resource_dict["model"], resource_dict["attributes"])
 
 
+def get_libc_version() -> str:
+    """
+    Return a string of the form "{lib}:{version}", where lib is the name
+    of the c library and the version its version number. An exception is raised
+    if we cannot determine the version of the c library.
+    """
+    lib, version = platform.libc_ver()
+    if not lib or not version:
+        raise Exception("Failed to determine libc version")
+    return f"{lib}:{version}"
+
+
 @dataclasses.dataclass
 class EnvBlueprint:
     """Represents a blueprint for creating virtual environments
@@ -116,19 +128,7 @@ class EnvBlueprint:
     project_constraints: str | None = dataclasses.field(default=None, kw_only=True)
     # The libc version determines which python packages are compatible with the machine they run on.
     # If this version is updated, pip might select different packages.
-    libc_version: str = dataclasses.field(default_factory=_get_libc_version, kw_only=True)
-
-    @staticmethod
-    def _get_libc_version() -> str:
-        """
-        Return a string of the form "{lib}:{version}", where lib is the name
-        of the c library and the version its version number. An exception is raised
-        if we cannot determine the version of the c library.
-        """
-        lib, version = platform.libc_ver()
-        if not lib or not version:
-            raise Exception("Failed to determine libc version")
-        return f"{lib}:{version}"
+    libc_version: str = dataclasses.field(default_factory=get_libc_version, kw_only=True)
 
     def __post_init__(self) -> None:
         # remove duplicates and make uniform
@@ -306,7 +306,7 @@ class ExecutorBlueprint(EnvBlueprint):
             other.sources,
             other.python_version,
             other.project_constraints,
-            other.libc_ver,
+            other.libc_version,
         )
 
     def __hash__(self) -> int:

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -26,7 +26,7 @@ import json
 import logging
 import os
 import pathlib
-import platform
+import platform as platform_mod
 import shutil
 import typing
 import uuid
@@ -117,12 +117,11 @@ class EnvBlueprint:
     # This instance variable contains the glibc version. This version determines which
     # python packages are compatible with the machine they run on. If this version is
     # updated, pip might select different packages.
-    platform_details: str
+    platform: str = dataclasses.field(default_factory=platform_mod.platform, kw_only=True)
 
     def __post_init__(self) -> None:
         # remove duplicates and make uniform
         self.requirements = sorted(set(self.requirements))
-        self.platform_details = platform.platform()
 
     def blueprint_hash(self) -> str:
         """
@@ -138,7 +137,7 @@ class EnvBlueprint:
                 "requirements": self.requirements,
                 "python_version": self.python_version,
                 "project_constraints": self.project_constraints,
-                "platform_details": self.platform_details,
+                "platform": self.platform,
             }
 
             # Serialize the blueprint dictionary to a JSON string, ensuring consistent ordering
@@ -158,14 +157,14 @@ class EnvBlueprint:
             set(self.requirements),
             self.python_version,
             self.project_constraints,
-            self.platform_details,
+            self.platform,
         ) == (
             other.environment_id,
             other.pip_config,
             set(other.requirements),
             other.python_version,
             other.project_constraints,
-            other.platform_details,
+            other.platform,
         )
 
     def __hash__(self) -> int:
@@ -177,7 +176,7 @@ class EnvBlueprint:
         return (
             f"EnvBlueprint(environment_id={self.environment_id}, requirements=[{str(req)}], "
             f"constraints=[{constraints}], pip={self.pip_config}, python_version={self.python_version}, "
-            f"platform_details={self.platform_details})"
+            f"platform={self.platform})"
         )
 
 
@@ -254,7 +253,7 @@ class ExecutorBlueprint(EnvBlueprint):
                 ],
                 "python_version": self.python_version,
                 "project_constraints": self.project_constraints,
-                "platform_details": self.platform_details,
+                "platform": self.platform,
             }
 
             # Serialize the extended blueprint dictionary to a JSON string, ensuring consistent ordering
@@ -275,7 +274,7 @@ class ExecutorBlueprint(EnvBlueprint):
             requirements=self.requirements,
             python_version=self.python_version,
             project_constraints=self.project_constraints,
-            platform_details=self.platform_details,
+            platform=self.platform,
         )
 
     def __eq__(self, other: object) -> bool:
@@ -288,7 +287,7 @@ class ExecutorBlueprint(EnvBlueprint):
             self.sources,
             self.python_version,
             self.project_constraints,
-            self.platform_details,
+            self.platform,
         ) == (
             other.environment_id,
             other.pip_config,
@@ -296,7 +295,7 @@ class ExecutorBlueprint(EnvBlueprint):
             other.sources,
             other.python_version,
             other.project_constraints,
-            other.platform_details,
+            other.platform,
         )
 
     def __hash__(self) -> int:

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -108,7 +108,7 @@ def get_libc_version() -> str:
     Return a string of the form "{lib}:{version}", where lib is the name
     of the c library and the version its version number. Return an empty
     string if the libc version cannot be determined. That can happen on
-    operating systems that are not Linux-based.
+    operating systems that don't rely on libc.
     """
     lib, version = platform.libc_ver()
     if not lib or not version:

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import platform
 import abc
 import asyncio
 import concurrent.futures
@@ -113,6 +114,7 @@ class EnvBlueprint:
     _hash_cache: str | None = dataclasses.field(default=None, init=False, repr=False)
     python_version: tuple[int, int]
     project_constraints: str | None = dataclasses.field(default=None, kw_only=True)
+    platform: str = platform.platform()
 
     def __post_init__(self) -> None:
         # remove duplicates and make uniform
@@ -132,6 +134,7 @@ class EnvBlueprint:
                 "requirements": self.requirements,
                 "python_version": self.python_version,
                 "project_constraints": self.project_constraints,
+                "platform": self.platform,
             }
 
             # Serialize the blueprint dictionary to a JSON string, ensuring consistent ordering
@@ -151,12 +154,14 @@ class EnvBlueprint:
             set(self.requirements),
             self.python_version,
             self.project_constraints,
+            self.platform,
         ) == (
             other.environment_id,
             other.pip_config,
             set(other.requirements),
             other.python_version,
             other.project_constraints,
+            other.platform,
         )
 
     def __hash__(self) -> int:
@@ -167,7 +172,8 @@ class EnvBlueprint:
         constraints = ",".join(self.project_constraints.split("\n")) if self.project_constraints else ""
         return (
             f"EnvBlueprint(environment_id={self.environment_id}, requirements=[{str(req)}], "
-            f"constraints=[{constraints}], pip={self.pip_config}, python_version={self.python_version})"
+            f"constraints=[{constraints}], pip={self.pip_config}, python_version={self.python_version}, "
+            f"platform={self.platform})"
         )
 
 


### PR DESCRIPTION
# Description

Add the glibc version to the hash function of an executor venv.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
