### PR TITLE
Issue/9817 agent api access

### DIFF
--- a/changelogs/unreleased/9817-agent-client-permissions.yml
+++ b/changelogs/unreleased/9817-agent-client-permissions.yml
@@ -1,0 +1,12 @@
+---
+description: >
+  Extend list of endpoints that the agent client is allowed to access:
+  - get_facts
+  - get_fact
+  - discovered_resources_get
+  - discovered_resources_get_batch
+  - discovered_resource_delete
+  - discovered_resource_delete_batch
+change-type: patch
+destination-branches: [master]
+issue-nr: 9817

--- a/changelogs/unreleased/9817-agent-client-permissions.yml
+++ b/changelogs/unreleased/9817-agent-client-permissions.yml
@@ -8,5 +8,5 @@ description: >
   - discovered_resource_delete
   - discovered_resource_delete_batch
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso9]
 issue-nr: 9817

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -936,7 +936,11 @@ def resource_logs(
 
 @auth(auth_label=const.CoreAuthorizationLabel.FACT_READ, read_only=True, environment_param="tid")
 @typedmethod(
-    path="/resource/<rid>/facts", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api, ClientType.agent], api_version=2
+    path="/resource/<rid>/facts",
+    operation="GET",
+    arg_options=methods.ENV_OPTS,
+    client_types=[ClientType.api, ClientType.agent],
+    api_version=2,
 )
 def get_facts(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> list[model.Fact]:
     """

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1750,7 +1750,7 @@ def discovered_resource_create_batch(tid: uuid.UUID, discovered_resources: Seque
     path="/discovered/<discovered_resource_id>",
     operation="GET",
     arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.api],
+    client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
 def discovered_resources_get(tid: uuid.UUID, discovered_resource_id: ResourceIdStr) -> model.DiscoveredResourceOutput:
@@ -1767,7 +1767,7 @@ def discovered_resources_get(tid: uuid.UUID, discovered_resource_id: ResourceIdS
     path="/discovered",
     operation="GET",
     arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.api],
+    client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
 def discovered_resources_get_batch(
@@ -1819,7 +1819,7 @@ def discovered_resources_get_batch(
     path="/discovered/<discovered_resource_id>",
     operation="DELETE",
     arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.api],
+    client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
 def discovered_resource_delete(
@@ -1841,7 +1841,7 @@ def discovered_resource_delete(
     path="/discovered/",
     operation="DELETE",
     arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.api],
+    client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
 def discovered_resource_delete_batch(tid: uuid.UUID, discovered_resource_ids: Sequence[str]) -> None:

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -936,7 +936,7 @@ def resource_logs(
 
 @auth(auth_label=const.CoreAuthorizationLabel.FACT_READ, read_only=True, environment_param="tid")
 @typedmethod(
-    path="/resource/<rid>/facts", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
+    path="/resource/<rid>/facts", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api, ClientType.agent], api_version=2
 )
 def get_facts(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> list[model.Fact]:
     """
@@ -953,7 +953,7 @@ def get_facts(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> list[model.Fa
     path="/resource/<rid>/facts/<id>",
     operation="GET",
     arg_options=methods.ENV_OPTS,
-    client_types=[ClientType.api],
+    client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
 def get_fact(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr, id: uuid.UUID) -> model.Fact:


### PR DESCRIPTION
# Description

Extend list of endpoints that the agent client is allowed to access:
  - get_facts
  - get_fact
  - discovered_resources_get
  - discovered_resources_get_batch
  - discovered_resource_delete
  - discovered_resource_delete_batch

closes #9817 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
