### PR TITLE
Redact passwords from logs/traces and add login audit logging

### DIFF
--- a/changelogs/unreleased/redact-passwords-and-login-audit-logging.yml
+++ b/changelogs/unreleased/redact-passwords-and-login-audit-logging.yml
@@ -1,0 +1,5 @@
+description: Passwords are no longer leaked into the server debug logs or tracing spans. The password parameters of the login, add_user and set_password API calls are now typed as pydantic SecretStr so their value is redacted wherever it is logged. In addition, every login attempt (success and failure) is now audit-logged with the username and source IP.
+change-type: minor
+destination-branches:
+  - master
+  - iso9

--- a/changelogs/unreleased/redact-passwords-and-login-audit-logging.yml
+++ b/changelogs/unreleased/redact-passwords-and-login-audit-logging.yml
@@ -1,4 +1,4 @@
-description: Passwords are no longer leaked into the server debug logs or tracing spans. The password parameters of the login, add_user and set_password API calls are now typed as pydantic SecretStr so their value is redacted wherever it is logged. In addition, every login attempt (success and failure) is now audit-logged with the username and source IP.
+description: Passwords are no longer leaked into the server debug logs or tracing spans for the development/lab only database authentication method. The password parameters of the login, add_user and set_password API calls are now typed as pydantic SecretStr so their value is redacted wherever it is logged. In addition, every login attempt (success and failure) is now audit-logged with the username and source IP.
 change-type: minor
 destination-branches:
   - master

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -79,12 +79,12 @@ V = typing_extensions.TypeVar("V", bound=types.SimpleTypes, covariant=True, defa
 class CallContext:
     """A context variable that provides more information about the current call context"""
 
-    request_headers: dict[str, str]
+    request_headers: Mapping[str, str]
     auth_token: Optional[auth.claim_type]
     auth_username: Optional[str]
 
     def __init__(
-        self, request_headers: dict[str, str], auth_token: Optional[auth.claim_type], auth_username: Optional[str]
+        self, request_headers: Mapping[str, str], auth_token: Optional[auth.claim_type], auth_username: Optional[str]
     ) -> None:
         self.request_headers = request_headers
         self.auth_token = auth_token
@@ -350,7 +350,19 @@ class InvalidMethodDefinition(Exception):
 
 
 VALID_URL_ARG_TYPES = (Enum, uuid.UUID, str, float, int, bool, datetime)
-VALID_SIMPLE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, bool, datetime, bytes, pydantic.AnyUrl)
+VALID_SIMPLE_ARG_TYPES = (
+    BaseModel,
+    Enum,
+    uuid.UUID,
+    str,
+    float,
+    int,
+    bool,
+    datetime,
+    bytes,
+    pydantic.AnyUrl,
+    pydantic.SecretStr,
+)
 
 
 class VersionMatch(str, Enum):
@@ -760,6 +772,14 @@ class MethodProperties(Generic[R]):
             for name, n in cnt.items():
                 if n > 1:
                     raise InvalidMethodDefinition(f"Union of argument {arg} can contain only one generic {name}")
+
+        elif isinstance(arg_type, type) and types.issubclass(
+            arg_type, VALID_URL_ARG_TYPES if in_url else VALID_SIMPLE_ARG_TYPES
+        ):
+            # A concrete class that is a valid simple type. This is checked before the generic
+            # branch because some concrete types (e.g. pydantic SecretStr) subclass a Generic base
+            # and would otherwise be misdetected as an unparameterized generic.
+            pass
 
         elif typing_inspect.is_generic_type(arg_type):
             orig = typing_inspect.get_origin(arg_type)

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -82,13 +82,21 @@ class CallContext:
     request_headers: Mapping[str, str]
     auth_token: Optional[auth.claim_type]
     auth_username: Optional[str]
+    # The peer IP of the connection (the direct client, or the reverse proxy when the API is
+    # fronted by one). None when it could not be determined (e.g. internal calls).
+    remote_ip: Optional[str]
 
     def __init__(
-        self, request_headers: Mapping[str, str], auth_token: Optional[auth.claim_type], auth_username: Optional[str]
+        self,
+        request_headers: Mapping[str, str],
+        auth_token: Optional[auth.claim_type],
+        auth_username: Optional[str],
+        remote_ip: Optional[str] = None,
     ) -> None:
         self.request_headers = request_headers
         self.auth_token = auth_token
         self.auth_username = auth_username
