### PR TITLE
Fix cleanup job leak in TimeBasedPoolManager

### DIFF
--- a/changelogs/unreleased/fix-cleanup-job-leak.yml
+++ b/changelogs/unreleased/fix-cleanup-job-leak.yml
@@ -1,0 +1,6 @@
+---
+description: "Fix bug where the TimeBasedPoolManager might leak cleanup jobs."
+issue-nr: 10502
+issue-repo: inmanta-core
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -351,8 +351,13 @@ class TimeBasedPoolManager(PoolManager[TPoolID, TIntPoolID, TPoolMember]):
         We split up `cleanup_inactive_pool_members` and `cleanup_inactive_pool_members_task` in order to be able to call the
         cleanup method in the test without being blocked in a loop.
         """
+        current_task: asyncio.Task | None = asyncio.current_task()
+        assert current_task is not None
         try:
             while self.running:
+                if current_task is not self.cleanup_job:
+                    # This is a stale cleanup job
+                    return
                 try:
                     sleep_interval = await self.cleanup_inactive_pool_members()
                 except Exception:

--- a/src/inmanta/agent/resourcepool.py
+++ b/src/inmanta/agent/resourcepool.py
@@ -351,7 +351,7 @@ class TimeBasedPoolManager(PoolManager[TPoolID, TIntPoolID, TPoolMember]):
         We split up `cleanup_inactive_pool_members` and `cleanup_inactive_pool_members_task` in order to be able to call the
         cleanup method in the test without being blocked in a loop.
         """
-        current_task: asyncio.Task | None = asyncio.current_task()
+        current_task: asyncio.Task[None] | None = asyncio.current_task()
         assert current_task is not None
         try:
             while self.running:

--- a/tests/forking_agent/test_resource_pool.py
+++ b/tests/forking_agent/test_resource_pool.py
@@ -20,6 +20,7 @@ import asyncio
 import itertools
 
 from inmanta.agent.resourcepool import PoolManager, PoolMember, SingleIdPoolManager, TimeBasedPoolManager
+from utils import retry_limited
 
 
 async def test_resource_pool():
@@ -163,6 +164,89 @@ async def test_timed_resource_pool_restart():
     await asyncio.wait_for(a.anchor.wait(), 2)
     assert not a.running
     assert not manager.pool
+
+
+async def test_timed_resource_pool_no_cleanup_job_leak():
+    """
+    The TimeBasedPoolManager create a new cleanup job every time the start()
+    method is called and it stops that cleanup job when request_shutdown() and join()
+    are called in succession. This test makes sure that we don't leak cleanup jobs
+    when start() is called after request_shutdown() without a join() in between.
+    """
+
+    counter = itertools.count()
+
+    # Used to block the cleanup job inside cleanup_inactive_pool_members() so we can
+    # interleave a restart while it is running rather than sleeping. During the sleep
+    # stage we cannot get any race conditions, because request_shutdown() would cancel
+    # the sleep task, which raises a CancelledError in the cleanup job.
+    inside_cleanup = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    class SimplePoolMember(PoolMember[str]):
+
+        def __init__(self, my_id: str) -> None:
+            super().__init__(my_id)
+            self.count = next(counter)
+            self.request_shutdown_finished_event = asyncio.Event()
+
+        def __repr__(self):
+            return self.id + str(self.count)
+
+        async def request_shutdown(self) -> None:
+            await super().request_shutdown()
+            await self.set_shutdown()
+            self.request_shutdown_finished_event.set()
+
+    class SimplePoolManager(TimeBasedPoolManager[str, str, SimplePoolMember]):
+        async def create_member(self, executor_id: str) -> SimplePoolMember:
+            return SimplePoolMember(my_id=executor_id)
+
+        def _id_to_internal(self, ext_id: str) -> str:
+            return ext_id
+
+        async def cleanup_inactive_pool_members(self) -> float:
+            # Block the very first cleanup invocation until the test releases it, leaving the
+            # cleanup job actively running (not sleeping) during the restart.
+            if not release_cleanup.is_set():
+                inside_cleanup.set()
+                await release_cleanup.wait()
+            return await super().cleanup_inactive_pool_members()
+
+    # Very short expiry
+    manager = SimplePoolManager(0.02)
+    await manager.start()
+    first_cleanup_job = manager.cleanup_job
+    assert first_cleanup_job is not None
+
+    # Wait until the original cleanup job is actively running cleanup (not sleeping).
+    await asyncio.wait_for(inside_cleanup.wait(), 2)
+
+    # Request shutdown and start again while the original cleanup job is still blocked
+    # inside cleanup_inactive_pool_members(). Because it is not sleeping, the
+    # shutdown can not cancel it, and start() resets `PoolManager.running` back to True.
+    await manager.request_shutdown()
+    await manager.start()
+    second_cleanup_job = manager.cleanup_job
+    assert second_cleanup_job is not None
+    assert first_cleanup_job is not second_cleanup_job
+
+    # Let the blocked cleanup invocations proceed.
+    release_cleanup.set()
+
+    # The stale (original) cleanup job must terminate itself instead of looping forever.
+    await retry_limited(lambda: first_cleanup_job.done(), timeout=5)
+
+    # The current cleanup job must still be running and cleaning up idle members.
+    assert manager.running
+    a = await manager.get("a")
+    await asyncio.wait_for(a.request_shutdown_finished_event.wait(), 2)
+    assert not a.running
+    assert not manager.pool
+
+    await manager.request_shutdown()
+    await manager.join()
+    assert second_cleanup_job.done()
 
 
 async def test_resource_pool_stacking():


### PR DESCRIPTION
# Description

The TimeBasedPoolManager might leak cleanup jobs when the following sequence of calls is done on that TimeBasedPoolManager:

`request_shutdown()` -> `start()` -> `join()`

The call to `start()` will start a new cleanup job. 

The old cleanup jobs might not be stopped when the following conditions hold:

* The `request_shutdown()` method is called while the `cleanup_inactive_pool_members_task` method is not sleeping. In that case the sleep call is not cancelled and no CancelledError will be raised inside the loop of the old cleanup job.
* If the `start()` method executes before the `running` flag is evaluated by the old cleanup job. In that case the running flag will evaluate to True again and the cleanup job will not drop out of its loop.

The result is that the old and the new cleanup job run side by side.

closes #10502

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
