### PR TITLE
Fix test case: Add model_version method

### DIFF
--- a/changelogs/unreleased/fix-test-add-model-version-method.yml
+++ b/changelogs/unreleased/fix-test-add-model-version-method.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix test case by adding missing model_version() method."
+change-type: patch
+destination-branches: [iso8]

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -49,6 +49,14 @@ from inmanta.util import retry_limited
 from utils import make_requires
 
 
+def model_version(
+    version: int,
+    *,
+    resources: Mapping[ResourceIdStr, state.ResourceIntent],
+) -> ModelVersion:
+    return ModelVersion(version=version, resources=resources, requires={}, undefined=set())
+
+
 async def retry_limited_fast(
     fun: Callable[..., bool] | Callable[..., Awaitable[bool]],
     timeout: float = 0.1,


### PR DESCRIPTION
# Description

[This PR](https://github.com/inmanta/inmanta-core/pull/10486) was merged on the iso8 branch, but the `tests/deploy/test_scheduler_agent.py` file didn't have the `model_version` method. Hence, the test case would fail. This PR adds that missing method.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~