### PR TITLE
Give login sessions their own expiry, decoupled from service tokens

### DIFF
--- a/changelogs/unreleased/login-session-expire.yml
+++ b/changelogs/unreleased/login-session-expire.yml
@@ -1,0 +1,10 @@
+description: >-
+  Add the server.login_session_expire option to give web-console login sessions their own lifetime,
+  decoupled from the auth_jwt `expire` that governs agent and compiler service tokens. An explicit
+  token expiry now takes precedence over the signing config's `expire` (which, as a side effect, makes
+  the `inmanta-cli token bootstrap` token honor its own 1-hour lifetime regardless of the configured
+  `expire`).
+change-type: minor
+destination-branches:
+  - master
+  - iso9

--- a/changelogs/unreleased/login-session-expire.yml
+++ b/changelogs/unreleased/login-session-expire.yml
@@ -1,9 +1,10 @@
 description: >-
-  Add the server.login_session_expire option to give web-console login sessions their own lifetime,
-  decoupled from the auth_jwt `expire` that governs agent and compiler service tokens. An explicit
-  token expiry now takes precedence over the signing config's `expire` (which, as a side effect, makes
-  the `inmanta-cli token bootstrap` token honor its own 1-hour lifetime regardless of the configured
-  `expire`).
+  Web-console login sessions (database and break-glass authentication) now expire after one hour by
+  default, controlled by the new server.login_session_expire option and decoupled from the auth_jwt
+  `expire` that governs agent and compiler service tokens. Set the option to 0 to restore the previous
+  behavior (login sessions follow the auth_jwt `expire`, which is eternal by default). As part of this,
+  an explicit token expiry now takes precedence over the signing config's `expire` (which also makes the
+  `inmanta-cli token bootstrap` token honor its own 1-hour lifetime regardless of the configured `expire`).
 change-type: minor
 destination-branches:
   - master

--- a/docs/administrators/authentication.rst
+++ b/docs/administrators/authentication.rst
@@ -96,12 +96,36 @@ the settings page.
    Generating a new token in the web-console.
 
 
-Setup the built-in authentication provider of the Inmanta server (See :ref:`auth-int`) or configure an external issuer 
+Setup the built-in authentication provider of the Inmanta server (See :ref:`auth-int`) or configure an external issuer
 (See :ref:`auth-ext`) for web-console access to bootstrap access to the create token api call.
-When no external issuer is available and web-console access is not required, the ``inmanta-cli token bootstrap`` command
-can be used to create a token that has access to everything. However, it expires after 3600s for security reasons.
+When no external issuer is available, or to recover from an identity-provider outage, use the
+``inmanta-cli token bootstrap`` command or the web-console local login fallback. Both are described in
+:ref:`auth-break-glass`.
 
-For this command to function, it requires the issuers configuration with sign=true to be available for the cli command.
+.. _auth-session-lifetime:
+
+Session and token lifetime
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Inmanta issues two kinds of tokens with independent lifetimes:
+
+* **Service tokens** (agents, compilers, CLI, and API integrations) expire according to the ``expire`` key of the
+  signing ``auth_jwt_*`` section (see :ref:`auth-config`). The default, ``expire=0``, means these tokens never
+  expire, which is usually what long-lived agents and integrations require.
+* **Web-console login sessions** issued by the built-in provider's ``/login`` endpoint expire after
+  :inmanta.config:option:`server.login-session-expire` seconds. This defaults to ``3600`` (one hour) and is
+  independent of the service-token ``expire``. Set it to ``0`` to have login sessions follow the signing section's
+  ``expire`` instead. When a session expires, the web-console returns the user to the login screen. For external
+  OIDC providers the session lifetime and renewal are governed by the identity provider, not by this option.
+
+Tokens created with ``inmanta-cli token create`` or the web-console ``tokens`` tab are attributed to the user that
+created them through a ``urn:inmanta:created_by`` claim. Actions performed with such a token are recorded in the
+access log with that attribution (for example ``token=api created_by=alice env=...``) instead of anonymously. When
+a token is minted using another already-attributed token, the original creator is carried over.
+
+The built-in provider audits authentication: every successful and failed login is logged with the username and the
+source address, and credentials (passwords and other parameters marked sensitive) are redacted from debug logs and
+tracing spans.
 
 .. _auth-config:
 
