### PR TITLE
Fix bug inconsistent administrative/operational scheduler state (iso8)

### DIFF
--- a/changelogs/unreleased/fix-inconsistent-scheduler-running-state.yml
+++ b/changelogs/unreleased/fix-inconsistent-scheduler-running-state.yml
@@ -1,0 +1,6 @@
+---
+description: "Fixed bug where the scheduler would stop processing new model versions if the database has been running in read-only mode."
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-inconsistent-scheduler-running-state.yml
+++ b/changelogs/unreleased/fix-inconsistent-scheduler-running-state.yml
@@ -1,6 +1,6 @@
 ---
 description: "Fixed bug where the scheduler would stop processing new model versions if the database has been running in read-only mode."
 change-type: patch
-destination-branches: [master, iso9, iso8]
+destination-branches: [iso8]
 sections:
   bugfix: "{{description}}"

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import asyncio
 import datetime
 import logging
 import os
@@ -69,6 +70,9 @@ class Agent(SessionEndpoint):
         self.executor_manager: executor.ExecutorManager[executor.Executor] = self.create_executor_manager()
         self.scheduler = scheduler.ResourceScheduler(self._env_id, self.executor_manager, self._client)
         self.working = False
+        # Prevents that the start_working() and stop_working() methods execute concurrently.
+        self._working_lock = asyncio.Lock()
+        self._stopping = False
 
     async def start(self) -> None:
         # Make mypy happy
@@ -95,8 +99,8 @@ class Agent(SessionEndpoint):
         )
 
     async def stop(self) -> None:
-        if self.working:
-            await self.stop_working()
+        self._stopping = True
+        await self.stop_working()
         if self._db_monitor:
             await self._db_monitor.stop()
         threadpools_to_join = [self.thread_pool]
@@ -113,18 +117,36 @@ class Agent(SessionEndpoint):
 
     async def start_working(self) -> None:
         """Start working, once we have a session"""
-
-        if self.working:
-            return
-        self.working = True
-        await self.executor_manager.start()
-        await self.scheduler.start()
-        LOGGER.info("Scheduler started for environment %s", self.environment)
+        async with self._working_lock:
+            if self.working:
+                return
+            if self._stopping:
+                LOGGER.warning(
+                    "Ignoring start_working request on scheduler for environment %s, because scheduler is shutting down.",
+                    self.environment,
+                )
+                return
+            try:
+                await self.executor_manager.start()
+                await self.scheduler.start()
+                self.working = True
+            except Exception:
+                await self._stop_working()
+                raise
+            else:
+                LOGGER.info("Scheduler started for environment %s", self.environment)
 
     async def stop_working(self, timeout: float = 0.0) -> None:
         """Stop working, connection lost"""
-        if not self.working:
-            return
+        async with self._working_lock:
+            if not self.working:
+                return
+            await self._stop_working(timeout=timeout)
+
+    async def _stop_working(self, timeout: float = 0.0) -> None:
+        """
+        This method must execute under the self._working_lock.
+        """
         self.working = False
         await self.scheduler.stop()
         await self.executor_manager.stop()

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -382,6 +382,8 @@ class ResourceScheduler(TaskManager):
         # - lock to serialize updates to the scheduler's intent (version, attributes, ...), e.g. process a new version.
         self._intent_lock: asyncio.Lock = asyncio.Lock()
 
+        # As long as self._running is False, no workers will be started and no work will be accepted
+        # (i.e. repair runs, deploy runs, etc.).
         self._running = False
         # Agent name to worker task
         # here to prevent it from being GC-ed

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -248,6 +248,48 @@ async def test_shutdown_notify_race(agent: TestAgent, make_resource_minimal):
     assert worker._task.done()
 
 
+async def test_atomicity_start_working_method_scheduler(environment, config, monkeypatch) -> None:
+    """
+    Verify that the `start_working()` and `stop_working()` methods of the scheduler are atomic.
+    Any unexpected exception that occurs during the execution of this method must result in
+    a scheduler that is not running and the administrative state of the scheduler (`working` flag)
+    must reflect that.
+    """
+
+    class StartFailure(Exception):
+        pass
+
+    agent = TestAgent(environment)
+
+    fail_start: bool = True
+    original_reset_resource_state = agent.scheduler.reset_resource_state
+
+    async def maybe_failing_reset_resource_state() -> None:
+        if fail_start:
+            raise StartFailure()
+        await original_reset_resource_state()
+
+    monkeypatch.setattr(agent.scheduler, "reset_resource_state", maybe_failing_reset_resource_state)
+
+    with pytest.raises(StartFailure):
+        await agent.start_working()
+
+    # The administrative and operational running state must remain consistent: we are not working and the
+    # scheduler is not running.
+    assert agent.working is False
+    assert agent.scheduler._running is False
+
+    fail_start = False
+    await agent.start_working()
+    assert agent.working is True
+    assert agent.scheduler._running is True
+
+    # Sanity check: a clean stop brings both states back down again.
+    await agent.stop_working()
+    assert agent.working is False
+    assert agent.scheduler._running is False
+
+
 async def test_deploy_scheduled_set(agent: TestAgent, make_resource_minimal) -> None:
     """
     Verify the behavior of various scheduler intricacies relating to which resources are added to the scheduled work,


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/10505, but applied on the iso8 branch due to a merge conflict. The merge conflicts were situated in the constructor of the Agent class and in the test suite.**

This PR fixes a bug that triggers in the following scenario:

* The DB is in read-only mode (because a node in the DB cluster failed and there is no quorum anymore).
* The scheduler starts and its `start_working()` method is invoked.
* The `self.working` flag of the scheduler is set to True, but the `await self.scheduler.start()` call raises an exception, because it needs write access to the DB. At this point there is an inconsistency between the administrative "working" state of the scheduler (value of the self.working flag) and the operational "working" state of the scheduler (whether the scheduler is actually performing work). The result is that the scheduler will not process new model version.
* When the DB cluster fully recovers, the scheduler will still be stuck and process no new model version.

Concrete fixes:

* Make sure we only set the `self.working` to True iff the scheduler was started successfully.
* Prevent a race condition where the `start_working()` and `stop_working()` method of the scheduler are executing concurrently.
* Make sure that the `start_working()` method doesn't start the scheduler anymore when `stop()` was called and the agent process is actually shutting down.

Part of #10502

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
