### PR TITLE
Backport to iso9: harden the built-in database login (#10537)

### DIFF
--- a/changelogs/unreleased/harden-database-login.yml
+++ b/changelogs/unreleased/harden-database-login.yml
@@ -1,0 +1,10 @@
+description: >-
+  Harden the built-in database login. Passwords must now be between 12 and 128 characters long and use
+  at least three of four character classes (lowercase, uppercase, digit, special), enforced on the API
+  and the inmanta-initial-user-setup tool. Login also verifies against a dummy password hash for unknown
+  users so the response time no longer reveals whether an account exists, a stored password hash that
+  cannot be parsed returns 401 instead of a 500 server error, and changing your own password now requires
+  providing the current one (an administrator changing another user's password does not).
+change-type: minor
+destination-branches:
+  - iso9

--- a/docs/administrators/authentication.rst
+++ b/docs/administrators/authentication.rst
@@ -200,7 +200,9 @@ Verify whether the hostname, in the generated configuration section, is correct 
 Step 3: Create the initial user
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Re-run the same command again to create the initial user. The password for this new user must be at least 8 characters long.
+Re-run the same command again to create the initial user. The password for this new user must be between 12 and 128
+characters long and contain at least three of the following four character classes: a lowercase letter, an uppercase
+letter, a digit, and a special character. The same policy applies to passwords set through the API.
 
 .. code-block:: ini
 

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -335,7 +335,11 @@ EXTENSION_MODULE = "extension"
 ENVELOPE_KEY = "data"
 
 # Minimum password length
-MIN_PASSWORD_LENGTH = 8
+MIN_PASSWORD_LENGTH = 12
+# Maximum password length, a guard against denial-of-service through very expensive password hashing
+MAX_PASSWORD_LENGTH = 128
+# The number of distinct character classes (lowercase, uppercase, digit, special) a password must use
+MIN_PASSWORD_CHARACTER_CLASSES = 3
 
 
 class AgentAction(str, Enum):

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1612,7 +1612,7 @@ def add_user(username: str, password: SecretStr) -> model.User:
     """Add a new user to the system
 
     :param username: The username of the new user. The username cannot be an empty string.
-    :param password: The password of this new user. The password should be at least 8 characters long.
+    :param password: The password of this new user. It should be between 12 and 128 characters long.
     :raises Conflict: Raised when there is already a user with this user_name
     :raises BadRequest: Raised when server authentication is not enabled
     """
@@ -1620,13 +1620,18 @@ def add_user(username: str, password: SecretStr) -> model.User:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_CHANGE_PASSWORD, read_only=False)
 @typedmethod(path="/user/<username>/password", operation="PATCH", client_types=[ClientType.api], api_version=2)
-def set_password(username: str, password: SecretStr) -> None:
+def set_password(username: str, password: SecretStr, current_password: Optional[SecretStr] = None) -> None:
     """Change the password of a user
 
     :param username: The username of the user
-    :param password: The password of this new user. The password should be at least 8 characters long.
+    :param password: The new password. It should be between 12 and 128 characters long.
+    :param current_password: The user's current password. Required when a user changes their own password
+                             (so a hijacked session cannot take over the account); ignored when an
+                             administrator changes another user's password.
     :raises NotFound: Raised when the user does not exist
-    :raises BadRequest: Raised when server authentication is not enabled
+    :raises BadRequest: Raised when server authentication is not enabled, or when a user changes their own
+                        password without providing the current one.
+    :raises UnauthorizedException: Raised when the provided current password is incorrect.
     """
 
 

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -19,14 +19,14 @@ Contact: code@inmanta.com
 import logging
 import uuid
 from collections.abc import Mapping
+from typing import Optional
 
 import asyncpg
 from pydantic import SecretStr
 
 import nacl.exceptions
 import nacl.pwhash
-from inmanta import const, data, protocol
-from inmanta.const import MIN_PASSWORD_LENGTH
+from inmanta import const, data, protocol, util
 from inmanta.data import AuthMethod, model
 from inmanta.protocol import common, exceptions
 from inmanta.protocol.auth import auth
@@ -43,6 +43,31 @@ def verify_authentication_enabled() -> None:
         raise exceptions.BadRequest(
             "Server authentication should be enabled. To setup the initial user use the inmanta-initial-user-setup tool."
         )
+
+
+def verify_password_policy(password: str) -> None:
+    """Raise a BadRequest if the password does not satisfy the password policy (length and complexity)."""
+    violation = util.password_policy_violation(password)
+    if violation is not None:
+        raise exceptions.BadRequest(violation)
+
+
+_dummy_password_hash: Optional[str] = None
+
+
+def verify_dummy_password(password: SecretStr) -> None:
+    """
+    Verify the password against a constant dummy hash. This makes the response time of a login for an
+    unknown user match that of a known user with a wrong password, preventing username enumeration
+    through timing.
+    """
+    global _dummy_password_hash
+    if _dummy_password_hash is None:
+        _dummy_password_hash = nacl.pwhash.str(b"a constant dummy password used only for timing").decode()
+    try:
+        nacl.pwhash.verify(_dummy_password_hash.encode(), password.get_secret_value().encode())
+    except nacl.exceptions.InvalidkeyError:
+        pass
 
 
 def _get_source_ip(context: common.CallContext) -> str:
@@ -81,8 +106,7 @@ class UserService(server_protocol.ServerSlice):
         if not username:
             raise exceptions.BadRequest("the username cannot be an empty string")
         secret = password.get_secret_value()
-        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
-            raise exceptions.BadRequest("the password should be at least 8 characters long")
+        verify_password_policy(secret)
 
         # hash the password
         pw_hash = nacl.pwhash.str(secret.encode())
@@ -109,21 +133,47 @@ class UserService(server_protocol.ServerSlice):
         await user.delete()
 
     @protocol.handle(protocol.methods_v2.set_password)
-    async def set_password(self, username: str, password: SecretStr) -> None:
+    async def set_password(
+        self,
+        username: str,
+        password: SecretStr,
+        context: common.CallContext,
+        current_password: Optional[SecretStr] = None,
+    ) -> None:
         verify_authentication_enabled()
         secret = password.get_secret_value()
-        if not secret or len(secret) < MIN_PASSWORD_LENGTH:
-            raise exceptions.BadRequest("the password should be at least 8 characters long")
+        verify_password_policy(secret)
+        source_ip = _get_source_ip(context)
         # check if the user already exists
         user = await data.User.get_one(username=username)
         if not user:
             raise exceptions.NotFound(f"User with name {username} does not exist.")
+
+        # Changing your own password requires proving you know the current one, so a hijacked session
+        # cannot silently take over the account. An administrator changing another user's password does not.
+        if context.auth_username == username:
+            if current_password is None:
+                raise exceptions.BadRequest("changing your own password requires the current password")
+            current_password_ok = bool(user.password_hash)
+            if current_password_ok:
+                try:
+                    nacl.pwhash.verify(user.password_hash.encode(), current_password.get_secret_value().encode())
+                except nacl.exceptions.InvalidkeyError:
+                    current_password_ok = False
+            else:
+                # No local password (e.g. an OIDC-only account): still run a verification so the response
+                # time does not reveal whether the account has a password.
+                verify_dummy_password(current_password)
+            if not current_password_ok:
+                LOGGER.warning("Failed password change for user '%s' from %s: incorrect current password", username, source_ip)
+                raise exceptions.UnauthorizedException(message="The current password is incorrect", no_prefix=True)
 
         # hash the password
         pw_hash = nacl.pwhash.str(secret.encode())
 
         # insert the user
         await user.update_fields(password_hash=pw_hash.decode())
+        LOGGER.info("Password for user '%s' changed by '%s' from %s", username, context.auth_username or "<unknown>", source_ip)
 
     @protocol.handle(protocol.methods_v2.login)
     async def login(
@@ -135,12 +185,21 @@ class UserService(server_protocol.ServerSlice):
         invalid_username_password_msg = "Invalid username or password"
         user = await data.User.get_one(username=username)
         if not user or not user.password_hash:
+            # Still run a verification against a dummy hash so the timing does not reveal that the user
+            # does not exist (username-enumeration resistance).
+            verify_dummy_password(password)
             LOGGER.warning("Failed login for user '%s' from %s: no such user", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
         try:
             nacl.pwhash.verify(user.password_hash.encode(), password.get_secret_value().encode())
         except nacl.exceptions.InvalidkeyError:
             LOGGER.warning("Failed login for user '%s' from %s: invalid password", username, source_ip)
+            raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
+        except (ValueError, nacl.exceptions.CryptoError):
+            # A stored hash that cannot be parsed is an authentication failure, not a server error. Most
+            # malformed hashes raise InvalidkeyError (a CryptoError subclass) and are handled above; this
+            # clause also covers a hash that is well-formed but too long, which raises a plain ValueError.
+            LOGGER.warning("Failed login for user '%s' from %s: malformed stored password hash", username, source_ip)
             raise exceptions.UnauthorizedException(message=invalid_username_password_msg, no_prefix=True)
 
         LOGGER.info("Successful login for user '%s' from %s", username, source_ip)

--- a/src/inmanta/user_setup.py
+++ b/src/inmanta/user_setup.py
@@ -25,11 +25,11 @@ from asyncpg import PostgresError
 
 import nacl.pwhash
 from inmanta import config, data
-from inmanta.const import MIN_PASSWORD_LENGTH
 from inmanta.data import start_engine, stop_engine
 from inmanta.data.model import AuthMethod
 from inmanta.protocol.auth import auth
 from inmanta.server import config as server_config
+from inmanta.util import password_policy_violation
 
 
 class ConnectionPoolException(Exception):
@@ -133,8 +133,9 @@ async def do_user_setup() -> None:
             raise click.ClickException("the username cannot be an empty string")
 
         password = click.prompt("What password do you want to use?", hide_input=True)
-        if not password or len(password) < MIN_PASSWORD_LENGTH:
-            raise click.ClickException("the password should be at least 8 characters long")
+        password_violation = password_policy_violation(password)
+        if password_violation is not None:
+            raise click.ClickException(password_violation)
 
         pw_hash = nacl.pwhash.str(password.encode())
 

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -72,6 +72,37 @@ T = TypeVar("T")
 S = TypeVar("S")
 
 
+def password_policy_violation(password: str) -> Optional[str]:
+    """
+    Return a human-readable reason the password violates the password policy, or None if it is acceptable.
+
+    The policy is a length range plus a basic complexity requirement (a mix of character classes). It is
+    shared by the API (add_user, set_password) and the inmanta-initial-user-setup CLI so both enforce the
+    same rules. Note this is a deliberately minimal, self-contained check: richer credential controls
+    (breached-password lists, history, rotation, MFA) are out of scope for the built-in provider and are
+    expected from an external OIDC identity provider instead.
+    """
+    if not password or len(password) < const.MIN_PASSWORD_LENGTH:
+        return f"the password should be at least {const.MIN_PASSWORD_LENGTH} characters long"
+    if len(password) > const.MAX_PASSWORD_LENGTH:
+        return f"the password should be at most {const.MAX_PASSWORD_LENGTH} characters long"
+    # Count the character classes used. "special" is anything that is not a letter or a digit.
+    classes = sum(
+        [
+            any(c.islower() for c in password),
+            any(c.isupper() for c in password),
+            any(c.isdigit() for c in password),
+            any(not c.isalnum() for c in password),
+        ]
+    )
+    if classes < const.MIN_PASSWORD_CHARACTER_CLASSES:
+        return (
+            f"the password should contain at least {const.MIN_PASSWORD_CHARACTER_CLASSES} of the following four "
+            "character classes: a lowercase letter, an uppercase letter, a digit, and a special character"
+        )
+    return None
+
+
 def groupby(mylist: list[T], f: Callable[[T], S]) -> Iterator[tuple[S, Iterator[T]]]:
     return itertools.groupby(sorted(mylist, key=f), f)
 

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -856,7 +856,7 @@ async def test_roles_failure_scenarios(server: protocol.Server, client, environm
     """
     Test the failure scenario's when manipulating roles and role assignments.
     """
-    result = await client.add_user(username="user", password="useruser")
+    result = await client.add_user(username="user", password="Str0ng-Pass!")
     assert result.code == 200
 
     # Create role that already exists

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -60,14 +60,14 @@ async def test_create_and_delete_user(server: protocol.Server, auth_client: endp
     # Try adding a user with a password that is too short
     response = await auth_client.add_user("admin", "test")
     assert response.code == 400
-    assert response.result["message"] == "Invalid request: the password should be at least 8 characters long"
+    assert response.result["message"] == "Invalid request: the password should be at least 12 characters long"
 
     # Try adding a user with no username
     response = await auth_client.add_user("", "test12345")
     assert response.code == 400
     assert response.result["message"] == "Invalid request: the username cannot be an empty string"
 
-    response = await auth_client.add_user("admin", "test1234")
+    response = await auth_client.add_user("admin", "Str0ng-Pass!")
     assert response.code == 200
 
     response = await auth_client.list_users()
@@ -76,7 +76,7 @@ async def test_create_and_delete_user(server: protocol.Server, auth_client: endp
     assert response.result["data"][0]["username"] == "admin"
 
     # Try adding a user with the same username
-    response = await auth_client.add_user("admin", "test12345")
+    response = await auth_client.add_user("admin", "Str0ng-Pass!")
     assert response.code == 409
     assert (
         response.result["message"] == "Request conflicts with the current state of the resource: A user with name admin "
@@ -93,7 +93,7 @@ async def test_create_and_delete_user(server: protocol.Server, auth_client: endp
 
 async def test_login(server: protocol.Server, client: endpoints.Client, auth_client: endpoints.Client) -> None:
     """Test the built-in user authentication"""
-    response = await auth_client.add_user("admin", "test1234")
+    response = await auth_client.add_user("admin", "Str0ng-Pass!")
     assert response.code == 200
 
     response = await auth_client.list_users()
@@ -110,7 +110,7 @@ async def test_login(server: protocol.Server, client: endpoints.Client, auth_cli
     response = await client.login("admin", "wrong")
     assert response.code == 401
 
-    response = await client.login("admin", "test1234")
+    response = await client.login("admin", "Str0ng-Pass!")
     assert response.code == 200
     assert "token" in response.result["data"]
     assert "user" in response.result["data"]
@@ -168,8 +168,8 @@ async def test_login_audit_logging_and_redaction(
 
 
 async def test_set_password(server: protocol.Server, auth_client: endpoints.Client) -> None:
-    old_pw = "old_password"
-    new_pw = "new_password"
+    old_pw = "Old-Passw0rd!"
+    new_pw = "New-Passw0rd!"
     response = await auth_client.add_user("admin", old_pw)
     assert response.code == 200
 
@@ -180,7 +180,7 @@ async def test_set_password(server: protocol.Server, auth_client: endpoints.Clie
 
     response = await auth_client.set_password("admin", "toshort")
     assert response.code == 400
-    assert response.result["message"] == "Invalid request: the password should be at least 8 characters long"
+    assert response.result["message"] == "Invalid request: the password should be at least 12 characters long"
 
     response = await auth_client.set_password("admin", new_pw)
     assert response.code == 200
@@ -229,3 +229,80 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     response = await auth_client.environment_create_token(tid=env_id, client_types=["api"])
     assert response.code == 200
     assert response.result["data"]
+
+
+async def test_password_max_length(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """Passwords longer than MAX_PASSWORD_LENGTH are rejected, on both add_user and set_password."""
+    too_long = "a" * (const.MAX_PASSWORD_LENGTH + 1)
+    at_max = "Aa1" + "a" * (const.MAX_PASSWORD_LENGTH - 3)
+
+    response = await auth_client.add_user("bob", too_long)
+    assert response.code == 400
+    assert "at most" in response.result["message"]
+
+    response = await auth_client.add_user("bob", at_max)
+    assert response.code == 200
+
+    response = await auth_client.set_password("bob", too_long)
+    assert response.code == 400
+    assert "at most" in response.result["message"]
+
+
+async def test_login_malformed_hash_is_401(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """A stored password hash that cannot be parsed yields 401, not a 500 server error."""
+    # A garbage-prefixed hash raises InvalidkeyError; a well-formed but oversized hash raises a plain
+    # ValueError. Use the latter so the dedicated (ValueError, CryptoError) branch is actually exercised.
+    for bad_hash in ["not-a-valid-argon2-hash", "$argon2id$" + "x" * 200]:
+        user = data.User(username=f"corrupt-{len(bad_hash)}", password_hash=bad_hash, auth_method=AuthMethod.database)
+        await user.insert()
+        response = await auth_client.login(user.username, "some_password_123")
+        assert response.code == 401
+
+
+async def test_set_password_self_service_requires_current(
+    server: protocol.Server, auth_client: endpoints.Client, caplog
+) -> None:
+    """Changing your own password requires the current password; an admin changing another user's does not."""
+    old = "old_password_123"
+    new = "new_password_123"
+
+    response = await auth_client.add_user("carol", old)
+    assert response.code == 200
+
+    # Log in as carol to obtain a session token whose sub is carol (i.e. a self-service caller).
+    response = await auth_client.login("carol", old)
+    assert response.code == 200
+    config.Config.set("client_rest_transport", "token", response.result["data"]["token"])
+    carol_client = protocol.Client("client")
+
+    # Self-service without the current password is refused.
+    response = await carol_client.set_password("carol", new)
+    assert response.code == 400
+
+    # Self-service with a wrong current password is refused and audited.
+    with caplog.at_level(logging.WARNING):
+        response = await carol_client.set_password("carol", new, current_password="not_the_password")
+        assert response.code == 401
+    assert any("Failed password change for user 'carol'" in r.getMessage() for r in caplog.records)
+
+    # Self-service with the correct current password succeeds and is audited.
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        response = await carol_client.set_password("carol", new, current_password=old)
+        assert response.code == 200
+    assert any("Password for user 'carol' changed by 'carol'" in r.getMessage() for r in caplog.records)
+    response = await auth_client.login("carol", new)
+    assert response.code == 200
+
+    # An administrator (a caller with a different identity) can reset it without the current password.
+    response = await auth_client.set_password("carol", "admin_reset_123")
+    assert response.code == 200
+
+
+def test_verify_dummy_password_smoke() -> None:
+    """The dummy-hash verification used for username-enumeration resistance runs without raising."""
+    from pydantic import SecretStr
+
+    from inmanta.server.services.userservice import verify_dummy_password
+
+    verify_dummy_password(SecretStr("any password"))

--- a/tests/test_default_policy.py
+++ b/tests/test_default_policy.py
@@ -166,16 +166,16 @@ async def test_default_policy_change_password(server, client) -> None:
     config.Config.set("client_rest_transport", "token", token)
     client_user1 = endpoints.Client("client")
 
-    # A user can change their own password
-    result = await client_user1.set_password(username=username1, password="testtest")
+    # A user can change their own password (self-service requires the current password)
+    result = await client_user1.set_password(username=username1, password="Str0ng-Pass!", current_password="password")
     assert result.code == 200
 
     # A user cannot change the password of another user
-    result = await client_user1.set_password(username=username2, password="testtest")
+    result = await client_user1.set_password(username=username2, password="Str0ng-Pass!")
     assert result.code == 403
 
     # A global admin can change any user's password
-    result = await global_admin_client.set_password(username=username2, password="testtest")
+    result = await global_admin_client.set_password(username=username2, password="Str0ng-Pass!")
     assert result.code == 200
 
 

--- a/tests/test_usersetup.py
+++ b/tests/test_usersetup.py
@@ -90,9 +90,9 @@ async def test_user_setup(
     cli = CLI_user_setup()
     result = await cli.run("yes", "new_user", "pw")
     assert result.exit_code == 1
-    assert result.stderr == "Error: the password should be at least 8 characters long\n"
+    assert result.stderr == "Error: the password should be at least 12 characters long\n"
 
-    result = await cli.run("yes", "new_user", "password")
+    result = await cli.run("yes", "new_user", "Str0ng-Pass!")
     assert result.exit_code == 0
 
     users = await data.User.get_list(connection=postgresql_client)
@@ -115,7 +115,7 @@ async def test_user_setup_empty_username(
     setup_config(tmpdir, postgres_db, database_name)
     cli = CLI_user_setup()
 
-    result = await cli.run("yes", "", "password")
+    result = await cli.run("yes", "", "Str0ng-Pass!")
     assert result.exit_code == 0
 
     users = await data.User.get_list(connection=postgresql_client)
@@ -133,7 +133,7 @@ async def test_user_setup_schema_outdated(
         await PGRestore(fh.readlines(), postgresql_client).run()
 
     cli = CLI_user_setup()
-    result = await cli.run("yes", "new_user", "password")
+    result = await cli.run("yes", "new_user", "Str0ng-Pass!")
     assert result.exit_code == 1
     assert (
         result.stderr == "Error: The version of the database is out of date: start the server"


### PR DESCRIPTION
Manual iso9 backport of #10537 (harden the built-in database login: password complexity policy, dummy-hash timing defense, malformed-hash 401, and current-password confirmation on self-service change). The merge tool could not auto-backport it (merge conflict, because iso9 was missing #10532), so this cherry-picks the master squash (`522cb0a4`).

## Clean cherry-pick

Now that #10532 is on iso9 (backport #10542, merged as `e3514ab40`), #10537's squash **applied with no conflicts** - iso9 already had the `SecretStr`/audit-logging baseline it builds on. The net diff vs iso9 is exactly #10537's own change (password constants + `password_policy_violation` in `util`, the `userservice` hardening, the `methods_v2` docstrings + `current_password` param, `user_setup`, the docs, and tests).

## Notes
- Changelog `destination-branches` set to `iso9` only (master already has #10537).
- `tests/server/test_user.py`, `tests/test_usersetup.py`, and `test_default_policy.py::test_default_policy_change_password` pass; black/flake8 clean.
- Backport of #10537; depends on #10532 (already on iso9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
