### PR TITLE
Raise exception on get() call when PoolManager not running

### DIFF
--- a/changelogs/unreleased/block-resourcepool-get-on-not-running.yml
+++ b/changelogs/unreleased/block-resourcepool-get-on-not-running.yml
@@ -1,0 +1,6 @@
+---
+description: "Fix race condition on scheduler shutdown where an executor can be created while the scheduler is shutting down. This executor will not be stopped or cleaned up."
+issue-nr: 10502
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -160,10 +160,13 @@ class Agent(SessionEndpoint):
         This method must execute under the self._working_lock.
         """
         self.working = False
+        # Stop pushing work to executors
         await self.scheduler.stop()
+        # Wait until in-flight deployments finished
+        await self.scheduler.join()
+        # Stop executors
         await self.executor_manager.stop()
         await self.executor_manager.join([], timeout=timeout)
-        await self.scheduler.join()
         LOGGER.info("Scheduler stopped for environment %s", self.environment)
 
     @protocol.handle(methods_v2.remove_executor_venvs)

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -160,13 +160,10 @@ class Agent(SessionEndpoint):
         This method must execute under the self._working_lock.
         """
         self.working = False
-        # Stop pushing work to executors
         await self.scheduler.stop()
-        # Wait until in-flight deployments finished
-        await self.scheduler.join()
-        # Stop executors
         await self.executor_manager.stop()
         await self.executor_manager.join([], timeout=timeout)
+        await self.scheduler.join()
         LOGGER.info("Scheduler stopped for environment %s", self.environment)
 
     @protocol.handle(methods_v2.remove_executor_venvs)

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -224,6 +224,11 @@ class PoolManager(abc.ABC, Generic[TPoolID, TIntPoolID, TPoolMember]):
         This implies nothing about the children
         """
         async with self._locks.global_exclusive_lock():
+            # Acquire the global_exclusive_lock to make sure that no call to
+            # self.get() is executing. This way we are sure that no new instances
+            # will be added to self.pool after this method call. Without this lock
+            # the sequence request_shutdown() -> join() can have a race condition
+            # where an in-flight call to get() is not stopped/joined.
             self.shut_down = True
             self.shutting_down = True
 

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -143,6 +143,15 @@ class PoolMember(abc.ABC, Generic[TIntPoolID]):
             await listener(self)
 
 
+class PoolManagerNotRunning(Exception):
+    """
+    This exception is raised if the get() method of a PoolManager is called
+    while the PoolManager is not running.
+    """
+
+    pass
+
+
 TPoolMember = TypeVar("TPoolMember", bound=PoolMember)
 
 
@@ -214,8 +223,9 @@ class PoolManager(abc.ABC, Generic[TPoolID, TIntPoolID, TPoolMember]):
 
         This implies nothing about the children
         """
