### PR TITLE
Attribute API tokens to their creating user in the access log

### DIFF
--- a/changelogs/unreleased/api-token-attribution.yml
+++ b/changelogs/unreleased/api-token-attribution.yml
@@ -1,0 +1,10 @@
+description: >-
+  Attribute API tokens to the user that created them. Tokens minted via
+  environment_create_token now carry a urn:inmanta:created_by claim, and the
+  per-call request log (debug level) reports the token's client types, creator
+  and environment (token=api created_by=bob env=...) instead of an anonymous
+  user=<>. As a result, an idempotent token now differs per creating user.
+change-type: minor
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -271,6 +271,7 @@ INTEGER_AS_LOG_LEVEL: abc.Mapping[int, LogLevel] = {value: log_level for log_lev
 INMANTA_URN = "urn:inmanta:"
 INMANTA_IS_ADMIN_URN = f"{INMANTA_URN}is_admin"
 INMANTA_ROLES_URN = f"{INMANTA_URN}roles"
+INMANTA_CREATED_BY_URN = f"{INMANTA_URN}created_by"
 
 
 class Compilestate(str, Enum):

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -617,16 +617,16 @@ class CallArguments:
         """
         Short description of the authenticated actor for the access log.
 
-        Interactive sessions carry a username (the `sub` claim) and are logged as ``user=<name>``.
-        API and service tokens have no `sub`; they are logged from their claims as
-        ``token=<client-types> created_by=<creator> env=<env>`` so that actions performed with a
-        token are attributable instead of appearing as ``user=<>``.
+        Interactive sessions carry a username (the sub claim) and are logged as user=<name>.
+        API and service tokens have no sub; they are logged from their claims as
+        token=<client-types> created_by=<creator> env=<env> so that actions performed with a
+        token are attributable instead of appearing as user=<>.
         """
         if self._auth_username:
             return f"user={self._auth_username}"
         if self._auth_token is None:
             return "user=<>"
-        # `ct` is decoded into a list of client types (see decode_token); render it comma-joined.
+        # ct is decoded into a list of client types (see decode_token); render it comma-joined.
         client_types = self._auth_token.get(const.INMANTA_URN + "ct")
         if isinstance(client_types, str):
             rendered_client_types = client_types

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -613,6 +613,36 @@ class CallArguments:
         client_types_token = self._auth_token[ct_key]
         return any(ct in {const.ClientType.agent.value, const.ClientType.compiler.value} for ct in client_types_token)
 
+    def describe_actor(self) -> str:
+        """
+        Short description of the authenticated actor for the access log.
+
+        Interactive sessions carry a username (the `sub` claim) and are logged as ``user=<name>``.
+        API and service tokens have no `sub`; they are logged from their claims as
+        ``token=<client-types> created_by=<creator> env=<env>`` so that actions performed with a
+        token are attributable instead of appearing as ``user=<>``.
+        """
+        if self._auth_username:
+            return f"user={self._auth_username}"
+        if self._auth_token is None:
+            return "user=<>"
+        # `ct` is decoded into a list of client types (see decode_token); render it comma-joined.
+        client_types = self._auth_token.get(const.INMANTA_URN + "ct")
+        if isinstance(client_types, str):
+            rendered_client_types = client_types
+        elif isinstance(client_types, Sequence) and client_types:
+            rendered_client_types = ",".join(str(ct) for ct in client_types)
+        else:
+            rendered_client_types = "<>"
+        parts: list[str] = [f"token={rendered_client_types}"]
+        created_by = self._auth_token.get(const.INMANTA_CREATED_BY_URN)
+        if created_by:
+            parts.append(f"created_by={created_by}")
+        env = self._auth_token.get(const.INMANTA_URN + "env")
+        if env:
+            parts.append(f"env={env}")
+        return " ".join(parts)
+
 
 # Shared
 class RESTBase(util.TaskHandler[None], abc.ABC):
@@ -678,10 +708,10 @@ async def execute_call(
             await authorization_provider.authorize_request(arguments)
 
         LOGGER.debug(
-            "Calling method %s(%s) user=%s",
+            "Calling method %s(%s) %s",
             config.method_name,
             ", ".join([f"{name}={common.shorten(str(value))}" for name, value in arguments.call_args.items()]),
-            arguments.auth_username if arguments.auth_username else "<>",
+            arguments.describe_actor(),
         )
 
         with tracing.span("Calling method " + config.method_name, arguments=arguments.call_args):

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -538,9 +538,16 @@ class EnvironmentService(protocol.ServerSlice):
         if not config.Config.getboolean("server", "auth", False):
             raise BadRequest("Authentication is disabled, generating a token is not allowed")
         # Attribute the token to the user that created it so that actions performed with it are not
-        # anonymous in the access log. This is a claim only; it is deliberately not stored in `sub`
-        # because the policy engine authorizes on `sub`.
-        custom_claims = {const.INMANTA_CREATED_BY_URN: context.auth_username} if context.auth_username else None
+        # anonymous in the access log. When the token is minted using another attributed token rather
+        # than an interactive session, carry over its creator so attribution survives token chains.
+        # This is a claim only; it is deliberately not stored in `sub` because the policy engine
+        # authorizes on `sub`.
+        created_by = context.auth_username
+        if not created_by and context.auth_token is not None:
+            inherited_creator = context.auth_token.get(const.INMANTA_CREATED_BY_URN)
+            if isinstance(inherited_creator, str):
+                created_by = inherited_creator
+        custom_claims = {const.INMANTA_CREATED_BY_URN: created_by} if created_by else None
         return encode_token(client_types, str(env.id), idempotent, custom_claims=custom_claims)
 
     @handle(methods_v2.environment_settings_list, env="tid")

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -34,10 +34,10 @@ from typing import Optional, cast
 import asyncpg
 from asyncpg import StringDataRightTruncationError
 
-from inmanta import config, data
+from inmanta import config, const, data
 from inmanta.data import AUTOSTART_AGENT_DEPLOY_INTERVAL, AUTOSTART_AGENT_REPAIR_INTERVAL, Setting, model
 from inmanta.protocol import encode_token, handle, methods, methods_v2
-from inmanta.protocol.common import ReturnValue, attach_warnings
+from inmanta.protocol.common import CallContext, ReturnValue, attach_warnings
 from inmanta.protocol.exceptions import BadRequest, Forbidden, NotFound, ServerError
 from inmanta.server import (
     SLICE_AGENT_MANAGER,
@@ -267,11 +267,13 @@ class EnvironmentService(protocol.ServerSlice):
         return 200
 
     @handle(methods.create_token, env="tid")
-    async def create_token(self, env: data.Environment, client_types: list[str], idempotent: bool) -> Apireturn:
+    async def create_token(
+        self, env: data.Environment, client_types: list[str], idempotent: bool, context: CallContext
+    ) -> Apireturn:
         """
         Create a new auth token for this environment
         """
-        return 200, {"token": await self.environment_create_token(env, client_types, idempotent)}
+        return 200, {"token": await self.environment_create_token(env, client_types, idempotent, context)}
 
     @handle(methods.list_settings, env="tid")
     async def list_settings(self, env: data.Environment) -> Apireturn:
@@ -527,13 +529,19 @@ class EnvironmentService(protocol.ServerSlice):
                     await self._resume(env, connection=connection)
 
     @handle(methods_v2.environment_create_token, env="tid")
-    async def environment_create_token(self, env: data.Environment, client_types: list[str], idempotent: bool) -> str:
+    async def environment_create_token(
+        self, env: data.Environment, client_types: list[str], idempotent: bool, context: CallContext
+    ) -> str:
         """
         Create a new auth token for this environment
         """
         if not config.Config.getboolean("server", "auth", False):
             raise BadRequest("Authentication is disabled, generating a token is not allowed")
-        return encode_token(client_types, str(env.id), idempotent)
+        # Attribute the token to the user that created it so that actions performed with it are not
+        # anonymous in the access log. This is a claim only; it is deliberately not stored in `sub`
+        # because the policy engine authorizes on `sub`.
+        custom_claims = {const.INMANTA_CREATED_BY_URN: context.auth_username} if context.auth_username else None
+        return encode_token(client_types, str(env.id), idempotent, custom_claims=custom_claims)
 
     @handle(methods_v2.environment_settings_list, env="tid")
     async def environment_settings_list(self, env: data.Environment) -> model.EnvironmentSettingsReponse:

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -540,8 +540,8 @@ class EnvironmentService(protocol.ServerSlice):
         # Attribute the token to the user that created it so that actions performed with it are not
         # anonymous in the access log. When the token is minted using another attributed token rather
         # than an interactive session, carry over its creator so attribution survives token chains.
-        # This is a claim only; it is deliberately not stored in `sub` because the policy engine
-        # authorizes on `sub`.
+        # This is a claim only; it is deliberately not stored in sub because the policy engine
+        # authorizes on sub.
         created_by = context.auth_username
         if not created_by and context.auth_token is not None:
             inherited_creator = context.auth_token.get(const.INMANTA_CREATED_BY_URN)

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -253,6 +253,11 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
         "token=api" in message and "created_by=admin" in message and f"env={env_id}" in message for message in access_logs
     )
     assert all("user=<>" not in message for message in access_logs)
+    # Attribution chains: a token minted using an attributed token keeps the original creator, even
+    # though the minting token has no `sub`.
+    chained_claims, _ = auth.decode_token(response.result["data"])
+    assert chained_claims[const.INMANTA_CREATED_BY_URN] == "admin"
+    assert "sub" not in chained_claims
 
 
 async def test_password_max_length(server: protocol.Server, auth_client: endpoints.Client) -> None:

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -203,8 +203,8 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     option is set via an environment variable.
     Reproduction of bug: https://github.com/inmanta/inmanta-core/issues/8962
 
-    Also verify that the minted token is attributed to its creator (a `created_by` claim) and that
-    the access log attributes calls made with it to that creator instead of the anonymous `user=<>`.
+    Also verify that the minted token is attributed to its creator (a created_by claim) and that
+    the access log attributes calls made with it to that creator instead of the anonymous user=<>.
     """
     config.Config.set("server", "auth", "false")
     monkeypatch.setenv("INMANTA_SERVER_AUTH", "true")
@@ -234,13 +234,13 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     assert response.result["data"]
 
     # The token is attributed to the user that created it via a dedicated claim. It is deliberately
-    # not stored in `sub`, because the policy engine authorizes on `sub`.
+    # not stored in sub, because the policy engine authorizes on sub.
     api_token = response.result["data"]
     claims, _ = auth.decode_token(api_token)
     assert claims[const.INMANTA_CREATED_BY_URN] == "admin"
     assert "sub" not in claims
 
-    # A call made with that token is attributed to its creator in the access log, instead of `user=<>`.
+    # A call made with that token is attributed to its creator in the access log, instead of user=<>.
     config.Config.set("client_rest_transport", "token", api_token)
     token_client = protocol.Client("client")
     caplog.clear()
@@ -254,7 +254,7 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     )
     assert all("user=<>" not in message for message in access_logs)
     # Attribution chains: a token minted using an attributed token keeps the original creator, even
-    # though the minting token has no `sub`.
+    # though the minting token has no sub.
     chained_claims, _ = auth.decode_token(response.result["data"])
     assert chained_claims[const.INMANTA_CREATED_BY_URN] == "admin"
     assert "sub" not in chained_claims

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -197,11 +197,14 @@ async def test_set_password(server: protocol.Server, auth_client: endpoints.Clie
     assert response.code == 200
 
 
-async def test_environment_create_token(server: protocol.Server, auth_client: endpoints.Client, monkeypatch) -> None:
+async def test_environment_create_token(server: protocol.Server, auth_client: endpoints.Client, monkeypatch, caplog) -> None:
     """
     Verify that the environment_create_token endpoint works correctly when the server.auth=true
     option is set via an environment variable.
     Reproduction of bug: https://github.com/inmanta/inmanta-core/issues/8962
+
+    Also verify that the minted token is attributed to its creator (a `created_by` claim) and that
+    the access log attributes calls made with it to that creator instead of the anonymous `user=<>`.
     """
     config.Config.set("server", "auth", "false")
     monkeypatch.setenv("INMANTA_SERVER_AUTH", "true")
@@ -229,6 +232,27 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     response = await auth_client.environment_create_token(tid=env_id, client_types=["api"])
     assert response.code == 200
     assert response.result["data"]
+
+    # The token is attributed to the user that created it via a dedicated claim. It is deliberately
+    # not stored in `sub`, because the policy engine authorizes on `sub`.
+    api_token = response.result["data"]
+    claims, _ = auth.decode_token(api_token)
+    assert claims[const.INMANTA_CREATED_BY_URN] == "admin"
+    assert "sub" not in claims
+
+    # A call made with that token is attributed to its creator in the access log, instead of `user=<>`.
+    config.Config.set("client_rest_transport", "token", api_token)
+    token_client = protocol.Client("client")
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="inmanta.protocol.rest"):
+        response = await token_client.environment_create_token(tid=env_id, client_types=["api"])
+        assert response.code == 200
+    access_logs = [r.getMessage() for r in caplog.records if "Calling method environment_create_token" in r.getMessage()]
+    assert access_logs
+    assert all(
+        "token=api" in message and "created_by=admin" in message and f"env={env_id}" in message for message in access_logs
+    )
+    assert all("user=<>" not in message for message in access_logs)
 
 
 async def test_password_max_length(server: protocol.Server, auth_client: endpoints.Client) -> None:


### PR DESCRIPTION
API-token actions are logged as `user=<>`. The token minted by `environment_create_token` carries only `iss`, `aud`, `ct` and the env id: no `sub`, no marker of who created it. So "who did this?" is unanswerable for any API-token action, which also fails SOC2-style audit requirements.

## Change (stateless, claims-only, no schema/DB)

- `environment_create_token` (and the v1 `create_token` that delegates to it) now embed a `urn:inmanta:created_by` claim taken from the call context's authenticated user at mint time.
- The per-call request log line derives its actor from the token claims via a new `CallArguments.describe_actor()`:
  - interactive session (has `sub`): `user=bob` (unchanged)
  - API/service token: `token=api created_by=bob env=<id>` instead of `user=<>`
  - no token (auth disabled): `user=<>` (unchanged)
- The creator is **not** written to `sub`, because the policy engine authorizes on `sub` (`default_policy.rego`) and API tokens pass through it; overloading `sub` would change authorization, not just logging. The claim rides inside the signed, signature-verified token, so it cannot be spoofed short of a signing-key compromise.

## Notes for reviewers

- **Log level.** This enriches the existing per-call dispatch log line, which is `DEBUG` (it dumps all call arguments, so it must stay off by default in production; the `tornado.access` INFO line is separate). A persistent, always-on audit trail (last-used, per-token) via a token registry is future work, not this PR.
- **Idempotency.** `idempotent=True` tokens were previously byte-identical for a given `(client_types, env)` regardless of requester. They now vary per creator, since `created_by` is baked into the signed payload. Idempotency is preserved per-creator (same user, same env -> same token). This is intentional.
- **Attribution chains.** When a token is minted using another attributed token (which has a `created_by` claim but no `sub`), the original creator is carried over to the new token.

## Tests

Extends `test_environment_create_token` to assert the minted token carries `created_by=admin` (and no `sub`), that a call made with that token is attributed in the log as `token=api created_by=admin env=...` rather than `user=<>`, and that a token minted using that token keeps `created_by=admin` (chaining).

## Changelog

`changelogs/unreleased/api-token-attribution.yml` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)