### PR TITLE
Add database singleton lock to prevent multiple active servers

### DIFF
--- a/changelogs/unreleased/database-singleton-lock.yml
+++ b/changelogs/unreleased/database-singleton-lock.yml
@@ -1,0 +1,15 @@
+---
+description: >
+  The server now guards against more than one instance being active on the same database. On startup it
+  acquires a PostgreSQL advisory lock and holds it for its whole lifetime; a second server pointed at the
+  same database waits for the lock and refuses to start if it cannot acquire it, and a running server shuts
+  down if it loses the lock. This prevents database corruption from stray or duplicate servers and is the
+  foundation for active/passive high availability.
+change-type: minor
+destination-branches: [master]
+sections:
+  feature: >
+    Added a database singleton lock so at most one Inmanta server can be active on a given database. It is
+    enabled by default and configurable via the new ``database.singleton_lock`` and
+    ``database.singleton_lock_wait_time`` options. A second server on the same database refuses to start,
+    and a server that loses the lock (for example after a database failover) shuts down.

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -58,6 +58,32 @@ db_name = Option("database", "name", "inmanta", "The name of the database on the
 db_username = Option("database", "username", "postgres", "The username to access the database in the PostgreSQL server", is_str)
 db_password = Option("database", "password", None, "The password that belong to the database user", is_str)
 
+db_singleton_lock = Option(
+    "database",
+    "singleton_lock",
+    True,
+    "Guard against more than one Inmanta server being active on the same database at the same time. "
+    "When enabled (the default), the server acquires a PostgreSQL advisory lock on startup and holds it "
+    "for its entire lifetime. A second server pointed at the same database will wait for the lock (see "
+    ":inmanta.config:option:`database.singleton_lock_wait_time`) and refuse to start if it cannot get it. "
+    "Running two servers against one database corrupts it, so only disable this if you are certain no "
+    "other server is running. The lock requires a session-mode connection to the primary: it does not "
+    "work through a transaction-pooling proxy such as pgbouncer in transaction mode.",
+    is_bool,
+)
+
+db_singleton_lock_wait_time = Option(
+    "database",
+    "singleton_lock_wait_time",
+    30,
+    "How long, in seconds, the server waits for the singleton lock (see "
+    ":inmanta.config:option:`database.singleton_lock`) to be released by another server before it gives "
+    "up and refuses to start. This absorbs restarts where the previous server has not fully released the "
+    "lock yet. If set to 0, the server tries only once. If set to a negative value, the server waits "
+    "forever.",
+    is_time,
+)
+
 db_connection_pool_min_size = Option(
     "database",
     "connection_pool_min_size",

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -67,8 +67,11 @@ db_singleton_lock = Option(
     "for its entire lifetime. A second server pointed at the same database will wait for the lock (see "
     ":inmanta.config:option:`database.singleton_lock_wait_time`) and refuse to start if it cannot get it. "
     "Running two servers against one database corrupts it, so only disable this if you are certain no "
-    "other server is running. The lock requires a session-mode connection to the primary: it does not "
-    "work through a transaction-pooling proxy such as pgbouncer in transaction mode.",
+    "other server is running. The lock uses one dedicated database connection, separate from and in "
+    "addition to the server's connection pool (see "
+    ":inmanta.config:option:`server.db_connection_pool_max_size`), so size the database's max_connections "
+    "accordingly. The lock requires a session-mode connection to the primary: it does not work through a "
+    "transaction-pooling proxy such as pgbouncer in transaction mode.",
     is_bool,
 )
 
@@ -77,7 +80,7 @@ db_singleton_lock_wait_time = Option(
     "singleton_lock_wait_time",
     30,
     "How long, in seconds, the server waits for the singleton lock (see "
-    ":inmanta.config:option:`database.singleton_lock`) to be released by another server before it gives "
+    ":inmanta.config:option:`database.singleton_lock`) to be acquired before it gives "
     "up and refuses to start. This absorbs restarts where the previous server has not fully released the "
     "lock yet. If set to 0, the server tries only once. If set to a negative value, the server waits "
     "forever.",

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -20,8 +20,9 @@ import asyncio
 import json
 import logging
 import os.path
+import signal
 from functools import total_ordering
-from typing import Mapping, Optional
+from typing import Callable, Mapping, Optional
 
 import asyncpg
 
@@ -251,6 +252,166 @@ class DatabaseMonitor:
         return False
 
 
+class SingletonLock:
+    """
+    Enforces that at most one Inmanta server is active on a given database.
+
+    On startup the server acquires a PostgreSQL session-level advisory lock on a dedicated connection
+    (not part of the shared pool) and holds it for the whole lifetime of the process. Because a
+    session-level advisory lock is released automatically when its owning connection ends, a standby
+    server can take over as soon as the active one goes away. While the server runs, a monitor verifies
+    that the lock is still held; if it is lost (the connection dropped or the database became read-only
+    after a failover) the caller is notified so it can shut down before another server takes over.
+    """
+
+    # Fixed 64-bit key identifying the "single active server" lock. All servers must agree on it.
+    # Value is int.from_bytes(b"INMANTA", "big"). PostgreSQL keeps the single-bigint advisory keyspace
+    # separate from the two-int keyspace used elsewhere in inmanta.data, so this cannot collide with those.
+    LOCK_KEY: int = 20633767014978625
+
+    # How often (in seconds) to verify the lock is still held while the server is running.
+    MONITOR_INTERVAL: float = 5.0
+
+    def __init__(self, *, host: str, port: int, username: str, password: Optional[str], database: str) -> None:
+        self._host = host
+        self._port = port
+        self._username = username
+        self._password = password
+        self._database = database
+        self._connection: Optional[asyncpg.Connection] = None
+        self._monitor_task: Optional[asyncio.Task[None]] = None
+        self._on_lock_lost: Optional[Callable[[], None]] = None
+        self._lock_lost_signalled: bool = False
+
+    async def acquire(self, *, wait_time: int, connection_timeout: int = 5) -> None:
+        """
+        Open the dedicated connection and acquire the advisory lock.
+
+        :param wait_time: How long to wait for the lock to become available:
+            0 tries only once, a negative value waits forever, a positive value is a timeout in seconds.
+        :param connection_timeout: Timeout (in seconds) for establishing the dedicated connection.
+        :raises ServerStartFailure: If the lock cannot be acquired within wait_time, i.e. another server
+            is already active on this database.
+        """
+        self._connection = await asyncpg.connect(
+            host=self._host,
+            port=self._port,
+            user=self._username,
+            password=self._password,
+            database=self._database,
+            timeout=connection_timeout,
+        )
+        try:
+            # The lock connection must be on the primary. Refuse a read-only (standby) connection.
+            if await self._connection.fetchval("SELECT pg_is_in_recovery()"):
+                raise ServerStartFailure(
+                    f"The database at {self._host}:{self._port} is a read-only standby. The Inmanta server must "
+                    "connect to the primary. Point the server at the primary (or its failover address) and try again."
+                )
+
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + wait_time
+            announced_wait = False
+            while True:
+                acquired = await self._connection.fetchval("SELECT pg_try_advisory_lock($1)", self.LOCK_KEY)
+                if acquired:
+                    LOGGER.info("Acquired the database singleton lock: this server is the active instance.")
+                    return
+                if not announced_wait:
+                    LOGGER.info(
+                        "Another Inmanta server is active on database '%s' at %s:%s. Waiting %s for the "
+                        "singleton lock to be released.",
+                        self._database,
+                        self._host,
+                        self._port,
+                        "forever" if wait_time < 0 else f"up to {wait_time} seconds",
+                    )
+                    announced_wait = True
+                if wait_time == 0 or (wait_time > 0 and loop.time() >= deadline):
+                    raise ServerStartFailure(
+                        f"Another Inmanta server is already active on database '{self._database}' at "
+                        f"{self._host}:{self._port}: could not acquire the database singleton lock within "
+                        f"{wait_time} seconds. Refusing to start to avoid corrupting the database. If you are "
+                        "certain no other server is running, see the database.singleton_lock and "
+                        "database.singleton_lock_wait_time options."
+                    )
+                await asyncio.sleep(1)
+        except BaseException:
+            await self._close_connection()
+            raise
+
+    def start_monitor(self, on_lock_lost: Callable[[], None]) -> None:
+        """
+        Start watching the lock. If it is lost, on_lock_lost is invoked exactly once.
+        """
+        self._on_lock_lost = on_lock_lost
+        self._monitor_task = asyncio.ensure_future(self._monitor())
+
+    async def _monitor(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self.MONITOR_INTERVAL)
+                if not await self._still_holding_lock():
+                    LOGGER.critical(
+                        "Lost the database singleton lock: the connection to the database dropped or the "
+                        "database became read-only. Another server may become active, so this server must "
+                        "shut down to avoid corrupting the database."
+                    )
+                    self._signal_lock_lost()
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # A bug in the monitor must not silently leave the server running unguarded.
+            LOGGER.exception("The database singleton lock monitor crashed; shutting the server down as a precaution.")
+            self._signal_lock_lost()
+
+    async def _still_holding_lock(self) -> bool:
+        """
+        A session-level advisory lock cannot be stolen, so as long as our connection is alive, on the
+        primary, we still hold it.
+        """
+        connection = self._connection
+        if connection is None or connection.is_closed():
+            return False
+        try:
+            in_recovery = await asyncio.wait_for(
+                connection.fetchval("SELECT pg_is_in_recovery()"), timeout=self.MONITOR_INTERVAL
+            )
+            return not in_recovery
+        except Exception:
+            LOGGER.warning("Database singleton lock health check failed.", exc_info=True)
+            return False
+
+    def _signal_lock_lost(self) -> None:
+        if self._lock_lost_signalled:
+            return
+        self._lock_lost_signalled = True
+        if self._on_lock_lost is not None:
+            self._on_lock_lost()
+
+    async def stop(self) -> None:
+        """
+        Stop the monitor and release the lock by closing the dedicated connection.
+        """
+        if self._monitor_task is not None:
+            self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
+            self._monitor_task = None
+        await self._close_connection()
+
+    async def _close_connection(self) -> None:
+        if self._connection is not None:
+            try:
+                await self._connection.close(timeout=5)
+            except Exception:
+                LOGGER.warning("Failed to cleanly close the database singleton lock connection.", exc_info=True)
+            self._connection = None
+
+
 class DatabaseService(protocol.ServerSlice):
     """Slice to initialize the database"""
 
@@ -258,11 +419,15 @@ class DatabaseService(protocol.ServerSlice):
         super().__init__(SLICE_DATABASE)
         self._pool: Optional[asyncpg.pool.Pool] = None
         self._db_monitor: Optional[DatabaseMonitor] = None
+        self._singleton_lock: Optional[SingletonLock] = None
 
     async def start(self) -> None:
         database_status_checker = DatabaseStatusChecker()
         await database_status_checker.check_database_before_server_start()
         await super().start()
+        # Acquire the singleton lock before touching the schema, so a stray second server can neither run
+        # migrations nor serve against the same database.
+        await self._acquire_singleton_lock()
         await self.connect_database()
 
         assert self._pool is not None  # Make mypy happy
@@ -275,6 +440,40 @@ class DatabaseService(protocol.ServerSlice):
             await self._db_monitor.stop()
         await self.disconnect_database()
         self._pool = None
+        # Release the singleton lock last, so no other server takes over while this one is still shutting down.
+        if self._singleton_lock is not None:
+            await self._singleton_lock.stop()
+            self._singleton_lock = None
+
+    async def _acquire_singleton_lock(self) -> None:
+        """
+        Acquire the database singleton lock unless it has been explicitly disabled, and start monitoring it.
+        """
+        if not opt.db_singleton_lock.get():
+            LOGGER.warning(
+                "The database singleton lock is disabled (database.singleton_lock=false). Running more than one "
+                "Inmanta server against the same database will corrupt it."
+            )
+            return
+        self._singleton_lock = SingletonLock(
+            host=opt.db_host.get(),
+            port=opt.db_port.get(),
+            username=opt.db_username.get(),
+            password=opt.db_password.get(),
+            database=opt.db_name.get(),
+        )
+        await self._singleton_lock.acquire(wait_time=opt.db_singleton_lock_wait_time.get())
+        self._singleton_lock.start_monitor(on_lock_lost=self._on_singleton_lock_lost)
+
+    def _on_singleton_lock_lost(self) -> None:
+        """
+        Called when the singleton lock is lost while the server is running. Requests a graceful shutdown of
+        the whole process (a hard-exit timer in the signal handler backstops a stuck shutdown).
+        """
+        if self.is_stopping():
+            return
+        LOGGER.critical("Shutting down the server because the database singleton lock was lost.")
+        os.kill(os.getpid(), signal.SIGTERM)
 
     def get_dependencies(self) -> list[str]:
         return []

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -281,7 +281,7 @@ class SingletonLock:
         self._connection: Optional[asyncpg.Connection] = None
         self._monitor_task: Optional[asyncio.Task[None]] = None
         self._on_lock_lost: Optional[Callable[[], None]] = None
-        self._lock_lost_signalled: bool = False
+        self._lock_lost_signaled: bool = False
 
     async def acquire(self, *, wait_time: int, connection_timeout: int = 5) -> None:
         """
@@ -384,9 +384,9 @@ class SingletonLock:
             return False
 
     def _signal_lock_lost(self) -> None:
-        if self._lock_lost_signalled:
+        if self._lock_lost_signaled:
             return
-        self._lock_lost_signalled = True
+        self._lock_lost_signaled = True
         if self._on_lock_lost is not None:
             self._on_lock_lost()
 
@@ -472,7 +472,7 @@ class DatabaseService(protocol.ServerSlice):
         """
         if self.is_stopping():
             return
-        LOGGER.critical("Shutting down the server because the database singleton lock was lost.")
+        # The monitor task has already logged why the lock was lost; just trigger the shutdown here.
         os.kill(os.getpid(), signal.SIGTERM)
 
     def get_dependencies(self) -> list[str]:

--- a/tests/test_singleton_lock.py
+++ b/tests/test_singleton_lock.py
@@ -1,0 +1,120 @@
+"""
+Copyright 2026 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+import asyncio
+
+import pytest
+
+from inmanta import config
+from inmanta.server.bootloader import InmantaBootloader
+from inmanta.server.protocol import ServerStartFailure
+from inmanta.server.services.databaseservice import SingletonLock
+
+
+def make_lock(postgres_db, database_name: str) -> SingletonLock:
+    return SingletonLock(
+        host=postgres_db.host,
+        port=postgres_db.port,
+        username=postgres_db.user,
+        password=postgres_db.password,
+        database=database_name,
+    )
+
+
+async def test_singleton_lock_conflict_and_handover(postgres_db, database_name):
+    """
+    While one instance holds the lock, a second one refuses immediately (wait_time=0). Once the first
+    releases the lock, the second can take over.
+    """
+    lock1 = make_lock(postgres_db, database_name)
+    lock2 = make_lock(postgres_db, database_name)
+    try:
+        await lock1.acquire(wait_time=0)
+
+        with pytest.raises(ServerStartFailure) as exc_info:
+            await lock2.acquire(wait_time=0)
+        assert "already active" in str(exc_info.value)
+
+        # Hand over: once the holder releases, the second instance can acquire.
+        await lock1.stop()
+        await lock2.acquire(wait_time=0)
+    finally:
+        await lock1.stop()
+        await lock2.stop()
+
+
+async def test_singleton_lock_waits_for_release(postgres_db, database_name):
+    """
+    With a positive wait_time, a second instance blocks until the holder releases the lock, then acquires it.
+    """
+    lock1 = make_lock(postgres_db, database_name)
+    lock2 = make_lock(postgres_db, database_name)
+    try:
+        await lock1.acquire(wait_time=0)
+
+        async def release_after_delay() -> None:
+            await asyncio.sleep(1)
+            await lock1.stop()
+
+        releaser = asyncio.ensure_future(release_after_delay())
+        # Should block for ~1s until lock1 is released, then succeed well within wait_time.
+        await lock2.acquire(wait_time=10)
+        await releaser
+    finally:
+        await lock1.stop()
+        await lock2.stop()
+
+
+async def test_singleton_lock_monitor_detects_loss(postgres_db, database_name):
+    """
+    When the lock connection drops while the server runs, the monitor invokes the lock-lost callback so the
+    server can fail fast.
+    """
+    lock = make_lock(postgres_db, database_name)
+    lock_lost = asyncio.Event()
+    try:
+        await lock.acquire(wait_time=0)
+        lock.MONITOR_INTERVAL = 0.1  # speed up the test
+        lock.start_monitor(on_lock_lost=lock_lost.set)
+
+        # Simulate the dedicated connection dropping (e.g. a database failover).
+        assert lock._connection is not None
+        await lock._connection.close()
+
+        await asyncio.wait_for(lock_lost.wait(), timeout=5)
+    finally:
+        await lock.stop()
+
+
+async def test_server_refuses_to_start_when_lock_is_held(server_config, postgres_db, database_name, hard_clean_db):
+    """
+    A full server refuses to start (with singleton_lock_wait_time=0) when another instance already holds the
+    singleton lock on the same database.
+    """
+    holder = make_lock(postgres_db, database_name)
+    await holder.acquire(wait_time=0)
+    config.Config.set("database", "singleton_lock_wait_time", "0")
+
+    ibl = InmantaBootloader(configure_logging=True)
+    try:
+        with pytest.raises(ServerStartFailure) as exc_info:
+            await ibl.start()
+        assert "singleton lock" in str(exc_info.value)
+    finally:
+        await ibl.stop(timeout=20)
+        await holder.stop()

--- a/tests/test_singleton_lock.py
+++ b/tests/test_singleton_lock.py
@@ -74,7 +74,8 @@ async def test_singleton_lock_waits_for_release(postgres_db, database_name):
         releaser = asyncio.ensure_future(release_after_delay())
         # Should block for ~1s until lock1 is released, then succeed well within wait_time.
         await lock2.acquire(wait_time=10)
-        await releaser
+        # acquire only returned because lock1 was released, so the releaser must already be done.
+        assert releaser.done()
     finally:
         await lock1.stop()
         await lock2.stop()

--- a/tests/test_singleton_lock.py
+++ b/tests/test_singleton_lock.py
@@ -72,10 +72,13 @@ async def test_singleton_lock_waits_for_release(postgres_db, database_name):
             await lock1.stop()
 
         releaser = asyncio.ensure_future(release_after_delay())
-        # Should block for ~1s until lock1 is released, then succeed well within wait_time.
+        start = asyncio.get_event_loop().time()
+        # Should block until lock1 is released (~1s), then succeed well within wait_time.
         await lock2.acquire(wait_time=10)
-        # acquire only returned because lock1 was released, so the releaser must already be done.
-        assert releaser.done()
+        waited = asyncio.get_event_loop().time() - start
+        await releaser
+        # acquire must have blocked until lock1 released the lock, not returned immediately.
+        assert waited >= 0.5
     finally:
         await lock1.stop()
         await lock2.stop()


### PR DESCRIPTION
> :robot: Opened by Claude on behalf of Bart.

# Description

Enforce that **at most one Inmanta server is active on a given database**, treating it as a data-integrity invariant rather than an opt-in HA feature.

On startup the `DatabaseService` acquires a PostgreSQL **session-level advisory lock** on a dedicated connection (separate from the shared pool) and holds it for the whole lifetime of the process:

- A second server pointed at the same database **waits** for the lock (`database.singleton_lock_wait_time`, default 30s, same tri-state semantics as `database.wait_time`: `0` = try once, `<0` = wait forever) and **refuses to start** with a clear error if it cannot acquire it. Startup contention surfaces as a `ServerStartFailure`.
- The lock is acquired **before** schema migration, so a stray second server can neither migrate nor serve.
- While running, a monitor verifies the lock is still held. If it is lost (connection dropped, or the DB became read-only after a failover), the server **fails fast** (self-`SIGTERM`) so it stops before another instance takes over. Because a session-level advisory lock is released automatically when its owning connection ends, a standby can then take over immediately.

Advisory locks include `MyDatabaseId` in their tag, so this is scoped **per database**: multiple Inmanta databases in one PostgreSQL cluster do not conflict.

This is enabled by default. It can be disabled with `database.singleton_lock=false` (logs a loud warning; unsafe). The lock needs a **session-mode** connection to the primary, so it does not work through a transaction-pooling proxy (pgbouncer in transaction mode).

### Motivation

Today two servers against one database silently corrupt state (double deploys, scheduler races). This converts that silent failure into a loud, safe refusal to start, and provides the primitive that external active/passive HA (e.g. keepalived) builds on.

### New config options

| Option                              | Default | Purpose                                              |
| ----------------------------------- | ------- | ---------------------------------------------------- |
| `database.singleton_lock`           | `true`  | Enable the single-active-server guard.               |
| `database.singleton_lock_wait_time` | `30`    | Seconds to wait for the lock before refusing to start. |

closes ~*Add ticket reference here*~

### Notes for reviewers

- `change-type` is set to **minor**; it is arguably breaking since a (previously silently racing) two-instance setup now refuses to start. Happy to bump to `major` if preferred.
- Fail-fast uses `os.kill(os.getpid(), SIGTERM)` to reuse the existing graceful-shutdown path (with the signal handler's hard-exit timer as backstop).
- End-user HA documentation is not included here; suggest a follow-up docs section describing the singleton lock and the active/passive setup.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (diff is mypy-baseline clean; `make mypy` locally shows only pre-existing environment-specific noise in untouched files)
- [x] Sufficient test cases (`tests/test_singleton_lock.py`: conflict/refusal, wait-then-acquire handover, monitor fail-fast, and full-server refusal)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] ~~If this PR fixes a race condition in the test suite~~
