### PR TITLE
Allow a break-glass database user under auth_method=oidc

### DIFF
--- a/changelogs/unreleased/allow-breakglass-db-user-under-oidc.yml
+++ b/changelogs/unreleased/allow-breakglass-db-user-under-oidc.yml
@@ -1,0 +1,5 @@
+description: The inmanta-initial-user-setup tool can now provision a database (break-glass) admin user while auth_method is oidc or jwt, so the web-console local login fallback has an account to use when the identity provider is unavailable.
+change-type: minor
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/user_setup.py
+++ b/src/inmanta/user_setup.py
@@ -67,14 +67,24 @@ def validate_server_setup() -> None:
 
         click.echo(f"{'Server authentication: ' : <50}{click.style('enabled', fg='green')}")
 
-        # make sure the method is set to database
-        if server_config.server_auth_method.get() != "database":
+        # The database user is the primary credential when auth_method=database, and a break-glass
+        # fallback account when auth_method is oidc or jwt (used via the web-console local login
+        # fallback). Any other value is rejected to catch typos.
+        auth_method = server_config.server_auth_method.get()
+        allowed_auth_methods = ("database", "oidc", "jwt")
+        if auth_method not in allowed_auth_methods:
             raise click.ClickException(
-                "The server authentication method should be set to database to continue. Make sure auth_method in the server "
-                "section is set to database"
+                f"The server authentication method (auth_method in the server section) is '{auth_method}', "
+                f"expected one of {', '.join(allowed_auth_methods)}."
             )
 
-        click.echo(f"{'Server authentication method: ' : <50}{click.style('database', fg='green')}")
+        click.echo(f"{'Server authentication method: ' : <50}{click.style(auth_method, fg='green')}")
+
+        if auth_method != "database":
+            click.echo(
+                f"Note: auth_method is '{auth_method}'. Creating a break-glass database user for the web-console "
+                "local login fallback. Make sure web-ui.oidc_local_fallback is enabled so it can be used."
+            )
 
         # make sure there is auth config that supports signing tokens
         cfg = auth.AuthJWTConfig.get_sign_config()

--- a/tests/test_usersetup.py
+++ b/tests/test_usersetup.py
@@ -20,9 +20,11 @@ import asyncio
 import logging
 import os
 
+import pytest
 from click import testing
 
 from inmanta import data
