### PR TITLE
Add a login/renew endpoint to keep active sessions alive

### DIFF
--- a/changelogs/unreleased/login-session-renew.yml
+++ b/changelogs/unreleased/login-session-renew.yml
@@ -9,3 +9,9 @@ change-type: minor
 destination-branches:
   - master
   - iso9
+sections:
+  feature: >
+    Added a POST /api/v2/login/renew endpoint that lets an authenticated client exchange its current,
+    still-valid session token for a fresh one with a new expiry, without re-entering a password. The login
+    and renew responses now report expires_in so clients can renew before the session expires; the web
+    console uses this to keep an active database or break-glass session alive.

--- a/changelogs/unreleased/login-session-renew.yml
+++ b/changelogs/unreleased/login-session-renew.yml
@@ -1,0 +1,11 @@
+description: >-
+  Add a POST /api/v2/login/renew endpoint that lets an authenticated client exchange its current, still-valid
+  session token for a fresh one with a new expiry, without re-entering a password. The renewed token reflects
+  the user's current roles and admin status. The login and renew responses now also report expires_in (the token
+  lifetime in seconds, or null when the token does not expire) so clients can renew before the session lapses.
+  This lets the web console keep an active session alive under database or break-glass authentication instead of
+  logging the user out when the one-hour session expires.
+change-type: minor
+destination-branches:
+  - master
+  - iso9

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -910,6 +910,7 @@ src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-bo
 src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
 src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
 src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
+src/inmanta/protocol/methods_v2.py:0: error: Missing return statement  [empty-body]
 src/inmanta/protocol/methods_v2.py:0: error: Module "inmanta.protocol.methods" does not explicitly export attribute "ArgOption"  [attr-defined]
 src/inmanta/protocol/methods_v2.py:0: error: Module "inmanta.protocol.methods" does not explicitly export attribute "ArgOption"  [attr-defined]
 src/inmanta/protocol/openapi/converter.py:0: error: "object" has no attribute "__iter__"; maybe "__dir__" or "__str__"? (not iterable)  [attr-defined]

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -928,10 +928,13 @@ class LoginReturn(BaseModel):
 
     :param token: A token representing the user's authentication session
     :param user: The user object for which the token was created
+    :param expires_in: Lifetime of the token in seconds, or None when the token does not expire. Clients can use
+                       this to renew the session before it expires.
     """
 
     token: str
     user: User
+    expires_in: Optional[int] = None
 
 
 def _check_resource_id_str(v: str) -> ResourceIdStr:

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -1578,6 +1578,23 @@ def login(username: str, password: SecretStr) -> ReturnValue[model.LoginReturn]:
     """
 
 
+@auth(auth_label=const.CoreAuthorizationLabel.USER_READ, read_only=True)
+@typedmethod(path="/login/renew", operation="POST", client_types=[ClientType.api], api_version=2)
+def login_renew() -> ReturnValue[model.LoginReturn]:
+    """Renew the current login session.
+
+    The caller authenticates with their current, still-valid session token; no password is required. A fresh
+    token is returned (with a new expiry) carrying the user's current roles and admin status. This lets an
+    interactive client, such as the web console, keep an active session alive instead of forcing the user to
+    log in again when the session expires. The user is taken from the token, so a caller can only ever renew
+    their own session.
+
+    :raises BadRequest: Raised when the token is not a login session (for example an API token), or if server
+                        authentication is not enabled
+    :raises UnauthorizedException: Raised when the user no longer exists
+    """
+
+
 @auth(auth_label=const.CoreAuthorizationLabel.ROLE_ASSIGNMENT_READ, read_only=True)
 @typedmethod(path="/user", operation="GET", client_types=[ClientType.api], api_version=2)
 def list_users() -> list[model.UserWithRoles]:

--- a/src/inmanta/server/services/userservice.py
+++ b/src/inmanta/server/services/userservice.py
@@ -84,6 +84,30 @@ def _get_source_ip(context: common.CallContext) -> str:
     return remote_ip
 
 
+def issue_session_token(user: data.User, role_assignments: model.RoleAssignmentsPerEnvironment) -> tuple[str, int | None]:
+    """
+    Mint a login-session token for the given user and return it together with its lifetime in seconds
+    (None when the token does not expire). Shared by the login and session-renewal endpoints so both issue
+    identical claims and honor the same session lifetime, and so renewal always reflects the user's current
+    roles and admin status.
+    """
+    custom_claims: Mapping[str, str | bool | Mapping[str, list[str]]] = {
+        "sub": user.username,
+        const.INMANTA_ROLES_URN: {str(env_id): roles for env_id, roles in role_assignments.assignments.items()},
+        const.INMANTA_IS_ADMIN_URN: user.is_admin,
+    }
+    # Give login sessions their own lifetime, decoupled from the auth_jwt expire that governs
+    # agent/compiler service tokens. When the option is 0, fall back to the signing config's expire.
+    session_expire = server_config.server_login_session_expire.get()
+    expires_in = session_expire if session_expire > 0 else None
+    token = auth.encode_token(
+        [str(const.ClientType.api.value)],
+        expire=expires_in,
+        custom_claims=custom_claims,
+    )
+    return token, expires_in
+
+
 class UserService(server_protocol.ServerSlice):
     """Slice for managing users"""
 
