### PR TITLE
Harden the built-in database login

### DIFF
--- a/changelogs/unreleased/harden-database-login.yml
+++ b/changelogs/unreleased/harden-database-login.yml
@@ -1,0 +1,10 @@
+description: >-
+  Harden the built-in database login. Login now verifies against a dummy password hash for unknown
+  users so the response time no longer reveals whether an account exists, a stored password hash that
+  cannot be parsed returns 401 instead of a 500 server error, passwords are capped at 128 characters,
+  and changing your own password now requires providing the current one (an administrator changing
+  another user's password does not).
+change-type: minor
+destination-branches:
+  - master
+  - iso9

--- a/changelogs/unreleased/harden-database-login.yml
+++ b/changelogs/unreleased/harden-database-login.yml
@@ -1,9 +1,10 @@
 description: >-
-  Harden the built-in database login. Login now verifies against a dummy password hash for unknown
+  Harden the built-in database login. Passwords must now be between 12 and 128 characters long and use
+  at least three of four character classes (lowercase, uppercase, digit, special), enforced on the API
+  and the inmanta-initial-user-setup tool. Login also verifies against a dummy password hash for unknown
   users so the response time no longer reveals whether an account exists, a stored password hash that
-  cannot be parsed returns 401 instead of a 500 server error, passwords are capped at 128 characters,
-  and changing your own password now requires providing the current one (an administrator changing
-  another user's password does not).
+  cannot be parsed returns 401 instead of a 500 server error, and changing your own password now requires
+  providing the current one (an administrator changing another user's password does not).
 change-type: minor
 destination-branches:
   - master

--- a/docs/administrators/authentication.rst
+++ b/docs/administrators/authentication.rst
@@ -200,7 +200,9 @@ Verify whether the hostname, in the generated configuration section, is correct 
 Step 3: Create the initial user
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Re-run the same command again to create the initial user. The password for this new user must be at least 8 characters long.
+Re-run the same command again to create the initial user. The password for this new user must be between 12 and 128
+characters long and contain at least three of the following four character classes: a lowercase letter, an uppercase
+letter, a digit, and a special character. The same policy applies to passwords set through the API.
 
 .. code-block:: ini
 

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -342,37 +342,6 @@ MAX_PASSWORD_LENGTH = 128
 MIN_PASSWORD_CHARACTER_CLASSES = 3
 
 
-def password_policy_violation(password: str) -> Optional[str]:
-    """
-    Return a human-readable reason the password violates the password policy, or None if it is acceptable.
-
-    The policy is a length range plus a basic complexity requirement (a mix of character classes). It is
-    shared by the API (add_user, set_password) and the inmanta-initial-user-setup CLI so both enforce the
-    same rules. Note this is a deliberately minimal, self-contained check: richer credential controls
-    (breached-password lists, history, rotation, MFA) are out of scope for the built-in provider and are
-    expected from an external OIDC identity provider instead.
-    """
-    if not password or len(password) < MIN_PASSWORD_LENGTH:
-        return f"the password should be at least {MIN_PASSWORD_LENGTH} characters long"
-    if len(password) > MAX_PASSWORD_LENGTH:
-        return f"the password should be at most {MAX_PASSWORD_LENGTH} characters long"
-    # Count the character classes used. "special" is anything that is not a letter or a digit.
-    classes = sum(
-        [
-            any(c.islower() for c in password),
-            any(c.isupper() for c in password),
-            any(c.isdigit() for c in password),
-            any(not c.isalnum() for c in password),
-        ]
-    )
-    if classes < MIN_PASSWORD_CHARACTER_CLASSES:
-        return (
-            f"the password should contain at least {MIN_PASSWORD_CHARACTER_CLASSES} of the following four "
-            "character classes: a lowercase letter, an uppercase letter, a digit, and a special character"
-        )
-    return None
-
-
 class AgentAction(str, Enum):
     pause = "pause"
     unpause = "unpause"

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -336,6 +336,8 @@ ENVELOPE_KEY = "data"
 
 # Minimum password length
 MIN_PASSWORD_LENGTH = 8
+# Maximum password length, a guard against denial-of-service through very expensive password hashing
+MAX_PASSWORD_LENGTH = 128
 
 
 class AgentAction(str, Enum):

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -335,9 +335,42 @@ EXTENSION_MODULE = "extension"
 ENVELOPE_KEY = "data"
 
 # Minimum password length
-MIN_PASSWORD_LENGTH = 8
+MIN_PASSWORD_LENGTH = 12
 # Maximum password length, a guard against denial-of-service through very expensive password hashing
 MAX_PASSWORD_LENGTH = 128
+# The number of distinct character classes (lowercase, uppercase, digit, special) a password must use
+MIN_PASSWORD_CHARACTER_CLASSES = 3
+
+
+def password_policy_violation(password: str) -> Optional[str]:
+    """
+    Return a human-readable reason the password violates the password policy, or None if it is acceptable.
+
+    The policy is a length range plus a basic complexity requirement (a mix of character classes). It is
+    shared by the API (add_user, set_password) and the inmanta-initial-user-setup CLI so both enforce the
+    same rules. Note this is a deliberately minimal, self-contained check: richer credential controls
+    (breached-password lists, history, rotation, MFA) are out of scope for the built-in provider and are
+    expected from an external OIDC identity provider instead.
+    """
+    if not password or len(password) < MIN_PASSWORD_LENGTH:
+        return f"the password should be at least {MIN_PASSWORD_LENGTH} characters long"
+    if len(password) > MAX_PASSWORD_LENGTH:
+        return f"the password should be at most {MAX_PASSWORD_LENGTH} characters long"
+    # Count the character classes used. "special" is anything that is not a letter or a digit.
+    classes = sum(
+        [
+            any(c.islower() for c in password),
+            any(c.isupper() for c in password),
+            any(c.isdigit() for c in password),
+            any(not c.isalnum() for c in password),
+        ]
+    )
+    if classes < MIN_PASSWORD_CHARACTER_CLASSES:
+        return (
+            f"the password should contain at least {MIN_PASSWORD_CHARACTER_CLASSES} of the following four "
+            "character classes: a lowercase letter, an uppercase letter, a digit, and a special character"
+        )
+    return None
 
 
 class AgentAction(str, Enum):

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1612,7 +1612,7 @@ def add_user(username: str, password: SecretStr) -> model.User:
     """Add a new user to the system
 
     :param username: The username of the new user. The username cannot be an empty string.
-    :param password: The password of this new user. The password should be at least 8 characters long.
+    :param password: The password of this new user. It should be between 8 and 128 characters long.
     :raises Conflict: Raised when there is already a user with this user_name
     :raises BadRequest: Raised when server authentication is not enabled
     """
@@ -1620,13 +1620,18 @@ def add_user(username: str, password: SecretStr) -> model.User:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_CHANGE_PASSWORD, read_only=False)
 @typedmethod(path="/user/<username>/password", operation="PATCH", client_types=[ClientType.api], api_version=2)
-def set_password(username: str, password: SecretStr) -> None:
+def set_password(username: str, password: SecretStr, current_password: Optional[SecretStr] = None) -> None:
     """Change the password of a user
 
     :param username: The username of the user
-    :param password: The password of this new user. The password should be at least 8 characters long.
+    :param password: The new password. It should be between 8 and 128 characters long.
+    :param current_password: The user's current password. Required when a user changes their own password
+                             (so a hijacked session cannot take over the account); ignored when an
+                             administrator changes another user's password.
     :raises NotFound: Raised when the user does not exist
-    :raises BadRequest: Raised when server authentication is not enabled
+    :raises BadRequest: Raised when server authentication is not enabled, or when a user changes their own
+                        password without providing the current one.
+    :raises UnauthorizedException: Raised when the provided current password is incorrect.
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1612,7 +1612,7 @@ def add_user(username: str, password: SecretStr) -> model.User:
     """Add a new user to the system
 
     :param username: The username of the new user. The username cannot be an empty string.
-    :param password: The password of this new user. It should be between 8 and 128 characters long.
+    :param password: The password of this new user. It should be between 12 and 128 characters long.
     :raises Conflict: Raised when there is already a user with this user_name
     :raises BadRequest: Raised when server authentication is not enabled
     """
@@ -1624,7 +1624,7 @@ def set_password(username: str, password: SecretStr, current_password: Optional[
     """Change the password of a user
 
     :param username: The username of the user
-    :param password: The new password. It should be between 8 and 128 characters long.
+    :param password: The new password. It should be between 12 and 128 characters long.
     :param current_password: The user's current password. Required when a user changes their own password
                              (so a hijacked session cannot take over the account); ignored when an
                              administrator changes another user's password.

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -19,6 +19,7 @@ Contact: code@inmanta.com
 import logging
 import uuid
 from collections.abc import Mapping
+from typing import Optional
 
 import asyncpg
 from pydantic import SecretStr
@@ -26,7 +27,7 @@ from pydantic import SecretStr
 import nacl.exceptions
 import nacl.pwhash
 from inmanta import const, data, protocol
-from inmanta.const import MIN_PASSWORD_LENGTH
+from inmanta.const import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 from inmanta.data import AuthMethod, model
 from inmanta.protocol import common, exceptions
 from inmanta.protocol.auth import auth
@@ -43,6 +44,32 @@ def verify_authentication_enabled() -> None:
         raise exceptions.BadRequest(
             "Server authentication should be enabled. To setup the initial user use the inmanta-initial-user-setup tool."
         )
+
+
+def verify_password_policy(password: str) -> None:
+    """Raise a BadRequest if the password does not satisfy the length policy."""
+    if not password or len(password) < MIN_PASSWORD_LENGTH:
+        raise exceptions.BadRequest(f"the password should be at least {MIN_PASSWORD_LENGTH} characters long")
+    if len(password) > MAX_PASSWORD_LENGTH:
+        raise exceptions.BadRequest(f"the password should be at most {MAX_PASSWORD_LENGTH} characters long")
+
+
+_dummy_password_hash: Optional[str] = None
+
+
+def verify_dummy_password(password: SecretStr) -> None:
+    """
+    Verify the password against a constant dummy hash. This makes the response time of a login for an
+    unknown user match that of a known user with a wrong password, preventing username enumeration
+    through timing.
+    """
+    global _dummy_password_hash
+    if _dummy_password_hash is None:
+        _dummy_password_hash = nacl.pwhash.str(b"a constant dummy password used only for timing").decode()
+    try:
+        nacl.pwhash.verify(_dummy_password_hash.encode(), password.get_secret_value().encode())
+    except nacl.exceptions.InvalidkeyError:
+        pass
 
 
 def _get_source_ip(context: common.CallContext) -> str:
@@ -81,8 +108,7 @@ class UserService(server_protocol.ServerSlice):
         if not username:
             raise exceptions.BadRequest("the username cannot be an empty string")
         secret = password.get_secret_value()
-        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
-            raise exceptions.BadRequest("the password should be at least 8 characters long")
+        verify_password_policy(secret)
 
         # hash the password
         pw_hash = nacl.pwhash.str(secret.encode())
@@ -109,15 +135,32 @@ class UserService(server_protocol.ServerSlice):
         await user.delete()
 
     @protocol.handle(protocol.methods_v2.set_password)
-    async def set_password(self, username: str, password: SecretStr) -> None:
+    async def set_password(
+        self,
+        username: str,
+        password: SecretStr,
+        context: common.CallContext,
+        current_password: Optional[SecretStr] = None,
+    ) -> None:
         verify_authentication_enabled()
         secret = password.get_secret_value()
-        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
-            raise exceptions.BadRequest("the password should be at least 8 characters long")
+        verify_password_policy(secret)
         # check if the user already exists
         user = await data.User.get_one(username=username)
         if not user:
             raise exceptions.NotFound(f"User with name {username} does not exist.")
+
+        # Changing your own password requires proving you know the current one, so a hijacked session
+        # cannot silently take over the account. An administrator changing another user's password does not.
+        if context.auth_username == username:
+            if current_password is None:
+                raise exceptions.BadRequest("changing your own password requires the current password")
+            try:
+                if not user.password_hash:
+                    raise nacl.exceptions.InvalidkeyError()
+                nacl.pwhash.verify(user.password_hash.encode(), current_password.get_secret_value().encode())
+            except nacl.exceptions.InvalidkeyError:
+                raise exceptions.UnauthorizedException(message="The current password is incorrect", no_prefix=True)
 
         # hash the password
         pw_hash = nacl.pwhash.str(secret.encode())
@@ -135,12 +178,19 @@ class UserService(server_protocol.ServerSlice):
         invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
+            # Still run a verification against a dummy hash so the timing does not reveal that the user
+            # does not exist (username-enumeration resistance).
+            verify_dummy_password(password)
             LOGGER.warning("Failed login for user '%s' from %s: no such user", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
         try:
             nacl.pwhash.verify(user.password_hash.encode(), password.get_secret_value().encode())
         except nacl.exceptions.InvalidkeyError:
             LOGGER.warning("Failed login for user '%s' from %s: invalid password", username, source_ip)
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
+        except (ValueError, nacl.exceptions.CryptoError):
+            # A stored hash that cannot be parsed is an authentication failure, not a server error.
+            LOGGER.warning("Failed login for user '%s' from %s: malformed stored password hash", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
 
         LOGGER.info("Successful login for user '%s' from %s", username, source_ip)

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -27,7 +27,6 @@ from pydantic import SecretStr
 import nacl.exceptions
 import nacl.pwhash
 from inmanta import const, data, protocol
-from inmanta.const import MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH
 from inmanta.data import AuthMethod, model
 from inmanta.protocol import common, exceptions
 from inmanta.protocol.auth import auth
@@ -47,11 +46,10 @@ def verify_authentication_enabled() -> None:
 
 
 def verify_password_policy(password: str) -> None:
-    """Raise a BadRequest if the password does not satisfy the length policy."""
-    if not password or len(password) < MIN_PASSWORD_LENGTH:
-        raise exceptions.BadRequest(f"the password should be at least {MIN_PASSWORD_LENGTH} characters long")
-    if len(password) > MAX_PASSWORD_LENGTH:
-        raise exceptions.BadRequest(f"the password should be at most {MAX_PASSWORD_LENGTH} characters long")
+    """Raise a BadRequest if the password does not satisfy the password policy (length and complexity)."""
+    violation = const.password_policy_violation(password)
+    if violation is not None:
+        raise exceptions.BadRequest(violation)
 
 
 _dummy_password_hash: Optional[str] = None

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -26,7 +26,7 @@ from pydantic import SecretStr
 
 import nacl.exceptions
 import nacl.pwhash
-from inmanta import const, data, protocol
+from inmanta import const, data, protocol, util
 from inmanta.data import AuthMethod, model
 from inmanta.protocol import common, exceptions
 from inmanta.protocol.auth import auth
@@ -47,7 +47,7 @@ def verify_authentication_enabled() -> None:
 
 def verify_password_policy(password: str) -> None:
     """Raise a BadRequest if the password does not satisfy the password policy (length and complexity)."""
-    violation = const.password_policy_violation(password)
+    violation = util.password_policy_violation(password)
     if violation is not None:
         raise exceptions.BadRequest(violation)
 

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -145,6 +145,7 @@ class UserService(server_protocol.ServerSlice):
         verify_authentication_enabled()
         secret = password.get_secret_value()
         verify_password_policy(secret)
+        source_ip = _get_source_ip(context)
         # check if the user already exists
         user = await data.User.get_one(username=username)
         if not user:
@@ -155,11 +156,18 @@ class UserService(server_protocol.ServerSlice):
         if context.auth_username == username:
             if current_password is None:
                 raise exceptions.BadRequest("changing your own password requires the current password")
-            try:
-                if not user.password_hash:
-                    raise nacl.exceptions.InvalidkeyError()
-                nacl.pwhash.verify(user.password_hash.encode(), current_password.get_secret_value().encode())
-            except nacl.exceptions.InvalidkeyError:
+            current_password_ok = bool(user.password_hash)
+            if current_password_ok:
+                try:
+                    nacl.pwhash.verify(user.password_hash.encode(), current_password.get_secret_value().encode())
+                except nacl.exceptions.InvalidkeyError:
+                    current_password_ok = False
+            else:
+                # No local password (e.g. an OIDC-only account): still run a verification so the response
+                # time does not reveal whether the account has a password.
+                verify_dummy_password(current_password)
+            if not current_password_ok:
+                LOGGER.warning("Failed password change for user '%s' from %s: incorrect current password", username, source_ip)
                 raise exceptions.UnauthorizedException(message="The current password is incorrect", no_prefix=True)
 
         # hash the password
@@ -167,6 +175,7 @@ class UserService(server_protocol.ServerSlice):
 
         # insert the user
         await user.update_fields(password_hash=pw_hash.decode())
+        LOGGER.info("Password for user '%s' changed by '%s' from %s", username, context.auth_username or "<unknown>", source_ip)
 
     @protocol.handle(protocol.methods_v2.login)
     async def login(
@@ -189,7 +198,9 @@ class UserService(server_protocol.ServerSlice):
             LOGGER.warning("Failed login for user '%s' from %s: invalid password", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
         except (ValueError, nacl.exceptions.CryptoError):
-            # A stored hash that cannot be parsed is an authentication failure, not a server error.
+            # A stored hash that cannot be parsed is an authentication failure, not a server error. Most
+            # malformed hashes raise InvalidkeyError (a CryptoError subclass) and are handled above; this
+            # clause also covers a hash that is well-formed but too long, which raises a plain ValueError.
             LOGGER.warning("Failed login for user '%s' from %s: malformed stored password hash", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
 

--- a/src/inmanta/user_setup.py
+++ b/src/inmanta/user_setup.py
@@ -25,11 +25,11 @@ from asyncpg import PostgresError
 
 import nacl.pwhash
 from inmanta import config, data
-from inmanta.const import password_policy_violation
 from inmanta.data import start_engine, stop_engine
 from inmanta.data.model import AuthMethod
 from inmanta.protocol.auth import auth
 from inmanta.server import config as server_config
+from inmanta.util import password_policy_violation
 
 
 class ConnectionPoolException(Exception):

--- a/src/inmanta/user_setup.py
+++ b/src/inmanta/user_setup.py
@@ -25,7 +25,7 @@ from asyncpg import PostgresError
 
 import nacl.pwhash
 from inmanta import config, data
-from inmanta.const import MIN_PASSWORD_LENGTH
+from inmanta.const import password_policy_violation
 from inmanta.data import start_engine, stop_engine
 from inmanta.data.model import AuthMethod
 from inmanta.protocol.auth import auth
@@ -133,8 +133,9 @@ async def do_user_setup() -> None:
             raise click.ClickException("the username cannot be an empty string")
 
         password = click.prompt("What password do you want to use?", hide_input=True)
-        if not password or len(password) < MIN_PASSWORD_LENGTH:
-            raise click.ClickException("the password should be at least 8 characters long")
+        password_violation = password_policy_violation(password)
+        if password_violation is not None:
+            raise click.ClickException(password_violation)
 
         pw_hash = nacl.pwhash.str(password.encode())
 

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -72,6 +72,37 @@ T = TypeVar("T")
 S = TypeVar("S")
 
 
+def password_policy_violation(password: str) -> Optional[str]:
+    """
+    Return a human-readable reason the password violates the password policy, or None if it is acceptable.
+
+    The policy is a length range plus a basic complexity requirement (a mix of character classes). It is
+    shared by the API (add_user, set_password) and the inmanta-initial-user-setup CLI so both enforce the
+    same rules. Note this is a deliberately minimal, self-contained check: richer credential controls
+    (breached-password lists, history, rotation, MFA) are out of scope for the built-in provider and are
+    expected from an external OIDC identity provider instead.
+    """
+    if not password or len(password) < const.MIN_PASSWORD_LENGTH:
+        return f"the password should be at least {const.MIN_PASSWORD_LENGTH} characters long"
+    if len(password) > const.MAX_PASSWORD_LENGTH:
+        return f"the password should be at most {const.MAX_PASSWORD_LENGTH} characters long"
+    # Count the character classes used. "special" is anything that is not a letter or a digit.
+    classes = sum(
+        [
+            any(c.islower() for c in password),
+            any(c.isupper() for c in password),
+            any(c.isdigit() for c in password),
+            any(not c.isalnum() for c in password),
+        ]
+    )
+    if classes < const.MIN_PASSWORD_CHARACTER_CLASSES:
+        return (
+            f"the password should contain at least {const.MIN_PASSWORD_CHARACTER_CLASSES} of the following four "
+            "character classes: a lowercase letter, an uppercase letter, a digit, and a special character"
+        )
+    return None
+
+
 def groupby(mylist: list[T], f: Callable[[T], S]) -> Iterator[tuple[S, Iterator[T]]]:
     return itertools.groupby(sorted(mylist, key=f), f)
 

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -856,7 +856,7 @@ async def test_roles_failure_scenarios(server: protocol.Server, client, environm
     """
     Test the failure scenario's when manipulating roles and role assignments.
     """
-    result = await client.add_user(username="user", password="useruser")
+    result = await client.add_user(username="user", password="Str0ng-Pass!")
     assert result.code == 200
 
     # Create role that already exists

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -229,3 +229,71 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     response = await auth_client.environment_create_token(tid=env_id, client_types=["api"])
     assert response.code == 200
     assert response.result["data"]
+
+
+async def test_password_max_length(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """Passwords longer than MAX_PASSWORD_LENGTH are rejected, on both add_user and set_password."""
+    too_long = "a" * (const.MAX_PASSWORD_LENGTH + 1)
+    at_max = "a" * const.MAX_PASSWORD_LENGTH
+
+    response = await auth_client.add_user("bob", too_long)
+    assert response.code == 400
+    assert "at most" in response.result["message"]
+
+    response = await auth_client.add_user("bob", at_max)
+    assert response.code == 200
+
+    response = await auth_client.set_password("bob", too_long)
+    assert response.code == 400
+    assert "at most" in response.result["message"]
+
+
+async def test_login_malformed_hash_is_401(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """A stored password hash that cannot be parsed yields 401, not a 500 server error."""
+    user = data.User(username="corrupt", password_hash="not-a-valid-argon2-hash", auth_method=AuthMethod.database)
+    await user.insert()
+
+    response = await auth_client.login("corrupt", "some_password_123")
+    assert response.code == 401
+
+
+async def test_set_password_self_service_requires_current(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """Changing your own password requires the current password; an admin changing another user's does not."""
+    old = "old_password_123"
+    new = "new_password_123"
+
+    response = await auth_client.add_user("carol", old)
+    assert response.code == 200
+
+    # Log in as carol to obtain a session token whose sub is carol (i.e. a self-service caller).
+    response = await auth_client.login("carol", old)
+    assert response.code == 200
+    config.Config.set("client_rest_transport", "token", response.result["data"]["token"])
+    carol_client = protocol.Client("client")
+
+    # Self-service without the current password is refused.
+    response = await carol_client.set_password("carol", new)
+    assert response.code == 400
+
+    # Self-service with a wrong current password is refused.
+    response = await carol_client.set_password("carol", new, current_password="not_the_password")
+    assert response.code == 401
+
+    # Self-service with the correct current password succeeds.
+    response = await carol_client.set_password("carol", new, current_password=old)
+    assert response.code == 200
+    response = await auth_client.login("carol", new)
+    assert response.code == 200
+
+    # An administrator (a caller with a different identity) can reset it without the current password.
+    response = await auth_client.set_password("carol", "admin_reset_123")
+    assert response.code == 200
+
+
+def test_verify_dummy_password_smoke() -> None:
+    """The dummy-hash verification used for username-enumeration resistance runs without raising."""
+    from pydantic import SecretStr
+
+    from inmanta.server.services.userservice import verify_dummy_password
+
+    verify_dummy_password(SecretStr("any password"))

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -250,14 +250,18 @@ async def test_password_max_length(server: protocol.Server, auth_client: endpoin
 
 async def test_login_malformed_hash_is_401(server: protocol.Server, auth_client: endpoints.Client) -> None:
     """A stored password hash that cannot be parsed yields 401, not a 500 server error."""
-    user = data.User(username="corrupt", password_hash="not-a-valid-argon2-hash", auth_method=AuthMethod.database)
-    await user.insert()
+    # A garbage-prefixed hash raises InvalidkeyError; a well-formed but oversized hash raises a plain
+    # ValueError. Use the latter so the dedicated (ValueError, CryptoError) branch is actually exercised.
+    for bad_hash in ["not-a-valid-argon2-hash", "$argon2id$" + "x" * 200]:
+        user = data.User(username=f"corrupt-{len(bad_hash)}", password_hash=bad_hash, auth_method=AuthMethod.database)
+        await user.insert()
+        response = await auth_client.login(user.username, "some_password_123")
+        assert response.code == 401
 
-    response = await auth_client.login("corrupt", "some_password_123")
-    assert response.code == 401
 
-
-async def test_set_password_self_service_requires_current(server: protocol.Server, auth_client: endpoints.Client) -> None:
+async def test_set_password_self_service_requires_current(
+    server: protocol.Server, auth_client: endpoints.Client, caplog
+) -> None:
     """Changing your own password requires the current password; an admin changing another user's does not."""
     old = "old_password_123"
     new = "new_password_123"
@@ -275,13 +279,18 @@ async def test_set_password_self_service_requires_current(server: protocol.Serve
     response = await carol_client.set_password("carol", new)
     assert response.code == 400
 
-    # Self-service with a wrong current password is refused.
-    response = await carol_client.set_password("carol", new, current_password="not_the_password")
-    assert response.code == 401
+    # Self-service with a wrong current password is refused and audited.
+    with caplog.at_level(logging.WARNING):
+        response = await carol_client.set_password("carol", new, current_password="not_the_password")
+        assert response.code == 401
+    assert any("Failed password change for user 'carol'" in r.getMessage() for r in caplog.records)
 
-    # Self-service with the correct current password succeeds.
-    response = await carol_client.set_password("carol", new, current_password=old)
-    assert response.code == 200
+    # Self-service with the correct current password succeeds and is audited.
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        response = await carol_client.set_password("carol", new, current_password=old)
+        assert response.code == 200
+    assert any("Password for user 'carol' changed by 'carol'" in r.getMessage() for r in caplog.records)
     response = await auth_client.login("carol", new)
     assert response.code == 200
 

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -60,14 +60,14 @@ async def test_create_and_delete_user(server: protocol.Server, auth_client: endp
     # Try adding a user with a password that is too short
     response = await auth_client.add_user("admin", "test")
     assert response.code == 400
-    assert response.result["message"] == "Invalid request: the password should be at least 8 characters long"
+    assert response.result["message"] == "Invalid request: the password should be at least 12 characters long"
 
     # Try adding a user with no username
     response = await auth_client.add_user("", "test12345")
     assert response.code == 400
     assert response.result["message"] == "Invalid request: the username cannot be an empty string"
 
-    response = await auth_client.add_user("admin", "test1234")
+    response = await auth_client.add_user("admin", "Str0ng-Pass!")
     assert response.code == 200
 
     response = await auth_client.list_users()
@@ -76,7 +76,7 @@ async def test_create_and_delete_user(server: protocol.Server, auth_client: endp
     assert response.result["data"][0]["username"] == "admin"
 
     # Try adding a user with the same username
-    response = await auth_client.add_user("admin", "test12345")
+    response = await auth_client.add_user("admin", "Str0ng-Pass!")
     assert response.code == 409
     assert (
         response.result["message"] == "Request conflicts with the current state of the resource: A user with name admin "
@@ -93,7 +93,7 @@ async def test_create_and_delete_user(server: protocol.Server, auth_client: endp
 
 async def test_login(server: protocol.Server, client: endpoints.Client, auth_client: endpoints.Client) -> None:
     """Test the built-in user authentication"""
-    response = await auth_client.add_user("admin", "test1234")
+    response = await auth_client.add_user("admin", "Str0ng-Pass!")
     assert response.code == 200
 
     response = await auth_client.list_users()
@@ -110,7 +110,7 @@ async def test_login(server: protocol.Server, client: endpoints.Client, auth_cli
     response = await client.login("admin", "wrong")
     assert response.code == 401
 
-    response = await client.login("admin", "test1234")
+    response = await client.login("admin", "Str0ng-Pass!")
     assert response.code == 200
     assert "token" in response.result["data"]
     assert "user" in response.result["data"]
@@ -168,8 +168,8 @@ async def test_login_audit_logging_and_redaction(
 
 
 async def test_set_password(server: protocol.Server, auth_client: endpoints.Client) -> None:
-    old_pw = "old_password"
-    new_pw = "new_password"
+    old_pw = "Old-Passw0rd!"
+    new_pw = "New-Passw0rd!"
     response = await auth_client.add_user("admin", old_pw)
     assert response.code == 200
 
@@ -180,7 +180,7 @@ async def test_set_password(server: protocol.Server, auth_client: endpoints.Clie
 
     response = await auth_client.set_password("admin", "toshort")
     assert response.code == 400
-    assert response.result["message"] == "Invalid request: the password should be at least 8 characters long"
+    assert response.result["message"] == "Invalid request: the password should be at least 12 characters long"
 
     response = await auth_client.set_password("admin", new_pw)
     assert response.code == 200
@@ -234,7 +234,7 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
 async def test_password_max_length(server: protocol.Server, auth_client: endpoints.Client) -> None:
     """Passwords longer than MAX_PASSWORD_LENGTH are rejected, on both add_user and set_password."""
     too_long = "a" * (const.MAX_PASSWORD_LENGTH + 1)
-    at_max = "a" * const.MAX_PASSWORD_LENGTH
+    at_max = "Aa1" + "a" * (const.MAX_PASSWORD_LENGTH - 3)
 
     response = await auth_client.add_user("bob", too_long)
     assert response.code == 400

--- a/tests/test_default_policy.py
+++ b/tests/test_default_policy.py
@@ -167,15 +167,15 @@ async def test_default_policy_change_password(server, client) -> None:
     client_user1 = endpoints.Client("client")
 
     # A user can change their own password (self-service requires the current password)
-    result = await client_user1.set_password(username=username1, password="testtest", current_password="password")
+    result = await client_user1.set_password(username=username1, password="Str0ng-Pass!", current_password="password")
     assert result.code == 200
 
     # A user cannot change the password of another user
-    result = await client_user1.set_password(username=username2, password="testtest")
+    result = await client_user1.set_password(username=username2, password="Str0ng-Pass!")
     assert result.code == 403
 
     # A global admin can change any user's password
-    result = await global_admin_client.set_password(username=username2, password="testtest")
+    result = await global_admin_client.set_password(username=username2, password="Str0ng-Pass!")
     assert result.code == 200
 
 

--- a/tests/test_default_policy.py
+++ b/tests/test_default_policy.py
@@ -166,8 +166,8 @@ async def test_default_policy_change_password(server, client) -> None:
     config.Config.set("client_rest_transport", "token", token)
     client_user1 = endpoints.Client("client")
 
-    # A user can change their own password
-    result = await client_user1.set_password(username=username1, password="testtest")
+    # A user can change their own password (self-service requires the current password)
+    result = await client_user1.set_password(username=username1, password="testtest", current_password="password")
     assert result.code == 200
 
     # A user cannot change the password of another user

--- a/tests/test_usersetup.py
+++ b/tests/test_usersetup.py
@@ -90,9 +90,9 @@ async def test_user_setup(
     cli = CLI_user_setup()
     result = await cli.run("yes", "new_user", "pw")
     assert result.exit_code == 1
-    assert result.stderr == "Error: the password should be at least 8 characters long\n"
+    assert result.stderr == "Error: the password should be at least 12 characters long\n"
 
-    result = await cli.run("yes", "new_user", "password")
+    result = await cli.run("yes", "new_user", "Str0ng-Pass!")
     assert result.exit_code == 0
 
     users = await data.User.get_list(connection=postgresql_client)
@@ -115,7 +115,7 @@ async def test_user_setup_empty_username(
     setup_config(tmpdir, postgres_db, database_name)
     cli = CLI_user_setup()
 
-    result = await cli.run("yes", "", "password")
+    result = await cli.run("yes", "", "Str0ng-Pass!")
     assert result.exit_code == 0
 
     users = await data.User.get_list(connection=postgresql_client)
@@ -133,7 +133,7 @@ async def test_user_setup_schema_outdated(
         await PGRestore(fh.readlines(), postgresql_client).run()
 
     cli = CLI_user_setup()
-    result = await cli.run("yes", "new_user", "password")
+    result = await cli.run("yes", "new_user", "Str0ng-Pass!")
     assert result.exit_code == 1
     assert (
         result.stderr == "Error: The version of the database is out of date: start the server"


### PR DESCRIPTION
Four small hardening fixes to the built-in database authentication.

> Stacked on #10532 (base branch `auth-login-hardening`) so the diff is login-hardening-only. Retarget to master once #10532 merges. Web-console counterpart: inmanta/web-console#7071.

## Changes

- **Username-enumeration resistance.** A login for an unknown user now still runs an Argon2 verification against a constant dummy hash before returning 401, so response time no longer reveals whether an account exists. The same parity is applied in `set_password` for accounts without a local password (e.g. OIDC-only).
- **Malformed stored hash -> 401.** A stored password hash that cannot be parsed is treated as an authentication failure instead of raising a 500.
- **Maximum password length.** Passwords are capped at 128 characters (`MAX_PASSWORD_LENGTH`), enforced on `add_user` and `set_password`, as a guard against denial-of-service through very expensive hashing.
- **Require the current password on self-service change.** `set_password` gains an optional `current_password`; when a user changes their **own** password it is required and verified, so a hijacked session cannot silently take over the account. An administrator changing another user's password is unaffected. The authz boundary is unchanged (the OPA policy already only lets a user reach this handler for their own account or as a global admin). Password-change attempts are now audit-logged, mirroring login.

## Trade-off to sign off on

The dummy-hash verification means **every** login attempt (known or unknown user) now pays the Argon2 cost, which runs synchronously on the event loop. This widens the pre-auth CPU-DoS surface from "requires a known username" to "any request". This is a conscious trade-off for timing-safety and is consistent with the decision to handle brute-force protection / rate limiting at the network edge rather than in the application (documented in #10536). Offloading password hashing to an executor is a reasonable follow-up.

## Tests

`tests/server/test_user.py`: max-length rejection (add_user + set_password), malformed/oversized stored hash -> 401 (exercising both the InvalidkeyError and the ValueError branch), self-service change requires the current password (missing -> 400, wrong -> 401, correct -> 200, admin reset needs none) with audit-log assertions, and a dummy-hash smoke test. flake8 / black / mypy clean.

## Changelog

`changelogs/unreleased/harden-database-login.yml` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)