### PR TITLE
Improve log message regarding removed pool member

### DIFF
--- a/changelogs/unreleased/improve-log-message-inactive-pool-member.yml
+++ b/changelogs/unreleased/improve-log-message-inactive-pool-member.yml
@@ -1,0 +1,4 @@
+---
+description: "Improve log message regarding cleanup inactive pool member."
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -383,7 +383,7 @@ class TimeBasedPoolManager(PoolManager[TPoolID, TIntPoolID, TPoolMember]):
                         # Check that the executor can still be cleaned up by the time we have acquired the lock
                         if pool_member.can_be_cleaned_up() and pool_member.last_used < oldest_time and pool_member.running:
                             LOGGER.debug(
-                                "%s will be shutdown because it was inactive for %.2f, which is more than %d",
+                                "%s will be shutdown because it was inactive for %.2fs (retention time: %ds)",
                                 self.member_name(pool_member),
                                 (cleanup_start - pool_member.last_used).total_seconds(),
                                 self.retention_time,


### PR DESCRIPTION
# Description

The log message about a pool member being removed due to inactivity was incorrect. It said _"is more than"_, but the condition would allow equality too. Like that the server log would contain log messages like: _"... will be shutdown because it was inactive for 60.00, which is more than 60"._ This message is logically incorrect of course. This PR fixes that.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~