### PR TITLE
Backport to iso9: redact passwords from logs and add login audit logging (#10532)

### DIFF
--- a/changelogs/unreleased/redact-passwords-and-login-audit-logging.yml
+++ b/changelogs/unreleased/redact-passwords-and-login-audit-logging.yml
@@ -1,0 +1,4 @@
+description: Passwords are no longer leaked into the server debug logs or tracing spans for the development/lab only database authentication method. The password parameters of the login, add_user and set_password API calls are now typed as pydantic SecretStr so their value is redacted wherever it is logged. In addition, every login attempt (success and failure) is now audit-logged with the username and source IP.
+change-type: minor
+destination-branches:
+  - iso9

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -80,16 +80,24 @@ V = typing_extensions.TypeVar("V", bound=types.SimpleTypes, covariant=True, defa
 class CallContext:
     """A context variable that provides more information about the current call context"""
 
-    request_headers: dict[str, str]
+    request_headers: Mapping[str, str]
     auth_token: Optional[auth.claim_type]
     auth_username: Optional[str]
+    # The peer IP of the connection (the direct client, or the reverse proxy when the API is
+    # fronted by one). None when it could not be determined (e.g. internal calls).
+    remote_ip: Optional[str]
 
     def __init__(
-        self, request_headers: dict[str, str], auth_token: Optional[auth.claim_type], auth_username: Optional[str]
+        self,
+        request_headers: Mapping[str, str],
+        auth_token: Optional[auth.claim_type],
+        auth_username: Optional[str],
+        remote_ip: Optional[str] = None,
     ) -> None:
         self.request_headers = request_headers
         self.auth_token = auth_token
         self.auth_username = auth_username
+        self.remote_ip = remote_ip
 
 
 class ArgOption:
@@ -357,7 +365,19 @@ class InvalidMethodDefinition(Exception):
 
 
 VALID_URL_ARG_TYPES = (Enum, uuid.UUID, str, float, int, bool, datetime)
-VALID_SIMPLE_ARG_TYPES = (BaseModel, Enum, uuid.UUID, str, float, int, bool, datetime, bytes, pydantic.AnyUrl)
+VALID_SIMPLE_ARG_TYPES = (
+    BaseModel,
+    Enum,
+    uuid.UUID,
+    str,
+    float,
+    int,
+    bool,
+    datetime,
+    bytes,
+    pydantic.AnyUrl,
+    pydantic.SecretStr,
+)
 
 
 class MethodProperties(Generic[R]):
@@ -732,6 +752,14 @@ class MethodProperties(Generic[R]):
             for name, n in cnt.items():
                 if n > 1:
                     raise InvalidMethodDefinition(f"Union of argument {arg} can contain only one generic {name}")
+
+        elif isinstance(arg_type, type) and types.issubclass(
+            arg_type, VALID_URL_ARG_TYPES if in_url else VALID_SIMPLE_ARG_TYPES
+        ):
+            # A concrete class that is a valid simple type. This is checked before the generic
+            # branch because some concrete types (e.g. pydantic SecretStr) subclass a Generic base
+            # and would otherwise be misdetected as an unparameterized generic.
+            pass
 
         elif typing_inspect.is_generic_type(arg_type):
             orig = typing_inspect.get_origin(arg_type)

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -23,6 +23,8 @@ import uuid
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal, Optional, Union
 
+from pydantic import SecretStr
+
 import inmanta.types
 from inmanta import const
 from inmanta.const import AgentAction, AllAgentAction, ApiDocsFormat, Change, ClientType, ParameterSource, ResourceState
@@ -1565,7 +1567,7 @@ def get_environment_metrics(
 
 
 @typedmethod(path="/login", operation="POST", client_types=[ClientType.api], enforce_auth=False, api_version=2)
-def login(username: str, password: str) -> ReturnValue[model.LoginReturn]:
+def login(username: str, password: SecretStr) -> ReturnValue[model.LoginReturn]:
     """Login a user.
 
      When the login succeeds an authentication header is returned with the Bearer token set.
@@ -1606,7 +1608,7 @@ def delete_user(username: str) -> None:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_WRITE, read_only=False)
 @typedmethod(path="/user", operation="POST", client_types=[ClientType.api], api_version=2)
-def add_user(username: str, password: str) -> model.User:
+def add_user(username: str, password: SecretStr) -> model.User:
     """Add a new user to the system
 
     :param username: The username of the new user. The username cannot be an empty string.
@@ -1618,7 +1620,7 @@ def add_user(username: str, password: str) -> model.User:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_CHANGE_PASSWORD, read_only=False)
 @typedmethod(path="/user/<username>/password", operation="PATCH", client_types=[ClientType.api], api_version=2)
-def set_password(username: str, password: str) -> None:
+def set_password(username: str, password: SecretStr) -> None:
     """Change the password of a user
 
     :param username: The username of the user

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -61,17 +61,20 @@ class CallArguments:
         config: common.UrlMethod,
         message: dict[str, Optional[object]],
         request_headers: Mapping[str, str],
+        remote_ip: Optional[str] = None,
     ) -> None:
         """
         :param config: The method configuration that contains the metadata and functions to call
         :param message: The message received by the RPC call
         :param request_headers: The headers received by the RPC call
+        :param remote_ip: The peer IP of the connection, or None when it could not be determined
         :param handler: The handler for the call
         """
         self._config = config
         self._properties = self._config.properties
         self._message = message
         self._request_headers = request_headers
+        self._remote_ip = remote_ip
         self._argspec: inspect.FullArgSpec = inspect.getfullargspec(self._properties.function)
 
         self._call_args: JsonType = {}
@@ -343,7 +346,10 @@ class CallArguments:
         # verify if we need to inject a CallContext
         if call_context_var := self.get_call_context():
             self._call_args[call_context_var] = common.CallContext(
-                request_headers=self._headers, auth_token=self._auth_token, auth_username=self._auth_username
+                request_headers=self._request_headers,
+                auth_token=self._auth_token,
+                auth_username=self._auth_username,
+                remote_ip=self._remote_ip,
             )
 
         self._processed = True
@@ -643,6 +649,7 @@ class RESTBase(util.TaskHandler[None], abc.ABC):
         config: common.UrlMethod,
         message: dict[str, object],
         request_headers: Mapping[str, str],
+        remote_ip: Optional[str] = None,
     ) -> common.Response:
         try:
             if config is None:
@@ -658,7 +665,7 @@ class RESTBase(util.TaskHandler[None], abc.ABC):
             # First check if the call is authenticated, then process the request so we can handle it and then authorize it.
             # Authorization might need data from the request but we do not want to process it before we are sure the call
             # is authenticated.
-            arguments = CallArguments(config, message, request_headers)
+            arguments = CallArguments(config, message, request_headers, remote_ip=remote_ip)
             is_auth_enabled: bool = self.is_auth_enabled()
             arguments.authenticate(auth_enabled=is_auth_enabled)
             await arguments.process()

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -133,7 +133,9 @@ class RESTHandler(tornado.web.RequestHandler):
                             else:
                                 message[key] = [v.decode("latin-1") for v in value]
 
-                        result = await self._transport._execute_call(call_config, message, self.request.headers)
+                        result = await self._transport._execute_call(
+                            call_config, message, self.request.headers, remote_ip=self.request.remote_ip
+                        )
                         self.respond(result.body, result.headers, result.status_code)
                     except JSONDecodeError as e:
                         error_message = f"The request body couldn't be decoded as a JSON: {e}"

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -21,6 +21,7 @@ import uuid
 from collections.abc import Mapping
 
 import asyncpg
+from pydantic import SecretStr
 
 import nacl.exceptions
 import nacl.pwhash
@@ -44,6 +45,20 @@ def verify_authentication_enabled() -> None:
         )
 
 
+def _get_source_ip(context: common.CallContext) -> str:
+    """
+    Source of the request for audit logging. This is the connection peer IP, which is the client
+    for direct access (the common case for the web console) and the reverse proxy when the API is
+    fronted by one. In the latter case the originating client is reported by the proxy in the
+    X-Forwarded-For header, so it is appended when present.
+    """
+    remote_ip = context.remote_ip or "unknown"
+    forwarded = context.request_headers.get("X-Forwarded-For") or context.request_headers.get("x-forwarded-for")
+    if forwarded:
+        return f"{remote_ip} (X-Forwarded-For: {forwarded.split(',')[0].strip()})"
+    return remote_ip
+
+
 class UserService(server_protocol.ServerSlice):
     """Slice for managing users"""
 
@@ -61,15 +76,16 @@ class UserService(server_protocol.ServerSlice):
         return await data.User.list_users_with_roles()
 
     @protocol.handle(protocol.methods_v2.add_user)
-    async def add_user(self, username: str, password: str) -> model.User:
+    async def add_user(self, username: str, password: SecretStr) -> model.User:
         verify_authentication_enabled()
         if not username:
             raise exceptions.BadRequest("the username cannot be an empty string")
-        if not password or len(password) < MIN_PASSWORD_LENGTH:
+        secret = password.get_secret_value()
+        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
             raise exceptions.BadRequest("the password should be at least 8 characters long")
 
         # hash the password
-        pw_hash = nacl.pwhash.str(password.encode())
+        pw_hash = nacl.pwhash.str(secret.encode())
 
         # insert the user
         try:
@@ -93,9 +109,10 @@ class UserService(server_protocol.ServerSlice):
         await user.delete()
 
     @protocol.handle(protocol.methods_v2.set_password)
-    async def set_password(self, username: str, password: str) -> None:
+    async def set_password(self, username: str, password: SecretStr) -> None:
         verify_authentication_enabled()
-        if not password or len(password) < MIN_PASSWORD_LENGTH:
+        secret = password.get_secret_value()
+        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
             raise exceptions.BadRequest("the password should be at least 8 characters long")
         # check if the user already exists
         user = await data.User.get_one(username=username)
@@ -103,24 +120,30 @@ class UserService(server_protocol.ServerSlice):
             raise exceptions.NotFound(f"User with name {username} does not exist.")
 
         # hash the password
-        pw_hash = nacl.pwhash.str(password.encode())
+        pw_hash = nacl.pwhash.str(secret.encode())
 
         # insert the user
         await user.update_fields(password_hash=pw_hash.decode())
 
     @protocol.handle(protocol.methods_v2.login)
-    async def login(self, username: str, password: str) -> common.ReturnValue[model.LoginReturn]:
+    async def login(
+        self, username: str, password: SecretStr, context: common.CallContext
+    ) -> common.ReturnValue[model.LoginReturn]:
         verify_authentication_enabled()
+        source_ip = _get_source_ip(context)
         # check if the user exists
         invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
+            LOGGER.warning("Failed login for user '%s' from %s: no such user", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
         try:
-            nacl.pwhash.verify(user.password_hash.encode(), password.encode())
+            nacl.pwhash.verify(user.password_hash.encode(), password.get_secret_value().encode())
         except nacl.exceptions.InvalidkeyError:
+            LOGGER.warning("Failed login for user '%s' from %s: invalid password", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
 
+        LOGGER.info("Successful login for user '%s' from %s", username, source_ip)
         role_assignments: model.RoleAssignmentsPerEnvironment = await data.Role.get_roles_for_user(username)
 
         custom_claims: Mapping[str, str | bool | Mapping[str, list[str]]] = {

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -534,6 +534,11 @@ def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
     if isinstance(o, (uuid.UUID, pydantic.AnyUrl, pydantic_core.Url)):
         return str(o)
 
+    if isinstance(o, pydantic.SecretStr):
+        # Never serialize the secret value across a (de)serialization boundary (e.g. the policy
+        # engine input); emit the redacted form (str(SecretStr) == "**********").
+        return str(o)
+
     if isinstance(o, datetime.datetime):
         return o.isoformat(timespec="microseconds")
 

--- a/tests/protocol/test_protocol.py
+++ b/tests/protocol/test_protocol.py
@@ -980,7 +980,7 @@ async def test_method_definition():
 
     assert (
         "Type object of argument name must be one of BaseModel, Enum, UUID, str, float, int, bool, datetime, "
-        "bytes, AnyUrl or a List of these types or a Dict with str keys and values of these types."
+        "bytes, AnyUrl, SecretStr or a List of these types or a Dict with str keys and values of these types."
     ) in str(e.value)
 
     with pytest.raises(InvalidMethodDefinition) as e:
@@ -1005,7 +1005,7 @@ async def test_method_definition():
 
     assert (
         "Type object of argument name must be one of BaseModel, Enum, UUID, str, float, int, bool, datetime, "
-        "bytes, AnyUrl or a List of these types or a Dict with str keys and values of these types."
+        "bytes, AnyUrl, SecretStr or a List of these types or a Dict with str keys and values of these types."
     ) in str(e.value)
 
     @auth(auth_label=const.CoreAuthorizationLabel.TEST, read_only=False)

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -16,6 +16,8 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import logging
+
 import pytest
 
 import nacl.pwhash
@@ -125,6 +127,44 @@ async def test_login(server: protocol.Server, client: endpoints.Client, auth_cli
     response = await new_auth_client.list_users()
     assert response.code == 200
     assert response.result["data"][0]["username"] == "admin"
+
+
+async def test_login_audit_logging_and_redaction(
+    server: protocol.Server, client: endpoints.Client, auth_client: endpoints.Client, caplog
+) -> None:
+    """Login attempts are audit-logged and passwords are never written to the logs (SecretStr redaction)."""
+    password = "sup3r-s3cret-unique-pw"
+    wrong_password = "wrong-unique-pw"
+    response = await auth_client.add_user("admin", password)
+    assert response.code == 200
+
+    with caplog.at_level(logging.DEBUG):
+        response = await client.login("admin", wrong_password)
+        assert response.code == 401
+        response = await client.login("admin", password)
+        assert response.code == 200
+
+    # Every login attempt is audit-logged with the username and the connection peer IP.
+    failed = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "Failed login for user 'admin'" in r.getMessage()
+    ]
+    succeeded = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.INFO and "Successful login for user 'admin'" in r.getMessage()
+    ]
+    assert failed
+    assert succeeded
+    # The source IP is captured from the connection (not "unknown"), which is the direct client
+    # for the in-process test rather than an X-Forwarded-For header.
+    assert all("unknown" not in line for line in failed + succeeded)
+
+    # The dispatcher logs the call arguments at debug level; the password must be redacted there.
+    login_call_logs = [record.getMessage() for record in caplog.records if "Calling method login" in record.getMessage()]
+    assert login_call_logs
+    assert all(password not in message and wrong_password not in message for message in login_call_logs)
 
 
 async def test_set_password(server: protocol.Server, auth_client: endpoints.Client) -> None:


### PR DESCRIPTION
Manual iso9 backport of #10532 (redact passwords from logs/traces + login audit logging). The merge tool could not auto-backport it (merge conflict), so this cherry-picks the master squash (`9bbde7a07`) onto iso9.

## Conflict resolution

The only conflicts were in the REST dispatch layer, and they were **not** caused by #10532's own changes but by an unrelated refactor that lives on master and not on iso9: master has a module-level `execute_call(endpoint, ...)` function (plus `match_call`), whereas iso9 still uses the `RESTBase._execute_call(self, ...)` method. #10532's actual change to that layer is small - it threads the connection `remote_ip` through so the audit log can record the source IP.

Resolved by applying #10532's `remote_ip` threading to iso9's structure:
- `CallArguments` gains the `remote_ip` parameter (auto-merged) and passes it into the injected `CallContext` (this also carries #10532's fix of passing `self._request_headers` instead of the response-header dict).
- iso9's `RESTBase._execute_call` method gains `remote_ip: Optional[str] = None` and forwards it to `CallArguments`.
- The `server.py` call site passes `remote_ip=self.request.remote_ip`.
- The master-only module-level `execute_call`/`match_call` refactor was **not** pulled in.

Everything else (SecretStr typing of the password params, the `_validate_type_arg`/`VALID_SIMPLE_ARG_TYPES` handling, the `SecretStr` redaction in `_custom_json_encoder`, the `userservice` audit logging, and the tests) applied cleanly.

## Notes
- Changelog `destination-branches` set to `iso9` only (master already has #10532).
- `tests/server/test_user.py` and the touched `test_protocol.py` cases pass; black/flake8 clean.
- **This is a prerequisite for the #10537 iso9 backport** (which builds on #10532).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
