### PR TITLE
Issue/10351 stale session bugfix iso9

### DIFF
--- a/changelogs/unreleased/10351-stale-session-cleanup-bugfix.yml
+++ b/changelogs/unreleased/10351-stale-session-cleanup-bugfix.yml
@@ -4,7 +4,6 @@ description: >
 issue-nr: 10351
 change-type: patch
 destination-branches:
-  - iso8
   - iso9
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/10351-stale-session-cleanup-bugfix.yml
+++ b/changelogs/unreleased/10351-stale-session-cleanup-bugfix.yml
@@ -1,0 +1,11 @@
+description: >
+  Fix bug in the logic to cleanup stale sessions. A loss of connectivity towards the database could
+  sometimes cause the scheduler to miss new versions notifications.
+issue-nr: 10351
+change-type: patch
+destination-branches:
+  - iso8
+  - iso9
+sections:
+  bugfix: "{{description}}"
+

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -572,7 +572,18 @@ class AgentManager(ServerSlice, SessionListener):
             LOGGER.debug("expiring session %s", sid)
             del self.sessions[sid]
             del self.endpoints_for_sid[sid]
-            endpoints_with_new_primary = await self._failover_endpoints(session, endpoint_names_snapshot)
+            try:
+                endpoints_with_new_primary = await self._failover_endpoints(session, endpoint_names_snapshot)
+            except Exception:
+                # _failover_endpoints issues a DB query as its first operation. When the DB is
+                # unavailable it raises before touching tid_endpoint_to_session, leaving a stale
+                # reference to the now-deleted session. Clean it up so that a reconnecting session
+                # can be correctly promoted to primary.
+                for endpoint_name in endpoint_names_snapshot:
+                    key = (session.tid, endpoint_name)
+                    if key in self.tid_endpoint_to_session and self.tid_endpoint_to_session[key].get_id() == sid:
+                        del self.tid_endpoint_to_session[key]
+                raise
 
         self.add_background_task(self._log_session_expiry_to_db(tid, endpoints_with_new_primary, session, now))
 
@@ -645,7 +656,8 @@ class AgentManager(ServerSlice, SessionListener):
         result = []
         for endpoint in endpoints:
             key = (session.tid, endpoint)
-            if key not in self.tid_endpoint_to_session and agent_statuses[endpoint] != AgentStatus.paused:
+            existing = self.tid_endpoint_to_session.get(key)
+            if (existing is None or existing.id not in self.sessions) and agent_statuses[endpoint] != AgentStatus.paused:
                 LOGGER.debug("set session %s as primary for agent %s in env %s", session.id, endpoint, session.tid)
                 self.tid_endpoint_to_session[key] = session
                 self.add_background_task(session.get_client().set_state(endpoint, enabled=True))

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -766,6 +766,73 @@ async def test_session_creation_fails(server, environment, async_finalizer, capl
     assert len(session_manager._sessions) == 0
 
 
+@pytest.fixture()
+def quick_reconnect():
+    config.Config.set("config", "agent-reconnect-delay", "1")
+
+
+@pytest.mark.parametrize("auto_start_agent", [False])  # prevent autostart to keep agent under control
+async def test_session_expiration(quick_reconnect, server, environment, async_finalizer, caplog, postgres_db, database_name):
+    """
+    Verify that session expiration works correctly in case the connectivity to the database breaks.
+    """
+
+    async def wait_for_session() -> protocol.Session:
+        # Wait until session is created
+        await retry_limited(lambda: (env_id, "agent1") in agentmanager.tid_endpoint_to_session, 10)
+
+        # Verify that the session is created correctly
+        session = agentmanager.tid_endpoint_to_session[(env_id, "agent1")]
+        session_manager = session._sessionstore
+        assert len(agentmanager.sessions) == 1
+        assert session in agentmanager.sessions.values()
+        assert len(session_manager._sessions) == 1
+        assert session in session_manager._sessions.values()
+        assert "Heartbeat failed" not in caplog.text
+        return session
+
+    env_id = UUID(environment)
+    agentmanager = server.get_slice(SLICE_AGENT_MANAGER)
+
+    assert len(agentmanager.sessions) == 0
+
+    a = NullAgent(environment=environment)
+    await a.add_end_point_name("agent1")
+    async_finalizer(a.stop)
+    await a.start()
+
+    session = await wait_for_session()
+
+    # Remove connectivity to the database
+    await data.disconnect()
+    caplog.clear()
+
+    await retry_limited(lambda: "Heartbeat failed" in caplog.text, 10)
+
+    # Wait until session expired
+    await session.expire(0)
+    await retry_limited(lambda: len(agentmanager.tid_endpoint_to_session) == 0, 10)
+
+    caplog.clear()
+
+    # Verify session expiry
+    assert len(agentmanager.sessions) == 0
+    assert len(agentmanager.tid_endpoint_to_session) == 0
+    assert len(session._sessionstore._sessions) == 0
+
+    # reconnect db
+    await data.connect(
+        host=postgres_db.host,
+        port=postgres_db.port,
+        username=postgres_db.user,
+        password=postgres_db.password,
+        database=database_name,
+    )
+
+    # Check that the agent can reconnect once the db is back up.
+    await wait_for_session()
+
+
 async def test_agent_on_resume_actions(server, environment, client, agent) -> None:
     config.Config.set("config", "agent-deploy-interval", "0")
     config.Config.set("config", "agent-repair-interval", "0")

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -804,7 +804,7 @@ async def test_session_expiration(quick_reconnect, server, environment, async_fi
     session = await wait_for_session()
 
     # Remove connectivity to the database
-    await data.disconnect()
+    await data.disconnect_pool()
     caplog.clear()
 
     await retry_limited(lambda: "Heartbeat failed" in caplog.text, 10)
@@ -821,7 +821,7 @@ async def test_session_expiration(quick_reconnect, server, environment, async_fi
     assert len(session._sessionstore._sessions) == 0
 
     # reconnect db
-    await data.connect(
+    await data.connect_pool(
         host=postgres_db.host,
         port=postgres_db.port,
         username=postgres_db.user,


### PR DESCRIPTION
# Description

iso9 PR for https://github.com/inmanta/inmanta-core/pull/10415

Only diff is in the `test_session_expiration` test: the methods to break and re-enable connectivity with the db are `data.connect_pool` and `data.disconnect_pool` (vs iso8 `data.connect` and `data.disconnect`)

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
