### PR TITLE
Pin graphql-core to the 3.2 series

### DIFF
--- a/changelogs/unreleased/pin-graphql-core-3.2.yml
+++ b/changelogs/unreleased/pin-graphql-core-3.2.yml
@@ -1,0 +1,5 @@
+change-type: patch
+description: Pin graphql-core to the 3.2 series to avoid pulling the incompatible 3.3 pre-releases via strawberry-graphql.
+destination-branches:
+  - master
+  - iso9

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ requires = [
     "setproctitle~=1.3",
     "SQLAlchemy~=2.0",
     "strawberry-sqlalchemy-mapper==0.8.0",
+    # strawberry-graphql only caps graphql-core at <3.4, but the graphql-core 3.3 pre-releases
+    # (e.g. 3.3.0a14) restructured graphql.execution and break strawberry's imports. Keep
+    # graphql-core on the stable 3.2 series (<3.3 also excludes the 3.3 pre-releases per PEP 440)
+    # until strawberry supports 3.3.
+    "graphql-core>=3.2,<3.3",
     "jsonpath-ng~=1.7",
     # cookiecutter requires requests and (via binaryornot) chardet. With this extra we ensure that it stays in the valid range for requests
     "requests[use_chardet_on_py3]",


### PR DESCRIPTION
> Claude opened this PR on behalf of @bartv.

## Problem

All module test pipelines (std, aci, and every other module) started failing at **pytest collection time** with:

```
ImportError: cannot import name 'ExecutionContext' from 'graphql.execution'. Did you mean: 'ValidationContext'?
```

(e.g. [modules/std #2796](https://jenkins.inmanta.com/job/modules/job/std/job/master/2796/console), [modules/aci #1086](https://jenkins.inmanta.com/job/modules/job/aci/job/master/1086/console))

This is a dependency-resolution regression, not a test bug. Module envs install with pre-releases enabled (the same builds also pulled `SQLAlchemy-2.1.0b2`). `strawberry-graphql` only caps its dependency at `graphql-core<3.4.0,>=3.2.0`, and since `inmanta-core` left `graphql-core` **unpinned**, the resolver pulled the pre-release **`graphql-core 3.3.0a14`**. That alpha restructured `graphql.execution` and no longer exposes `ExecutionContext`, so strawberry's `from graphql.execution import ExecutionContext` throws at import.

Because `pytest-inmanta` imports `inmanta.protocol → inmanta.graphql → strawberry`, collection crashes before any test runs — so every module breaks identically.

## Fix

Cap `graphql-core` to the stable 3.2 series in `setup.py`. `inmanta-core` also imports graphql-core directly (`inmanta/graphql/graphql.py` uses `graphql.error.GraphQLError`), so this is a legitimate direct dependency. The constraint propagates to every module env via inmanta-core's published metadata, fixing them all at once.

`<3.3` excludes the 3.3 pre-releases per PEP 440 even when pre-releases are allowed, so the alpha can no longer be selected.

## Verification

Built a fresh venv against the internal dev index with `--pre` (faithfully reproducing CI), with this branch installed editable:

| | CI (broken) | This branch |
|------------------|------------------------------|---------------------|
| `strawberry-graphql` | 0.316.0                  | 0.316.0             |
| `graphql-core`       | **3.3.0a14** → import crash | **3.2.11** ✓        |
| std test suite       | 0 run — collection error    | **124 passed**      |

## Changelog / branches

`patch` changelog targeting `[master, iso9]` — iso9 carries the same unpinned `strawberry-sqlalchemy-mapper==0.8.0` and is equally exposed; the merge tool backports via destination-branches.