### PR TITLE
Rename ModuleInstallSpec to InmantaModuleInstallSpec

### DIFF
--- a/changelogs/unreleased/rename-inmanta-module-install-spec.yml
+++ b/changelogs/unreleased/rename-inmanta-module-install-spec.yml
@@ -1,0 +1,4 @@
+description: Rename the internal `ModuleInstallSpec` class to `InmantaModuleInstallSpec`.
+change-type: patch
+destination-branches:
+  - master

--- a/src/inmanta/agent/code_manager.py
+++ b/src/inmanta/agent/code_manager.py
@@ -24,7 +24,7 @@ import uuid
 import inmanta.data.sqlalchemy as models
 from inmanta import data
 from inmanta.agent import executor
-from inmanta.agent.executor import ModuleInstallSpec
+from inmanta.agent.executor import InmantaModuleInstallSpec
 from inmanta.data.model import LEGACY_PIP_DEFAULT, ModuleSource, ModuleSourceMetadata, PipConfig
 from inmanta.util.async_lru import async_lru_cache
 from sqlalchemy import and_, select
@@ -47,13 +47,13 @@ class CodeManager:
     """
 
     @async_lru_cache(maxsize=1024)
-    async def get_code(self, environment: uuid.UUID, model_version: int, agent_name: str) -> list[ModuleInstallSpec]:
+    async def get_code(self, environment: uuid.UUID, model_version: int, agent_name: str) -> list[InmantaModuleInstallSpec]:
         """
         Get the list of installation specifications (i.e. pip config, python package dependencies,
         Inmanta modules sources) required to deploy resources on a given agent for a given configuration
         model version.
 
-        :return: list of ModuleInstallSpec for this agent and this model version.
+        :return: list of InmantaModuleInstallSpec for this agent and this model version.
         """
         module_install_specs = []
 
@@ -122,7 +122,7 @@ class CodeManager:
 
                 pip_config = LEGACY_PIP_DEFAULT if _pip_config is None else PipConfig(**_pip_config)
                 module_install_specs.append(
-                    ModuleInstallSpec(
+                    InmantaModuleInstallSpec(
                         module_name=module_name,
                         module_version=first_row.inmanta_module_version,
                         blueprint=executor.ExecutorBlueprint(

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -205,10 +205,10 @@ class ExecutorBlueprint(EnvBlueprint):
         self.sources = sorted(set(self.sources))
 
     @classmethod
-    def from_specs(cls, code: typing.Collection["ModuleInstallSpec"]) -> "ExecutorBlueprint":
+    def from_specs(cls, code: typing.Collection["InmantaModuleInstallSpec"]) -> "ExecutorBlueprint":
         """
         Create a single ExecutorBlueprint by combining the blueprint(s) of several
-        ModuleInstallSpec by merging respectively their module sources and their
+        InmantaModuleInstallSpec by merging respectively their module sources and their
         requirements and making sure they all share the same pip config.
         """
 
@@ -341,7 +341,7 @@ class ExecutorId:
 
 
 @dataclass(frozen=True)
-class ModuleInstallSpec:
+class InmantaModuleInstallSpec:
     """
     This class encapsulates the requirements for a specific (module_name, module_version).
 
@@ -767,14 +767,14 @@ class ExecutorManager(abc.ABC, typing.Generic[E]):
     """
 
     @abc.abstractmethod
-    async def get_executor(self, agent_name: str, agent_uri: str, code: typing.Collection[ModuleInstallSpec]) -> E:
+    async def get_executor(self, agent_name: str, agent_uri: str, code: typing.Collection[InmantaModuleInstallSpec]) -> E:
         """
         Retrieves an Executor for a given agent with the relevant handler code loaded in its venv.
         If an Executor does not exist for the given configuration, a new one is created.
 
         :param agent_name: The name of the agent for which an Executor is being retrieved or created.
         :param agent_uri: The name of the host on which the agent is running.