@@ -204,27 +228,42 @@ class UserService(server_protocol.ServerSlice):
 
         LOGGER.info("Successful login for user '%s' from %s", username, source_ip)
         role_assignments: model.RoleAssignmentsPerEnvironment = await data.Role.get_roles_for_user(username)
-
-        custom_claims: Mapping[str, str | bool | Mapping[str, list[str]]] = {
-            "sub": username,
-            const.INMANTA_ROLES_URN: {str(env_id): roles for env_id, roles in role_assignments.assignments.items()},
-            const.INMANTA_IS_ADMIN_URN: user.is_admin,
-        }
-        # Give login sessions their own lifetime, decoupled from the auth_jwt expire that governs
-        # agent/compiler service tokens. When the option is 0, fall back to the signing config's expire.
-        session_expire = server_config.server_login_session_expire.get()
-        token = auth.encode_token(
-            [str(const.ClientType.api.value)],
-            expire=session_expire if session_expire > 0 else None,
-            custom_claims=custom_claims,
-        )
+        token, expires_in = issue_session_token(user, role_assignments)
         return common.ReturnValue(
             status_code=200,
             headers={"Authorization": f"Bearer {token}"},
-            response=model.LoginReturn(
-                user=user.to_dao(),
-                token=token,
-            ),
+            response=model.LoginReturn(user=user.to_dao(), token=token, expires_in=expires_in),
+        )
+
+    @protocol.handle(protocol.methods_v2.login_renew)
+    async def login_renew(self, context: common.CallContext) -> common.ReturnValue[model.LoginReturn]:
+        verify_authentication_enabled()
+        # Renewal is authenticated by the caller's current, still-valid token: a valid token is the
+        # credential, so no password is checked. Two things must hold for a token to be renewable:
+        #  1. It carries a sub claim identifying the user; a service token (agent/compiler/API) has none.
+        #  2. It was minted by this server's own signing authority. A token merely accepted by decode_token
+        #     is not enough: with an external issuer configured (the break-glass topology where a local
+        #     sign=true section coexists with an OIDC section), a user authenticated against that external
+        #     issuer would otherwise be handed a fresh, locally-signed token carrying the roles and is_admin
+        #     of a same-named local account. So we require the token's issuer to be our own signing issuer.
+        # The user is taken from the token's sub claim, so a caller can only ever renew their own session.
+        sign_config = auth.AuthJWTConfig.get_sign_config()
+        username = context.auth_username
+        token_issuer = context.auth_token.get("iss") if context.auth_token else None
+        if not username or sign_config is None or token_issuer != sign_config.issuer:
+            raise exceptions.BadRequest("Only login sessions issued by this server can be renewed.")
+        user = await data.User.get_one(username=username)
+        if not user:
+            # The user was removed while the session was still active; force a fresh login.
+            raise exceptions.UnauthorizedException(message="User account no longer exists.", no_prefix=True)
+
+        role_assignments: model.RoleAssignmentsPerEnvironment = await data.Role.get_roles_for_user(username)
+        token, expires_in = issue_session_token(user, role_assignments)
+        LOGGER.debug("Renewed the login session for user '%s'", username)
+        return common.ReturnValue(
+            status_code=200,
+            headers={"Authorization": f"Bearer {token}"},
+            response=model.LoginReturn(user=user.to_dao(), token=token, expires_in=expires_in),
         )
 
     @protocol.handle(protocol.methods_v2.get_current_user)

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import base64
 import logging
 
 import jwt
