### PR TITLE
Bump opa to v1.18.2

### DIFF
--- a/changelogs/unreleased/bump-opa-1-18-2.yml
+++ b/changelogs/unreleased/bump-opa-1-18-2.yml
@@ -1,0 +1,6 @@
+---
+description: "Version of opa was bumped to v1.18.2"
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  upgrade-note: "{{description}}"

--- a/src/inmanta/__init__.py
+++ b/src/inmanta/__init__.py
@@ -16,7 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-OPA_VERSION = "1.17.1"
+OPA_VERSION = "1.18.2"
 # This version is managed by bumpversion. Should you ever update it manually, make sure to consistently update it everywhere
 # (See the bumpversion.cfg file for relevant locations).
 __version__ = "19.0.0"


### PR DESCRIPTION
# Description

Given that we are moving towards a release, we need to make sure the version of opa is up-to-date.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [ ] ~~Type annotations are present~~
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~