-        :param code: Collection of ModuleInstallSpec defining the configuration for the Executor i.e.
+        :param code: Collection of InmantaModuleInstallSpec defining the configuration for the Executor i.e.
             which resource types it can act on and all necessary information to install the relevant
             handler code in its venv. Must have at least one element.
         :return: An Executor instance

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -1075,7 +1075,7 @@ class MPManager(
         self,
         agent_name: str,
         agent_uri: str,
-        code: typing.Collection[executor.ModuleInstallSpec],
+        code: typing.Collection[executor.InmantaModuleInstallSpec],
     ) -> MPExecutor:
         """
         Retrieves an Executor for a given agent with the relevant handler code loaded in its venv.
@@ -1083,7 +1083,7 @@ class MPManager(
 
         :param agent_name: The name of the agent for which an Executor is being retrieved or created.
         :param agent_uri: The name of the host on which the agent is running.
-        :param code: Collection of ModuleInstallSpec defining the configuration for the Executor i.e.
+        :param code: Collection of InmantaModuleInstallSpec defining the configuration for the Executor i.e.
             which resource types it can act on and all necessary information to install the relevant
             handler code in its venv. Must have at least one element.
         :return: An Executor instance

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -592,7 +592,7 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
         await asyncio.gather(*(child.join() for child in self.executors.values()))
 
     async def get_executor(
-        self, agent_name: str, agent_uri: str, code: typing.Collection[executor.ModuleInstallSpec]
+        self, agent_name: str, agent_uri: str, code: typing.Collection[executor.InmantaModuleInstallSpec]
     ) -> InProcessExecutor:
         """
         Retrieves an Executor for a given agent with the relevant handler code loaded in its venv.
@@ -600,7 +600,7 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
 
         :param agent_name: The name of the agent for which an Executor is being retrieved or created.
         :param agent_uri: The name of the host on which the agent is running.
-        :param code: Collection of ModuleInstallSpec defining the configuration for the Executor i.e.
+        :param code: Collection of InmantaModuleInstallSpec defining the configuration for the Executor i.e.
             all necessary information to install the relevant handler code in its venv. Must have
             at least one element.
         :return: An Executor instance
@@ -624,7 +624,7 @@ class InProcessExecutorManager(executor.ExecutorManager[InProcessExecutor]):
 
         return out
 
-    async def ensure_code(self, code: typing.Collection[executor.ModuleInstallSpec]) -> FailedInmantaModules:
+    async def ensure_code(self, code: typing.Collection[executor.InmantaModuleInstallSpec]) -> FailedInmantaModules:
         """Ensure that the code for the given environment and version is loaded"""
 
         failed_to_load: FailedInmantaModules = defaultdict(dict)

--- a/src/inmanta/agent/write_barier_executor.py
+++ b/src/inmanta/agent/write_barier_executor.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 
 from inmanta import const
 from inmanta.agent import executor
-from inmanta.agent.executor import DeployReport, DryrunReport, GetFactReport, ModuleInstallSpec, ResourceDetails
+from inmanta.agent.executor import DeployReport, DryrunReport, GetFactReport, InmantaModuleInstallSpec, ResourceDetails
 from inmanta.types import ResourceIdStr
 
 
@@ -71,7 +71,7 @@ class WriteBarierExecutorManager(executor.ExecutorManager[WriteBarierExecutor]):
         self.delegate = delegate
 
     async def get_executor(
-        self, agent_name: str, agent_uri: str, code: typing.Collection[ModuleInstallSpec]
+        self, agent_name: str, agent_uri: str, code: typing.Collection[InmantaModuleInstallSpec]
     ) -> WriteBarierExecutor:
         if not code:
             raise ValueError(f"{self.__class__.__name__}.get_executor() expects at least one resource install specification")

--- a/tests/deploy/scheduler_mocks.py
+++ b/tests/deploy/scheduler_mocks.py
@@ -30,7 +30,7 @@ from asyncpg import Connection
 
 from inmanta import const
 from inmanta.agent import Agent, executor
