### PR TITLE
Add generic GraphQL filter composition (extensions can contribute filter fields)

### DIFF
--- a/changelogs/unreleased/add-resource-filter-composition.yml
+++ b/changelogs/unreleased/add-resource-filter-composition.yml
@@ -1,0 +1,6 @@
+description: >
+  Enable extensions to contribute their own resource filter fields to the GraphQL `resources` query (via
+  GraphQLContribution.get_resource_filter_input_class), composed into a single ResourceFilter input. Also add a
+  `modelVersion` filter to fetch resources as present in a specific version of the model.
+change-type: minor
+destination-branches: [master, iso9]

--- a/changelogs/unreleased/add-resource-filter-composition.yml
+++ b/changelogs/unreleased/add-resource-filter-composition.yml
@@ -1,6 +1,7 @@
 description: >
-  Enable extensions to contribute their own resource filter fields to the GraphQL `resources` query (via
-  GraphQLContribution.get_resource_filter_input_class), composed into a single ResourceFilter input. Also add a
-  `modelVersion` filter to fetch resources as present in a specific version of the model.
+  Enable extensions to contribute their own filter fields to the GraphQL queries (resources, environments,
+  notifications) via GraphQLContribution.get_filter_input_class, composed generically into each query's filter input
+  (mirroring the output-field contribution mechanism). Also add a `modelVersion` filter to the `resources` query to
+  fetch resources as present in a specific version of the model.
 change-type: minor
 destination-branches: [master, iso9]

--- a/changelogs/unreleased/add-resource-filter-composition.yml
+++ b/changelogs/unreleased/add-resource-filter-composition.yml
@@ -5,3 +5,7 @@ description: >
   fetch resources as present in a specific version of the model.
 change-type: minor
 destination-branches: [master, iso9]
+sections:
+  minor-improvement: >
+    Add a `modelVersion` filter to the `resources` GraphQL query to fetch the resources present in a specific
+    version of the model, instead of the latest released version.

--- a/src/inmanta/graphql/graphql.py
+++ b/src/inmanta/graphql/graphql.py
@@ -18,7 +18,7 @@ from typing import Any
 from graphql.error import GraphQLError
 from inmanta.graphql.result import GraphQLResult
 from inmanta.graphql.schema import (
-    REGISTRABLE_MODELS,
+    CONTRIBUTABLE_MODELS,
     GraphQLContext,
     GraphQLContribution,
     GraphQLTypeName,
@@ -72,10 +72,10 @@ class GraphQLSlice(protocol.ServerSlice):
             )
         target_model = contribution.get_target_model()
         type_name = graphql_type_name(target_model)
-        if target_model not in REGISTRABLE_MODELS:
+        if target_model not in CONTRIBUTABLE_MODELS:
             raise Exception(
                 f"Can't register a GraphQL contribution for {type_name}: "
-                f"only contributions for {', '.join(graphql_type_name(model) for model in REGISTRABLE_MODELS)} are supported."
+                f"only contributions for {', '.join(graphql_type_name(model) for model in CONTRIBUTABLE_MODELS)} are supported."
             )
         contributions_for_type = self.extension_contributions[type_name]
         if extension_name in contributions_for_type:

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -502,7 +502,7 @@ class StrawberryFilter:
         """
         Returns the provided filter fields in dict form, to feed to the SQLAlchemy query as an exact-match filter.
         Fields left UNSET are skipped (not filtered on) -- this is what lets a filter compose with others that carry
-        their own fields (see `decompose_filter`), where any given component only has some of the fields set.
+        their own fields (see `decompose_filter`).
         This is only used for simple filters i.e. exact match on the same table.
         """
         return {key: value for key, value in self.__dict__.items() if value is not strawberry.UNSET}
@@ -750,8 +750,6 @@ class ResourceFilterABC(StrawberryFilter):
     """
     Abstract base class that defines the shared attributes/behaviour of every resource filter component: core's
     `CoreResourceFilter` and each extension's resource filter (contributed via `GraphQLContribution.get_filter_input_class`).
-    These components are composed into the single `ResourceFilter` GraphQL input type exposed on the `resources` query
-    by the generic filter composition (see `get_filter_components` / `build_composed_filter_input` and `get_schema`).
     The version-selection hooks below are specific to resources; other object types' filters compose the same way but
     have no version concept.
 
@@ -809,7 +807,7 @@ class CoreResourceFilter(ResourceFilterABC):
     def validate_filter(self) -> None:
         # modelVersion returns the resources exactly as they were in that version of the model. The filters below
         # reflect the *current* state of a resource (tracked on ResourcePersistentState, which is not versioned),
-        # so combining them with modelVersion would mix a historical snapshot with current state; reject that.
+        # so combining them with modelVersion would mix a historical snapshot with current state.
         if is_provided(self.model_version):
             current_state_filters = {
                 "isOrphan": self.is_orphan,
@@ -951,8 +949,11 @@ def add_filter_and_sort[*Ts](
     """
     Adds filter and sorting to the given statement.
 
+    :param stmt: the query to add the filter and sorting to.
+    :param default_sorting: the sorting to apply for each key not already covered by `order_by`.
     :param filter: the filter components to apply. A single query can have several components: the `resources` query
         composes core and extension filters, while the other queries pass a single (or no) filter.
+    :param order_by: the sorting requested by the user, taking precedence over `default_sorting` for the same key.
     """
     for filter_component in filter:
         stmt = filter_component.apply_filter(stmt)
@@ -1219,9 +1220,9 @@ def get_filter_components(
 ) -> tuple[type[StrawberryFilter], ...]:
     """
     Return the filter components that compose an object type's filter input type: the type's `core_filter` followed by
-    every extension-contributed filter class (see `GraphQLContribution.get_filter_input_class`). `build_composed_filter_input`
-    builds the composed input from these by multiple inheritance, and each query's resolver decomposes the received
-    filter back into one instance per component (see `decompose_filter`) to apply them.
+    every extension-contributed filter class. `build_composed_filter_input` builds the composed input from these by multiple
+    inheritance, and each query's resolver decomposes the received filter back
+    into one instance per component (see `decompose_filter`) to apply them.
 
     :param core_filter: the core filter class of the object type (e.g. `CoreResourceFilter`).
     :param contributions: the extension contributions that target the same object type.
@@ -1239,13 +1240,7 @@ def build_composed_filter_input(
 ) -> tuple[tuple[type[StrawberryFilter], ...], type]:
     """
     Build the filter input type for an object type, composed of its core filter and the extensions' contributed
-    filters (mirrors `build_strawberry_output_type` on the output side). The components are merged by multiple
-    inheritance into a single `@strawberry.input` named `{type_name}Filter` (the user-facing filter type), while the
-    core filter keeps a distinct name (e.g. `CoreResourceFilter`). `get_schema` is called once per process, so a fixed
-    class name is fine.
-
-    Returns the tuple of components (so the resolver can decompose the received filter, see `decompose_filter`) and
-    the composed input type (to expose as the query's `filter` argument).
+    filters. The components are merged by multiple inheritance into a single `@strawberry.input` named `{type_name}Filter`.
 
     :param type_name: the name of the object type being built (e.g. "Resource").
     :param core_filter: the core filter class of the object type (e.g. `CoreResourceFilter`).
@@ -1269,17 +1264,14 @@ def build_composed_filter_input(
 
 def decompose_filter[F: StrawberryFilter](filter: object, components: tuple[type[F], ...]) -> list[F]:
     """
-    Split a composed filter value (built by `build_composed_filter_input`) back into one instance per component,
-    reading each component's fields off the composed value. This lets every component apply its own `apply_filter`
-    (and, for resources, its version-selection hooks) on just its own fields.
+    Split a composed filter value back into one instance per component, reading each component's fields off the composed value.
+    This lets every component apply its own `apply_filter` on just its own fields.
 
     :param filter: the composed filter value received by the resolver.
-    :param components: the filter components the composed type was built from (see `get_filter_components`).
+    :param components: the filter components the composed type was built from.
     """
     decomposed: list[F] = []
     for component in components:
-        # Every component is a @strawberry.input, hence a dataclass, but that isn't visible through the StrawberryFilter
-        # bound (the base class is not itself a dataclass), so mypy can't tell dataclasses.fields accepts it.
         component_fields = dataclasses.fields(component)  # type: ignore[arg-type]
         decomposed.append(component(**{field.name: getattr(filter, field.name) for field in component_fields}))
     return decomposed
@@ -1299,8 +1291,7 @@ class RegistrableGraphQLType:
 
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
 # model to its core building blocks. `get_schema` composes each of these from the core building blocks and the
-# registered contributions; registrations for any other model are rejected. The GraphQL output type name is always the
-# model's class name (e.g. `models.Resource` -> "Resource"), which is also the key the contributions are grouped under.
+# registered contributions; registrations for any other model are rejected.
 REGISTRABLE_MODELS: "Mapping[type[models.Base], RegistrableGraphQLType]" = {
     models.Resource: RegistrableGraphQLType(core_mixin=CoreResourceMixin, core_filter=CoreResourceFilter),
     models.Environment: RegistrableGraphQLType(core_mixin=CoreEnvironmentMixin, core_filter=CoreEnvironmentFilter),
@@ -1362,11 +1353,9 @@ def get_schema(
             stmt = contribution.populate_sqlalchemy_columns(stmt, composed_model, requested_fields)
         return stmt
 
-    # For each registrable object type, build its (possibly extension-composed) output type and filter input type.
-    # The output type and the filter input are composed the same generic way from the type's core building blocks and
-    # the contributions targeting it; each query's resolver decomposes the received filter back into its components.
+    # Build each registrable object type's output type and (extension-composed) filter input, both composed the same
+    # generic way from the type's core building blocks (see RegistrableGraphQLType) and the contributions targeting it.
     built_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
-    # type_name -> (filter components the composed input was built from, composed filter input type)
     built_filters: dict[GraphQLTypeName, tuple[tuple[type[StrawberryFilter], ...], type]] = {}
     for base_model, registrable in REGISTRABLE_MODELS.items():
         type_name = graphql_type_name(base_model)
@@ -1374,12 +1363,12 @@ def get_schema(
         built_types[type_name] = build_output_type(base_model, registrable.core_mixin)
         built_filters[type_name] = build_composed_filter_input(type_name, registrable.core_filter, contributions)
 
-    environment_model, Environment = built_types["Environment"]
-    notification_model, Notification = built_types["Notification"]
-    resource_model, Resource = built_types["Resource"]
-    environment_filter_components, EnvironmentFilter = built_filters["Environment"]
-    notification_filter_components, NotificationFilter = built_filters["Notification"]
-    resource_filter_components, ResourceFilter = built_filters["Resource"]
+    environment_model, Environment = built_types[graphql_type_name(models.Environment)]
+    notification_model, Notification = built_types[graphql_type_name(models.Notification)]
+    resource_model, Resource = built_types[graphql_type_name(models.Resource)]
+    environment_filter_components, EnvironmentFilter = built_filters[graphql_type_name(models.Environment)]
+    notification_filter_components, NotificationFilter = built_filters[graphql_type_name(models.Notification)]
+    resource_filter_components, ResourceFilter = built_filters[graphql_type_name(models.Resource)]
 
     class CustomInfo(Info):
         @property
@@ -1396,8 +1385,6 @@ def get_schema(
             after: typing.Optional[str] = strawberry.UNSET,
             last: typing.Optional[int] = strawberry.UNSET,
             before: typing.Optional[str] = strawberry.UNSET,
-            # The declared type is the core filter (so it stays typed), but the GraphQL input the user gets is the
-            # composed type carrying the core + extension fields.
             filter: typing.Annotated[
                 typing.Optional[CoreEnvironmentFilter], strawberry.argument(graphql_type=typing.Optional[EnvironmentFilter])
             ] = strawberry.UNSET,
@@ -1417,8 +1404,6 @@ def get_schema(
         async def notifications(
             self,
             info: CustomInfo,
-            # The declared type is the core filter (so it stays typed), but the GraphQL input the user gets is the
-            # composed type carrying the core + extension fields.
             filter: typing.Annotated[CoreNotificationFilter, strawberry.argument(graphql_type=NotificationFilter)],
             first: typing.Optional[int] = strawberry.UNSET,
             after: typing.Optional[str] = strawberry.UNSET,
@@ -1440,8 +1425,6 @@ def get_schema(
         async def resources(
             self,
             info: CustomInfo,
-            # The declared type is CoreResourceFilter (so filter.<core field> stays typed), but the GraphQL input
-            # the user actually gets is the composed type carrying core + extension fields.
             filter: typing.Annotated[CoreResourceFilter, strawberry.argument(graphql_type=ResourceFilter)],
             first: typing.Optional[int] = strawberry.UNSET,
             after: typing.Optional[str] = strawberry.UNSET,
@@ -1459,7 +1442,7 @@ def get_schema(
 
             # Decompose the composed ResourceFilter into one instance per component (core + each extension). Every
             # resource filter component is a ResourceFilterABC, and at most one may take over version selection
-            # (`handles_version`); core does it by default.
+            # Core does it by default.
             resource_filter_instances = cast(list[ResourceFilterABC], decompose_filter(filter, resource_filter_components))
             version_handler: ResourceFilterABC | None = None
             filters_on_resource_table: bool = False

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1292,10 +1292,10 @@ class RegistrableGraphQLType:
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
 # model to its core building blocks. `get_schema` composes each of these from the core building blocks and the
 # registered contributions; registrations for any other model are rejected.
-REGISTRABLE_MODELS: "Mapping[type[models.Base], RegistrableGraphQLType]" = {
-    models.Resource: RegistrableGraphQLType(core_mixin=CoreResourceMixin, core_filter=CoreResourceFilter),
-    models.Environment: RegistrableGraphQLType(core_mixin=CoreEnvironmentMixin, core_filter=CoreEnvironmentFilter),
-    models.Notification: RegistrableGraphQLType(core_mixin=CoreNotificationMixin, core_filter=CoreNotificationFilter),
+CONTRIBUTABLE_MODELS: "Mapping[type[models.Base], RegistrableGraphQLType]" = {
+    models.Resource: ContributableGraphQLType(core_mixin=CoreResourceMixin, core_filter=CoreResourceFilter),
+    models.Environment: ContributableGraphQLType(core_mixin=CoreEnvironmentMixin, core_filter=CoreEnvironmentFilter),
+    models.Notification: ContributableGraphQLType(core_mixin=CoreNotificationMixin, core_filter=CoreNotificationFilter),
 }
 
 
@@ -1354,12 +1354,12 @@ def get_schema(
         return stmt
 
     # Build each registrable object type's output type and filter input.
-    built_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
+    built_output_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
     built_filters: dict[GraphQLTypeName, tuple[tuple[type[StrawberryFilter], ...], type]] = {}
     for base_model, registrable in REGISTRABLE_MODELS.items():
         type_name = graphql_type_name(base_model)
         contributions = extension_contributions.get(type_name, [])
-        built_types[type_name] = build_output_type(base_model, registrable.core_mixin)
+        built_output_types[type_name] = build_output_type(base_model, registrable.core_mixin)
         built_filters[type_name] = build_composed_filter_input(type_name, registrable.core_filter, contributions)
 
     environment_model, Environment = built_types[graphql_type_name(models.Environment)]

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1278,7 +1278,7 @@ def decompose_filter[F: StrawberryFilter](filter: object, components: tuple[type
 
 
 @dataclasses.dataclass(frozen=True)
-class RegistrableGraphQLType:
+class ContributableGraphQLType:
     """
     The core building blocks of an object type that extensions can contribute to (see `GraphQLContribution`):
     the mixin carrying its core output fields and the class carrying its core filter fields. `get_schema` composes
@@ -1292,7 +1292,7 @@ class RegistrableGraphQLType:
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
 # model to its core building blocks. `get_schema` composes each of these from the core building blocks and the
 # registered contributions; registrations for any other model are rejected.