-        self.shut_down = True
-        self.shutting_down = True
+        async with self._locks.global_exclusive_lock():
+            self.shut_down = True
+            self.shutting_down = True
 
     async def join(self) -> None:
         """
@@ -254,6 +264,8 @@ class PoolManager(abc.ABC, Generic[TPoolID, TIntPoolID, TPoolMember]):
         internal_id = self._id_to_internal(member_id)
         # Acquire a lock based on the executor's pool id
         async with self._locks.get(self.get_lock_name_for(internal_id)):
+            if not self.running:
+                raise PoolManagerNotRunning()
             it = self.pool.get(internal_id, None)
             if it is not None:
                 if not it.shutting_down:

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -261,7 +261,7 @@ class DryRun(Task):
                 rvid=executor_resource_details.rvid,
                 agent=agent,
                 started=started,
-                log_msg_for_log="Skipping dryrun for resource %s because due to an error in constructing the executor",
+                log_msg_for_log="Skipping dryrun for resource %s due to an error when constructing the executor",
                 log_msg_for_report="Unable to construct an executor for this resource",
             )
         else:

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -249,7 +249,7 @@ class DryRun(Task):
                 version=self.version,
             )
         except resourcepool.PoolManagerNotRunning:
-            self._log_failure_and_create_dryrun_report(
+            dryrun_report = self._log_failure_and_create_dryrun_report(
                 rvid=executor_resource_details.rvid,
                 agent=agent,
                 started=started,
@@ -257,7 +257,7 @@ class DryRun(Task):
                 log_msg_for_report="Unable to construct an executor for this resource, because executor manager is not running",
             )
         except Exception:
-            self._log_failure_and_create_dryrun_report(
+            dryrun_report = self._log_failure_and_create_dryrun_report(
                 rvid=executor_resource_details.rvid,
                 agent=agent,
                 started=started,
@@ -268,7 +268,7 @@ class DryRun(Task):
             try:
                 dryrun_report = await my_executor.dry_run(executor_resource_details, self.dry_run_id)
             except Exception:
-                self._log_failure_and_create_dryrun_report(
+                dryrun_report = self._log_failure_and_create_dryrun_report(
                     rvid=executor_resource_details.rvid,
                     agent=agent,
                     started=started,

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -25,11 +25,11 @@ import uuid
 from dataclasses import dataclass
 
 from inmanta import data, resources
-from inmanta.agent import executor
+from inmanta.agent import executor, resourcepool
 from inmanta.agent.executor import DeployReport, ModuleLoadingException
 from inmanta.data.model import AttributeStateChange
 from inmanta.deploy import scheduler, state
-from inmanta.types import ResourceIdStr
+from inmanta.types import ResourceIdStr, ResourceVersionIdStr
 from inmanta.vendor import pyformance
 
 LOGGER = logging.getLogger(__name__)
@@ -152,6 +152,16 @@ class Deploy(Task):
                         agent_name=agent,
                         version=version,
                     )
+                except resourcepool.PoolManagerNotRunning as e:
+                    log_line = data.LogLine.log(
+                        logging.ERROR,
+                        "Trying to create executor while executor manager is not running.\n%(traceback)s",
+                        traceback="".join(traceback.format_tb(e.__traceback__)),
+                    )
+                    log_line.write_to_logger_for_resource(agent, executor_resource_details.rvid, exc_info=True)
+                    deploy_report = DeployReport.undeployable(executor_resource_details.rvid, action_id, log_line)
+                    return
+
                 except ModuleLoadingException as e:
                     e.log_resource_action_to_scheduler_log(
                         agent=agent, rid=executor_resource_details.rvid, include_exception_info=True
@@ -238,42 +248,52 @@ class DryRun(Task):
                 agent_name=agent,
                 version=self.version,
             )
-        except Exception:
-            logger_for_agent(agent).error(
-                "Skipping dryrun for resource %s because due to an error in constructing the executor",
-                executor_resource_details.rvid,
-                exc_info=True,
-            )
-            dryrun_report = executor.DryrunReport(
+        except resourcepool.PoolManagerNotRunning:
+            self._log_failure_and_create_dryrun_report(
                 rvid=executor_resource_details.rvid,
-                dryrun_id=self.dry_run_id,
-                changes={
-                    "handler": AttributeStateChange(
-                        current="FAILED", desired="Unable to construct an executor for this resource"
-                    )
-                },
+                agent=agent,
                 started=started,
-                finished=datetime.datetime.now().astimezone(),
-                messages=[],
+                log_msg_for_log="Skipping dryrun for resource %s because the executor manager is not running",
+                log_msg_for_report="Unable to construct an executor for this resource, because executor manager is not running",
+            )
+        except Exception:
+            self._log_failure_and_create_dryrun_report(
+                rvid=executor_resource_details.rvid,
+                agent=agent,
+                started=started,
+                log_msg_for_log="Skipping dryrun for resource %s because due to an error in constructing the executor",
+                log_msg_for_report="Unable to construct an executor for this resource",
             )
         else:
             try:
                 dryrun_report = await my_executor.dry_run(executor_resource_details, self.dry_run_id)
             except Exception:
-                logger_for_agent(agent).error(
-                    "Skipping dryrun for resource %s because it is in undeployable state",
-                    executor_resource_details.rvid,
-                    exc_info=True,
-                )
-                dryrun_report = executor.DryrunReport(
+                self._log_failure_and_create_dryrun_report(
                     rvid=executor_resource_details.rvid,
-                    dryrun_id=self.dry_run_id,
-                    changes={"handler": AttributeStateChange(current="FAILED", desired="Resource is in an undeployable state")},
+                    agent=agent,
                     started=started,
-                    finished=datetime.datetime.now().astimezone(),
-                    messages=[],
+                    log_msg_for_log="Skipping dryrun for resource %s because it is in undeployable state",
+                    log_msg_for_report="Resource is in an undeployable state",
                 )
         await task_manager.dryrun_done(dryrun_report)
+
+    def _log_failure_and_create_dryrun_report(
+        self,
+        rvid: ResourceVersionIdStr,
+        agent: str,
+        started: datetime.datetime,
+        log_msg_for_log: str,
+        log_msg_for_report: str,
+    ) -> executor.DryrunReport:
+        logger_for_agent(agent).error(log_msg_for_log, rvid, exc_info=True)
+        return executor.DryrunReport(
+            rvid=rvid,
+            dryrun_id=self.dry_run_id,
+            changes={"handler": AttributeStateChange(current="FAILED", desired=log_msg_for_report)},
+            started=started,
+            finished=datetime.datetime.now().astimezone(),
+            messages=[],
+        )
 
 
 class RefreshFact(Task):
@@ -295,6 +315,12 @@ class RefreshFact(Task):
                 agent_name=agent,
                 version=version,
             )
+        except resourcepool.PoolManagerNotRunning:
+            logger_for_agent(agent).warning(
+                "Cannot retrieve fact for %s because no executor can be created while the executor manager is not running.",
+                executor_resource_details.rvid,
+            )
+            return
         except Exception:
             logger_for_agent(agent).warning(
                 "Cannot retrieve fact for %s because resource is undeployable or code could not be loaded",

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -37,9 +37,9 @@ import typing
 import uuid
 import warnings
 from abc import ABC, abstractmethod
-from asyncio import AbstractEventLoop, CancelledError, Lock, Task, ensure_future, gather
+from asyncio import AbstractEventLoop, CancelledError, Event, Lock, Task, ensure_future, gather
 from collections import abc, defaultdict
-from collections.abc import Awaitable, Callable, Collection, Coroutine, Iterable, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Coroutine, Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from logging import Logger
@@ -752,22 +752,45 @@ class NamedLock:
     """Create fine grained locks"""
 
     def __init__(self) -> None:
+        self._global_exclusive_lock: Lock = Lock()
+        self._all_named_locks_released_event: Event = Event()
         self._master_lock: Lock = Lock()
         self._named_locks: dict[str, Lock] = {}
         self._named_locks_counters: dict[str, int] = {}
+
+    @contextlib.asynccontextmanager
+    async def global_exclusive_lock(self) -> AsyncIterator[None]:
+        """
+        Context manager that ensures that no named lock is acquired
+        while its context is executing. If named locks are acquired
+        when this method is called, the context will only be entered
+        when all named locks are released. While waiting for this
+        condition, all attempts to acquire a named lock will block
+        until this exclusive lock is released.
+        """
+        async with self._global_exclusive_lock:
+            if not self._named_locks:
+                # No locks were acquired
+                yield
+            else:
+                # Wait until all acquired named locks are released
+                self._all_named_locks_released_event.clear()
+                await self._all_named_locks_released_event.wait()
+                yield
 
     def get(self, name: str) -> NamedSubLock:
         return NamedSubLock(self, name)
 
     async def acquire(self, name: str) -> None:
-        async with self._master_lock:
-            if name in self._named_locks:
-                lock = self._named_locks[name]
-                self._named_locks_counters[name] += 1
-            else:
-                lock = Lock()
-                self._named_locks[name] = lock
-                self._named_locks_counters[name] = 1
+        async with self._global_exclusive_lock:
+            async with self._master_lock:
+                if name in self._named_locks:
+                    lock = self._named_locks[name]
+                    self._named_locks_counters[name] += 1
+                else:
+                    lock = Lock()
+                    self._named_locks[name] = lock
+                    self._named_locks_counters[name] = 1
         await lock.acquire()
 
     async def release(self, name: str) -> None:
@@ -779,6 +802,8 @@ class NamedLock:
             if self._named_locks_counters[name] <= 0:
                 del self._named_locks[name]
                 del self._named_locks_counters[name]
+            if not self._named_locks:
+                self._all_named_locks_released_event.set()
 
 
 class nullcontext(contextlib.nullcontext[T], contextlib.AbstractAsyncContextManager[T]):

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -767,6 +767,9 @@ class NamedLock:
         when all named locks are released. While waiting for this
         condition, all attempts to acquire a named lock will block
         until this exclusive lock is released.
+
+        A named lock and this global_exclusive_lock cannot be acquired
+        simultaneously as this would result in a deadlock.
         """
         async with self._global_exclusive_lock:
             if not self._named_locks:

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -487,6 +487,127 @@ async def test_named_lock():
     assert not lock._named_locks
 
 