@@ -195,6 +196,106 @@ async def test_login_session_expire(server: protocol.Server, auth_client: endpoi
     assert response.code == 200
     claims = jwt.decode(response.result["data"]["token"], options={"verify_signature": False})
     assert claims["exp"] - claims["iat"] == 7200
+
+
+async def test_login_reports_expires_in(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """login reports the session lifetime in seconds so a client can renew before it expires."""
+    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+
+    response = await auth_client.login("admin", "adminadmin")
+    assert response.code == 200
+    assert response.result["data"]["expires_in"] == 3600
+
+    # When the option is 0 (eternal), no lifetime is reported.
+    config.Config.set("server", "login_session_expire", "0")
+    response = await auth_client.login("admin", "adminadmin")
+    assert response.code == 200
+    assert response.result["data"]["expires_in"] is None
+
+
+async def test_login_renew(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """A logged-in user renews their session with the session token and gets a fresh, working token."""
+    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+
+    login = await auth_client.login("admin", "adminadmin")
+    assert login.code == 200
+    session_token = login.result["data"]["token"]
+
+    # A client holding the session token can renew it (no password), getting a new token and lifetime.
+    config.Config.set("client_rest_transport", "token", session_token)
+    session_client = protocol.Client("client")
+    renew = await session_client.login_renew()
+    assert renew.code == 200
+    assert renew.result["data"]["expires_in"] == 3600
+    new_token = renew.result["data"]["token"]
+    claims = jwt.decode(new_token, options={"verify_signature": False})
+    assert claims["sub"] == "admin"
+
+    # The renewed token authenticates subsequent calls.
+    config.Config.set("client_rest_transport", "token", new_token)
+    renewed_client = protocol.Client("client")
+    assert (await renewed_client.list_users()).code == 200
+
+
+async def test_login_renew_reflects_current_admin_status(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """A renewed token carries the user's current admin status, not the status captured at login time."""
+    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+
+    login = await auth_client.login("admin", "adminadmin")
+    assert login.code == 200
+    session_token = login.result["data"]["token"]
+    assert jwt.decode(session_token, options={"verify_signature": False})[const.INMANTA_IS_ADMIN_URN] is False
+
+    # Promote the user, then renew: the fresh token must reflect the new admin status.
+    assert (await auth_client.set_is_admin("admin", True)).code == 200
+    config.Config.set("client_rest_transport", "token", session_token)
+    session_client = protocol.Client("client")
+    renew = await session_client.login_renew()
+    assert renew.code == 200
+    assert jwt.decode(renew.result["data"]["token"], options={"verify_signature": False})[const.INMANTA_IS_ADMIN_URN] is True
+
+
+async def test_login_renew_rejects_non_session_token(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """Renewal only applies to login sessions: a token without a sub claim (an API token) is rejected."""
+    # The auth_client fixture's token is a bare API token, minted without a sub claim.
+    response = await auth_client.login_renew()
+    assert response.code == 400
+    assert "login sessions" in response.result["message"]
+
+
+async def test_login_renew_rejects_external_issuer_token(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """
+    A token from another issuer must not be renewable, even when its username matches a local account.
+    In the break-glass topology (a local sign=true section alongside an external OIDC issuer) this would
+    otherwise let a user authenticated against the external issuer obtain a locally-signed token carrying
+    the roles and admin status of a same-named local account.
+    """
+    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+
+    # Register a second, verify-only issuer, as an external OIDC provider would be. It shares the HS256 key
+    # of the fixture's signing config purely to keep the test deterministic; only the issuer differs.
+    key_b64 = "eciwliGyqECVmXtIkNpfVrtBLutZiITZKSKYhogeHMM"
+    key_bytes = base64.urlsafe_b64decode((key_b64 + "==").encode("ascii"))
+    external_issuer = "https://external.example/"
+    config.Config.set("auth_jwt_external", "algorithm", "HS256")
+    config.Config.set("auth_jwt_external", "sign", "false")
+    config.Config.set("auth_jwt_external", "client_types", "api")
+    config.Config.set("auth_jwt_external", "key", key_b64)
+    config.Config.set("auth_jwt_external", "issuer", external_issuer)
+    config.Config.set("auth_jwt_external", "audience", external_issuer)
+
+    # A token minted by that external issuer whose sub happens to match the local "admin" account.
+    external_token = jwt.encode(
+        {"iss": external_issuer, "aud": [external_issuer], "sub": "admin"},
+        key_bytes,
+        algorithm="HS256",
+    )
+    config.Config.set("client_rest_transport", "token", external_token)
+    external_client = protocol.Client("client")
+
+    response = await external_client.login_renew()
+    assert response.code == 400
+    assert "issued by this server" in response.result["message"]
 
 
 async def test_set_password(server: protocol.Server, auth_client: endpoints.Client) -> None:

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -200,24 +200,24 @@ async def test_login_session_expire(server: protocol.Server, auth_client: endpoi
 
 async def test_login_reports_expires_in(server: protocol.Server, auth_client: endpoints.Client) -> None:
     """login reports the session lifetime in seconds so a client can renew before it expires."""
-    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+    assert (await auth_client.add_user("admin", "Str0ng-Pass!")).code == 200
 
-    response = await auth_client.login("admin", "adminadmin")
+    response = await auth_client.login("admin", "Str0ng-Pass!")
     assert response.code == 200
     assert response.result["data"]["expires_in"] == 3600
 
     # When the option is 0 (eternal), no lifetime is reported.
     config.Config.set("server", "login_session_expire", "0")
-    response = await auth_client.login("admin", "adminadmin")
+    response = await auth_client.login("admin", "Str0ng-Pass!")
     assert response.code == 200
     assert response.result["data"]["expires_in"] is None
 
 
 async def test_login_renew(server: protocol.Server, auth_client: endpoints.Client) -> None:
     """A logged-in user renews their session with the session token and gets a fresh, working token."""
-    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+    assert (await auth_client.add_user("admin", "Str0ng-Pass!")).code == 200
 
-    login = await auth_client.login("admin", "adminadmin")
+    login = await auth_client.login("admin", "Str0ng-Pass!")
     assert login.code == 200
     session_token = login.result["data"]["token"]
 
@@ -239,9 +239,9 @@ async def test_login_renew(server: protocol.Server, auth_client: endpoints.Clien
 
 async def test_login_renew_reflects_current_admin_status(server: protocol.Server, auth_client: endpoints.Client) -> None:
     """A renewed token carries the user's current admin status, not the status captured at login time."""
-    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+    assert (await auth_client.add_user("admin", "Str0ng-Pass!")).code == 200
 
-    login = await auth_client.login("admin", "adminadmin")
+    login = await auth_client.login("admin", "Str0ng-Pass!")
     assert login.code == 200
     session_token = login.result["data"]["token"]
     assert jwt.decode(session_token, options={"verify_signature": False})[const.INMANTA_IS_ADMIN_URN] is False
@@ -270,7 +270,7 @@ async def test_login_renew_rejects_external_issuer_token(server: protocol.Server
     otherwise let a user authenticated against the external issuer obtain a locally-signed token carrying
     the roles and admin status of a same-named local account.
     """
-    assert (await auth_client.add_user("admin", "adminadmin")).code == 200
+    assert (await auth_client.add_user("admin", "Str0ng-Pass!")).code == 200
 
     # Register a second, verify-only issuer, as an external OIDC provider would be. It shares the HS256 key
     # of the fixture's signing config purely to keep the test deterministic; only the issuer differs.


### PR DESCRIPTION
Let an interactive client keep an active login session alive instead of being logged out when the session expires.

> Supersedes #10540, which was auto-closed when its base branch (`auth-login-session-expire`, #10534) was deleted on merge. This is the same change rebased onto master; no content changes.

## Why

#10534 gave login sessions a finite lifetime (default one hour). That fixed a real exposure problem, but it also means an actively-used web-console session is now silently dropped after an hour, forcing a re-login mid-work. The OIDC and Keycloak providers already renew their tokens silently through their client libraries; the built-in database provider had no equivalent, so this brings it to parity.

## Change

- New `POST /api/v2/login/renew`. It is authenticated by the caller's current, still-valid session token (no password), and returns a fresh token with a new expiry.
- The renewed token is rebuilt from the current database state, so it reflects the user's **current** roles and admin status rather than whatever was captured at login time.
- `LoginReturn` now carries `expires_in` (token lifetime in seconds, or `null` when the token does not expire), reported by both `login` and `login/renew`, so a client knows when to renew.
- Token issuance is factored into a shared `issue_session_token` helper so `login` and `login/renew` stay in lockstep. `login`'s behavior is otherwise unchanged.

## Security

- **Self-scoped**: the user is taken from the token's `sub` claim, so a caller can only ever renew their own session.
- **Own-issuer only**: only tokens minted by this server's own signing authority can be renewed. A token merely accepted by `decode_token` is not sufficient - in the break-glass topology (a local `sign=true` section alongside an external OIDC issuer) a user authenticated against the external issuer would otherwise be handed a fresh, locally-signed token carrying the roles and `is_admin` of a same-named local account. The endpoint checks the token's `iss` against the local signing issuer and rejects anything else. Service tokens (no `sub`) are rejected too.
- **Sliding session, by design**: an actively-used session can be renewed indefinitely while an idle one still lapses. This deliberately relaxes #10534's absolute one-hour cap for active sessions (standard interactive-session behavior); there is intentionally no absolute lifetime ceiling.

## Tests

`test_login_reports_expires_in`, `test_login_renew` (fresh token works), `test_login_renew_reflects_current_admin_status`, `test_login_renew_rejects_non_session_token` (no `sub`), and `test_login_renew_rejects_external_issuer_token` (a matching-username token from another issuer is rejected). flake8 / black clean; mypy baseline updated for the new endpoint stub.

## Changelog

`changelogs/unreleased/login-session-renew.yml` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
