### PR TITLE
Document scope and limitations of built-in database auth

### DIFF
--- a/changelogs/unreleased/document-db-auth-limitations.yml
+++ b/changelogs/unreleased/document-db-auth-limitations.yml
@@ -1,0 +1,9 @@
+description: >-
+  Document the scope and limitations of the built-in database authentication provider. Password policy,
+  MFA, SSO and brute-force protection are intentionally out of scope for the built-in provider and are
+  expected to be provided by an external OIDC identity provider or by the network layers around the
+  orchestrator (reverse proxy, WAF).
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/docs/administrators/authentication.rst
+++ b/docs/administrators/authentication.rst
@@ -235,12 +235,12 @@ Scope and limitations
 
 The built-in provider is intended for small, trusted, or edge deployments where direct login is limited to a small
 number of technical users who already reach the orchestrator through other layers of security (network segmentation,
-a VPN or reverse proxy, ...). It deliberately keeps credential management minimal: the only password rule it enforces
-is a minimum length of 8 characters.
+a VPN or reverse proxy, ...). It deliberately keeps credential management minimal: passwords must be between 12 and
+128 characters long and use at least three of the four character classes (lowercase, uppercase, digit, special), but
+beyond that the provider does little.
 
 In particular, the built-in provider does **not** provide:
 
-* password complexity or composition rules;
 * checks against breached or common-password lists;
 * password expiry, rotation, reuse history, or a self-service reset / forgot-password flow;
 * multi-factor authentication (MFA);

--- a/docs/administrators/authentication.rst
+++ b/docs/administrators/authentication.rst
@@ -228,6 +228,38 @@ Now, restart the orchestrator to activate the new configuration.
 After the restart of the orchestrator, authentication is enabled on all API endpoints. This also means that the
 web-console will ask for your credentials.
 
+.. _auth-int-limitations:
+
+Scope and limitations
+^^^^^^^^^^^^^^^^^^^^^
+
+The built-in provider is intended for small, trusted, or edge deployments where direct login is limited to a small
+number of technical users who already reach the orchestrator through other layers of security (network segmentation,
+a VPN or reverse proxy, ...). It deliberately keeps credential management minimal: the only password rule it enforces
+is a minimum length of 8 characters.
+
+In particular, the built-in provider does **not** provide:
+
+* password complexity or composition rules;
+* checks against breached or common-password lists;
+* password expiry, rotation, reuse history, or a self-service reset / forgot-password flow;
+* multi-factor authentication (MFA);
+* login rate limiting, brute-force back-off, or account lockout;
+* SSO or automated (SCIM) user provisioning.
+
+By design, these controls are expected to come from the layers around the orchestrator rather than from the built-in
+provider:
+
+* **Password policy, MFA, SSO, and credential lifecycle**: use an external OpenID Connect (OIDC) identity provider
+  (Entra ID, Authentik, Keycloak, Okta, Auth0, ...) instead of the built-in provider. Such providers supply these
+  natively. See :ref:`auth-ext`.
+* **Brute-force protection and rate limiting**: place the login and API endpoints behind a reverse proxy, WAF, or
+  network controls that provide rate limiting and back-off - the same edge you should already use before exposing the
+  API. An external IdP additionally moves the interactive login surface off the orchestrator entirely.
+
+Use the built-in provider only where direct login stays limited to a small set of trusted technical users behind such
+layers; whenever the login endpoint would be exposed more broadly, prefer an external OIDC provider.
+
 .. _auth-ext:
 
 External authentication providers


### PR DESCRIPTION
Document what the built-in database authentication provider deliberately does not do, and where those controls come from instead.

## Why

The built-in provider is for small, trusted, or edge deployments where direct login is limited to a few technical users already behind other layers of security. Rather than growing it into a full identity provider, we keep credential management minimal and point operators at the right layer for stronger controls. This records two explicit product decisions:

- **No breached/common-password blocklist** (and no complexity rules, MFA, SSO, credential lifecycle) - use an external OIDC provider for these.
- **No in-application login rate limiting / brute-force protection** - that belongs to the reverse proxy / WAF / network edge (the same edge that should front the API before it is exposed), or is avoided entirely by using an external IdP.

## Change

Adds a "Scope and limitations" section to `docs/administrators/authentication.rst` under the built-in provider: it lists what the provider does not enforce and directs operators to an external OIDC provider (for password policy / MFA / SSO / lifecycle) or the surrounding network layers (for rate limiting / brute-force protection).

Docs-only.

## Changelog

`changelogs/unreleased/document-db-auth-limitations.yml` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)