+        self.remote_ip = remote_ip
 
 
 class ArgOption:

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -23,6 +23,8 @@ import uuid
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal, Optional, Union
 
+from pydantic import SecretStr
+
 import inmanta.types
 from inmanta import const
 from inmanta.const import AgentAction, AllAgentAction, ApiDocsFormat, Change, ClientType, ParameterSource, ResourceState
@@ -1565,7 +1567,7 @@ def get_environment_metrics(
 
 
 @typedmethod(path="/login", operation="POST", client_types=[ClientType.api], enforce_auth=False, api_version=2)
-def login(username: str, password: str) -> ReturnValue[model.LoginReturn]:
+def login(username: str, password: SecretStr) -> ReturnValue[model.LoginReturn]:
     """Login a user.
 
      When the login succeeds an authentication header is returned with the Bearer token set.
@@ -1606,7 +1608,7 @@ def delete_user(username: str) -> None:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_WRITE, read_only=False)
 @typedmethod(path="/user", operation="POST", client_types=[ClientType.api], api_version=2)
-def add_user(username: str, password: str) -> model.User:
+def add_user(username: str, password: SecretStr) -> model.User:
     """Add a new user to the system
 
     :param username: The username of the new user. The username cannot be an empty string.
@@ -1618,7 +1620,7 @@ def add_user(username: str, password: str) -> model.User:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_CHANGE_PASSWORD, read_only=False)
 @typedmethod(path="/user/<username>/password", operation="PATCH", client_types=[ClientType.api], api_version=2)
-def set_password(username: str, password: str) -> None:
+def set_password(username: str, password: SecretStr) -> None:
     """Change the password of a user
 
     :param username: The username of the user

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -344,7 +344,7 @@ class CallArguments:
         # verify if we need to inject a CallContext
         if call_context_var := self.get_call_context():
             self._call_args[call_context_var] = common.CallContext(
-                request_headers=self._headers, auth_token=self._auth_token, auth_username=self._auth_username
+                request_headers=self._request_headers, auth_token=self._auth_token, auth_username=self._auth_username
             )
 
         self._processed = True

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -62,17 +62,20 @@ class CallArguments:
         config: common.UrlMethod,
         message: dict[str, Optional[object]],
         request_headers: Mapping[str, str],
+        remote_ip: Optional[str] = None,
     ) -> None:
         """
         :param config: The method configuration that contains the metadata and functions to call
         :param message: The message received by the RPC call
         :param request_headers: The headers received by the RPC call
+        :param remote_ip: The peer IP of the connection, or None when it could not be determined
         :param handler: The handler for the call
         """
         self._config = config
         self._properties = self._config.properties
         self._message = message
         self._request_headers = request_headers
+        self._remote_ip = remote_ip
         self._argspec: inspect.FullArgSpec = inspect.getfullargspec(self._properties.function)
 
         self._call_args: JsonType = {}
@@ -344,7 +347,10 @@ class CallArguments:
         # verify if we need to inject a CallContext
         if call_context_var := self.get_call_context():
             self._call_args[call_context_var] = common.CallContext(
-                request_headers=self._request_headers, auth_token=self._auth_token, auth_username=self._auth_username
+                request_headers=self._request_headers,
+                auth_token=self._auth_token,
+                auth_username=self._auth_username,
+                remote_ip=self._remote_ip,
             )
 
         self._processed = True
@@ -654,6 +660,7 @@ async def execute_call(
     config: common.UrlMethod | None,
     message: dict[str, object],
     request_headers: Mapping[str, str],
+    remote_ip: Optional[str] = None,
 ) -> common.Response:
     if config is None:
         raise Exception("This method is unknown! This should not occur!")
@@ -661,7 +668,7 @@ async def execute_call(
         # First check if the call is authenticated, then process the request so we can handle it and then authorize it.
         # Authorization might need data from the request but we do not want to process it before we are sure the call
         # is authenticated.
-        arguments = CallArguments(config, message, request_headers)
+        arguments = CallArguments(config, message, request_headers, remote_ip=remote_ip)
         is_auth_enabled: bool = endpoint.is_auth_enabled()
         arguments.authenticate(auth_enabled=is_auth_enabled)
         await arguments.process()

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -133,7 +133,9 @@ class RESTHandler(tornado.web.RequestHandler):
                             else:
                                 message[key] = [v.decode("latin-1") for v in value]
 
-                        result = await execute_call(self._transport, call_config, message, self.request.headers)
+                        result = await execute_call(
+                            self._transport, call_config, message, self.request.headers, remote_ip=self.request.remote_ip
+                        )
                         self.respond(result.body, result.headers, result.status_code)
                     except JSONDecodeError as e:
                         error_message = f"The request body couldn't be decoded as a JSON: {e}"

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -47,14 +47,16 @@ def verify_authentication_enabled() -> None:
 
 def _get_source_ip(context: common.CallContext) -> str:
     """