+from inmanta.data.model import AuthMethod
 from inmanta.db.util import PGRestore
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.user_setup import cmd
@@ -101,27 +103,29 @@ async def test_user_setup(
     assert users[0].is_admin
 
 
-async def test_user_setup_oidc(
-    tmpdir, server_pre_start, postgres_db, postgresql_client, database_name, hard_clean_db, hard_clean_db_post
+@pytest.mark.parametrize("auth_method", ["oidc", "jwt"])
+async def test_user_setup_break_glass(
+    tmpdir, server_pre_start, postgres_db, postgresql_client, database_name, hard_clean_db, hard_clean_db_post, auth_method
 ):
     """
-    A break-glass database admin can be provisioned while auth_method is oidc, so the web-console
-    local login fallback has an account to log into when the IdP is unavailable.
+    A break-glass database admin can be provisioned while auth_method is oidc or jwt, so the web-console
+    local login fallback has an account to log into when the identity provider is unavailable.
     """
     ibl = InmantaBootloader(configure_logging=True)
     await ibl.start()
     await ibl.stop(timeout=20)
 
-    setup_config(tmpdir, postgres_db, database_name, auth_method="oidc")
+    setup_config(tmpdir, postgres_db, database_name, auth_method=auth_method)
     cli = CLI_user_setup()
 
-    result = await cli.run("yes", "breakglass", "password")
+    result = await cli.run("yes", "breakglass", "Str0ng-Pass!")
     assert result.exit_code == 0
 
     users = await data.User.get_list(connection=postgresql_client)
     assert len(users) == 1
     assert users[0].username == "breakglass"
     assert users[0].is_admin
+    assert users[0].auth_method == AuthMethod.database
 
 
 async def test_user_setup_invalid_auth_method(

--- a/tests/test_usersetup.py
+++ b/tests/test_usersetup.py
@@ -45,7 +45,7 @@ class CLI_user_setup:
         return result
 
 
-def setup_config(tmpdir, postgres_db, database_name):
+def setup_config(tmpdir, postgres_db, database_name, auth_method="database"):
     """
     set up the needed config to use usersetup
     """
@@ -54,7 +54,7 @@ def setup_config(tmpdir, postgres_db, database_name):
         f.write(f"""
     [server]
     auth=true
-    auth_method=database
+    auth_method={auth_method}
 
     [auth_jwt_default]
     algorithm=HS256
@@ -99,6 +99,45 @@ async def test_user_setup(
     assert len(users) == 1
     assert users[0].username == "new_user"
     assert users[0].is_admin
+
+
+async def test_user_setup_oidc(
+    tmpdir, server_pre_start, postgres_db, postgresql_client, database_name, hard_clean_db, hard_clean_db_post
+):
+    """
+    A break-glass database admin can be provisioned while auth_method is oidc, so the web-console
+    local login fallback has an account to log into when the IdP is unavailable.
+    """
+    ibl = InmantaBootloader(configure_logging=True)
+    await ibl.start()
+    await ibl.stop(timeout=20)
+
+    setup_config(tmpdir, postgres_db, database_name, auth_method="oidc")
+    cli = CLI_user_setup()
+
+    result = await cli.run("yes", "breakglass", "password")
+    assert result.exit_code == 0
+
+    users = await data.User.get_list(connection=postgresql_client)
+    assert len(users) == 1
+    assert users[0].username == "breakglass"
+    assert users[0].is_admin
+
+
+async def test_user_setup_invalid_auth_method(
+    tmpdir, server_pre_start, postgres_db, postgresql_client, database_name, hard_clean_db, hard_clean_db_post
+):
+    """An unknown auth_method value is rejected with a helpful error."""
+    ibl = InmantaBootloader(configure_logging=True)
+    await ibl.start()
+    await ibl.stop(timeout=20)
+
+    setup_config(tmpdir, postgres_db, database_name, auth_method="databse")
+    cli = CLI_user_setup()
+
+    result = await cli.run("yes", "new_user", "password")
+    assert result.exit_code == 1
+    assert "expected one of" in result.stderr
 
 
 async def test_user_setup_empty_username(


### PR DESCRIPTION
_Claude, opening this on behalf of @bartv._

## What
`inmanta-initial-user-setup` now accepts `auth_method` `oidc` and `jwt`, not only `database`, so a break-glass **database admin** can be provisioned while the server runs in OIDC mode. This is the backend prerequisite for the web-console database login fallback (an admin can then sign in locally when the identity provider is unavailable).

- The signing-config check is kept (login needs an HS256 issuer to mint a token).
- Unknown `auth_method` values are rejected with a helpful error.
- When `auth_method != database`, the tool prints a note that it is creating a break-glass account and points at `web-ui.oidc_local_fallback`.

## Tests
- `tests/test_usersetup.py`: added `test_user_setup_oidc` (creates an admin under `auth_method=oidc`) and `test_user_setup_invalid_auth_method`; existing tests still pass.
- `make mypy` clean, `flake8`/`black`/`isort` clean.

## Related
Part of the OIDC database-login fallback feature:
- inmanta-ui: emits the `localFallback` flag in `config.js`
- web-console: the fallback provider + user management under a fallback session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs / MRs
- inmanta-core: https://github.com/inmanta/inmanta-core/pull/10531 (stacked on #10529 `db-singleton-lock`)
- inmanta-ui: https://github.com/inmanta/inmanta-ui/pull/822
- web-console: https://github.com/inmanta/web-console/pull/7069
- local-setup (test harness): https://code.inmanta.com/inmanta/local-setup/-/merge_requests/48

> Note: this PR targets `db-singleton-lock` (#10529), not master. GitHub will retarget it to master once #10529 merges.