-CONTRIBUTABLE_MODELS: "Mapping[type[models.Base], RegistrableGraphQLType]" = {
+CONTRIBUTABLE_MODELS: "Mapping[type[models.Base], ContributableGraphQLType]" = {
     models.Resource: ContributableGraphQLType(core_mixin=CoreResourceMixin, core_filter=CoreResourceFilter),
     models.Environment: ContributableGraphQLType(core_mixin=CoreEnvironmentMixin, core_filter=CoreEnvironmentFilter),
     models.Notification: ContributableGraphQLType(core_mixin=CoreNotificationMixin, core_filter=CoreNotificationFilter),
@@ -1356,15 +1356,15 @@ def get_schema(
     # Build each registrable object type's output type and filter input.
     built_output_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
     built_filters: dict[GraphQLTypeName, tuple[tuple[type[StrawberryFilter], ...], type]] = {}
-    for base_model, registrable in REGISTRABLE_MODELS.items():
+    for base_model, registrable in CONTRIBUTABLE_MODELS.items():
         type_name = graphql_type_name(base_model)
         contributions = extension_contributions.get(type_name, [])
         built_output_types[type_name] = build_output_type(base_model, registrable.core_mixin)
         built_filters[type_name] = build_composed_filter_input(type_name, registrable.core_filter, contributions)
 
-    environment_model, Environment = built_types[graphql_type_name(models.Environment)]
-    notification_model, Notification = built_types[graphql_type_name(models.Notification)]
-    resource_model, Resource = built_types[graphql_type_name(models.Resource)]
+    environment_model, Environment = built_output_types[graphql_type_name(models.Environment)]
+    notification_model, Notification = built_output_types[graphql_type_name(models.Notification)]
+    resource_model, Resource = built_output_types[graphql_type_name(models.Resource)]
     environment_filter_components, EnvironmentFilter = built_filters[graphql_type_name(models.Environment)]
     notification_filter_components, NotificationFilter = built_filters[graphql_type_name(models.Notification)]
     resource_filter_components, ResourceFilter = built_filters[graphql_type_name(models.Resource)]

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -116,7 +116,7 @@ There are 4 important building blocks that we have to take into account:
         ```
         `get_schema` composes this core filter with any extension-contributed filters (see `GraphQLContribution` and
         `build_composed_filter_input`) into the user-facing `EnvironmentFilter` input; the resolver decomposes a
-        received value back into its components with `decompose_filter` and applies each.
+        received value back into its components with `decompose_and_validate_filter` and applies each.
         This class determines what fields we allow our users to filter on and what type we expect to receive.
 
         We can also define custom filters to handle more complex behaviour than simple equality.
@@ -502,7 +502,7 @@ class StrawberryFilter:
         """
         Returns the provided filter fields in dict form, to feed to the SQLAlchemy query as an exact-match filter.
         Fields left UNSET are skipped (not filtered on) -- this is what lets a filter compose with others that carry
-        their own fields (see `decompose_filter`).
+        their own fields (see `decompose_and_validate_filter`).
         This is only used for simple filters i.e. exact match on the same table.
         """
         return {key: value for key, value in self.__dict__.items() if value is not strawberry.UNSET}
@@ -661,7 +661,6 @@ class CoreEnvironmentMixin:
     settings: scalars.JSON = strawberry.field(resolver=get_settings, description="The settings for this environment.")
 
 
-@dataclasses.dataclass(kw_only=True)
 @strawberry.input
 class CoreEnvironmentFilter(StrawberryFilter):
     id: typing.Optional[uuid.UUID] = strawberry.UNSET
@@ -692,7 +691,6 @@ class CoreNotificationMixin:
     __exclude__ = ["environment_", "compile"]
 
 
-@dataclasses.dataclass(kw_only=True)
 @strawberry.input
 class CoreNotificationFilter(StrawberryFilter):
     environment: uuid.UUID
@@ -744,7 +742,75 @@ class CoreResourceMixin:
     )
 
 
-@dataclasses.dataclass(kw_only=True)
+def latest_scheduled_model_version(environment: "uuid.UUID | ColumnElement[uuid.UUID]") -> ColumnElement[int]:
+    """
+    The latest model version the scheduler has processed for `environment` as a scalar_subquery.
+    """
+    return (
+        select(models.Scheduler.last_processed_model_version)
+        .where(models.Scheduler.environment == environment)
+        .scalar_subquery()
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class ModelVersionSelection:
+    """
+    The model version a `resources` query resolves to, produced by the filter component that owns version selection
+    (see `ResourceFilterABC.resolve_model_version`) and recorded on the query (see `resolved_model_version`). Build one
+    with `pinned` (a specific version, taken exactly as it was) or `latest` (the latest scheduled version, optionally
+    including orphans); orphans are a concept of the latest selection only, not of a pinned version.
+    """
+
+    version: int | ColumnElement[int]
+    include_orphans: bool = False
+
+    @staticmethod
+    def pinned(version: "int | ColumnElement[int]") -> "ModelVersionSelection":
+        """Select every resource exactly at `version` (a concrete model version, or a scalar expression computing one)."""
+        return ModelVersionSelection(version=version)
+
+    @staticmethod
+    def latest(environment: uuid.UUID, *, include_orphans: bool = True) -> "ModelVersionSelection":
+        """
+        The latest scheduled model version. Orphaned resources are additionally taken at the last version they were
+        present in when `include_orphans` is True; when False, only resources present in the latest version are selected.
+        """
+        return ModelVersionSelection(
+            version=latest_scheduled_model_version(environment),
+            include_orphans=include_orphans,
+        )
+
+    def resource_version_column(self) -> "int | ColumnElement[int]":
+        """
+        The model version each resource is taken at, as the expression to match `t_resource_set_configuration_model`'s
+        `model` column against. A pinned version takes every resource exactly at it; the latest selection additionally
+        takes orphaned resources at the last version they were present in (`orphaned_after`) when `include_orphans` is
+        True, falling back to the selected version for resources present in it.
+        """
+        if self.include_orphans:
+            return func.coalesce(models.ResourcePersistentState.orphaned_after, self.version)
+        return self.version
+
+
+# Execution-option key under which the `resources` resolver records the ModelVersionSelection its resources resolve to.
+RESOLVED_MODEL_VERSION_EXECUTION_OPTION = "inmanta_resolved_model_version"
+
+
+def with_resolved_model_version[*Ts](stmt: Select[tuple[*Ts]], selection: ModelVersionSelection) -> Select[tuple[*Ts]]:
+    """Record on `stmt` the ModelVersionSelection its resources resolve to, for contributions to read back."""
+    return stmt.execution_options(**{RESOLVED_MODEL_VERSION_EXECUTION_OPTION: selection})
+
+
+def resolved_model_version[*Ts](stmt: Select[tuple[*Ts]]) -> ModelVersionSelection:
+    """
+    The ModelVersionSelection the resources of `stmt` resolve to, as recorded by the `resources` resolver. Read by
+    filter components and extension column population to resolve version-dependent data at the query's version
+    (via `resolved_model_version(stmt).version`), consistent with the resources the query returns.
+    """
+    return cast(ModelVersionSelection, stmt.get_execution_options()[RESOLVED_MODEL_VERSION_EXECUTION_OPTION])
+
+
 @strawberry.input
 class ResourceFilterABC(StrawberryFilter):
     """
@@ -765,26 +831,28 @@ class ResourceFilterABC(StrawberryFilter):
         """
         return False
 
-    def apply_version_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+    def resolve_model_version(self) -> ModelVersionSelection:
         """
-        Restrict the query to the appropriate version(s) of the model. Only invoked on the single component
-        responsible for version selection: an extension whose `handles_version()` is True, or core otherwise.
+        Return the model version this component selects resources at, as a `ModelVersionSelection`. Only called on the
+        component that owns version selection. The resolver pins the query's resources to it and records the selection
+        on the query  so version-dependent data stays consistent with the resources returned.
         """
         raise NotImplementedError(
-            f"{type(self).__name__} returns handles_version()=True but does not implement apply_version_filter()."
+            f"{type(self).__name__} returns handles_version()=True but does not implement resolve_model_version()."
         )
 
-    def filters_on_resource_table(self) -> bool:
+    def allows_persistent_state_count(self) -> bool:
         """
-        Return True if this component's `apply_filter` constrains the `Resource` table (`models.Resource`) rather
-        than only `ResourcePersistentState`. The `resources` query uses this to decide whether the efficient count
-        (which counts `ResourcePersistentState` alone, without joining `Resource`) is valid: it is only used when no
-        applied component filters on the `Resource` table.
+        Return True if this component keeps the `resources` query's efficient count valid. That count sums
+        `ResourcePersistentState` rows directly, without joining `Resource`. Meaning that this can only be true
+        when this component does not pin a version directly or applies a filter on the `Resource` table.
+
+        The default is `False` (the safe, conservative answer): it disables the efficient count, so a component that
+        forgets to set this still gets a correct count without having to know about this optimization.
         """
         return False
 
 
-@dataclasses.dataclass(kw_only=True)
 @strawberry.input
 class CoreResourceFilter(ResourceFilterABC):
     resource_type: StrFilter | None = strawberry.UNSET
@@ -829,35 +897,16 @@ class CoreResourceFilter(ResourceFilterABC):
         # means core owns version selection.
         return is_provided(self.is_orphan) or is_provided(self.model_version)
 
-    def apply_version_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
-        # Determine which version of the model each resource should be taken from:
-        #  - if a specific version was requested, pin every resource set to that version
-        #  - otherwise take each resource at the latest scheduled version, except orphaned resources which are
-        #    taken at the last version they were present in (orphaned_after).
-        #    For non-orphaned resources orphaned_after is NULL, so coalesce falls back to the latest scheduled version.
-        version: int | ColumnElement[int]
+    def resolve_model_version(self) -> ModelVersionSelection:
         if is_provided(self.model_version):
-            version = self.model_version
-        else:
-            # Compute the latest scheduled version once, as a CTE, instead of inlining the subquery in the join
-            # condition below, so it is not (re-)evaluated per candidate row.
-            latest_scheduled_version = (
-                select(models.Scheduler.last_processed_model_version.label("version"))
-                .where(models.Scheduler.environment == self.environment)
-                .cte()
-            )
-            version = func.coalesce(
-                models.ResourcePersistentState.orphaned_after,
-                select(latest_scheduled_version.c.version).scalar_subquery(),
-            )
-        return stmt.join(
-            models.t_resource_set_configuration_model,
-            and_(
-                models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
-                models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
-                models.t_resource_set_configuration_model.c.model == version,
-            ),
-        )
+            return ModelVersionSelection.pinned(self.model_version)
+        include_orphans = not is_provided(self.is_orphan) or self.is_orphan is True
+        return ModelVersionSelection.latest(self.environment, include_orphans=include_orphans)
+
+    def allows_persistent_state_count(self) -> bool:
+        # A pinned modelVersion is a historical snapshot whose membership depends on the version, and `purged` is the
+        # only core filter applied on the `Resource` table (`attributes`); either invalidates the RPS-only count.
+        return not is_provided(self.model_version) and not is_provided(self.purged)
 
     def apply_filter[*Ts](
         self, stmt: Select[tuple[*Ts]]
@@ -883,11 +932,6 @@ class CoreResourceFilter(ResourceFilterABC):
         if is_provided(self.is_orphan):
             stmt = stmt.filter(models.ResourcePersistentState.is_orphan.is_(self.is_orphan))
         return stmt
-
-    def filters_on_resource_table(self) -> bool:
-        # `purged` is the only core filter applied on the `Resource` table (`attributes`); every other core filter
-        # constrains `ResourcePersistentState`.
-        return is_provided(self.purged)
 
 
 class ResourceOrder(StrawberryOrder):
@@ -1141,7 +1185,7 @@ class GraphQLContribution(ABC):
 
         The class must be compatible with the target type's core filter, since the two are composed by multiple
         inheritance: for `models.Resource` that means a `ResourceFilterABC` subclass (which may also take over version
-        selection via `handles_version` / `apply_version_filter`); for other types, a `StrawberryFilter` subclass.
+        selection via `handles_version` / `resolve_model_version`); for other types, a `StrawberryFilter` subclass.
         """
         return None
 
@@ -1224,7 +1268,7 @@ def get_filter_components(
     Return the filter components that compose an object type's filter input type: the type's `core_filter` followed by
     every extension-contributed filter class. `build_composed_filter_input` builds the composed input from these by multiple
     inheritance, and each query's resolver decomposes the received filter back
-    into one instance per component (see `decompose_filter`) to apply them.
+    into one instance per component (see `decompose_and_validate_filter`) to apply them.
 
     :param core_filter: the core filter class of the object type (e.g. `CoreResourceFilter`).
     :param contributions: the extension contributions that target the same object type.
@@ -1238,6 +1282,7 @@ def get_filter_components(
 def build_composed_filter_input(
     type_name: str,
     core_filter: type[StrawberryFilter],
+    base_filter: type,
     contributions: Sequence[type[GraphQLContribution]],
 ) -> tuple[tuple[type[StrawberryFilter], ...], type]:
     """
@@ -1246,6 +1291,7 @@ def build_composed_filter_input(
 
     :param type_name: the name of the object type being built (e.g. "Resource").
     :param core_filter: the core filter class of the object type (e.g. `CoreResourceFilter`).
+    :param base_filter: the base filter class of the object type (e.g. `ResourceFilterABC`).
     :param contributions: the extension contributions that target this type.
     """
     components = get_filter_components(core_filter, contributions)
@@ -1253,6 +1299,8 @@ def build_composed_filter_input(
     # __annotations__ is used because it doesn't contain the fields of the parent class so those are excluded for the comparison
     seen_fields: set[str] = set()
     for component in components:
+        if not issubclass(component, base_filter):
+            raise Exception(f"{component.__name__} must subclass {base_filter} to filter on {type_name}.")
         for field_name in component.__dict__.get("__annotations__", {}):
             if field_name in seen_fields:
                 raise Exception(f"{field_name} defined more than once in {type_name} filters.")
@@ -1264,19 +1312,23 @@ def build_composed_filter_input(
     return components, composed
 
 
-def decompose_filter[F: StrawberryFilter](filter: object, components: tuple[type[F], ...]) -> list[F]:
+def decompose_and_validate_filter[F: StrawberryFilter](filter: object, components: tuple[type[F], ...]) -> list[F]:
     """
-    Split a composed filter value back into one instance per component, reading each component's fields off the composed value.
-    This lets every component apply its own `apply_filter` on just its own fields.
+    Split a composed filter value back into one instance per component, reading each component's fields off the composed
+    value, and run each component's `validate_filter`. Returns an empty list when no filter was provided.
 
-    :param filter: the composed filter value received by the resolver.
+    :param filter: the composed filter value received by the resolver (possibly UNSET when the filter is optional).
     :param components: the filter components the composed type was built from.
     """
-    decomposed: list[F] = []
+    if not is_provided(filter):
+        return []
+    instances: list[F] = []
     for component in components:
         component_fields = dataclasses.fields(component)  # type: ignore[arg-type]
-        decomposed.append(component(**{field.name: getattr(filter, field.name) for field in component_fields}))
-    return decomposed
+        instance = component(**{field.name: getattr(filter, field.name) for field in component_fields})
+        instance.validate_filter()
+        instances.append(instance)
+    return instances
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1289,13 +1341,16 @@ class ContributableGraphQLType:
 
     core_mixin: type
     core_filter: type[StrawberryFilter]
+    base_filter: type = StrawberryFilter
 
 
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
 # model to its core building blocks. `get_schema` composes each of these from the core building blocks and the
 # registered contributions; registrations for any other model are rejected.
 CONTRIBUTABLE_MODELS: "Mapping[type[models.Base], ContributableGraphQLType]" = {
-    models.Resource: ContributableGraphQLType(core_mixin=CoreResourceMixin, core_filter=CoreResourceFilter),
+    models.Resource: ContributableGraphQLType(
+        core_mixin=CoreResourceMixin, base_filter=ResourceFilterABC, core_filter=CoreResourceFilter
+    ),
     models.Environment: ContributableGraphQLType(core_mixin=CoreEnvironmentMixin, core_filter=CoreEnvironmentFilter),
     models.Notification: ContributableGraphQLType(core_mixin=CoreNotificationMixin, core_filter=CoreNotificationFilter),
 }
@@ -1358,11 +1413,13 @@ def get_schema(
     # Build each registrable object type's output type and filter input.
     built_output_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
     built_filters: dict[GraphQLTypeName, tuple[tuple[type[StrawberryFilter], ...], type]] = {}
-    for base_model, registrable in CONTRIBUTABLE_MODELS.items():
+    for base_model, model_specs in CONTRIBUTABLE_MODELS.items():
         type_name = graphql_type_name(base_model)
         contributions = extension_contributions.get(type_name, [])
-        built_output_types[type_name] = build_output_type(base_model, registrable.core_mixin)
-        built_filters[type_name] = build_composed_filter_input(type_name, registrable.core_filter, contributions)
+        built_output_types[type_name] = build_output_type(base_model, model_specs.core_mixin)
+        built_filters[type_name] = build_composed_filter_input(
+            type_name, model_specs.core_filter, model_specs.base_filter, contributions
+        )
 
     environment_model, Environment = built_output_types[graphql_type_name(models.Environment)]
     notification_model, Notification = built_output_types[graphql_type_name(models.Notification)]
@@ -1393,9 +1450,7 @@ def get_schema(
         ) -> CustomListConnection[Environment]:
             stmt = select(environment_model)
             stmt = populate_extension_columns(stmt, models.Environment, environment_model, info)
-            filters = decompose_filter(filter, environment_filter_components) if is_provided(filter) else []
-            for filter_component in filters:
-                filter_component.validate_filter()
+            filters = decompose_and_validate_filter(filter, environment_filter_components)
             stmt = add_filter_and_sort(stmt, EnvironmentOrder.default_order(), filters, order_by)
             return await get_connection(
                 stmt, info=info, model="Environment", first=first, after=after, last=last, before=before
@@ -1414,9 +1469,7 @@ def get_schema(
         ) -> CustomListConnection[Notification]:
             stmt = select(notification_model)
             stmt = populate_extension_columns(stmt, models.Notification, notification_model, info)
-            filters = decompose_filter(filter, notification_filter_components)
-            for filter_component in filters:
-                filter_component.validate_filter()
+            filters = decompose_and_validate_filter(filter, notification_filter_components)
             stmt = add_filter_and_sort(stmt, NotificationOrder.default_order(), filters, order_by)
             return await get_connection(
                 stmt, info=info, model="Notification", first=first, after=after, last=last, before=before
@@ -1444,11 +1497,11 @@ def get_schema(
             # Decompose the composed ResourceFilter into one instance per component (core + each extension). Every
             # resource filter component is a ResourceFilterABC, and at most one may take over version selection
             # Core does it by default.
-            resource_filter_instances = cast(list[ResourceFilterABC], decompose_filter(filter, resource_filter_components))
+            resource_filter_instances = cast(
+                list[ResourceFilterABC], decompose_and_validate_filter(filter, resource_filter_components)
+            )
             version_handler: ResourceFilterABC | None = None
-            filters_on_resource_table: bool = False
             for filter_instance in resource_filter_instances:
-                filter_instance.validate_filter()
                 if filter_instance.handles_version():
                     if version_handler is not None:
                         raise ValueError(
@@ -1456,34 +1509,39 @@ def get_schema(
                             "an extension (via handles_version), or core (via isOrphan / modelVersion)."
                         )
                     version_handler = filter_instance
-                if filter_instance.filters_on_resource_table():
-                    filters_on_resource_table = True
 
-            # Only a genuine change to version selection invalidates the ResourcePersistentState-only count: an
-            # extension taking over selection, or a pinned model_version (a historical snapshot). is_orphan leaves
-            # the default selection unchanged, so it must not disable the fast count -- it only enforces the
-            # single-version-owner rule above.
-            custom_version_selection = version_handler is not None and (
-                not isinstance(version_handler, CoreResourceFilter) or is_provided(version_handler.model_version)
-            )
+            # At most one component owns version selection; core selects the default when none does.
             if version_handler is None:
                 version_handler = next(i for i in resource_filter_instances if isinstance(i, CoreResourceFilter))
-            stmt = version_handler.apply_version_filter(stmt)
+            model_version = version_handler.resolve_model_version()
+
+            # Restrict every resource to the resolved model version, and record the selection on the query so
+            # contributions resolve version-dependent data at the same version.
+            resource_version = model_version.resource_version_column()
+            stmt = stmt.join(
+                models.t_resource_set_configuration_model,
+                and_(
+                    models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
+                    models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
+                    models.t_resource_set_configuration_model.c.model == resource_version,
+                ),
+            )
+            stmt = with_resolved_model_version(stmt, model_version)
 
             stmt = populate_extension_columns(stmt, models.Resource, resource_model, info)
             stmt = add_filter_and_sort(stmt, ResourceOrder.default_order(), resource_filter_instances, order_by)
             count_stmt: Select[tuple[int]] | None
             # The efficient count below only selects from ResourcePersistentState, so it is only valid when the row
-            # set it counts matches the real query: no component may change the version selection, and no component's
-            # apply_filter may constrain the Resource table.
+            # set it counts matches the real query: every component must keep it valid (no pinned version selection,
+            # and no apply_filter constraining the Resource table.
             # Otherwise, fall back to counting the actual (version-aware) resource query.
-            if custom_version_selection or filters_on_resource_table:
-                count_stmt = None
-            else:
+            if all(instance.allows_persistent_state_count() for instance in resource_filter_instances):
                 # more efficient count statement that doesn't require joining on resource
                 count_stmt = add_filter_and_sort(
                     select(func.count()).select_from(models.ResourcePersistentState), {}, resource_filter_instances
                 )
+            else:
+                count_stmt = None
             return await get_connection(
                 stmt, info=info, model="Resource", first=first, after=after, last=last, before=before, count_stmt=count_stmt
             )

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -765,18 +765,20 @@ class ModelVersionSelection:
     version: int | ColumnElement[int]
     include_orphans: bool = False
 
-    @staticmethod
-    def pinned(version: "int | ColumnElement[int]") -> "ModelVersionSelection":
+    @classmethod
+    def create_for_exact_version(cls, version: "int | ColumnElement[int]") -> "ModelVersionSelection":
         """Select every resource exactly at `version` (a concrete model version, or a scalar expression computing one)."""
-        return ModelVersionSelection(version=version)
+        return cls(version=version)
 
-    @staticmethod
-    def latest(environment: uuid.UUID, *, include_orphans: bool = True) -> "ModelVersionSelection":
+    @classmethod
+    def create_for_latest_scheduled_version(
+        cls, environment: uuid.UUID, *, include_orphans: bool = True
+    ) -> "ModelVersionSelection":
         """
         The latest scheduled model version. Orphaned resources are additionally taken at the last version they were
         present in when `include_orphans` is True; when False, only resources present in the latest version are selected.
         """
-        return ModelVersionSelection(
+        return cls(
             version=latest_scheduled_model_version(environment),
             include_orphans=include_orphans,
         )
@@ -899,9 +901,9 @@ class CoreResourceFilter(ResourceFilterABC):
 
     def resolve_model_version(self) -> ModelVersionSelection:
         if is_provided(self.model_version):
-            return ModelVersionSelection.pinned(self.model_version)
+            return ModelVersionSelection.create_for_exact_version(self.model_version)
         include_orphans = not is_provided(self.is_orphan) or self.is_orphan is True
-        return ModelVersionSelection.latest(self.environment, include_orphans=include_orphans)
+        return ModelVersionSelection.create_for_latest_scheduled_version(self.environment, include_orphans=include_orphans)
 
     def allows_persistent_state_count(self) -> bool:
         # A pinned modelVersion is a historical snapshot whose membership depends on the version, and `purged` is the

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -91,7 +91,9 @@ There are 4 important building blocks that we have to take into account:
                 order_by: typing.Optional[Sequence[EnvironmentOrder]] = strawberry.UNSET,
             ) -> CustomListConnection[Environment]:
                 stmt = select(models.Environment)
-                stmt = add_filter_and_sort(stmt, EnvironmentOrder.default_order(), filter, order_by)
+                stmt = add_filter_and_sort(
+                    stmt, EnvironmentOrder.default_order(), [filter] if is_provided(filter) else [], order_by
+                )
                 return await get_connection(
                     stmt, info=info, model="Environment", first=first, after=after, last=last, before=before
                 )
@@ -506,7 +508,7 @@ class StrawberryFilter:
             filter_dict[key] = value
         return filter_dict
 
-    def apply_filters[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+    def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
         """
         Applies the filters to the given query.
         """
@@ -733,9 +735,38 @@ class CoreResourceMixin:
     )
 
 
+@dataclasses.dataclass(kw_only=True)
 @strawberry.input
-class ResourceFilter(StrawberryFilter):
+class ResourceFilterABC(StrawberryFilter):
+    """
+    Abstract base class that defines the shared attributes/behaviour of every resource filter component: core's
+    `CoreResourceFilter` and each extension's filter (contributed via `GraphQLContribution.get_resource_filter_input_class`).
+    These components are composed into the single `ResourceFilter` GraphQL input type exposed on the `resources` query
+    (see `get_resource_filter_components` and `get_schema`).
+
+    :param environment: The environment the resources belong to.
+    """
+
     environment: uuid.UUID
+
+    def handles_version(self) -> bool:
+        """
+        Return True if this filter component takes over selection of the model version from core. At most one
+        component may do so; when none does, core (`CoreResourceFilter`) selects the version by default.
+        """
+        return False
+
+    def apply_version_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+        """
+        Restrict the query to the appropriate version(s) of the model. Only invoked on the single component
+        responsible for version selection: an extension whose `handles_version()` is True, or core otherwise.
+        """
+        raise NotImplementedError()
+
+
+@dataclasses.dataclass(kw_only=True)
+@strawberry.input
+class CoreResourceFilter(ResourceFilterABC):
     resource_type: StrFilter | None = strawberry.UNSET
     resource_id_value: StrFilter | None = strawberry.UNSET
     agent: StrFilter | None = strawberry.UNSET
@@ -745,6 +776,7 @@ class ResourceFilter(StrawberryFilter):
     last_handler_run: EnumFilter[state.HandlerResult] | None = strawberry.UNSET
     is_deploying: bool | None = strawberry.UNSET
     is_orphan: bool | None = strawberry.UNSET
+    model_version: int | None = strawberry.UNSET
 
     @property
     def model(self) -> type[models.Base]:
@@ -754,7 +786,38 @@ class ResourceFilter(StrawberryFilter):
     def rps_model(self) -> type[models.Base]:
         return models.ResourcePersistentState
 
-    def apply_filters[*Ts](
+    def handles_version(self) -> bool:
+        # is_orphan and model_version both control which version(s) of the model are selected, so providing either
+        # means core owns version selection. This also lets us detect a conflict when an extension tries to take it over.
+        return is_provided(self.is_orphan) or is_provided(self.model_version)
+
+    def apply_version_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+        # Determine which version of the model each resource should be taken from:
+        #  - if a specific version was requested, pin every resource set to that version
+        #  - otherwise take each resource at the latest scheduled version, except orphaned resources which are
+        #    taken at the last version they were present in (orphaned_after). ResourcePersistentState is already
+        #    joined onto the query, so orphaned_after is available directly (no extra CTE/join needed). For
+        #    non-orphaned resources orphaned_after is NULL, so coalesce falls back to the latest scheduled version.
+        version = (
+            self.model_version
+            if is_provided(self.model_version)
+            else func.coalesce(
+                models.ResourcePersistentState.orphaned_after,
+                select(models.Scheduler.last_processed_model_version)
+                .where(models.Scheduler.environment == self.environment)
+                .scalar_subquery(),
+            )
+        )
+        return stmt.join(
+            models.t_resource_set_configuration_model,
+            and_(
+                models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
+                models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
+                models.t_resource_set_configuration_model.c.model == version,
+            ),
+        )
+
+    def apply_filter[*Ts](
         self, stmt: Select[tuple[*Ts]]
     ) -> Select[tuple[*Ts]]:  # Every filter we apply to the resource is custom, so we don't use `get_filter_dict`
         rps_keys = [
@@ -835,14 +898,17 @@ class ComposedResourceSummary:
 def add_filter_and_sort[*Ts](
     stmt: Select[tuple[*Ts]],
     default_sorting: dict[str, UnaryExpression[typing.Any]],
-    filter: typing.Optional[StrawberryFilter] = strawberry.UNSET,
+    filter: Sequence[StrawberryFilter] = (),
     order_by: typing.Optional[Sequence[StrawberryOrder]] = strawberry.UNSET,
 ) -> Select[tuple[*Ts]]:
     """
     Adds filter and sorting to the given statement.
+
+    :param filter: the filter components to apply. A single query can have several components: the `resources` query
+        composes core and extension filters, while the other queries pass a single (or no) filter.
     """
-    if is_provided(filter):
-        stmt = filter.apply_filters(stmt)
+    for filter_component in filter:
+        stmt = filter_component.apply_filter(stmt)
     order_expressions: dict[str, UnaryExpression[typing.Any]] = {}
     if is_provided(order_by):
         for order in order_by:
@@ -1016,6 +1082,17 @@ class GraphQLContribution(ABC):
         """
         return stmt
 
+    @classmethod
+    def get_resource_filter_input_class(cls) -> "type[ResourceFilterABC] | None":
+        """
+        Return a `ResourceFilterABC` subclass (a `@strawberry.input`) whose fields are composed into the `resources`
+        query's `ResourceFilter` input type, letting this extension filter resources on its own fields. The class'
+        `apply_filter` is applied alongside core's, and it may take over version selection via `handles_version` /
+        `apply_version_filter`. Only meaningful for a contribution targeting `models.Resource`; return None (the
+        default) to contribute no filter fields.
+        """
+        return None
+
 
 def build_composed_sqlalchemy_model(
     base_model: type[models.Base],
@@ -1085,6 +1162,23 @@ def build_strawberry_output_type(
         type,
         mapper.type(model)(type(type_name, (), {"__annotations__": annotations, "__exclude__": excludes, **attrs})),
     )
+
+
+def get_resource_filter_components(
+    contributions: Sequence[type[GraphQLContribution]],
+) -> tuple[type[ResourceFilterABC], ...]:
+    """
+    Return the filter components that compose the `resources` query's `ResourceFilter` input type: `CoreResourceFilter`
+    followed by every extension-contributed filter class (see `GraphQLContribution.get_resource_filter_input_class`).
+    `get_schema` builds the composed input type from these by multiple inheritance, and the `resources` resolver
+    decomposes the received filter back into one instance per component to apply them.
+
+    :param contributions: the extension contributions that target `models.Resource`.
+    """
+    extension_filters: list[type[ResourceFilterABC]] = [
+        cls for c in contributions if (cls := c.get_resource_filter_input_class()) is not None
+    ]
+    return (CoreResourceFilter, *extension_filters)
 
 
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
@@ -1160,6 +1254,16 @@ def get_schema(
     notification_model, Notification = built_types["Notification"]
     resource_model, Resource = built_types["Resource"]
 
+    # Compose the `resources` filter input type from core's filter and the extensions' contributed filters. It is built
+    # by multiple inheritance so the resulting GraphQL input exposes the union of all their fields; the resolver
+    # decomposes a received value back into one instance per component (see `resource_filter_components`).
+    resource_filter_components = get_resource_filter_components(
+        extension_contributions.get(graphql_type_name(models.Resource), [])
+    )
+    composed_resource_filter: type = strawberry.input(
+        dataclasses.dataclass(kw_only=True)(type("ResourceFilter", resource_filter_components, {}))
+    )
+
     class CustomInfo(Info):
         @property
         def context(self) -> ContextType:  # type: ignore[type-var]
@@ -1180,7 +1284,9 @@ def get_schema(
         ) -> CustomListConnection[Environment]:
             stmt = select(environment_model)
             stmt = populate_extension_columns(stmt, models.Environment, environment_model, info)
-            stmt = add_filter_and_sort(stmt, EnvironmentOrder.default_order(), filter, order_by)
+            stmt = add_filter_and_sort(
+                stmt, EnvironmentOrder.default_order(), [filter] if is_provided(filter) else [], order_by
+            )
             return await get_connection(
                 stmt, info=info, model="Environment", first=first, after=after, last=last, before=before
             )
@@ -1198,7 +1304,7 @@ def get_schema(
         ) -> CustomListConnection[Notification]:
             stmt = select(notification_model)
             stmt = populate_extension_columns(stmt, models.Notification, notification_model, info)
-            stmt = add_filter_and_sort(stmt, NotificationOrder.default_order(), filter, order_by)
+            stmt = add_filter_and_sort(stmt, NotificationOrder.default_order(), [filter], order_by)
             return await get_connection(
                 stmt, info=info, model="Notification", first=first, after=after, last=last, before=before
             )
@@ -1207,19 +1313,18 @@ def get_schema(
         async def resources(
             self,
             info: CustomInfo,
-            filter: ResourceFilter,
+            # The declared type is CoreResourceFilter (so filter.<core field> stays typed), but the GraphQL input
+            # the user actually gets is the composed type carrying core + extension fields.
+            filter: typing.Annotated[CoreResourceFilter, strawberry.argument(graphql_type=composed_resource_filter)],
             first: typing.Optional[int] = strawberry.UNSET,
             after: typing.Optional[str] = strawberry.UNSET,
             last: typing.Optional[int] = strawberry.UNSET,
             before: typing.Optional[str] = strawberry.UNSET,
             order_by: typing.Optional[Sequence[ResourceOrder]] = strawberry.UNSET,
         ) -> CustomListConnection[Resource]:
-            if filter.is_orphan is False:
-                include_orphans = False
-            else:
-                include_orphans = True
+            if is_provided(filter.model_version) and is_provided(filter.is_orphan):
+                raise Exception("is_orphan cannot be provided when filtering by model_version")
 
-            # Only fetch resources in their latest version
             # Logic based on src/inmanta/data/dataview.py::ResourceView
             # We select `resource_model` (a subclass of models.Resource carrying the extensions' extra columns when
             # there are any, models.Resource otherwise) so each row is a single ORM object that can carry them.
@@ -1231,64 +1336,39 @@ def get_schema(
                 ),
             )
 
-            # CTE that fetches the latest scheduled version
-            latest_scheduled_version_cte = (
-                select(models.Scheduler.last_processed_model_version.label("version"))
-                .where(models.Scheduler.environment == filter.environment)
-                .cte()
-            )
+            # Decompose the composed ResourceFilter into one instance per component (core + each extension). Each
+            # component's fields are read off the received filter, and at most one component may take over version
+            # selection (`handles_version`); core does it by default.
+            resource_filter_instances: list[ResourceFilterABC] = []
+            version_handler: ResourceFilterABC | None = None
+            for filter_type in resource_filter_components:
+                filter_fields = {field.name: getattr(filter, field.name) for field in dataclasses.fields(filter_type)}
+                filter_instance = filter_type(**filter_fields)
+                resource_filter_instances.append(filter_instance)
+                if filter_instance.handles_version():
+                    if version_handler is not None:
+                        raise Exception("Only one extension can determine version logic.")
+                    version_handler = filter_instance
 
-            if include_orphans:
-                # CTE that checks if a resource is orphaned or not and returns the appropriate version
-                # - If it is not orphaned, return the resource in the latest released version
-                # - If it is orphaned, return the resource in the latest version that it was present in.
-                included_orphans_cte = (
-                    select(
-                        models.ResourcePersistentState.environment,
-                        models.ResourcePersistentState.resource_id,
-                        func.coalesce(
-                            models.ResourcePersistentState.orphaned_after,
-                            latest_scheduled_version_cte.c.version,
-                        ).label("version"),
-                    )
-                    .where(
-                        models.ResourcePersistentState.environment == filter.environment,
-                    )
-                    .cte()
-                )
-                stmt = stmt.join(
-                    models.t_resource_set_configuration_model,
-                    and_(
-                        models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
-                        models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
-                    ),
-                ).join(
-                    included_orphans_cte,
-                    and_(
-                        models.Resource.environment == included_orphans_cte.c.environment,
-                        models.Resource.resource_id == included_orphans_cte.c.resource_id,
-                        models.t_resource_set_configuration_model.c.model == included_orphans_cte.c.version,
-                    ),
-                )
-            else:
-                stmt = stmt.join(
-                    models.t_resource_set_configuration_model,
-                    and_(
-                        models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
-                        models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
-                        models.t_resource_set_configuration_model.c.model
-                        == select(latest_scheduled_version_cte.c.version).scalar_subquery(),
-                    ),
-                )
+            # True when a component actively took over version selection (core via is_orphan/model_version, or an
+            # extension) rather than the plain default of "latest scheduled version + orphans".
+            custom_version_selection = version_handler is not None
+            if version_handler is None:
+                version_handler = next(i for i in resource_filter_instances if isinstance(i, CoreResourceFilter))
+            stmt = version_handler.apply_version_filter(stmt)
+
             stmt = populate_extension_columns(stmt, models.Resource, resource_model, info)
-
-            stmt = add_filter_and_sort(stmt, ResourceOrder.default_order(), filter, order_by)
+            stmt = add_filter_and_sort(stmt, ResourceOrder.default_order(), resource_filter_instances, order_by)
             count_stmt: Select[tuple[int]] | None
-            if filter.purged is not strawberry.UNSET:
+            if is_provided(filter.purged) or is_provided(filter.model_version) or custom_version_selection:
+                # These filters are not (only) applied on ResourcePersistentState, so the more efficient count below
+                # would not match; fall back to counting the actual (version-aware) resource query.
                 count_stmt = None
             else:
                 # more efficient count statement that doesn't require joining on resource
-                count_stmt = add_filter_and_sort(select(func.count()).select_from(models.ResourcePersistentState), {}, filter)
+                count_stmt = add_filter_and_sort(
+                    select(func.count()).select_from(models.ResourcePersistentState), {}, resource_filter_instances
+                )
             return await get_connection(
                 stmt, info=info, model="Resource", first=first, after=after, last=last, before=before, count_stmt=count_stmt
             )

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1459,9 +1459,13 @@ def get_schema(
                 if filter_instance.filters_on_resource_table():
                     filters_on_resource_table = True
 
-            # True when a component actively took over version selection
-            # rather than the plain default of "latest scheduled version + orphans".
-            custom_version_selection = version_handler is not None
+            # Only a genuine change to version selection invalidates the ResourcePersistentState-only count: an
+            # extension taking over selection, or a pinned model_version (a historical snapshot). is_orphan leaves
+            # the default selection unchanged, so it must not disable the fast count -- it only enforces the
+            # single-version-owner rule above.
+            custom_version_selection = version_handler is not None and (
+                not isinstance(version_handler, CoreResourceFilter) or is_provided(version_handler.model_version)
+            )
             if version_handler is None:
                 version_handler = next(i for i in resource_filter_instances if isinstance(i, CoreResourceFilter))
             stmt = version_handler.apply_version_filter(stmt)

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1353,8 +1353,7 @@ def get_schema(
             stmt = contribution.populate_sqlalchemy_columns(stmt, composed_model, requested_fields)
         return stmt
 
-    # Build each registrable object type's output type and (extension-composed) filter input, both composed the same
-    # generic way from the type's core building blocks (see RegistrableGraphQLType) and the contributions targeting it.
+    # Build each registrable object type's output type and filter input.
     built_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
     built_filters: dict[GraphQLTypeName, tuple[tuple[type[StrawberryFilter], ...], type]] = {}
     for base_model, registrable in REGISTRABLE_MODELS.items():
@@ -1455,8 +1454,8 @@ def get_schema(
                 if filter_instance.filters_on_resource_table():
                     filters_on_resource_table = True
 
-            # True when a component actively took over version selection (core via is_orphan/model_version, or an
-            # extension) rather than the plain default of "latest scheduled version + orphans".
+            # True when a component actively took over version selection
+            # rather than the plain default of "latest scheduled version + orphans".
             custom_version_selection = version_handler is not None
             if version_handler is None:
                 version_handler = next(i for i in resource_filter_instances if isinstance(i, CoreResourceFilter))

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -32,7 +32,7 @@ from inmanta.deploy import state
 from inmanta.server.services.compilerservice import CompilerService
 from sqlakeyset import Marker, unserialize_bookmark
 from sqlakeyset.asyncio import select_page
-from sqlalchemy import Boolean, Select, UnaryExpression, and_, asc, desc, func, not_, select
+from sqlalchemy import Boolean, ColumnElement, Select, UnaryExpression, and_, asc, desc, func, not_, select
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapper
 from strawberry import relay, scalars
@@ -752,6 +752,12 @@ class ResourceFilterABC(StrawberryFilter):
 
     environment: uuid.UUID
 
+    def validate_filter(self) -> None:
+        """
+        Checks if the provided filter fields are valid.
+        """
+        return
+
     def handles_version(self) -> bool:
         """
         Return True if this filter component takes over selection of the model version from core. At most one
@@ -765,6 +771,15 @@ class ResourceFilterABC(StrawberryFilter):
         responsible for version selection: an extension whose `handles_version()` is True, or core otherwise.
         """
         raise NotImplementedError()
+
+    def filters_on_resource_table(self) -> bool:
+        """
+        Return True if this component's `apply_filter` constrains the `Resource` table (`models.Resource`) rather
+        than only `ResourcePersistentState`. The `resources` query uses this to decide whether the efficient count
+        (which counts `ResourcePersistentState` alone, without joining `Resource`) is valid: it is only used when no
+        applied component filters on the `Resource` table.
+        """
+        return False
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -789,28 +804,50 @@ class CoreResourceFilter(ResourceFilterABC):
     def rps_model(self) -> type[models.Base]:
         return models.ResourcePersistentState
 
+    def validate_filter(self) -> None:
+        # modelVersion returns the resources exactly as they were in that version of the model. The filters below
+        # reflect the *current* state of a resource (tracked on ResourcePersistentState, which is not versioned),
+        # so combining them with modelVersion would mix a historical snapshot with current state; reject that.
+        if is_provided(self.model_version):
+            current_state_filters = {
+                "isOrphan": self.is_orphan,
+                "isDeploying": self.is_deploying,
+                "blocked": self.blocked,
+                "compliance": self.compliance,
+                "lastHandlerRun": self.last_handler_run,
+            }
+            conflicting = [name for name, value in current_state_filters.items() if is_provided(value)]
+            if conflicting:
+                raise ValueError(
+                    "modelVersion cannot be combined with filters on the current resource state: " + ", ".join(conflicting)
+                )
+
     def handles_version(self) -> bool:
         # is_orphan and model_version both control which version(s) of the model are selected, so providing either
-        # means core owns version selection. This also lets us detect a conflict when an extension tries to take it over.
+        # means core owns version selection.
         return is_provided(self.is_orphan) or is_provided(self.model_version)
 
     def apply_version_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
         # Determine which version of the model each resource should be taken from:
         #  - if a specific version was requested, pin every resource set to that version
         #  - otherwise take each resource at the latest scheduled version, except orphaned resources which are
-        #    taken at the last version they were present in (orphaned_after). ResourcePersistentState is already
-        #    joined onto the query, so orphaned_after is available directly (no extra CTE/join needed). For
-        #    non-orphaned resources orphaned_after is NULL, so coalesce falls back to the latest scheduled version.
-        version = (
-            self.model_version
-            if is_provided(self.model_version)
-            else func.coalesce(
-                models.ResourcePersistentState.orphaned_after,
-                select(models.Scheduler.last_processed_model_version)
+        #    taken at the last version they were present in (orphaned_after).
+        #    For non-orphaned resources orphaned_after is NULL, so coalesce falls back to the latest scheduled version.
+        version: int | ColumnElement[int]
+        if is_provided(self.model_version):
+            version = self.model_version
+        else:
+            # Compute the latest scheduled version once, as a CTE, instead of inlining the subquery in the join
+            # condition below, so it is not (re-)evaluated per candidate row.
+            latest_scheduled_version = (
+                select(models.Scheduler.last_processed_model_version.label("version"))
                 .where(models.Scheduler.environment == self.environment)
-                .scalar_subquery(),
+                .cte()
             )
-        )
+            version = func.coalesce(
+                models.ResourcePersistentState.orphaned_after,
+                select(latest_scheduled_version.c.version).scalar_subquery(),
+            )
         return stmt.join(
             models.t_resource_set_configuration_model,
             and_(
@@ -844,6 +881,11 @@ class CoreResourceFilter(ResourceFilterABC):
         if is_provided(self.is_orphan):
             stmt = stmt.filter(models.ResourcePersistentState.is_orphan.is_(self.is_orphan))
         return stmt
+
+    def filters_on_resource_table(self) -> bool:
+        # `purged` is the only core filter applied on the `Resource` table (`attributes`); every other core filter
+        # constrains `ResourcePersistentState`.
+        return is_provided(self.purged)
 
 
 class ResourceOrder(StrawberryOrder):
@@ -1393,12 +1435,6 @@ def get_schema(
             before: typing.Optional[str] = strawberry.UNSET,
             order_by: typing.Optional[Sequence[ResourceOrder]] = strawberry.UNSET,
         ) -> CustomListConnection[Resource]:
-            if is_provided(filter.model_version) and is_provided(filter.is_orphan):
-                raise Exception("is_orphan cannot be provided when filtering by model_version")
-
-            # Logic based on src/inmanta/data/dataview.py::ResourceView
-            # We select `resource_model` (a subclass of models.Resource carrying the extensions' extra columns when
-            # there are any, models.Resource otherwise) so each row is a single ORM object that can carry them.
             stmt = select(resource_model).join(
                 models.ResourcePersistentState,
                 and_(
@@ -1412,11 +1448,15 @@ def get_schema(
             # (`handles_version`); core does it by default.
             resource_filter_instances = cast(list[ResourceFilterABC], decompose_filter(filter, resource_filter_components))
             version_handler: ResourceFilterABC | None = None
+            filters_on_resource_table: bool = False
             for filter_instance in resource_filter_instances:
+                filter_instance.validate_filter()
                 if filter_instance.handles_version():
                     if version_handler is not None:
-                        raise Exception("Only one extension can determine version logic.")
+                        raise ValueError("Only one extension can determine version logic.")
                     version_handler = filter_instance
+                if filter_instance.filters_on_resource_table():
+                    filters_on_resource_table = True
 
             # True when a component actively took over version selection (core via is_orphan/model_version, or an
             # extension) rather than the plain default of "latest scheduled version + orphans".
@@ -1428,9 +1468,11 @@ def get_schema(
             stmt = populate_extension_columns(stmt, models.Resource, resource_model, info)
             stmt = add_filter_and_sort(stmt, ResourceOrder.default_order(), resource_filter_instances, order_by)
             count_stmt: Select[tuple[int]] | None
-            if is_provided(filter.purged) or is_provided(filter.model_version) or custom_version_selection:
-                # These filters are not (only) applied on ResourcePersistentState, so the more efficient count below
-                # would not match; fall back to counting the actual (version-aware) resource query.
+            # The efficient count below only selects from ResourcePersistentState, so it is only valid when the row
+            # set it counts matches the real query: no component may change the version selection, and no component's
+            # apply_filter may constrain the Resource table.
+            # Otherwise, fall back to counting the actual (version-aware) resource query.
+            if custom_version_selection or filters_on_resource_table:
                 count_stmt = None
             else:
                 # more efficient count statement that doesn't require joining on resource

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -108,12 +108,15 @@ There are 4 important building blocks that we have to take into account:
         The strawberry-sqlalchemy-mapper (mapper for short) library
         will generate the `Connection` class for it as well in runtime.
 
-    3) The `StrawberryFilter` child class for our strawberry model i.e.
+    3) The `StrawberryFilter` child class for our strawberry model, declared as the type's "core filter" i.e.
         ```
             @strawberry.input
-            class EnvironmentFilter(StrawberryFilter):
+            class CoreEnvironmentFilter(StrawberryFilter):
                 id: typing.Optional[str] = strawberry.UNSET
         ```
+        `get_schema` composes this core filter with any extension-contributed filters (see `GraphQLContribution` and
+        `build_composed_filter_input`) into the user-facing `EnvironmentFilter` input; the resolver decomposes a
+        received value back into its components with `decompose_filter` and applies each.
         This class determines what fields we allow our users to filter on and what type we expect to receive.
 
         We can also define custom filters to handle more complex behaviour than simple equality.
@@ -497,16 +500,12 @@ class StrawberryFilter:
 
     def get_filter_dict(self) -> dict[str, typing.Any]:
         """
-        Returns the filter in dict form.
-        This is fed to the SQLAlchemy query to apply as filter.
-        This is only used for simple filters i.e. exact match on the same table
+        Returns the provided filter fields in dict form, to feed to the SQLAlchemy query as an exact-match filter.
+        Fields left UNSET are skipped (not filtered on) -- this is what lets a filter compose with others that carry
+        their own fields (see `decompose_filter`), where any given component only has some of the fields set.
+        This is only used for simple filters i.e. exact match on the same table.
         """
-        filter_dict = {}
-        for key, value in self.__dict__.items():
-            if value is strawberry.UNSET:
-                raise ValueError(f"Filter {key} was requested but no value was provided")
-            filter_dict[key] = value
-        return filter_dict
+        return {key: value for key, value in self.__dict__.items() if value is not strawberry.UNSET}
 
     def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
         """
@@ -654,8 +653,9 @@ class CoreEnvironmentMixin:
     settings: scalars.JSON = strawberry.field(resolver=get_settings, description="The settings for this environment.")
 
 
+@dataclasses.dataclass(kw_only=True)
 @strawberry.input
-class EnvironmentFilter(StrawberryFilter):
+class CoreEnvironmentFilter(StrawberryFilter):
     id: typing.Optional[uuid.UUID] = strawberry.UNSET
 
 
@@ -684,8 +684,9 @@ class CoreNotificationMixin:
     __exclude__ = ["environment_", "compile"]
 
 
+@dataclasses.dataclass(kw_only=True)
 @strawberry.input
-class NotificationFilter(StrawberryFilter):
+class CoreNotificationFilter(StrawberryFilter):
     environment: uuid.UUID
     cleared: typing.Optional[bool] = strawberry.UNSET
 
@@ -740,9 +741,11 @@ class CoreResourceMixin:
 class ResourceFilterABC(StrawberryFilter):
     """
     Abstract base class that defines the shared attributes/behaviour of every resource filter component: core's
-    `CoreResourceFilter` and each extension's filter (contributed via `GraphQLContribution.get_resource_filter_input_class`).
+    `CoreResourceFilter` and each extension's resource filter (contributed via `GraphQLContribution.get_filter_input_class`).
     These components are composed into the single `ResourceFilter` GraphQL input type exposed on the `resources` query
-    (see `get_resource_filter_components` and `get_schema`).
+    by the generic filter composition (see `get_filter_components` / `build_composed_filter_input` and `get_schema`).
+    The version-selection hooks below are specific to resources; other object types' filters compose the same way but
+    have no version concept.
 
     :param environment: The environment the resources belong to.
     """
@@ -1083,13 +1086,15 @@ class GraphQLContribution(ABC):
         return stmt
 
     @classmethod
-    def get_resource_filter_input_class(cls) -> "type[ResourceFilterABC] | None":
+    def get_filter_input_class(cls) -> "type[StrawberryFilter] | None":
         """
-        Return a `ResourceFilterABC` subclass (a `@strawberry.input`) whose fields are composed into the `resources`
-        query's `ResourceFilter` input type, letting this extension filter resources on its own fields. The class'
-        `apply_filter` is applied alongside core's, and it may take over version selection via `handles_version` /
-        `apply_version_filter`. Only meaningful for a contribution targeting `models.Resource`; return None (the
-        default) to contribute no filter fields.
+        Return a `@strawberry.input` filter class whose fields are composed into the target type's filter input,
+        letting this extension filter that type's query on its own fields (its `apply_filter` runs alongside core's).
+        Return None (the default) to contribute no filter fields.
+
+        The class must be compatible with the target type's core filter, since the two are composed by multiple
+        inheritance: for `models.Resource` that means a `ResourceFilterABC` subclass (which may also take over version
+        selection via `handles_version` / `apply_version_filter`); for other types, a `StrawberryFilter` subclass.
         """
         return None
 
@@ -1164,31 +1169,90 @@ def build_strawberry_output_type(
     )
 
 
-def get_resource_filter_components(
+def get_filter_components(
+    core_filter: type[StrawberryFilter],
     contributions: Sequence[type[GraphQLContribution]],
-) -> tuple[type[ResourceFilterABC], ...]:
+) -> tuple[type[StrawberryFilter], ...]:
     """
-    Return the filter components that compose the `resources` query's `ResourceFilter` input type: `CoreResourceFilter`
-    followed by every extension-contributed filter class (see `GraphQLContribution.get_resource_filter_input_class`).
-    `get_schema` builds the composed input type from these by multiple inheritance, and the `resources` resolver
-    decomposes the received filter back into one instance per component to apply them.
+    Return the filter components that compose an object type's filter input type: the type's `core_filter` followed by
+    every extension-contributed filter class (see `GraphQLContribution.get_filter_input_class`). `build_composed_filter_input`
+    builds the composed input from these by multiple inheritance, and each query's resolver decomposes the received
+    filter back into one instance per component (see `decompose_filter`) to apply them.
 
-    :param contributions: the extension contributions that target `models.Resource`.
+    :param core_filter: the core filter class of the object type (e.g. `CoreResourceFilter`).
+    :param contributions: the extension contributions that target the same object type.
     """
-    extension_filters: list[type[ResourceFilterABC]] = [
-        cls for c in contributions if (cls := c.get_resource_filter_input_class()) is not None
+    extension_filters: list[type[StrawberryFilter]] = [
+        cls for c in contributions if (cls := c.get_filter_input_class()) is not None
     ]
-    return (CoreResourceFilter, *extension_filters)
+    return (core_filter, *extension_filters)
+
+
+def build_composed_filter_input(
+    type_name: str,
+    core_filter: type[StrawberryFilter],
+    contributions: Sequence[type[GraphQLContribution]],
+) -> tuple[tuple[type[StrawberryFilter], ...], type]:
+    """
+    Build the filter input type for an object type, composed of its core filter and the extensions' contributed
+    filters (mirrors `build_strawberry_output_type` on the output side). The components are merged by multiple
+    inheritance into a single `@strawberry.input` named `{type_name}Filter` (the user-facing filter type), while the
+    core filter keeps a distinct name (e.g. `CoreResourceFilter`). `get_schema` is called once per process, so a fixed
+    class name is fine.
+
+    Returns the tuple of components (so the resolver can decompose the received filter, see `decompose_filter`) and
+    the composed input type (to expose as the query's `filter` argument).
+
+    :param type_name: the name of the object type being built (e.g. "Resource").
+    :param core_filter: the core filter class of the object type (e.g. `CoreResourceFilter`).
+    :param contributions: the extension contributions that target this type.
+    """
+    components = get_filter_components(core_filter, contributions)
+    composed = cast(
+        type,
+        strawberry.input(dataclasses.dataclass(kw_only=True)(type(f"{type_name}Filter", components, {}))),
+    )
+    return components, composed
+
+
+def decompose_filter[F: StrawberryFilter](filter: object, components: tuple[type[F], ...]) -> list[F]:
+    """
+    Split a composed filter value (built by `build_composed_filter_input`) back into one instance per component,
+    reading each component's fields off the composed value. This lets every component apply its own `apply_filter`
+    (and, for resources, its version-selection hooks) on just its own fields.
+
+    :param filter: the composed filter value received by the resolver.
+    :param components: the filter components the composed type was built from (see `get_filter_components`).
+    """
+    decomposed: list[F] = []
+    for component in components:
+        # Every component is a @strawberry.input, hence a dataclass, but that isn't visible through the StrawberryFilter
+        # bound (the base class is not itself a dataclass), so mypy can't tell dataclasses.fields accepts it.
+        component_fields = dataclasses.fields(component)  # type: ignore[arg-type]
+        decomposed.append(component(**{field.name: getattr(filter, field.name) for field in component_fields}))
+    return decomposed
+
+
+@dataclasses.dataclass(frozen=True)
+class RegistrableGraphQLType:
+    """
+    The core building blocks of an object type that extensions can contribute to (see `GraphQLContribution`):
+    the mixin carrying its core output fields and the class carrying its core filter fields. `get_schema` composes
+    each with the registered contributions to build the object type's output type and filter input type.
+    """
+
+    core_mixin: type
+    core_filter: type[StrawberryFilter]
 
 
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
-# model to the mixin carrying its core output fields. `get_schema` composes each of these from the core mixin and the
+# model to its core building blocks. `get_schema` composes each of these from the core building blocks and the
 # registered contributions; registrations for any other model are rejected. The GraphQL output type name is always the
 # model's class name (e.g. `models.Resource` -> "Resource"), which is also the key the contributions are grouped under.
-REGISTRABLE_MODELS: "Mapping[type[models.Base], type]" = {
-    models.Resource: CoreResourceMixin,
-    models.Environment: CoreEnvironmentMixin,
-    models.Notification: CoreNotificationMixin,
+REGISTRABLE_MODELS: "Mapping[type[models.Base], RegistrableGraphQLType]" = {
+    models.Resource: RegistrableGraphQLType(core_mixin=CoreResourceMixin, core_filter=CoreResourceFilter),
+    models.Environment: RegistrableGraphQLType(core_mixin=CoreEnvironmentMixin, core_filter=CoreEnvironmentFilter),
+    models.Notification: RegistrableGraphQLType(core_mixin=CoreNotificationMixin, core_filter=CoreNotificationFilter),
 }
 
 
@@ -1246,23 +1310,24 @@ def get_schema(
             stmt = contribution.populate_sqlalchemy_columns(stmt, composed_model, requested_fields)
         return stmt
 
-    built_types = {
-        graphql_type_name(base_model): build_output_type(base_model, core_mixin)
-        for base_model, core_mixin in REGISTRABLE_MODELS.items()
-    }
+    # For each registrable object type, build its (possibly extension-composed) output type and filter input type.
+    # The output type and the filter input are composed the same generic way from the type's core building blocks and
+    # the contributions targeting it; each query's resolver decomposes the received filter back into its components.
+    built_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
+    # type_name -> (filter components the composed input was built from, composed filter input type)
+    built_filters: dict[GraphQLTypeName, tuple[tuple[type[StrawberryFilter], ...], type]] = {}
+    for base_model, registrable in REGISTRABLE_MODELS.items():
+        type_name = graphql_type_name(base_model)
+        contributions = extension_contributions.get(type_name, [])
+        built_types[type_name] = build_output_type(base_model, registrable.core_mixin)
+        built_filters[type_name] = build_composed_filter_input(type_name, registrable.core_filter, contributions)
+
     environment_model, Environment = built_types["Environment"]
     notification_model, Notification = built_types["Notification"]
     resource_model, Resource = built_types["Resource"]
-
-    # Compose the `resources` filter input type from core's filter and the extensions' contributed filters. It is built
-    # by multiple inheritance so the resulting GraphQL input exposes the union of all their fields; the resolver
-    # decomposes a received value back into one instance per component (see `resource_filter_components`).
-    resource_filter_components = get_resource_filter_components(
-        extension_contributions.get(graphql_type_name(models.Resource), [])
-    )
-    composed_resource_filter: type = strawberry.input(
-        dataclasses.dataclass(kw_only=True)(type("ResourceFilter", resource_filter_components, {}))
-    )
+    environment_filter_components, EnvironmentFilter = built_filters["Environment"]
+    notification_filter_components, NotificationFilter = built_filters["Notification"]
+    resource_filter_components, ResourceFilter = built_filters["Resource"]
 
     class CustomInfo(Info):
         @property
@@ -1279,14 +1344,17 @@ def get_schema(
             after: typing.Optional[str] = strawberry.UNSET,
             last: typing.Optional[int] = strawberry.UNSET,
             before: typing.Optional[str] = strawberry.UNSET,
-            filter: typing.Optional[EnvironmentFilter] = strawberry.UNSET,
+            # The declared type is the core filter (so it stays typed), but the GraphQL input the user gets is the
+            # composed type carrying the core + extension fields.
+            filter: typing.Annotated[
+                typing.Optional[CoreEnvironmentFilter], strawberry.argument(graphql_type=typing.Optional[EnvironmentFilter])
+            ] = strawberry.UNSET,
             order_by: typing.Optional[Sequence[EnvironmentOrder]] = strawberry.UNSET,
         ) -> CustomListConnection[Environment]:
             stmt = select(environment_model)
             stmt = populate_extension_columns(stmt, models.Environment, environment_model, info)
-            stmt = add_filter_and_sort(
-                stmt, EnvironmentOrder.default_order(), [filter] if is_provided(filter) else [], order_by
-            )
+            filters = decompose_filter(filter, environment_filter_components) if is_provided(filter) else []
+            stmt = add_filter_and_sort(stmt, EnvironmentOrder.default_order(), filters, order_by)
             return await get_connection(
                 stmt, info=info, model="Environment", first=first, after=after, last=last, before=before
             )
@@ -1295,7 +1363,9 @@ def get_schema(
         async def notifications(
             self,
             info: CustomInfo,
-            filter: NotificationFilter,
+            # The declared type is the core filter (so it stays typed), but the GraphQL input the user gets is the
+            # composed type carrying the core + extension fields.
+            filter: typing.Annotated[CoreNotificationFilter, strawberry.argument(graphql_type=NotificationFilter)],
             first: typing.Optional[int] = strawberry.UNSET,
             after: typing.Optional[str] = strawberry.UNSET,
             last: typing.Optional[int] = strawberry.UNSET,
@@ -1304,7 +1374,8 @@ def get_schema(
         ) -> CustomListConnection[Notification]:
             stmt = select(notification_model)
             stmt = populate_extension_columns(stmt, models.Notification, notification_model, info)
-            stmt = add_filter_and_sort(stmt, NotificationOrder.default_order(), [filter], order_by)
+            filters = decompose_filter(filter, notification_filter_components)
+            stmt = add_filter_and_sort(stmt, NotificationOrder.default_order(), filters, order_by)
             return await get_connection(
                 stmt, info=info, model="Notification", first=first, after=after, last=last, before=before
             )
@@ -1315,7 +1386,7 @@ def get_schema(
             info: CustomInfo,
             # The declared type is CoreResourceFilter (so filter.<core field> stays typed), but the GraphQL input
             # the user actually gets is the composed type carrying core + extension fields.
-            filter: typing.Annotated[CoreResourceFilter, strawberry.argument(graphql_type=composed_resource_filter)],
+            filter: typing.Annotated[CoreResourceFilter, strawberry.argument(graphql_type=ResourceFilter)],
             first: typing.Optional[int] = strawberry.UNSET,
             after: typing.Optional[str] = strawberry.UNSET,
             last: typing.Optional[int] = strawberry.UNSET,
@@ -1336,15 +1407,12 @@ def get_schema(
                 ),
             )
 
-            # Decompose the composed ResourceFilter into one instance per component (core + each extension). Each
-            # component's fields are read off the received filter, and at most one component may take over version
-            # selection (`handles_version`); core does it by default.
-            resource_filter_instances: list[ResourceFilterABC] = []
+            # Decompose the composed ResourceFilter into one instance per component (core + each extension). Every
+            # resource filter component is a ResourceFilterABC, and at most one may take over version selection
+            # (`handles_version`); core does it by default.
+            resource_filter_instances = cast(list[ResourceFilterABC], decompose_filter(filter, resource_filter_components))
             version_handler: ResourceFilterABC | None = None
-            for filter_type in resource_filter_components:
-                filter_fields = {field.name: getattr(filter, field.name) for field in dataclasses.fields(filter_type)}
-                filter_instance = filter_type(**filter_fields)
-                resource_filter_instances.append(filter_instance)
+            for filter_instance in resource_filter_instances:
                 if filter_instance.handles_version():
                     if version_handler is not None:
                         raise Exception("Only one extension can determine version logic.")

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -513,6 +513,14 @@ class StrawberryFilter:
         """
         return stmt.filter_by(**self.get_filter_dict())
 
+    def validate_filter(self) -> None:
+        """
+        Validate the provided filter fields, raising a `ValueError` if they are inconsistent (e.g. two mutually
+        exclusive fields are set). Called on every component of a composed filter before it is applied. The default
+        accepts everything; override to add component-specific validation.
+        """
+        return
+
 
 @strawberry.input
 class StrawberryOrder:
@@ -751,12 +759,6 @@ class ResourceFilterABC(StrawberryFilter):
     """
 
     environment: uuid.UUID
-
-    def validate_filter(self) -> None:
-        """
-        Checks if the provided filter fields are valid.
-        """
-        return
 
     def handles_version(self) -> bool:
         """
@@ -1250,6 +1252,14 @@ def build_composed_filter_input(
     :param contributions: the extension contributions that target this type.
     """
     components = get_filter_components(core_filter, contributions)
+    # Guard against multiple components having the same field that is not shared
+    # __annotations__ is used because it doesn't contain the fields of the parent class so those are excluded for the comparison
+    seen_fields: set[str] = set()
+    for component in components:
+        for field_name in component.__dict__.get("__annotations__", {}):
+            if field_name in seen_fields:
+                raise Exception(f"{field_name} defined more than once in {type_name} filters.")
+            seen_fields.add(field_name)
     composed = cast(
         type,
         strawberry.input(dataclasses.dataclass(kw_only=True)(type(f"{type_name}Filter", components, {}))),
@@ -1396,6 +1406,8 @@ def get_schema(
             stmt = select(environment_model)
             stmt = populate_extension_columns(stmt, models.Environment, environment_model, info)
             filters = decompose_filter(filter, environment_filter_components) if is_provided(filter) else []
+            for filter_component in filters:
+                filter_component.validate_filter()
             stmt = add_filter_and_sort(stmt, EnvironmentOrder.default_order(), filters, order_by)
             return await get_connection(
                 stmt, info=info, model="Environment", first=first, after=after, last=last, before=before
@@ -1417,6 +1429,8 @@ def get_schema(
             stmt = select(notification_model)
             stmt = populate_extension_columns(stmt, models.Notification, notification_model, info)
             filters = decompose_filter(filter, notification_filter_components)
+            for filter_component in filters:
+                filter_component.validate_filter()
             stmt = add_filter_and_sort(stmt, NotificationOrder.default_order(), filters, order_by)
             return await get_connection(
                 stmt, info=info, model="Notification", first=first, after=after, last=last, before=before

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -770,7 +770,9 @@ class ResourceFilterABC(StrawberryFilter):
         Restrict the query to the appropriate version(s) of the model. Only invoked on the single component
         responsible for version selection: an extension whose `handles_version()` is True, or core otherwise.
         """
-        raise NotImplementedError()
+        raise NotImplementedError(
+            f"{type(self).__name__} returns handles_version()=True but does not implement apply_version_filter()."
+        )
 
     def filters_on_resource_table(self) -> bool:
         """
@@ -1449,7 +1451,10 @@ def get_schema(
                 filter_instance.validate_filter()
                 if filter_instance.handles_version():
                     if version_handler is not None:
-                        raise ValueError("Only one extension can determine version logic.")
+                        raise ValueError(
+                            "Multiple filter components tried to control version selection; at most one may: "
+                            "an extension (via handles_version), or core (via isOrphan / modelVersion)."
+                        )
                     version_handler = filter_instance
                 if filter_instance.filters_on_resource_table():
                     filters_on_resource_table = True

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1659,22 +1659,34 @@ async def test_query_resources_model_version(server, client, environment, setup_
     # A version that does not exist yields no resources
     assert_resources(await query_resources(f"modelVersion: {latest_version + 1}"), set())
 
-    # modelVersion and isOrphan are mutually exclusive: a specific version is returned as-is, so filtering it by
-    # the current orphan state is not allowed and results in an error.
-    for orphan_value in ("true", "false"):
+    # modelVersion returns a specific version as-is, so it cannot be combined with filters on the current
+    # (unversioned) resource state; doing so results in an error. isOrphan/isDeploying are booleans, the others
+    # are enum filters, so exercise a representative of each. Identity filters (agent, resourceType,
+    # resourceIdValue) are version-independent and DO combine with modelVersion (covered above for `agent`).
+    for extra, expected_conflicts in (
+        ("isOrphan: true", "isOrphan"),
+        ("isOrphan: false", "isOrphan"),
+        ("isDeploying: true", "isDeploying"),
+        ("blocked: {eq: BLOCKED}", "blocked"),
+        ("compliance: {eq: HAS_UPDATE}", "compliance"),
+        ("lastHandlerRun: {eq: NEW}", "lastHandlerRun"),
+        ("isOrphan: true isDeploying: true", "isOrphan, isDeploying"),
+    ):
         result = await client.graphql(query="""
             {
-                resources (filter: {environment: "%s" modelVersion: 1 isOrphan: %s}) {
+                resources (filter: {environment: "%s" modelVersion: 1 %s}) {
                     totalCount
                     edges { node { resourceId } }
                 }
             }
-            """ % (environment, orphan_value))
+            """ % (environment, extra))
         assert result.code == 400
         data = result.result["data"]
         assert data["data"] is None
         assert len(data["errors"]) == 1
-        assert data["errors"][0] == "is_orphan cannot be provided when filtering by model_version"
+        assert data["errors"][0] == (
+            "modelVersion cannot be combined with filters on the current resource state: " + expected_conflicts
+        )
 
 
 async def test_custom_extension_resource_filter(server, environment, client, caplog, mixed_resource_generator):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -21,6 +21,7 @@ import uuid
 import pytest
 
 import inmanta.data.sqlalchemy as models
+import inmanta.graphql.schema as graphql_schema
 import strawberry
 from inmanta import const, data
 from inmanta.data import model
@@ -28,19 +29,21 @@ from inmanta.deploy import state
 from inmanta.graphql.graphql import GraphQLSlice
 from inmanta.graphql.schema import (
     GraphQLContribution,
+    ModelVersionSelection,
     ResourceFilterABC,
     StrawberryFilter,
     _docstring_param_cache,
     build_composed_sqlalchemy_model,
     is_provided,
     mapper,
+    resolved_model_version,
     to_snake_case,
 )
 from inmanta.protocol import Result
 from inmanta.server import SLICE_COMPILER, SLICE_GRAPHQL
 from inmanta.server.services.compilerservice import CompilerService
 from inmanta.util import retry_limited
-from sqlalchemy import Select, and_, func, literal, select, true
+from sqlalchemy import ColumnElement, Integer, Select, func, literal, select, true
 from sqlalchemy.orm import query_expression, with_expression
 from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyMapper
 from strawberry_sqlalchemy_mapper.mapper import _GENERATED_FIELD_KEYS_KEY
@@ -1106,7 +1109,7 @@ async def test_graphql_variables_and_operation_name(server, client, setup_databa
     """
     # omit variables: the optional $environment is absent, so `id` is left unset and simply not filtered on -- rather
     # than erroring. This is consistent with how every other filter field treats an unset value, and is what lets
-    # filters compose (a component only carries some of the composed filter's fields, see decompose_filter).
+    # filters compose (a component only carries some of the composed filter's fields, see decompose_and_validate_filter).
     result = await client.graphql(query=query)
     check_correct_graphql_response(result)
     # `id` was not filtered on, so all environments are returned.
@@ -1440,6 +1443,77 @@ async def test_custom_extension_contributions(server, environment, client, caplo
         log_doesnt_contain(caplog, __name__, logging.INFO, "Populated joined_value column")
 
 
+async def test_resolved_model_version_available_to_contributions(server, environment, client, mixed_resource_generator):
+    """
+    The `resources` resolver records the model version it resolves the query to on the query statement, so a
+    contribution can read it back with `resolved_model_version(stmt)` in populate_sqlalchemy_columns and resolve
+    version-dependent columns at that same version. It is the requested `modelVersion`,
+    or the environment's latest scheduled version for the default selection.
+    """
+
+    class ResolvedVersionMixin:
+        # Output field echoing the model version the query resolved to (the latest scheduled version by default).
+        resolved_version: int | None = strawberry.field(description="The model version this query resolved to.")
+
+    class ResolvedVersionContribution(GraphQLContribution):
+        @classmethod
+        def get_target_model(cls) -> type:
+            return models.Resource
+
+        @classmethod
+        def get_graphql_output_type_mixin(cls) -> type | None:
+            return ResolvedVersionMixin
+
+        @classmethod
+        def get_sqlalchemy_columns(cls) -> dict[str, object]:
+            return {"resolved_version": query_expression()}
+
+        @classmethod
+        def populate_sqlalchemy_columns[*Ts](
+            cls, stmt: Select[tuple[*Ts]], model: type, requested_fields: typing.AbstractSet[str]
+        ) -> Select[tuple[*Ts]]:
+            if "resolved_version" not in requested_fields:
+                return stmt
+            # Adds the resolved version to an output column to make sure that we are piping the correct version
+            version = resolved_model_version(stmt).version
+            version_col = version if isinstance(version, ColumnElement) else literal(version, type_=Integer)
+            echoed = select(version_col.label("resolved_version")).subquery()
+            return stmt.join(echoed, true()).options(
+                with_expression(getattr(model, "resolved_version"), echoed.c.resolved_version)
+            )
+
+    graphql_slice = server.get_slice(SLICE_GRAPHQL)
+    assert isinstance(graphql_slice, GraphQLSlice)
+    # GraphQLSlice has already started, so we reset its schema to make registering possible again for this test.
+    graphql_slice.schema = None
+    graphql_slice.register_graphql_contribution_for_extension("example", ResolvedVersionContribution)
+    await graphql_slice.start()
+
+    await mixed_resource_generator(environment, 1, 6)
+
+    async def resolved_versions(extra_filter: str) -> set[int | None]:
+        result = await client.graphql(query="""
+            {
+                resources (filter: {environment: "%s" %s}) {
+                    edges {
+                        node {
+                            resolvedVersion
+                            }
+                        }
+                }
+            }
+            """ % (environment, extra_filter))
+        check_correct_graphql_response(result)
+        edges = result.result["data"]["data"]["resources"]["edges"]
+        assert len(edges) > 0
+        return {edge["node"]["resolvedVersion"] for edge in edges}
+
+    # A specific modelVersion is recorded on the query and echoed back by the contribution.
+    assert await resolved_versions("modelVersion: 1") == {1}
+    # The default selection resolves to the environment's latest scheduled version
+    assert await resolved_versions("") == {2}
+
+
 def test_build_composed_sqlalchemy_model_rejects_duplicate_columns() -> None:
     """Two contributions declaring the same SQLAlchemy column on the same model is rejected."""
 
@@ -1699,7 +1773,7 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
     Test that an extension can contribute its own resource filter fields (via
     GraphQLContribution.get_filter_input_class): they are composed into the `resources` query's
     ResourceFilter input, the extension's apply_filter runs alongside core's, and the extension can take over
-    version selection through handles_version / apply_version_filter (mutually exclusive with core's own
+    version selection through handles_version / resolve_model_version (mutually exclusive with core's own
     version selection).
     """
 
@@ -1722,17 +1796,10 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
             # This extension takes over version selection from core when `at_version` is provided.
             return is_provided(self.at_version)
 
-        def apply_version_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
-            # Pin every resource set to the requested version of the model.
+        def resolve_model_version(self) -> ModelVersionSelection:
+            # Pin every resource to the requested version of the model -- no join boilerplate, the resolver joins.
             LOGGER.info("Applied version filter %s", self.at_version)
-            return stmt.join(
-                models.t_resource_set_configuration_model,
-                and_(
-                    models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
-                    models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
-                    models.t_resource_set_configuration_model.c.model == self.at_version,
-                ),
-            )
+            return ModelVersionSelection.pinned(self.at_version)
 
         def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
             LOGGER.info("Applied filter %s %s", self.my_attr, self.other_attr)
@@ -1828,7 +1895,10 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
     assert result.code == 400
     assert result.result["data"]["data"] is None
     assert len(result.result["data"]["errors"]) == 1
-    assert result.result["data"]["errors"][0] == "Only one extension can determine version logic."
+    assert result.result["data"]["errors"][0] == (
+        "Multiple filter components tried to control version selection; at most one may: "
+        "an extension (via handles_version), or core (via isOrphan / modelVersion)."
+    )
 
     # Likewise for an extension and core (via isOrphan) both selecting the version.
     result = await client.graphql(query="""
@@ -1841,7 +1911,95 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
     assert result.code == 400
     assert result.result["data"]["data"] is None
     assert len(result.result["data"]["errors"]) == 1
-    assert result.result["data"]["errors"][0] == "Only one extension can determine version logic."
+    assert result.result["data"]["errors"][0] == (
+        "Multiple filter components tried to control version selection; at most one may: "
+        "an extension (via handles_version), or core (via isOrphan / modelVersion)."
+    )
+
+
+async def test_resources_count_path(server, environment, client, monkeypatch, mixed_resource_generator):
+    """
+    The resources query computes totalCount with an efficient ResourcePersistentState-only statement
+    only when every filter component keeps it valid. It falls back to counting the full version-aware query
+    (count_stmt is None) as soon as one component pins a model version or filters on the Resource table.
+
+    Both paths return the same totalCount, so this asserts the *path actually taken* by capturing the count_stmt the
+    resolver hands to get_connection.
+    """
+
+    @strawberry.input
+    class CountResourceFilter(ResourceFilterABC):
+        # With at_version unset the extension constrains nothing on the Resource table, so it keeps the fast count
+        # valid; with it set the extension takes over version selection by pinning, which disables the fast count.
+        at_version: int | None = strawberry.UNSET
+
+        def handles_version(self) -> bool:
+            return is_provided(self.at_version)
+
+        def resolve_model_version(self) -> ModelVersionSelection:
+            return ModelVersionSelection.pinned(self.at_version)
+
+        def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+            # Never constrains the Resource table.
+            return stmt
+
+        def allows_persistent_state_count(self) -> bool:
+            return not self.handles_version()
+
+    class CountContribution(GraphQLContribution):
+        @classmethod
+        def get_target_model(cls) -> type:
+            return models.Resource
+
+        @classmethod
+        def get_filter_input_class(cls) -> type[ResourceFilterABC] | None:
+            return CountResourceFilter
+
+    graphql_slice = server.get_slice(SLICE_GRAPHQL)
+    assert isinstance(graphql_slice, GraphQLSlice)
+    # The slice already started, so reset its schema to register a contribution and rebuild.
+    graphql_slice.schema = None
+    graphql_slice.register_graphql_contribution_for_extension("count", CountContribution)
+    await graphql_slice.start()
+
+    await mixed_resource_generator(environment, 1, 6)
+
+    # Capture the count_stmt the resolver builds and hands to get_connection: None -> full version-aware fallback,
+    # a ResourcePersistentState-only select -> efficient path.
+    captured: list[object] = []
+    real_get_connection = graphql_schema.get_connection
+
+    async def spy_get_connection(*args: object, **kwargs: object) -> object:
+        captured.append(kwargs.get("count_stmt"))
+        return await real_get_connection(*args, **kwargs)
+
+    monkeypatch.setattr(graphql_schema, "get_connection", spy_get_connection)
+
+    async def is_count_path_efficient(extra_filter: str) -> bool:
+        captured.clear()
+        query = """
+        {
+            resources (filter: {environment: "%s" %s}) {
+                totalCount
+                edges {
+                    node {
+                        resourceId
+                        }
+                    }
+            }
+        }
+        """ % (environment, extra_filter)
+        result = await client.graphql(query=query)
+        check_correct_graphql_response(result)
+        assert len(captured) == 1, "expected exactly one resources query"
+        count_stmt = captured[0]
+        return count_stmt is not None
+
+    assert await is_count_path_efficient('agent: {eq: ["agent0"]}')
+    assert await is_count_path_efficient("isOrphan: false")
+    assert not await is_count_path_efficient("purged: false")
+    assert not await is_count_path_efficient("modelVersion: 1")
+    assert not await is_count_path_efficient("atVersion: 1")
 
 
 async def test_custom_extension_environment_filter(server, client, project_default, caplog):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1793,7 +1793,7 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
         def resolve_model_version(self) -> ModelVersionSelection:
             # Pin every resource to the requested version of the model -- no join boilerplate, the resolver joins.
             LOGGER.info("Applied version filter %s", self.at_version)
-            return ModelVersionSelection.pinned(self.at_version)
+            return ModelVersionSelection.create_for_exact_version(self.at_version)
 
         def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
             LOGGER.info("Applied filter %s %s", self.my_attr, self.other_attr)
@@ -1931,7 +1931,7 @@ async def test_resources_count_path(server, environment, client, monkeypatch, mi
             return is_provided(self.at_version)
 
         def resolve_model_version(self) -> ModelVersionSelection:
-            return ModelVersionSelection.pinned(self.at_version)
+            return ModelVersionSelection.create_for_exact_version(self.at_version)
 
         def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
             # Never constrains the Resource table.

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1635,16 +1635,12 @@ async def test_query_resources_model_version(server, client, environment, setup_
     """
     instances = 2
     resources_per_version = 10
-    orphans = resources_per_version // 2
+    orphans = resources_per_version / 2
     total_resources_in_latest_version = resources_per_version * instances
     await mixed_resource_generator(environment, instances, resources_per_version)
 
-    # mixed_resource_generator creates 2 versions per instance (agent). With 2 instances this gives us
-    # the following configuration model versions (each agent owns resource set "set<agent_index>"):
-    #   v1: full compile, set0 created with <resources_per_version> resources (agent0)
-    #   v2: put_partial, set0 updated -> <resources_per_version> resources, the un-updated half becomes orphaned
-    #   v3: put_partial, set1 created with <resources_per_version> resources (agent1), set0 unchanged
-    #   v4: put_partial, set1 updated -> <resources_per_version> resources, the un-updated half becomes orphaned
+    # mixed_resource_generator creates 2 versions per instance (agent).
+    # With 2 instances this gives us 4 configuration model versions:
     latest_version = instances * 2
 
     async def query_resources(extra_filter: str) -> dict[str, object]:
@@ -1695,15 +1691,14 @@ async def test_query_resources_model_version(server, client, environment, setup_
     no_version = await query_resources("")
     assert no_version["totalCount"] == total_resources_in_latest_version + orphans * instances
 
-    # v1: only set0 (agent0) exists, with its original resources. Note that a specific version is returned as-is:
-    # it includes resources that are orphaned in the latest model (ids "5" .. "9"), regardless of their current
-    # orphan state.
+    # v1: only set0 (agent0) exists, with its original resources. Some of its resources were orphaned in the next version
     v1 = await query_resources("modelVersion: 1")
     assert_resources(v1, {("agent0", rid) for rid in original_ids})
     assert any(edge["node"]["state"]["isOrphan"] is True for edge in v1["edges"])
     assert any(edge["node"]["state"]["isOrphan"] is False for edge in v1["edges"])
 
-    # v2: set0 was recompiled (agent0 only), the upper half was replaced
+    # v2: set0 was recompiled (agent0 only).
+    # Only contains set0 resources as they appear on the latest model version (no orphans)
     v2 = await query_resources("modelVersion: 2")
     assert_resources(
         v2,
@@ -1720,7 +1715,7 @@ async def test_query_resources_model_version(server, client, environment, setup_
     assert any(edge["node"]["state"]["isOrphan"] is True for edge in v3["edges"])
     assert any(edge["node"]["state"]["isOrphan"] is False for edge in v3["edges"])
 
-    # v4 == latest: both sets recompiled. Equivalent to not specifying a version, but without the orphans, so
+    # v4 == latest. Equivalent to not specifying a version, but without the orphans, so
     # none of the returned resources are orphaned.
     latest_resources = {("agent0", rid) for rid in updated_ids} | {("agent1", rid) for rid in updated_ids}
     assert len(latest_resources) == total_resources_in_latest_version
@@ -1770,11 +1765,10 @@ async def test_query_resources_model_version(server, client, environment, setup_
 
 async def test_custom_extension_resource_filter(server, environment, client, caplog, mixed_resource_generator):
     """
-    Test that an extension can contribute its own resource filter fields (via
-    GraphQLContribution.get_filter_input_class): they are composed into the `resources` query's
-    ResourceFilter input, the extension's apply_filter runs alongside core's, and the extension can take over
-    version selection through handles_version / resolve_model_version (mutually exclusive with core's own
-    version selection).
+    Test that an extension can contribute its own resource filter fields: they are composed into the `resources` query's
+    ResourceFilter input, the extension's apply_filter runs after core's.
+    The extension can take over version selection through handles_version / resolve_model_version
+    (mutually exclusive with core's own version selection).
     """
 
     def get_example(root: "ExampleResourceMixin") -> str:
@@ -1852,7 +1846,7 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
         for edge in result.result["data"]["data"]["resources"]["edges"]:
             assert edge["node"]["example"] == "my-example"
 
-    orphans = resources_per_version // 2
+    orphans = resources_per_version / 2
 
     # When the extension provides `atVersion` its handles_version() returns True, so it takes over version selection
     # from core.

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -29,6 +29,7 @@ from inmanta.graphql.graphql import GraphQLSlice
 from inmanta.graphql.schema import (
     GraphQLContribution,
     ResourceFilterABC,
+    StrawberryFilter,
     _docstring_param_cache,
     build_composed_sqlalchemy_model,
     is_provided,
@@ -1103,12 +1104,13 @@ async def test_graphql_variables_and_operation_name(server, client, setup_databa
         }
     }
     """
-    # omit variables
+    # omit variables: the optional $environment is absent, so `id` is left unset and simply not filtered on -- rather
+    # than erroring. This is consistent with how every other filter field treats an unset value, and is what lets
+    # filters compose (a component only carries some of the composed filter's fields, see decompose_filter).
     result = await client.graphql(query=query)
-    assert result.code == 400
-    assert result.result["data"]["data"] is None
-    assert len(result.result["data"]["errors"]) == 1
-    assert result.result["data"]["errors"][0] == "Filter id was requested but no value was provided"
+    check_correct_graphql_response(result)
+    # `id` was not filtered on, so all environments are returned.
+    assert len(result.result["data"]["data"]["environments"]["edges"]) == 3
 
     # Test with multiple variables
     query = """
@@ -1678,7 +1680,7 @@ async def test_query_resources_model_version(server, client, environment, setup_
 async def test_custom_extension_resource_filter(server, environment, client, caplog, mixed_resource_generator):
     """
     Test that an extension can contribute its own resource filter fields (via
-    GraphQLContribution.get_resource_filter_input_class): they are composed into the `resources` query's
+    GraphQLContribution.get_filter_input_class): they are composed into the `resources` query's
     ResourceFilter input, the extension's apply_filter runs alongside core's, and the extension can take over
     version selection through handles_version / apply_version_filter (mutually exclusive with core's own
     version selection).
@@ -1729,7 +1731,7 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
             return ExampleResourceMixin
 
         @classmethod
-        def get_resource_filter_input_class(cls) -> type[ResourceFilterABC] | None:
+        def get_filter_input_class(cls) -> type[ResourceFilterABC] | None:
             return ExampleResourceFilter
 
     graphql_slice = server.get_slice(SLICE_GRAPHQL)
@@ -1823,3 +1825,61 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
     assert result.result["data"]["data"] is None
     assert len(result.result["data"]["errors"]) == 1
     assert result.result["data"]["errors"][0] == "Only one extension can determine version logic."
+
+
+async def test_custom_extension_environment_filter(server, client, project_default, caplog):
+    """
+    Filter composition is generic across object types, not resource-specific: an extension can contribute a filter
+    (via GraphQLContribution.get_filter_input_class) to the `environments` query too. Its fields are composed into the
+    EnvironmentFilter input and its apply_filter runs alongside core's.
+    """
+
+    @strawberry.input
+    class ExampleEnvironmentFilter(StrawberryFilter):
+        name_contains: str | None = strawberry.UNSET
+
+        def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+            LOGGER.info("Applied environment filter %s", self.name_contains)
+            if is_provided(self.name_contains):
+                stmt = stmt.where(models.Environment.name.ilike(f"%{self.name_contains}%"))
+            return stmt
+
+    class ExampleEnvironmentContribution(GraphQLContribution):
+        @classmethod
+        def get_target_model(cls) -> type:
+            return models.Environment
+
+        @classmethod
+        def get_filter_input_class(cls) -> type[StrawberryFilter] | None:
+            return ExampleEnvironmentFilter
+
+    graphql_slice = server.get_slice(SLICE_GRAPHQL)
+    assert isinstance(graphql_slice, GraphQLSlice)
+    # GraphQLSlice has already started, so we reset its schema to make registering possible again for this test.
+    graphql_slice.schema = None
+    graphql_slice.register_graphql_contribution_for_extension("example", ExampleEnvironmentContribution)
+    await graphql_slice.start()
+
+    for name in ("alpha", "alpine", "beta"):
+        result = await client.environment_create(project_id=project_default, name=name)
+        assert result.code == 200
+
+    # The contributed field filters the environments query, alongside core sorting.
+    with caplog.at_level(logging.INFO):
+        result = await client.graphql(query="""
+            {
+                environments (filter: {nameContains: "alp"}) {
+                    edges { node { name } }
+                }
+            }
+            """)
+        check_correct_graphql_response(result)
+        log_contains(caplog, __name__, logging.INFO, "Applied environment filter alp")
+    names = {edge["node"]["name"] for edge in result.result["data"]["data"]["environments"]["edges"]}
+    assert names == {"alpha", "alpine"}
+
+    # The filter is optional: without it, all environments are returned.
+    result = await client.graphql(query="{ environments { edges { node { name } } } }")
+    check_correct_graphql_response(result)
+    all_names = {edge["node"]["name"] for edge in result.result["data"]["data"]["environments"]["edges"]}
+    assert {"alpha", "alpine", "beta"} <= all_names

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1846,9 +1846,7 @@ async def test_custom_extension_resource_filter(server, environment, client, cap
 
 async def test_custom_extension_environment_filter(server, client, project_default, caplog):
     """
-    Filter composition is generic across object types, not resource-specific: an extension can contribute a filter
-    (via GraphQLContribution.get_filter_input_class) to the `environments` query too. Its fields are composed into the
-    EnvironmentFilter input and its apply_filter runs alongside core's.
+    Validate that we can extend the environment filter with additional filter logic.
     """
 
     @strawberry.input
@@ -1886,7 +1884,11 @@ async def test_custom_extension_environment_filter(server, client, project_defau
         result = await client.graphql(query="""
             {
                 environments (filter: {nameContains: "alp"}) {
-                    edges { node { name } }
+                    edges {
+                        node {
+                            name
+                            }
+                        }
                 }
             }
             """)
@@ -1894,12 +1896,6 @@ async def test_custom_extension_environment_filter(server, client, project_defau
         log_contains(caplog, __name__, logging.INFO, "Applied environment filter alp")
     names = {edge["node"]["name"] for edge in result.result["data"]["data"]["environments"]["edges"]}
     assert names == {"alpha", "alpine"}
-
-    # The filter is optional: without it, all environments are returned.
-    result = await client.graphql(query="{ environments { edges { node { name } } } }")
-    check_correct_graphql_response(result)
-    all_names = {edge["node"]["name"] for edge in result.result["data"]["data"]["environments"]["edges"]}
-    assert {"alpha", "alpine", "beta"} <= all_names
 
 
 async def test_custom_extension_filter_field_collision(server):
@@ -1936,7 +1932,8 @@ async def test_custom_extension_filter_field_collision(server):
 
 async def test_custom_extension_filter_validation(server, client, project_default):
     """
-    Validate that an error is raised if a filter, contributed by extension, rejects an invalid filter combination using its validate_filter method.
+    Validate that an error is raised if a filter, contributed by extension,
+    rejects an invalid filter combination using its validate_filter method.
     """
 
     @strawberry.input

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -28,8 +28,10 @@ from inmanta.deploy import state
 from inmanta.graphql.graphql import GraphQLSlice
 from inmanta.graphql.schema import (
     GraphQLContribution,
+    ResourceFilterABC,
     _docstring_param_cache,
     build_composed_sqlalchemy_model,
+    is_provided,
     mapper,
     to_snake_case,
 )
@@ -37,7 +39,7 @@ from inmanta.protocol import Result
 from inmanta.server import SLICE_COMPILER, SLICE_GRAPHQL
 from inmanta.server.services.compilerservice import CompilerService
 from inmanta.util import retry_limited
-from sqlalchemy import Select, literal, select, true
+from sqlalchemy import Select, and_, literal, select, true
 from sqlalchemy.orm import query_expression, with_expression
 from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyMapper
 from strawberry_sqlalchemy_mapper.mapper import _GENERATED_FIELD_KEYS_KEY
@@ -1546,3 +1548,278 @@ async def test_extension_registers_multiple_contributions(server, environment, c
     assert len(environment_edges) > 0
     for edge in environment_edges:
         assert edge["node"]["environmentExample"] == "environment-example"
+
+
+async def test_query_resources_model_version(server, client, environment, setup_database, mixed_resource_generator):
+    """
+    Test that filtering the resource query on `modelVersion` returns the resources as present in that specific
+    version of the model, instead of the latest released version.
+
+    We include setup_database to have some resources in other envs to make sure we don't leak across environments.
+    """
+    instances = 2
+    resources_per_version = 10
+    orphans = resources_per_version // 2
+    total_resources_in_latest_version = resources_per_version * instances
+    await mixed_resource_generator(environment, instances, resources_per_version)
+
+    # mixed_resource_generator creates 2 versions per instance (agent). With 2 instances this gives us
+    # the following configuration model versions (each agent owns resource set "set<agent_index>"):
+    #   v1: full compile, set0 created with <resources_per_version> resources (agent0)
+    #   v2: put_partial, set0 updated -> <resources_per_version> resources, the un-updated half becomes orphaned
+    #   v3: put_partial, set1 created with <resources_per_version> resources (agent1), set0 unchanged
+    #   v4: put_partial, set1 updated -> <resources_per_version> resources, the un-updated half becomes orphaned
+    latest_version = instances * 2
+
+    async def query_resources(extra_filter: str) -> dict[str, object]:
+        query = """
+        {
+            resources (filter: {environment: "%s" %s}) {
+                totalCount
+                edges {
+                    node {
+                      resourceId
+                      agent
+                      resourceIdValue
+                      state {
+                        isOrphan
+                      }
+                    }
+                }
+            }
+        }
+        """ % (
+            environment,
+            extra_filter,
+        )
+        result = await client.graphql(query=query)
+        check_correct_graphql_response(result)
+        return result.result["data"]["data"]["resources"]
+
+    def assert_resources(connection: dict[str, object], expected: set[tuple[str, str]]) -> None:
+        """
+        Assert that the connection contains exactly the (agent, resourceIdValue) tuples in `expected`,
+        and that totalCount is consistent with the number of returned edges.
+        """
+        actual = {(edge["node"]["agent"], edge["node"]["resourceIdValue"]) for edge in connection["edges"]}
+        assert actual == expected
+        assert len(connection["edges"]) == len(expected)
+        # totalCount must take the modelVersion filter into account, just like the returned edges
+        assert connection["totalCount"] == len(expected)
+
+    # The original resource set has resourceIdValue "0" .. "<resources_per_version - 1>".
+    # When a set is recompiled (iteration 1), the upper half is replaced by new resources with ids "15" .. "19"
+    # and the lower half ("0" .. "4") is kept. The replaced resources ("5" .. "9") become orphans.
+    original_ids = {str(i) for i in range(resources_per_version)}
+    updated_ids = {str(i) for i in range(resources_per_version // 2)} | {
+        str(i + 10) for i in range(resources_per_version // 2, resources_per_version)
+    }
+
+    # Sanity check: without modelVersion we get the latest version of each set + the orphans
+    no_version = await query_resources("")
+    assert no_version["totalCount"] == total_resources_in_latest_version + orphans * instances
+
+    # v1: only set0 (agent0) exists, with its original resources. Note that a specific version is returned as-is:
+    # it includes resources that are orphaned in the latest model (ids "5" .. "9"), regardless of their current
+    # orphan state.
+    v1 = await query_resources("modelVersion: 1")
+    assert_resources(v1, {("agent0", rid) for rid in original_ids})
+    assert any(edge["node"]["state"]["isOrphan"] is True for edge in v1["edges"])
+    assert any(edge["node"]["state"]["isOrphan"] is False for edge in v1["edges"])
+
+    # v2: set0 was recompiled (agent0 only), the upper half was replaced
+    assert_resources(
+        await query_resources("modelVersion: 2"),
+        {("agent0", rid) for rid in updated_ids},
+    )
+
+    # v3: set1 (agent1) was added with its original resources, set0 is unchanged from v2
+    assert_resources(
+        await query_resources("modelVersion: 3"),
+        {("agent0", rid) for rid in updated_ids} | {("agent1", rid) for rid in original_ids},
+    )
+
+    # v4 == latest: both sets recompiled. Equivalent to not specifying a version, but without the orphans, so
+    # none of the returned resources are orphaned.
+    latest_resources = {("agent0", rid) for rid in updated_ids} | {("agent1", rid) for rid in updated_ids}
+    assert len(latest_resources) == total_resources_in_latest_version
+    latest = await query_resources(f"modelVersion: {latest_version}")
+    assert_resources(latest, latest_resources)
+    assert all(edge["node"]["state"]["isOrphan"] is False for edge in latest["edges"])
+
+    # modelVersion combines with other filters: only agent0 resources are present in v1
+    assert_resources(
+        await query_resources('modelVersion: 1 agent: {eq: ["agent0"]}'),
+        {("agent0", rid) for rid in original_ids},
+    )
+    assert_resources(await query_resources('modelVersion: 1 agent: {eq: ["agent1"]}'), set())
+
+    # A version that does not exist yields no resources
+    assert_resources(await query_resources(f"modelVersion: {latest_version + 1}"), set())
+
+    # modelVersion and isOrphan are mutually exclusive: a specific version is returned as-is, so filtering it by
+    # the current orphan state is not allowed and results in an error.
+    for orphan_value in ("true", "false"):
+        result = await client.graphql(query="""
+            {
+                resources (filter: {environment: "%s" modelVersion: 1 isOrphan: %s}) {
+                    totalCount
+                    edges { node { resourceId } }
+                }
+            }
+            """ % (environment, orphan_value))
+        assert result.code == 400
+        data = result.result["data"]
+        assert data["data"] is None
+        assert len(data["errors"]) == 1
+        assert data["errors"][0] == "is_orphan cannot be provided when filtering by model_version"
+
+
+async def test_custom_extension_resource_filter(server, environment, client, caplog, mixed_resource_generator):
+    """
+    Test that an extension can contribute its own resource filter fields (via
+    GraphQLContribution.get_resource_filter_input_class): they are composed into the `resources` query's
+    ResourceFilter input, the extension's apply_filter runs alongside core's, and the extension can take over
+    version selection through handles_version / apply_version_filter (mutually exclusive with core's own
+    version selection).
+    """
+
+    def get_example(root: "ExampleResourceMixin") -> str:
+        assert hasattr(root, "attributes")  # Make mypy happy
+        return "my-example"
+
+    class ExampleResourceMixin:
+        """Mixin merged into the Resource output type."""
+
+        example: str = strawberry.field(resolver=get_example, description="Checks if this mixin was loaded")
+
+    @strawberry.input
+    class ExampleResourceFilter(ResourceFilterABC):
+        my_attr: str | None = strawberry.UNSET
+        other_attr: str | None = strawberry.UNSET
+        at_version: int | None = strawberry.UNSET
+
+        def handles_version(self) -> bool:
+            # This extension takes over version selection from core when `at_version` is provided.
+            return is_provided(self.at_version)
+
+        def apply_version_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+            # Pin every resource set to the requested version of the model.
+            LOGGER.info("Applied version filter %s", self.at_version)
+            return stmt.join(
+                models.t_resource_set_configuration_model,
+                and_(
+                    models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
+                    models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
+                    models.t_resource_set_configuration_model.c.model == self.at_version,
+                ),
+            )
+
+        def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+            LOGGER.info("Applied filter %s %s", self.my_attr, self.other_attr)
+            return stmt
+
+    class ExampleQueryContribution(GraphQLContribution):
+        @classmethod
+        def get_target_model(cls) -> type:
+            return models.Resource
+
+        @classmethod
+        def get_graphql_output_type_mixin(cls) -> type | None:
+            return ExampleResourceMixin
+
+        @classmethod
+        def get_resource_filter_input_class(cls) -> type[ResourceFilterABC] | None:
+            return ExampleResourceFilter
+
+    graphql_slice = server.get_slice(SLICE_GRAPHQL)
+    assert isinstance(graphql_slice, GraphQLSlice)
+
+    # GraphQLSlice has already started, so we reset its schema to make registering possible again for this test.
+    graphql_slice.schema = None
+    graphql_slice.register_graphql_contribution_for_extension("example", ExampleQueryContribution)
+    await graphql_slice.start()
+
+    instances = 1
+    resources_per_version = 6
+    await mixed_resource_generator(environment, instances, resources_per_version)
+
+    query = """
+        {
+            resources ( filter: {environment: "%s" myAttr: "my_value"}
+                orderBy: [{key: "compliance" order: "asc"}]) {
+                edges {
+                    node {
+                      example
+                      state{
+                        compliance
+                      }
+                    }
+                }
+            }
+        }
+        """ % environment
+    with caplog.at_level(logging.INFO):
+        result = await client.graphql(query=query)
+        check_correct_graphql_response(result)
+        log_contains(caplog, __name__, logging.INFO, "Applied filter my_value")
+        for edge in result.result["data"]["data"]["resources"]["edges"]:
+            assert edge["node"]["example"] == "my-example"
+
+    orphans = resources_per_version // 2
+
+    # When the extension provides `atVersion` its handles_version() returns True, so it takes over version selection
+    # from core.
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        result = await client.graphql(query="""
+            {
+                resources (filter: {environment: "%s" atVersion: 1}) {
+                    totalCount
+                    edges { node { resourceIdValue } }
+                }
+            }
+            """ % environment)
+        check_correct_graphql_response(result)
+        log_contains(caplog, __name__, logging.INFO, "Applied version filter 1")
+    at_version_1 = result.result["data"]["data"]["resources"]
+    assert at_version_1["totalCount"] == resources_per_version
+    assert {edge["node"]["resourceIdValue"] for edge in at_version_1["edges"]} == {str(i) for i in range(resources_per_version)}
+
+    # Without `atVersion` the extension does not handle the version (handles_version() is False), so core selects
+    # the version by default: the latest version plus the orphaned resources.
+    result = await client.graphql(query="""
+        {
+            resources (filter: {environment: "%s"}) {
+                totalCount
+            }
+        }
+        """ % environment)
+    check_correct_graphql_response(result)
+    assert result.result["data"]["data"]["resources"]["totalCount"] == resources_per_version + orphans
+
+    # An extension and core (via modelVersion) both trying to select the version is rejected.
+    result = await client.graphql(query="""
+        {
+            resources (filter: {environment: "%s" atVersion: 1 modelVersion: 2}) {
+                totalCount
+            }
+        }
+        """ % environment)
+    assert result.code == 400
+    assert result.result["data"]["data"] is None
+    assert len(result.result["data"]["errors"]) == 1
+    assert result.result["data"]["errors"][0] == "Only one extension can determine version logic."
+
+    # Likewise for an extension and core (via isOrphan) both selecting the version.
+    result = await client.graphql(query="""
+        {
+            resources (filter: {environment: "%s" atVersion: 1 isOrphan: true}) {
+                totalCount
+            }
+        }
+        """ % environment)
+    assert result.code == 400
+    assert result.result["data"]["data"] is None
+    assert len(result.result["data"]["errors"]) == 1
+    assert result.result["data"]["errors"][0] == "Only one extension can determine version logic."

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1936,8 +1936,7 @@ async def test_custom_extension_filter_field_collision(server):
 
 async def test_custom_extension_filter_validation(server, client, project_default):
     """
-    validate_filter is available on every filter, not just resources: an extension contributing a filter to the
-    (non-resource) `environments` query can reject invalid field combinations, and the error is surfaced to the user.
+    Validate that an error is raised if a filter, contributed by extension, rejects an invalid filter combination using its validate_filter method.
     """
 
     @strawberry.input

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1630,16 +1630,21 @@ async def test_query_resources_model_version(server, client, environment, setup_
     assert any(edge["node"]["state"]["isOrphan"] is False for edge in v1["edges"])
 
     # v2: set0 was recompiled (agent0 only), the upper half was replaced
+    v2 = await query_resources("modelVersion: 2")
     assert_resources(
-        await query_resources("modelVersion: 2"),
+        v2,
         {("agent0", rid) for rid in updated_ids},
     )
+    assert all(edge["node"]["state"]["isOrphan"] is False for edge in v2["edges"])
 
     # v3: set1 (agent1) was added with its original resources, set0 is unchanged from v2
+    v3 = await query_resources("modelVersion: 3")
     assert_resources(
-        await query_resources("modelVersion: 3"),
+        v3,
         {("agent0", rid) for rid in updated_ids} | {("agent1", rid) for rid in original_ids},
     )
+    assert any(edge["node"]["state"]["isOrphan"] is True for edge in v3["edges"])
+    assert any(edge["node"]["state"]["isOrphan"] is False for edge in v3["edges"])
 
     # v4 == latest: both sets recompiled. Equivalent to not specifying a version, but without the orphans, so
     # none of the returned resources are orphaned.

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -40,7 +40,7 @@ from inmanta.protocol import Result
 from inmanta.server import SLICE_COMPILER, SLICE_GRAPHQL
 from inmanta.server.services.compilerservice import CompilerService
 from inmanta.util import retry_limited
-from sqlalchemy import Select, and_, literal, select, true
+from sqlalchemy import Select, and_, func, literal, select, true
 from sqlalchemy.orm import query_expression, with_expression
 from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyMapper
 from strawberry_sqlalchemy_mapper.mapper import _GENERATED_FIELD_KEYS_KEY
@@ -1895,3 +1895,81 @@ async def test_custom_extension_environment_filter(server, client, project_defau
     check_correct_graphql_response(result)
     all_names = {edge["node"]["name"] for edge in result.result["data"]["data"]["environments"]["edges"]}
     assert {"alpha", "alpine", "beta"} <= all_names
+
+
+async def test_custom_extension_filter_field_collision(server):
+    """
+    A contributed filter field whose name collides with a core field (or another extension's) is rejected when the
+    schema is built. The composed filter input is built by multiple inheritance, so a collision would silently
+    merge the two fields into one; detecting it up front surfaces the misconfigured extension instead.
+    """
+
+    @strawberry.input
+    class CollidingEnvironmentFilter(StrawberryFilter):
+        # `id` already exists on CoreEnvironmentFilter.
+        id: uuid.UUID | None = strawberry.UNSET
+
+        def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+            return stmt
+
+    class CollidingContribution(GraphQLContribution):
+        @classmethod
+        def get_target_model(cls) -> type:
+            return models.Environment
+
+        @classmethod
+        def get_filter_input_class(cls) -> type[StrawberryFilter] | None:
+            return CollidingEnvironmentFilter
+
+    graphql_slice = server.get_slice(SLICE_GRAPHQL)
+    assert isinstance(graphql_slice, GraphQLSlice)
+    graphql_slice.schema = None
+    graphql_slice.register_graphql_contribution_for_extension("example", CollidingContribution)
+    with pytest.raises(Exception, match="id defined more than once in Environment filters."):
+        await graphql_slice.start()
+
+
+async def test_custom_extension_filter_validation(server, client, project_default):
+    """
+    validate_filter is available on every filter, not just resources: an extension contributing a filter to the
+    (non-resource) `environments` query can reject invalid field combinations, and the error is surfaced to the user.
+    """
+
+    @strawberry.input
+    class ValidatingEnvironmentFilter(StrawberryFilter):
+        min_name_length: int | None = strawberry.UNSET
+
+        def validate_filter(self) -> None:
+            if is_provided(self.min_name_length) and self.min_name_length < 0:
+                raise ValueError("minNameLength must not be negative")
+
+        def apply_filter[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]]:
+            if is_provided(self.min_name_length):
+                stmt = stmt.where(func.length(models.Environment.name) >= self.min_name_length)
+            return stmt
+
+    class ValidatingContribution(GraphQLContribution):
+        @classmethod
+        def get_target_model(cls) -> type:
+            return models.Environment
+
+        @classmethod
+        def get_filter_input_class(cls) -> type[StrawberryFilter] | None:
+            return ValidatingEnvironmentFilter
+
+    graphql_slice = server.get_slice(SLICE_GRAPHQL)
+    assert isinstance(graphql_slice, GraphQLSlice)
+    graphql_slice.schema = None
+    graphql_slice.register_graphql_contribution_for_extension("example", ValidatingContribution)
+    await graphql_slice.start()
+
+    # An invalid value is rejected by validate_filter (proving it runs for non-resource filters too).
+    result = await client.graphql(query="{ environments (filter: {minNameLength: -1}) { edges { node { name } } } }")
+    assert result.code == 400
+    assert result.result["data"]["data"] is None
+    assert len(result.result["data"]["errors"]) == 1
+    assert result.result["data"]["errors"][0] == "minNameLength must not be negative"
+
+    # A valid value passes validation and is applied.
+    result = await client.graphql(query="{ environments (filter: {minNameLength: 0}) { edges { node { name } } } }")
+    check_correct_graphql_response(result)


### PR DESCRIPTION
closes: #10476
closes: #10475 

# Description

Lets extensions (e.g. LSM) contribute their own filter fields to the GraphQL queries, composed generically into each query's filter input. Builds on the already-merged output-field contribution mechanism (`GraphQLContribution` / `populate_sqlalchemy_columns`) — this adds the *filter* side, following the same generic, per-object-type pattern (keyed by `get_target_model`), not just for `resources`.

This is the filter-composition part of #10328, rebuilt on current master (most of that PR — the output-field contribution mechanism and the `is_provided` helper — is already merged, and the `GraphQLContribution` API has since been rewritten, so the original diff no longer applies).

The only end-user-visible change is the new `modelVersion` filter on the `resources` query (the changelog surfaces just that under `minor-improvement`); the filter-composition mechanism itself is extension-facing plumbing.

## What changed

- New generic hook `GraphQLContribution.get_filter_input_class()` returning a `@strawberry.input` filter class, merged into the target object type's filter input — the filter-side analogue of `get_graphql_output_type_mixin`.
- The registry now carries each object type's core building blocks (`ContributableGraphQLType`: `core_mixin` + `core_filter` + `base_filter`). The existing `EnvironmentFilter` / `NotificationFilter` are renamed to `CoreEnvironmentFilter` / `CoreNotificationFilter`; the composed inputs keep the user-facing `EnvironmentFilter` / `NotificationFilter` / `ResourceFilter` names, so **the exposed GraphQL schema is unchanged** (for the no-extension case). Each contributed filter is validated to subclass the type's `base_filter`, and duplicate field names across components are rejected.
- Generic `get_filter_components` / `build_composed_filter_input` compose each type's filter by multiple inheritance; `get_schema` builds every type's composed filter in the same loop as its output type; each resolver decomposes the received value back into components and validates them (`decompose_and_validate_filter`), then applies each `apply_filter`.
- Resources additionally split into `ResourceFilterABC` (shared base + version-selection hooks) and `CoreResourceFilter`. Version selection is delegated and expressed as data: at most one component may take it over via `handles_version()`, and that component returns a `ModelVersionSelection` (`pinned` / `latest`) from `resolve_model_version()` (an extension, else core by default). The resolver applies the version join once and records the selection on the query (`resolved_model_version` execution option), so contributions can resolve version-dependent data (output columns, filters) at the same version the resources are taken at. Core also exposes a new `modelVersion` filter to fetch resources as present in a specific model version. Since a specific version is returned as-is, `modelVersion` is mutually exclusive with the current-state filters (`isOrphan`, `isDeploying`, `blocked`, `compliance`, `lastHandlerRun`), which reflect a resource's current, unversioned state.
- New extension-facing hook `ResourceFilterABC.allows_persistent_state_count()`: a single predicate a filter component uses to keep the `resources` query's efficient `ResourcePersistentState`-only count valid. It replaces two overlapping concerns (version-selection validity + filtering on the `Resource` table) — the fast count is used only when every component allows it (no pinned historical version, and no `apply_filter` constraining the `Resource` table); otherwise the resolver falls back to counting the full version-aware query. Default is the conservative `False`.
- `StrawberryFilter.get_filter_dict` now skips `UNSET` fields instead of raising, so a component only carrying some of the composed filter's fields composes cleanly — consistent with how the resource filter already treats `UNSET`. One existing test relied on the old raise-on-omitted-optional-variable behaviour; it's updated to the new (skip) behaviour.

The previous orphan/latest-version CTE logic is now expressed through `CoreResourceFilter.resolve_model_version` (`ModelVersionSelection.latest`); behaviour for the existing filters (incl. `isOrphan`) is unchanged.

## Tests

- `test_query_resources_model_version` — the new `modelVersion` filter across model versions, orphans and combined filters (incl. the rejected combinations with current-state filters), asserting `totalCount` tracks the filter.
- `test_resources_count_path` — asserts the actual count path the resolver takes (efficient `ResourcePersistentState`-only vs. full version-aware fallback) by capturing the count statement: RPS-only filters and `isOrphan` stay efficient, while `purged` (Resource-table filter), `modelVersion` (pinned), and an extension taking over version selection each force the fallback. Also covers an extension whose `allows_persistent_state_count()` returns `True` keeping the fast count valid.
- `test_custom_extension_resource_filter` — an extension contributing a resource filter: its `apply_filter` runs, it can take over version selection via `atVersion` (`handles_version` / `resolve_model_version`), and conflicting version handlers (extension + core `modelVersion`/`isOrphan`) are rejected.
- `test_resolved_model_version_available_to_contributions` — a contribution reads back the resolved model version via `resolved_model_version(stmt)` and resolves a version-dependent output column at that same version.
- `test_custom_extension_environment_filter` — an extension contributing a filter to the (non-resource) `environments` query, proving the mechanism is generic.
- `test_custom_extension_filter_field_collision` / `test_custom_extension_filter_validation` — collision detection when composing filters, and that `validate_filter` runs for non-resource filters too.
- `test_custom_extension_contributions` / `test_extension_registers_multiple_contributions` — registration bookkeeping and multiple contributions per extension.

Full `tests/test_graphql.py` passes; `mypy` (no new baseline entries) and `flake8` clean.

> Note: the companion `inmanta-lsm` change (its resource filter migrated to the new `resolve_model_version` / `allows_persistent_state_count` hooks) is in a separate LSM PR and is not part of this one.

# Self Check:

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)