-    Best-effort source IP of the request for audit logging. The orchestrator is expected to run
-    behind a reverse proxy, so the client IP is taken from the X-Forwarded-For header.
+    Source of the request for audit logging. This is the connection peer IP, which is the client
+    for direct access (the common case for the web console) and the reverse proxy when the API is
+    fronted by one. In the latter case the originating client is reported by the proxy in the
+    X-Forwarded-For header, so it is appended when present.
     """
-    headers = context.request_headers
-    forwarded = headers.get("X-Forwarded-For") or headers.get("x-forwarded-for")
+    remote_ip = context.remote_ip or "unknown"
+    forwarded = context.request_headers.get("X-Forwarded-For") or context.request_headers.get("x-forwarded-for")
     if forwarded:
-        return forwarded.split(",")[0].strip()
-    return "unknown"
+        return f"{remote_ip} (X-Forwarded-For: {forwarded.split(',')[0].strip()})"
+    return remote_ip
 
 
 class UserService(server_protocol.ServerSlice):

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -21,6 +21,7 @@ import uuid
 from collections.abc import Mapping
 
 import asyncpg
+from pydantic import SecretStr
 
 import nacl.exceptions
 import nacl.pwhash
@@ -44,6 +45,18 @@ def verify_authentication_enabled() -> None:
         )
 
 
+def _get_source_ip(context: common.CallContext) -> str:
+    """
+    Best-effort source IP of the request for audit logging. The orchestrator is expected to run
+    behind a reverse proxy, so the client IP is taken from the X-Forwarded-For header.
+    """
+    headers = context.request_headers
+    forwarded = headers.get("X-Forwarded-For") or headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return "unknown"
+
+
 class UserService(server_protocol.ServerSlice):
     """Slice for managing users"""
 
@@ -61,15 +74,16 @@ class UserService(server_protocol.ServerSlice):
         return await data.User.list_users_with_roles()
 
     @protocol.handle(protocol.methods_v2.add_user)
-    async def add_user(self, username: str, password: str) -> model.User:
+    async def add_user(self, username: str, password: SecretStr) -> model.User:
         verify_authentication_enabled()
         if not username:
             raise exceptions.BadRequest("the username cannot be an empty string")
-        if not password or len(password) < MIN_PASSWORD_LENGTH:
+        secret = password.get_secret_value()
+        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
             raise exceptions.BadRequest("the password should be at least 8 characters long")
 
         # hash the password
-        pw_hash = nacl.pwhash.str(password.encode())
+        pw_hash = nacl.pwhash.str(secret.encode())
 
         # insert the user
         try:
@@ -93,9 +107,10 @@ class UserService(server_protocol.ServerSlice):
         await user.delete()
 
     @protocol.handle(protocol.methods_v2.set_password)
-    async def set_password(self, username: str, password: str) -> None:
+    async def set_password(self, username: str, password: SecretStr) -> None:
         verify_authentication_enabled()
-        if not password or len(password) < MIN_PASSWORD_LENGTH:
+        secret = password.get_secret_value()
+        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
             raise exceptions.BadRequest("the password should be at least 8 characters long")
         # check if the user already exists
         user = await data.User.get_one(username=username)
@@ -103,24 +118,30 @@ class UserService(server_protocol.ServerSlice):
             raise exceptions.NotFound(f"User with name {username} does not exist.")
 
         # hash the password
-        pw_hash = nacl.pwhash.str(password.encode())
+        pw_hash = nacl.pwhash.str(secret.encode())
 
         # insert the user
         await user.update_fields(password_hash=pw_hash.decode())
 
     @protocol.handle(protocol.methods_v2.login)
-    async def login(self, username: str, password: str) -> common.ReturnValue[model.LoginReturn]:
+    async def login(
+        self, username: str, password: SecretStr, context: common.CallContext
+    ) -> common.ReturnValue[model.LoginReturn]:
         verify_authentication_enabled()
+        source_ip = _get_source_ip(context)
         # check if the user exists
         invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
+            LOGGER.warning("Failed login for user '%s' from %s: no such user", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
         try:
-            nacl.pwhash.verify(user.password_hash.encode(), password.encode())
+            nacl.pwhash.verify(user.password_hash.encode(), password.get_secret_value().encode())
         except nacl.exceptions.InvalidkeyError:
+            LOGGER.warning("Failed login for user '%s' from %s: invalid password", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
 
+        LOGGER.info("Successful login for user '%s' from %s", username, source_ip)
         role_assignments: model.RoleAssignmentsPerEnvironment = await data.Role.get_roles_for_user(username)
 
         custom_claims: Mapping[str, str | bool | Mapping[str, list[str]]] = {

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -534,6 +534,11 @@ def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
     if isinstance(o, (uuid.UUID, pydantic.AnyUrl, pydantic_core.Url)):
         return str(o)
 
+    if isinstance(o, pydantic.SecretStr):
+        # Never serialize the secret value across a (de)serialization boundary (e.g. the policy
+        # engine input); emit the redacted form (str(SecretStr) == "**********").
+        return str(o)
+
     if isinstance(o, datetime.datetime):
         return o.isoformat(timespec="microseconds")
 

--- a/tests/protocol/test_protocol.py
+++ b/tests/protocol/test_protocol.py
@@ -980,7 +980,7 @@ async def test_method_definition():
 
     assert (
         "Type object of argument name must be one of BaseModel, Enum, UUID, str, float, int, bool, datetime, "
-        "bytes, AnyUrl or a List of these types or a Dict with str keys and values of these types."
+        "bytes, AnyUrl, SecretStr or a List of these types or a Dict with str keys and values of these types."
     ) in str(e.value)
 
     with pytest.raises(InvalidMethodDefinition) as e:
@@ -1005,7 +1005,7 @@ async def test_method_definition():
 
     assert (
         "Type object of argument name must be one of BaseModel, Enum, UUID, str, float, int, bool, datetime, "
-        "bytes, AnyUrl or a List of these types or a Dict with str keys and values of these types."
+        "bytes, AnyUrl, SecretStr or a List of these types or a Dict with str keys and values of these types."
     ) in str(e.value)
 
     @auth(auth_label=const.CoreAuthorizationLabel.TEST, read_only=False)

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -16,6 +16,8 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import logging
+
 import pytest
 
 import nacl.pwhash
@@ -125,6 +127,37 @@ async def test_login(server: protocol.Server, client: endpoints.Client, auth_cli
     response = await new_auth_client.list_users()
     assert response.code == 200
     assert response.result["data"][0]["username"] == "admin"
+
+
+async def test_login_audit_logging_and_redaction(
+    server: protocol.Server, client: endpoints.Client, auth_client: endpoints.Client, caplog
+) -> None:
+    """Login attempts are audit-logged and passwords are never written to the logs (SecretStr redaction)."""
+    password = "sup3r-s3cret-unique-pw"
+    wrong_password = "wrong-unique-pw"
+    response = await auth_client.add_user("admin", password)
+    assert response.code == 200
+
+    with caplog.at_level(logging.DEBUG):
+        response = await client.login("admin", wrong_password)
+        assert response.code == 401
+        response = await client.login("admin", password)
+        assert response.code == 200
+
+    # Every login attempt is audit-logged with the username.
+    assert any(
+        record.levelno == logging.WARNING and "Failed login for user 'admin'" in record.getMessage()
+        for record in caplog.records
+    )
+    assert any(
+        record.levelno == logging.INFO and "Successful login for user 'admin'" in record.getMessage()
+        for record in caplog.records
+    )
+
+    # The dispatcher logs the call arguments at debug level; the password must be redacted there.
+    login_call_logs = [record.getMessage() for record in caplog.records if "Calling method login" in record.getMessage()]
+    assert login_call_logs
+    assert all(password not in message and wrong_password not in message for message in login_call_logs)
 
 
 async def test_set_password(server: protocol.Server, auth_client: endpoints.Client) -> None:

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -144,15 +144,22 @@ async def test_login_audit_logging_and_redaction(
         response = await client.login("admin", password)
         assert response.code == 200
 
-    # Every login attempt is audit-logged with the username.
-    assert any(
-        record.levelno == logging.WARNING and "Failed login for user 'admin'" in record.getMessage()
-        for record in caplog.records
-    )
-    assert any(
-        record.levelno == logging.INFO and "Successful login for user 'admin'" in record.getMessage()
-        for record in caplog.records
-    )
+    # Every login attempt is audit-logged with the username and the connection peer IP.
+    failed = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "Failed login for user 'admin'" in r.getMessage()
+    ]
+    succeeded = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.INFO and "Successful login for user 'admin'" in r.getMessage()
+    ]
+    assert failed
+    assert succeeded
+    # The source IP is captured from the connection (not "unknown"), which is the direct client
+    # for the in-process test rather than an X-Forwarded-For header.
+    assert all("unknown" not in line for line in failed + succeeded)
 
     # The dispatcher logs the call arguments at debug level; the password must be redacted there.
     login_call_logs = [record.getMessage() for record in caplog.records if "Calling method login" in record.getMessage()]


### PR DESCRIPTION
_Claude, opening this on behalf of @bartv._

## What
This is part of hardening the database based login so that is no longer lab/development use only.

1. **Passwords are no longer leaked into logs or traces.** The `password` parameter of `login`, `add_user` and `set_password` is now typed as `pydantic.SecretStr`. The value is redacted (`**********`) wherever it is stringified, which covers both leak sites from the review: the REST dispatcher debug log (`rest/__init__.py`, `shorten(str(value))`) and the tracing span (`arguments=call_args`). No dispatcher change was needed - the redaction follows from the value's type.
2. **Every login attempt is audit-logged** (INFO on success, WARNING on failure) with the username and source IP.

## How / notable bits
- The client sends the raw string (the client `build_call` serialises raw args, not a validated model), so `SecretStr` is realised only server-side during validation - the wire and the handlers are unaffected apart from calling `.get_secret_value()`.
- `SecretStr` is added to `VALID_SIMPLE_ARG_TYPES`. The argument type validator (`_validate_type_arg`) now recognises concrete simple-type classes **before** the generic-type branch, because `SecretStr` subclasses pydantic's `Secret` Generic base and was otherwise misdetected as an unparameterised generic (this also fixes the same latent issue for any concrete subclass of a Generic base).
- For the source IP, the connection peer IP (`request.remote_ip`) is plumbed through `CallContext` and logged. The web console usually connects **directly** (no proxy), so this is the real client IP for the common case; when the API is fronted by a reverse proxy the peer is the proxy and the originating client is appended from `X-Forwarded-For` when present. (`CallContext` also now carries the raw request headers, which it previously did not.)

## Tests
- New `test_login_audit_logging_and_redaction`: asserts the audit lines are emitted and that the password never appears in the dispatcher's debug log line.
- Updated `test_protocol.py`'s valid-types message assertions to include `SecretStr`.
- `flake8`/`black`/`isort` clean; mypy adds no new violations in the changed files.

Note: `tests/server/test_auth.py::test_roles_failure_scenarios[True]` currently fails on a clean `master` too (a role-delete FK issue), i.e. it is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