-from inmanta.agent.executor import DeployReport, DryrunReport, GetFactReport, ModuleInstallSpec, ResourceDetails
+from inmanta.agent.executor import DeployReport, DryrunReport, GetFactReport, InmantaModuleInstallSpec, ResourceDetails
 from inmanta.const import Change
 from inmanta.data.model import AttributeStateChange
 from inmanta.deploy import state
@@ -189,7 +189,9 @@ class DummyManager(executor.ExecutorManager[executor.Executor]):
         self.executors[agent_name] = executor
         return executor
 
-    async def get_executor(self, agent_name: str, agent_uri: str, code: typing.Collection[ModuleInstallSpec]) -> DummyExecutor:
+    async def get_executor(
+        self, agent_name: str, agent_uri: str, code: typing.Collection[InmantaModuleInstallSpec]
+    ) -> DummyExecutor:
         if not code:
             raise ValueError(f"{self.__class__.__name__}.get_executor() expects at least one resource install specification")
         if agent_name not in self.executors:

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -37,7 +37,7 @@ from deploy.scheduler_mocks import FAIL_DEPLOY, NON_COMPLIANT_DEPLOY, DummyExecu
 from inmanta import const, data, util
 from inmanta.agent import executor
 from inmanta.agent.agent_new import Agent
-from inmanta.agent.executor import ModuleInstallSpec, ResourceDetails
+from inmanta.agent.executor import InmantaModuleInstallSpec, ResourceDetails
 from inmanta.config import Config
 from inmanta.deploy import state, tasks
 from inmanta.deploy.scheduler import ModelVersion, ResourceScheduler