+async def test_named_lock_global_exclusive_lock_no_named_locks_held():
+    """
+    When no named lock is held, the global exclusive lock can be entered immediately.
+    """
+    lock = NamedLock()
+    async with lock.global_exclusive_lock():
+        pass
+    # No state is leaked
+    assert not lock._named_locks
+
+
+async def test_named_lock_global_exclusive_lock_waits_for_held_named_locks():
+    """
+    When named locks are held at the time the global exclusive lock is requested, entering its
+    context is delayed until all those named locks are released.
+    """
+    lock = NamedLock()
+    await lock.acquire("a")
+    await lock.acquire("b")
+
+    entered = asyncio.Event()
+
+    async def enter_global_exclusive_lock() -> None:
+        async with lock.global_exclusive_lock():
+            entered.set()
+
+    fut = asyncio.create_task(enter_global_exclusive_lock())
+
+    # Give the task a chance to run: it must block because named locks are still held
+    await asyncio.sleep(0)
+    assert not entered.is_set()
+
+    # Releasing one of the two named locks is not enough
+    await lock.release("a")
+    await asyncio.sleep(0)
+    assert not entered.is_set()
+
+    # Releasing the last named lock unblocks the global exclusive lock
+    await lock.release("b")
+    await asyncio.wait_for(fut, timeout=1)
+    assert entered.is_set()
+
+
+async def test_named_lock_global_exclusive_lock_blocks_new_acquisitions():
+    """
+    While the global exclusive lock is held, no named lock can be acquired. New acquisitions
+    block until the global exclusive lock is released.
+    """
+    lock = NamedLock()
+
+    release_global_lock = asyncio.Event()
+    holding_global_lock = asyncio.Event()
+
+    async def hold_global_exclusive_lock() -> None:
+        async with lock.global_exclusive_lock():
+            holding_global_lock.set()
+            await release_global_lock.wait()
+
+    global_lock_task = asyncio.create_task(hold_global_exclusive_lock())
+    # No named locks are held, so the global exclusive lock is entered immediately
+    await asyncio.wait_for(holding_global_lock.wait(), timeout=1)
+
+    # An attempt to acquire a named lock must block while the global exclusive lock is held
+    acquire_fut = asyncio.create_task(lock.acquire("a"))
+    await asyncio.sleep(0)
+    assert not acquire_fut.done()
+
+    # Releasing the global exclusive lock unblocks the named lock acquisition
+    release_global_lock.set()
+    await asyncio.wait_for(global_lock_task, timeout=1)
+    await asyncio.wait_for(acquire_fut, timeout=1)
+
+    await lock.release("a")
+    # Don't leak
+    assert not lock._named_locks
+
+
+async def test_named_lock_global_exclusive_lock_mutual_exclusion():
+    """
+    The global exclusive lock guarantees that no named lock is held while its context executes:
+    a named lock acquired before the global exclusive lock must be released before the context
+    is entered, and a named lock acquired after the global exclusive lock is released cannot be
+    held while the context executes.
+    """
+    lock = NamedLock()
+    events: list[str] = []
+
+    await lock.acquire("a")
+
+    async def use_global_exclusive_lock() -> None:
+        async with lock.global_exclusive_lock():
+            events.append("global-enter")
+            # Yield control to give any (incorrectly) unblocked named lock acquisition a chance to run
+            await asyncio.sleep(0)
+            events.append("global-exit")
+
+    async def use_named_lock() -> None:
+        # Wait until the global exclusive lock is requested, then attempt to acquire a named lock
+        await lock.acquire("b")
+        events.append("named-acquired")
+        await lock.release("b")
+
+    global_task = asyncio.create_task(use_global_exclusive_lock())
+    # Make sure the global exclusive lock is requested first and is blocked on the held "a" lock
+    await asyncio.sleep(0)
+    named_task = asyncio.create_task(use_named_lock())
+    await asyncio.sleep(0)
+
+    # Neither task can make progress while "a" is held
+    assert events == []
+
+    # Releasing "a" lets the global exclusive lock proceed; the named lock acquisition must wait
+    # until the global exclusive lock context has fully completed.
+    await lock.release("a")
+    await asyncio.wait_for(asyncio.gather(global_task, named_task), timeout=1)
+
+    assert events == ["global-enter", "global-exit", "named-acquired"]
+    # Don't leak
+    assert not lock._named_locks
+
+
 def test_running_test_fixture():
     """
     Assert that the RUNNING_TESTS variable is set to True when we run the tests


### PR DESCRIPTION
# Description

Fix race condition on agent pause where an executor can be created during/after the shutdown of the executor manager. The executors created during this period of time will not be stopped or cleaned up.

Part of #10502

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