@@ -486,6 +510,52 @@ fill in ``oidc.cfg``:
 
 .. note:: Authentik by default sets the ``aud`` claim to the client id. If you customize the audience via a property mapper,
     the ``audience`` value in ``oidc.cfg`` must match whatever appears in the token.
+
+
+.. _auth-break-glass:
+
+Break-glass and recovery access
+-------------------------------
+
+If the configured identity provider becomes unavailable or misconfigured, the following recovery paths remain
+available.
+
+CLI bootstrap token
+^^^^^^^^^^^^^^^^^^^
+
+When run locally on the orchestrator, ``inmanta-cli token bootstrap`` mints a token that grants access to
+everything. It is valid for 3600 seconds (one hour) and is intended purely for recovery and initial setup.
+
+.. code-block:: sh
+
+    inmanta-cli token bootstrap
+
+The command signs the token locally, so it requires the signing ``auth_jwt_*`` section (``sign=true``) to be
+available in the CLI's configuration. Because it needs local access to the signing key, it can only be run on the
+orchestrator host itself. The resulting token can be used as the ``token`` option in a transport configuration or
+as a bearer token for direct API calls; it cannot be used to log in to the web-console.
+
+Web-console local login fallback under OIDC
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the web-console is configured for an external OIDC provider, a local database account can be kept as a
+break-glass login for when the identity provider is unreachable. To enable it:
+
+#. Provision a database admin user alongside the OIDC configuration with ``inmanta-initial-user-setup`` (this is
+   permitted even while :inmanta.config:option:`server.auth-method` is ``oidc``).
+#. Set ``oidc_local_fallback=true`` in the ``[web-ui]`` section.
+
+.. code-block:: ini
+
+    [web-ui]
+    oidc_authority=<IdP authority URL>
+    oidc_client_id=<client id>
+    oidc_local_fallback=true
+
+On a normal load the web-console still redirects to the identity provider. Only when the provider fails does it
+offer a local login, and a ``/login`` URL is always available for deliberate break-glass access. The fallback is
+advertised only when database authentication is actually usable (a signing configuration is present and at least
+one local user exists), so it never presents a login form that cannot work.
 
 
 Reverse proxy with JWT validation

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -65,7 +65,7 @@ def encode_token(
         payload.update(custom_claims)
 
     if not idempotent:
-        # Use a single time source so iat and exp are consistent and the token lifetime is exactly `expire`.
+        # Use a single time source so iat and exp are consistent and the token lifetime is exactly the requested expiry.
         now = int(time.time())
         payload["iat"] = now
 

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -67,10 +67,13 @@ def encode_token(
     if not idempotent:
         payload["iat"] = int(time.time())
 
-        if cfg.expire > 0:
-            payload["exp"] = int(time.time() + cfg.expire)
-        elif expire is not None:
+        # An explicit expire argument takes precedence over the signing config's expire, so a caller
+        # (e.g. the login endpoint) can give its tokens a lifetime that is decoupled from the service
+        # token expiry configured on the signing config.
+        if expire is not None:
             payload["exp"] = int(time.time() + expire)
+        elif cfg.expire > 0:
+            payload["exp"] = int(time.time() + cfg.expire)
 
     if environment is not None:
         payload[const.INMANTA_URN + "env"] = environment

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -49,6 +49,19 @@ def encode_token(
     expire: Optional[float] = None,
     custom_claims: Optional[Mapping[str, str | bool | Mapping[str, list[str]]]] = None,
 ) -> str:
+    """
+    Encode and sign a JWT bearer token for the given client types.
+
+    :param client_types: The client types to embed in the token. Each must be allowed by the signing configuration.
+    :param environment: When set, scope the token to this environment by adding an environment claim.
+    :param idempotent: When True, omit the time-based claims (iat and exp) so that encoding identical inputs always
+        produces an identical token. Used for tokens that must be stable across calls, such as environment tokens.
+    :param expire: The token lifetime in seconds. Takes precedence over the expiry from the signing configuration.
+        Ignored when idempotent is True.
+    :param custom_claims: Additional claims to merge into the token payload.
+    :return: The signed JWT as a string.
+    :raises Exception: When no signing configuration is available or a requested client type is not allowed.
+    """
     cfg = AuthJWTConfig.get_sign_config()
     if cfg is None:
         raise Exception("No JWT signing configuration available.")

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -65,15 +65,17 @@ def encode_token(
         payload.update(custom_claims)
 
     if not idempotent:
-        payload["iat"] = int(time.time())
+        # Use a single time source so iat and exp are consistent and the token lifetime is exactly `expire`.
+        now = int(time.time())
+        payload["iat"] = now
 
         # An explicit expire argument takes precedence over the signing config's expire, so a caller
         # (e.g. the login endpoint) can give its tokens a lifetime that is decoupled from the service
         # token expiry configured on the signing config.
         if expire is not None:
-            payload["exp"] = int(time.time() + expire)
+            payload["exp"] = now + int(expire)
         elif cfg.expire > 0:
-            payload["exp"] = int(time.time() + cfg.expire)
+            payload["exp"] = now + int(cfg.expire)
 
     if environment is not None:
         payload[const.INMANTA_URN + "env"] = environment

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -65,7 +65,6 @@ def encode_token(
         payload.update(custom_claims)
 
     if not idempotent:
-        # Use a single time source so iat and exp are consistent and the token lifetime is exactly the requested expiry.
         now = int(time.time())
         payload["iat"] = now
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -167,11 +167,11 @@ server_additional_auth_header = Option(
 server_login_session_expire = Option(
     "server",
     "login_session_expire",
-    0,
-    "Lifetime in seconds of the session token issued by the /login endpoint (used by the web console under "
-    "database or break-glass authentication). When set to a value larger than 0, login sessions expire after "
-    "this many seconds, independently of the auth_jwt `expire` option that governs agent and compiler service "
-    "tokens. When 0 (the default), login sessions follow the auth_jwt `expire` behavior.",
+    3600,
+    "Lifetime in seconds of the session token issued by the /login endpoint, used by the web console under "
+    "database or break-glass authentication. Defaults to 3600 (one hour) and is independent of the auth_jwt "
+    "`expire` option that governs agent and compiler service tokens. Set to 0 to instead follow the auth_jwt "
+    "`expire` behavior (which is eternal by default).",
     is_time,
 )
 

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -164,6 +164,16 @@ server_auth_method = Option("server", "auth_method", "oidc", "The authentication
 server_additional_auth_header = Option(
     "server", "auth_additional_header", None, "An additional header to look for authentication tokens", is_str_opt
 )
+server_login_session_expire = Option(
+    "server",
+    "login_session_expire",
+    0,
+    "Lifetime in seconds of the session token issued by the /login endpoint (used by the web console under "
+    "database or break-glass authentication). When set to a value larger than 0, login sessions expire after "
+    "this many seconds, independently of the auth_jwt `expire` option that governs agent and compiler service "
+    "tokens. When 0 (the default), login sessions follow the auth_jwt `expire` behavior.",
+    is_time,
+)
 
 server_ssl_key = Option(
     "server", "ssl_key_file", None, "Server private key to use for this server Leave blank to disable SSL", is_str_opt

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -210,7 +210,7 @@ class UserService(server_protocol.ServerSlice):
             const.INMANTA_ROLES_URN: {str(env_id): roles for env_id, roles in role_assignments.assignments.items()},
             const.INMANTA_IS_ADMIN_URN: user.is_admin,
         }
-        # Give login sessions their own lifetime, decoupled from the auth_jwt `expire` that governs
+        # Give login sessions their own lifetime, decoupled from the auth_jwt expire that governs
         # agent/compiler service tokens. When the option is 0, fall back to the signing config's expire.
         session_expire = server_config.server_login_session_expire.get()
         token = auth.encode_token(

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -210,7 +210,14 @@ class UserService(server_protocol.ServerSlice):
             const.INMANTA_ROLES_URN: {str(env_id): roles for env_id, roles in role_assignments.assignments.items()},
             const.INMANTA_IS_ADMIN_URN: user.is_admin,
         }
-        token = auth.encode_token([str(const.ClientType.api.value)], expire=None, custom_claims=custom_claims)
+        # Give login sessions their own lifetime, decoupled from the auth_jwt `expire` that governs
+        # agent/compiler service tokens. When the option is 0, fall back to the signing config's expire.
+        session_expire = server_config.server_login_session_expire.get()
+        token = auth.encode_token(
+            [str(const.ClientType.api.value)],
+            expire=session_expire if session_expire > 0 else None,
+            custom_claims=custom_claims,
+        )
         return common.ReturnValue(
             status_code=200,
             headers={"Authorization": f"Bearer {token}"},

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -176,19 +176,25 @@ async def test_login_session_expire(server: protocol.Server, auth_client: endpoi
     response = await auth_client.add_user("admin", "Str0ng-Pass!")
     assert response.code == 200
 
-    # Default (option unset): the login token follows the signing config, which is eternal here.
+    # By default login sessions expire after one hour, even though the signing config's expire is 0.
+    response = await auth_client.login("admin", "Str0ng-Pass!")
+    assert response.code == 200
+    claims = jwt.decode(response.result["data"]["token"], options={"verify_signature": False})
+    assert claims["exp"] - claims["iat"] == 3600
+
+    # Setting the option to 0 restores the old behavior: fall back to the signing config's expire (eternal here).
+    config.Config.set("server", "login_session_expire", "0")
     response = await auth_client.login("admin", "Str0ng-Pass!")
     assert response.code == 200
     claims = jwt.decode(response.result["data"]["token"], options={"verify_signature": False})
     assert "exp" not in claims
 
-    # With the option set, the login session expires after that many seconds even though the signing
-    # config's expire is 0.
-    config.Config.set("server", "login_session_expire", "3600")
+    # A custom value is honored.
+    config.Config.set("server", "login_session_expire", "7200")
     response = await auth_client.login("admin", "Str0ng-Pass!")
     assert response.code == 200
     claims = jwt.decode(response.result["data"]["token"], options={"verify_signature": False})
-    assert claims["exp"] - claims["iat"] == 3600
+    assert claims["exp"] - claims["iat"] == 7200
 
 
 async def test_set_password(server: protocol.Server, auth_client: endpoints.Client) -> None:

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -18,6 +18,7 @@ Contact: code@inmanta.com
 
 import logging
 
+import jwt
 import pytest
 
 import nacl.pwhash
@@ -165,6 +166,29 @@ async def test_login_audit_logging_and_redaction(
     login_call_logs = [record.getMessage() for record in caplog.records if "Calling method login" in record.getMessage()]
     assert login_call_logs
     assert all(password not in message and wrong_password not in message for message in login_call_logs)
+
+
+async def test_login_session_expire(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """
+    The login session token gets its own lifetime via server.login_session_expire, decoupled from the
+    auth_jwt `expire` (which is 0/eternal in this fixture and governs agent/compiler service tokens).
+    """
+    response = await auth_client.add_user("admin", "Str0ng-Pass!")
+    assert response.code == 200
+
+    # Default (option unset): the login token follows the signing config, which is eternal here.
+    response = await auth_client.login("admin", "Str0ng-Pass!")
+    assert response.code == 200
+    claims = jwt.decode(response.result["data"]["token"], options={"verify_signature": False})
+    assert "exp" not in claims
+
+    # With the option set, the login session expires after that many seconds even though the signing
+    # config's expire is 0.
+    config.Config.set("server", "login_session_expire", "3600")
+    response = await auth_client.login("admin", "Str0ng-Pass!")
+    assert response.code == 200
+    claims = jwt.decode(response.result["data"]["token"], options={"verify_signature": False})
+    assert claims["exp"] - claims["iat"] == 3600
 
 
 async def test_set_password(server: protocol.Server, auth_client: endpoints.Client) -> None:

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -58,6 +58,25 @@ def test_jwt_create(inmanta_config):
     assert jot2 != jot3
 
 
+def test_encode_token_expire_precedence(inmanta_config):
+    """
+    An explicit expire argument takes precedence over the signing config's expire, so a caller (e.g. the
+    login endpoint) can give its tokens a lifetime decoupled from the service-token expiry.
+    """
+    config.Config.set("auth_jwt_default", "expire", "7200")
+
+    # No explicit expire -> falls back to the signing config's expire.
+    service = jwt.decode(auth.encode_token(["agent"]), options={"verify_signature": False})
+    assert service["exp"] - service["iat"] == 7200
+
+    # An explicit expire wins over the signing config's expire.
+    session = jwt.decode(auth.encode_token(["api"], expire=3600), options={"verify_signature": False})
+    assert session["exp"] - session["iat"] == 3600
+
+    # An idempotent token never gets an expiry, regardless of either setting.
+    assert "exp" not in jwt.decode(auth.encode_token(["api"], idempotent=True), options={"verify_signature": False})
+
+
 class PKHandler(web.RequestHandler):
     def get(self):
         public_key = {

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -75,8 +75,9 @@ def test_encode_token_expire_precedence(inmanta_config):
 
     # An idempotent token never gets an expiry, regardless of either setting.
     assert "exp" not in jwt.decode(auth.encode_token(["api"], idempotent=True), options={"verify_signature": False})
-    assert "exp" not in jwt.decode(auth.encode_token(["api"], idempotent=True, expire=3600), options={"verify_signature": False})
-
+    assert "exp" not in jwt.decode(
+        auth.encode_token(["api"], idempotent=True, expire=3600), options={"verify_signature": False}
+    )
 
 
 class PKHandler(web.RequestHandler):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -75,6 +75,8 @@ def test_encode_token_expire_precedence(inmanta_config):
 
     # An idempotent token never gets an expiry, regardless of either setting.
     assert "exp" not in jwt.decode(auth.encode_token(["api"], idempotent=True), options={"verify_signature": False})
+    assert "exp" not in jwt.decode(auth.encode_token(["api"], idempotent=True, expire=3600), options={"verify_signature": False})
+
 
 
 class PKHandler(web.RequestHandler):


### PR DESCRIPTION
Give web-console login sessions a bounded lifetime that is independent of the service-token expiry.

## Problem

A single option, `auth_jwt_<name>.expire`, governs the `exp` of every token signed with that config: web-console login sessions and agent/compiler service tokens alike. So an operator cannot give interactive sessions a sane lifetime without also expiring long-lived service tokens (and vice versa). Login session tokens are therefore effectively eternal in every deployment that keeps service tokens eternal (the default, `expire=0`).

## Change

- New `server.login_session_expire` option (seconds, default 3600 = one hour). The `/login` endpoint issues session tokens that expire after this many seconds, independently of `auth_jwt.expire`. Set it to `0` to fall back to the signing config's `expire` (eternal by default).
- `encode_token` now lets an explicit `expire` argument take precedence over the signing config's `expire`. This is what allows the login endpoint to override the service-token expiry. Callers that pass no `expire` (agents, compilers, idempotent API tokens) are unchanged.
- `encode_token` computes `iat` and `exp` from a single time source so a token's lifetime is exactly `expire` (previously two separate `time.time()` reads could make `exp - iat` off by one across a second boundary).

## Behavior changes on upgrade

- Login sessions now expire after 1 hour by default. Existing web-console database/break-glass sessions were eternal; after upgrade a new login is bounded to 1 hour (fixed at issuance, not sliding). When the session expires, a 401 sends the web-console back to the login screen. External OIDC sessions are unaffected (renewal is handled by the IdP). Set `login_session_expire=0` to keep eternal sessions.
- The precedence change also makes the `inmanta-cli token bootstrap` break-glass token honor its own 1-hour lifetime regardless of a configured `auth_jwt.expire`.

## Documentation

Updates `docs/administrators/authentication.rst`: the service-token vs login-session lifetime split, API-token attribution (`created_by`), login audit logging and credential redaction, and a Break-glass and recovery access section covering `inmanta-cli token bootstrap` and the web-console OIDC local login fallback.

## Tests

- `tests/test_jwt.py::test_encode_token_expire_precedence` - explicit `expire` wins over `cfg.expire`; no-`expire` falls back to `cfg.expire`; idempotent tokens never get an `exp`.
- `tests/server/test_user.py::test_login_session_expire` - the login token expires after the 1-hour default; `0` falls back to the (eternal) signing config; a custom value is honored.

## Notes for reviewers

- The `encode_token` precedence change is a no-op for all in-repo callers except login and bootstrap. `encode_token` is re-exported for extensions - worth a quick grep that no extension calls it with an explicit `expire` while relying on the old cfg.expire-wins behavior.
- The 1-hour default bounds all web-console database/break-glass sessions on upgrade; `0` opts out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)