@@ -2615,7 +2615,9 @@ class BrokenDummyManager(executor.ExecutorManager[executor.Executor]):
     A broken dummy ExecutorManager that fails on get_executor to test failure paths
     """
 
-    async def get_executor(self, agent_name: str, agent_uri: str, code: typing.Collection[ModuleInstallSpec]) -> DummyExecutor:
+    async def get_executor(
+        self, agent_name: str, agent_uri: str, code: typing.Collection[InmantaModuleInstallSpec]
+    ) -> DummyExecutor:
         raise Exception()
 
     async def stop_for_agent(self, agent_name: str) -> list[DummyExecutor]:

--- a/tests/forking_agent/test_agent_executor.py
+++ b/tests/forking_agent/test_agent_executor.py
@@ -52,8 +52,8 @@ def set_custom_executor_policy(server_config):
     inmanta.agent.config.agent_executor_cap.set(str(old_cap_value))
 
 
-def code_for(bp: executor.ExecutorBlueprint) -> list[executor.ModuleInstallSpec]:
-    return [executor.ModuleInstallSpec("test", "abcdef", bp)]
+def code_for(bp: executor.ExecutorBlueprint) -> list[executor.InmantaModuleInstallSpec]:
+    return [executor.InmantaModuleInstallSpec("test", "abcdef", bp)]
 
 
 async def test_process_manager(

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -96,7 +96,9 @@ async def test_executor_server(set_custom_executor_policy, mpmanager: MPManager,
         sources=[],
         python_version=sys.version_info[:2],
     )  # No pip
-    simplest = await manager.get_executor("agent1", "test", [executor.ModuleInstallSpec("test", "123456", simplest_blueprint)])
+    simplest = await manager.get_executor(
+        "agent1", "test", [executor.InmantaModuleInstallSpec("test", "123456", simplest_blueprint)]
+    )
 
     # check communications
     result = await simplest.call(Echo(["aaaa"]))
@@ -157,8 +159,10 @@ def test():
     )
 
     # Full runner install requires pip install, this can be slow, so we build it first to prevent the other one from timing out
-    oldest_executor = await manager.get_executor("agent2", "internal:", [executor.ModuleInstallSpec("test", 1, dummy)])
-    full_runner = await manager.get_executor("agent2", "internal:", [executor.ModuleInstallSpec("test:DDD:Test", 1, full)])
+    oldest_executor = await manager.get_executor("agent2", "internal:", [executor.InmantaModuleInstallSpec("test", 1, dummy)])
+    full_runner = await manager.get_executor(
+        "agent2", "internal:", [executor.InmantaModuleInstallSpec("test:DDD:Test", 1, full)]
+    )
 
     assert oldest_executor.id in manager.pool
 
@@ -184,7 +188,7 @@ def test():
         return oldest_executor not in manager.agent_map["agent2"]
 
     with caplog.at_level(logging.DEBUG):
-        _ = await manager.get_executor("agent2", "internal:", [executor.ModuleInstallSpec("test::Test", "1", dummy)])
+        _ = await manager.get_executor("agent2", "internal:", [executor.InmantaModuleInstallSpec("test::Test", "1", dummy)])
         assert not oldest_executor.running
         assert full_runner.running
         await retry_limited(oldest_gone, 1)
@@ -202,7 +206,9 @@ def test():
         await x.join()
     await retry_limited(lambda: len(manager.agent_map["agent2"]) == 0, 10)
 
-    full_runner = await manager.get_executor("agent2", "internal:", [executor.ModuleInstallSpec("test::Test", "1", full)])
+    full_runner = await manager.get_executor(
+        "agent2", "internal:", [executor.InmantaModuleInstallSpec("test::Test", "1", full)]
+    )
 
     await retry_limited(lambda: len(manager.agent_map["agent2"]) == 1, 1)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -88,7 +88,7 @@ async def agent_cache(agent, environment):
     )
 
     myagent_instance = await agent.executor_manager.delegate.get_executor(
-        "agent1", "local:", [executor.ModuleInstallSpec("test", "abcdef", blueprint1)]
+        "agent1", "local:", [executor.InmantaModuleInstallSpec("test", "abcdef", blueprint1)]
     )
     yield myagent_instance._cache
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -54,7 +54,7 @@ from inmanta import config, const, data, env, module, protocol, util
 from inmanta.agent import config as cfg
 from inmanta.agent import executor
 from inmanta.agent.code_manager import CodeManager
-from inmanta.agent.executor import ExecutorBlueprint, ModuleInstallSpec
+from inmanta.agent.executor import ExecutorBlueprint, InmantaModuleInstallSpec
 from inmanta.data.model import LEGACY_PIP_DEFAULT, AuthMethod, PipConfig, SchedulerStatusReport
 from inmanta.deploy import state
 from inmanta.deploy.scheduler import ResourceScheduler
@@ -1077,9 +1077,9 @@ class DummyCodeManager(CodeManager):
 
     async def get_code(
         self, environment: uuid.UUID, model_version: int, agent_name: str
-    ) -> tuple[Collection[ModuleInstallSpec], executor.FailedModules]:
+    ) -> tuple[Collection[InmantaModuleInstallSpec], executor.FailedModules]:
         dummyblueprint: ExecutorBlueprint = _get_dummy_blueprint_for(environment)
-        return ([ModuleInstallSpec("dummy_module", "0.0.0", dummyblueprint)], {})
+        return ([InmantaModuleInstallSpec("dummy_module", "0.0.0", dummyblueprint)], {})
 
 
 async def is_agent_done(scheduler: ResourceScheduler, agent_name: str) -> bool:


### PR DESCRIPTION
# Description

Pure mechanical rename of the internal `executor.ModuleInstallSpec` dataclass to `InmantaModuleInstallSpec`.

This is **prep PR 1 of 3**, split out of #10468 to keep that PR focused and reviewable. No behavior change — the diff is purely the rename plus black re-wrapping of the few lines that grew past 128 characters.

The class is not part of the `@stable_api`, so this is not a breaking public API change.

## Self Check

- [x] Changelog entry
- [x] Type annotations are present (unchanged)
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors
- [x] Correct, in line with design

🤖 Generated with [Claude Code](https://claude.com/claude-code)