### PR TITLE
Verify the local project state at server startup and recompile when it is stale

### DIFF
--- a/changelogs/unreleased/recompile-on-stale-local-state.yml
+++ b/changelogs/unreleased/recompile-on-stale-local-state.yml
@@ -1,0 +1,14 @@
+---
+description: >
+  The server keeps an environment's project checkout and compiler venv on its local filesystem, while compile
+  reports live in the database. These can disagree: the server may have been promoted after a failover, or its
+  state directory may have been wiped or restored from a snapshot. The server now records which compile last ran
+  against each project directory and verifies this at startup against the latest compile in the database. On a
+  mismatch it requests an update and recompile so the local state converges to the project definition.
+change-type: minor
+destination-branches: [master]
+sections:
+  feature: >
+    At startup the server now verifies for every environment that the project state on its local filesystem was
+    produced by that environment's latest compile (this can be false after a failover to another server or a
+    wiped state directory). If not, it automatically requests an update and recompile to converge the local state.

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -440,6 +440,13 @@ INMANTA_DISK_LAYOUT_VERSION = ".inmanta_disk_layout_version"
 DEFAULT_INMANTA_DISK_LAYOUT_VERSION = 2
 
 
+# File present in the root of an environment's project directory on the server. It contains the id of the last compile
+# that ran against this directory. At server start it is compared to the latest compile in the database to detect that
+# the local project state was not produced by that compile (e.g. after a failover to another server or a wiped state
+# directory), in which case an update and recompile is requested to converge.
+INMANTA_LAST_COMPILE_MARKER = ".inmanta_last_compile"
+
+
 # ID to represent the new scheduler as an agent
 AGENT_SCHEDULER_ID = "$__scheduler"
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -985,14 +985,95 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             self.fully_ready = True
             # start a waiting compile in each environment
             await self._process_next_compile_in_queue()
+            # A compile recovered above may itself converge stale local state, in which case the check below
+            # queues one redundant recovery compile behind it. This is bounded and self-corrects.
+            await self._recompile_environments_with_stale_local_state()
 
         self.add_background_task(sub_recovery())
+
+    def _get_project_dir(self, environment_id: uuid.UUID) -> str:
+        """Return the directory that holds the project checkout and compiler venv for the given environment."""
+        return os.path.join(self._server_state_dir, str(environment_id), "compiler")
+
+    def _write_last_compile_marker(self, environment_id: uuid.UUID, compile_id: uuid.UUID) -> None:
+        """
+        Record in the environment's project directory which compile last ran against it. The startup consistency
+        check compares this marker to the latest compile in the database.
+        """
+        project_dir = self._get_project_dir(environment_id)
+        if not os.path.isdir(project_dir):
+            # the compile never got to setting up the project directory
+            return
+        try:
+            with open(os.path.join(project_dir, const.INMANTA_LAST_COMPILE_MARKER), "w") as fh:
+                fh.write(str(compile_id))
+        except OSError:
+            LOGGER.warning("Failed to write the last-compile marker for environment %s", environment_id, exc_info=True)
+
+    async def _recompile_environments_with_stale_local_state(self) -> None:
+        """
+        Verify the local project state of every environment and request an update and recompile where it is stale.
+
+        Halted environments are skipped: a compile requested for them cannot run until they are resumed, so it would
+        only accumulate queued compiles across restarts (which the report retention cleanup does not touch for halted
+        environments). They are verified when they are resumed instead.
+        """
+        for env in await data.Environment.get_list():
+            if env.halted:
+                continue
+            await self._recompile_environment_with_stale_local_state(env)
+
+    async def _recompile_environment_with_stale_local_state(self, env: data.Environment) -> None:
+        """
+        The project checkout and compiler venv live on the server's local filesystem, while compile reports live in
+        the database. These can disagree: this server may have been promoted after a failover, or its state directory
+        may have been wiped or restored from a snapshot. In that case the project state on disk is not the state that
+        produced the environment's latest compile. Detect this by comparing the last-compile marker on disk to the
+        latest compile in the database, and request an update and recompile to converge the local state.
+        """
+        if not env.repo_url:
+            # without a repository the server cannot restore the local state by itself
+            return
+        last_compile = await data.Compile.get_last_run(env.id)
+        if last_compile is None:
+            # this environment never completed a compile: there is no local state to restore
+            return
+        # a merged compile records the compile that actually ran as its substitute
+        expected_id = last_compile.substitute_compile_id or last_compile.id
+        marker_path = os.path.join(self._get_project_dir(env.id), const.INMANTA_LAST_COMPILE_MARKER)
+        try:
+            with open(marker_path) as fh:
+                if fh.read().strip() == str(expected_id):
+                    return
+        except OSError:
+            pass
+        LOGGER.warning(
+            "The local project state of environment %s was not produced by compile %s, the latest compile"
+            " in the database (e.g. after a failover to another server or a wiped state directory)."
+            " Requesting an update and recompile to converge.",
+            env.id,
+            expected_id,
+        )
+        await self.request_recompile(
+            env,
+            force_update=True,
+            do_export=True,
+            remote_id=uuid.uuid4(),
+            metadata={
+                "type": "recovery",
+                "message": "Recompile because the local project state does not match the latest compile",
+            },
+        )
 
     async def resume_environment(self, environment: uuid.UUID) -> None:
         """
         Resume compiler service after halt.
         """
         await self._process_next_compile_in_queue(environment=environment)
+        env: Optional[data.Environment] = await data.Environment.get_by_id(environment)
+        if env is not None:
+            # halted environments are not verified at startup: verify the local project state now
+            await self._recompile_environment_with_stale_local_state(env)
 
     def is_environment_compiling(self, environment_id: uuid.UUID) -> bool:
         return environment_id in self._env_to_compile_task
@@ -1065,9 +1146,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             if not c.id == compile.id and CompilerService._compile_merge_key(c) == compile_merge_key
         ]
 
-        runner = self._get_compile_runner(
-            compile, project_dir=os.path.join(self._server_state_dir, str(compile.environment), "compiler")
-        )
+        runner = self._get_compile_runner(compile, project_dir=self._get_project_dir(compile.environment))
 
         merged_env_vars = dict(compile.mergeable_environment_variables)
         for merge_candidate in merge_candidates:
@@ -1094,6 +1173,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         end = datetime.datetime.now().astimezone()
         compile_data_json: Optional[dict[str, object]] = None if compile_data is None else compile_data.model_dump()
         await compile.update_fields(completed=end, success=success, version=version, compile_data=compile_data_json)
+        self._write_last_compile_marker(compile.environment, compile.id)
         awaitables = [
             merge_candidate.update_fields(
                 started=compile.started,

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -1019,9 +1019,8 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         environments). They are verified when they are resumed instead.
         """
         for env in await data.Environment.get_list():
-            if env.halted:
-                continue
-            await self._recompile_environment_with_stale_local_state(env)
+            if not env.halted:
+                await self._recompile_environment_with_stale_local_state(env)
 
     async def _recompile_environment_with_stale_local_state(self, env: data.Environment) -> None:
         """
@@ -1072,7 +1071,6 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         await self._process_next_compile_in_queue(environment=environment)
         env: Optional[data.Environment] = await data.Environment.get_by_id(environment)
         if env is not None:
-            # halted environments are not verified at startup: verify the local project state now
             await self._recompile_environment_with_stale_local_state(env)
 
     def is_environment_compiling(self, environment_id: uuid.UUID) -> bool:

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -985,8 +985,9 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             self.fully_ready = True
             # start a waiting compile in each environment
             await self._process_next_compile_in_queue()
-            # A compile recovered above may itself converge stale local state, in which case the check below
-            # queues one redundant recovery compile behind it. This is bounded and self-corrects.
+            # The call above may restart a compile that was still queued when the server went down. The check
+            # below cannot take the result of that compile into account, so it may request one extra recompile
+            # for such an environment. This is harmless: it happens at most once, at startup.
             await self._recompile_environments_with_stale_local_state()
 
         self.add_background_task(sub_recovery())
@@ -1012,7 +1013,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
 
     async def _recompile_environments_with_stale_local_state(self) -> None:
         """
-        Verify the local project state of every environment and request an update and recompile where it is stale.
+        Verify the local project checkout of every environment and request an update and recompile where it is stale.
 
         Halted environments are skipped: a compile requested for them cannot run until they are resumed, so it would
         only accumulate queued compiles across restarts (which the report retention cleanup does not touch for halted
@@ -1047,8 +1048,8 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         except OSError:
             pass
         LOGGER.warning(
-            "The local project state of environment %s was not produced by compile %s, the latest compile"
-            " in the database (e.g. after a failover to another server or a wiped state directory)."
+            "The local project checkout of environment %s was not produced by compile %s, the latest compile"
+            " in the database (This can be caused by a failover to another orchestrator server or a wiped state directory)."
             " Requesting an update and recompile to converge.",
             env.id,
             expected_id,
@@ -1060,7 +1061,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             remote_id=uuid.uuid4(),
             metadata={
                 "type": "recovery",
-                "message": "Recompile because the local project state does not match the latest compile",
+                "message": "Recompile because the local project checkout does not match the latest compile",
             },
         )
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -2403,22 +2403,39 @@ async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block
     # the mocked compile runner does not set up the project directory itself
     os.makedirs(project_dir)
 
-    # this environment never compiled: there is no local state to restore
+    # this environment never compiled: there is no local state to verify
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
-    # the database has a completed compile but the local disk has no marker: this server did not run that compile
-    now = datetime.datetime.now().astimezone()
-    completed_compile = data.Compile(
-        remote_id=uuid.uuid4(),
-        environment=env.id,
-        requested=now,
-        started=now,
-        completed=now,
-        success=True,
-        force_update=False,
+    # a compile records on disk that it ran against the local project directory, so nothing to converge
+    first_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    with open(marker_path) as fh:
+        assert fh.read() == str(first_id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # identical requests queued together are merged: only one compile runs and writes the marker. The disk state
+    # produced by that compile is up to date for the merged request as well. The two identical requests are queued
+    # behind a compile with a different merge key, so that they merge when the first of them starts.
+    await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    merged_into_id, _ = await compilerslice.request_recompile(
+        env=env, force_update=False, do_export=True, remote_id=uuid.uuid4()
     )
-    await completed_compile.insert()
+    merged_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=True, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    merged_compile = await data.Compile.get_by_id(merged_id)
+    assert merged_compile.substitute_compile_id == merged_into_id
+    with open(marker_path) as fh:
+        assert fh.read() == str(merged_into_id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # simulate a failover: the latest compile in the database ran against the disk of another server, this state
+    # directory is empty
+    shutil.rmtree(project_dir)
+    os.makedirs(project_dir)
 
     # without a repository the server cannot restore the local state by itself: the environment is skipped
     await env.update_fields(repo_url="")
@@ -2441,23 +2458,6 @@ async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
-    # a compile that was merged into another one records the compile that actually ran as its substitute:
-    # the marker matches the substitute, not the merged compile's own id
-    now = datetime.datetime.now().astimezone()
-    merged_compile = data.Compile(
-        remote_id=uuid.uuid4(),
-        environment=env.id,
-        requested=now,
-        started=now,
-        completed=now,
-        success=True,
-        force_update=False,
-        substitute_compile_id=requested.id,
-    )
-    await merged_compile.insert()
-    await compilerslice._recompile_environments_with_stale_local_state()
-    assert await data.Compile.get_next_run(env.id) is None
-
     # the marker records the last compile attempt, whether it succeeded or not: the local state was produced by
     # that attempt either way. Otherwise a compile that fails for reasons unrelated to the local state (a model
     # error, missing git credentials, ...) would be retried at every server restart, forever.
@@ -2477,24 +2477,21 @@ async def test_stale_local_state_halted_environment(mocked_compiler_service_bloc
     accumulate queued compiles across restarts. It is verified when the environment is resumed.
     """
     env = await data.Environment.get_by_id(uuid.UUID(environment))
-    await env.update_fields(repo_url="https://example.com/test/repo.git", halted=True)
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
     project_dir = compilerslice._get_project_dir(env.id)
     # the mocked compile runner does not set up the project directory itself
     os.makedirs(project_dir)
 
-    # the database has a completed compile but the local disk has no marker: this server did not run that compile
-    now = datetime.datetime.now().astimezone()
-    completed_compile = data.Compile(
-        remote_id=uuid.uuid4(),
-        environment=env.id,
-        requested=now,
-        started=now,
-        completed=now,
-        success=True,
-        force_update=False,
-    )
-    await completed_compile.insert()
+    # a compile ran normally, then the environment was halted
+    await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    await env.update_fields(halted=True)
+
+    # simulate a failover: the latest compile in the database ran against the disk of another server, this state
+    # directory is empty
+    shutil.rmtree(project_dir)
+    os.makedirs(project_dir)
 
     # halted: nothing is requested at startup
     await compilerslice._recompile_environments_with_stale_local_state()

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -2390,9 +2390,9 @@ async def test_drain_multibyte_utf8_at_chunk_boundary(tmp_path, drain_method: st
     assert "\u2026" in getattr(run.stage, stream_kwarg)
 
 
-async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+async def test_recompile_when_local_checkout_is_stale(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
     """
-    A server whose local project state was not produced by the environment's latest compile (e.g. after a failover
+    A server whose local project checkout was not produced by the environment's latest compile (e.g. after a failover
     to another server or a wiped state directory) requests an update and recompile at startup to converge.
     """
     env = await data.Environment.get_by_id(uuid.UUID(environment))
@@ -2447,16 +2447,15 @@ async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
-    # simulate a failover to a standby that was never active before: its state directory is empty
+    # without a repository the server cannot restore the local checkout by itself: the environment is
+    # skipped even though its state directory is wiped (simulating a failover to a never-active standby)
+    await env.update_fields(repo_url="")
     shutil.rmtree(project_dir)
     os.makedirs(project_dir)
-
-    # without a repository the server cannot restore the local state by itself: the environment is skipped
-    await env.update_fields(repo_url="")
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
-    # with a repository the stale state is detected and an update and recompile is requested
+    # with the repository restored, the stale checkout is detected and an update and recompile is requested
     await env.update_fields(repo_url="https://example.com/test/repo.git")
     await compilerslice._recompile_environments_with_stale_local_state()
     requested = await data.Compile.get_next_run(env.id)

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -2432,8 +2432,22 @@ async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
-    # simulate a failover: the latest compile in the database ran against the disk of another server, this state
-    # directory is empty
+    # simulate a failover to a standby that holds an older version of the project: its marker points to an
+    # older compile than the latest one in the database, which ran on the server that is now gone
+    with open(marker_path, "w") as fh:
+        fh.write(str(first_id))
+    await compilerslice._recompile_environments_with_stale_local_state()
+    requested = await data.Compile.get_next_run(env.id)
+    assert requested is not None
+    assert requested.force_update
+    assert requested.metadata["type"] == "recovery"
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    with open(marker_path) as fh:
+        assert fh.read() == str(requested.id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # simulate a failover to a standby that was never active before: its state directory is empty
     shutil.rmtree(project_dir)
     os.makedirs(project_dir)
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -40,7 +40,7 @@ import inmanta.data.model as model
 import inmanta.util
 import utils
 from inmanta import config, data
-from inmanta.const import INMANTA_REMOVED_SET_ID, ParameterSource
+from inmanta.const import INMANTA_LAST_COMPILE_MARKER, INMANTA_REMOVED_SET_ID, ParameterSource
 from inmanta.data import APILIMIT, Compile, Report
 from inmanta.data.model import PipConfig
 from inmanta.env import PythonEnvironment, VirtualEnv
@@ -2388,3 +2388,187 @@ async def test_drain_multibyte_utf8_at_chunk_boundary(tmp_path, drain_method: st
 
     assert getattr(run.stage, stream_kwarg) == payload
     assert "\u2026" in getattr(run.stage, stream_kwarg)
+
+
+async def test_last_compile_marker_written(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+    """The id of the compile that last ran against an environment's project directory is recorded on disk."""
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    project_dir = compilerslice._get_project_dir(env.id)
+    # the mocked compile runner does not set up the project directory itself
+    os.makedirs(project_dir)
+
+    compile_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+
+    with open(os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)) as fh:
+        assert fh.read() == str(compile_id)
+
+
+async def test_last_compile_marker_written_for_failed_compile(
+    mocked_compiler_service_block: queue.Queue, server, environment
+) -> None:
+    """
+    The marker records the last compile attempt, whether it succeeded or not: the local state was produced by that
+    attempt either way. Otherwise a compile that fails for reasons unrelated to the local state (a model error,
+    missing git credentials, ...) would be retried at every server restart, forever.
+    """
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    project_dir = compilerslice._get_project_dir(env.id)
+    # the mocked compile runner does not set up the project directory itself
+    os.makedirs(project_dir)
+
+    compile_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=True)
+
+    failed_compile = await data.Compile.get_by_id(compile_id)
+    assert failed_compile.success is False
+    with open(os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)) as fh:
+        assert fh.read() == str(compile_id)
+
+    # the failed compile is not retried at startup
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+
+async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+    """
+    A server whose local project state was not produced by the environment's latest compile (e.g. after a failover
+    to another server or a wiped state directory) requests an update and recompile at startup to converge.
+    """
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    project_dir = compilerslice._get_project_dir(env.id)
+    # the mocked compile runner does not set up the project directory itself
+    os.makedirs(project_dir)
+
+    # this environment never compiled: there is no local state to restore
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # the database has a completed compile but the local disk has no marker: this server did not run that compile
+    now = datetime.datetime.now().astimezone()
+    completed_compile = data.Compile(
+        remote_id=uuid.uuid4(),
+        environment=env.id,
+        requested=now,
+        started=now,
+        completed=now,
+        success=True,
+        force_update=False,
+    )
+    await completed_compile.insert()
+
+    await compilerslice._recompile_environments_with_stale_local_state()
+    requested = await data.Compile.get_next_run(env.id)
+    assert requested is not None
+    assert requested.force_update
+    assert requested.do_export
+    assert requested.metadata["type"] == "recovery"
+
+    # running the requested compile records the marker, after which the check converges to a no-op
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+
+async def test_no_recompile_when_local_state_matches(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+    """A server that ran the environment's latest compile itself does not recompile at startup."""
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    project_dir = compilerslice._get_project_dir(env.id)
+    # the mocked compile runner does not set up the project directory itself
+    os.makedirs(project_dir)
+
+    compile_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # a compile that was merged into another one records the compile that actually ran as its substitute:
+    # the marker matches the substitute, not the merged compile's own id
+    now = datetime.datetime.now().astimezone()
+    merged_compile = data.Compile(
+        remote_id=uuid.uuid4(),
+        environment=env.id,
+        requested=now,
+        started=now,
+        completed=now,
+        success=True,
+        force_update=False,
+        substitute_compile_id=compile_id,
+    )
+    await merged_compile.insert()
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+
+async def test_no_recompile_without_repo_url(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+    """
+    An environment without a repository is not verified: the server cannot restore the local state by itself,
+    so a forced compile would only fail at every startup.
+    """
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    assert not env.repo_url
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+
+    # the database has a completed compile and there is no marker on disk, but there is no repository to restore from
+    now = datetime.datetime.now().astimezone()
+    completed_compile = data.Compile(
+        remote_id=uuid.uuid4(),
+        environment=env.id,
+        requested=now,
+        started=now,
+        completed=now,
+        success=True,
+        force_update=False,
+    )
+    await completed_compile.insert()
+
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+
+async def test_stale_local_state_halted_environment(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+    """
+    A halted environment is not verified at startup: the requested compile could not run anyway and would only
+    accumulate queued compiles across restarts. It is verified when the environment is resumed.
+    """
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.update_fields(repo_url="https://example.com/test/repo.git", halted=True)
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    project_dir = compilerslice._get_project_dir(env.id)
+    # the mocked compile runner does not set up the project directory itself
+    os.makedirs(project_dir)
+
+    # the database has a completed compile but the local disk has no marker: this server did not run that compile
+    now = datetime.datetime.now().astimezone()
+    completed_compile = data.Compile(
+        remote_id=uuid.uuid4(),
+        environment=env.id,
+        requested=now,
+        started=now,
+        completed=now,
+        success=True,
+        force_update=False,
+    )
+    await completed_compile.insert()
+
+    # halted: nothing is requested at startup
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # resuming the environment verifies the local state and requests the recompile
+    await env.update_fields(halted=False)
+    await compilerslice.resume_environment(env.id)
+    requested = await data.Compile.get_next_run(env.id)
+    assert requested is not None
+    assert requested.force_update
+    assert requested.metadata["type"] == "recovery"
+
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -2390,49 +2390,6 @@ async def test_drain_multibyte_utf8_at_chunk_boundary(tmp_path, drain_method: st
     assert "\u2026" in getattr(run.stage, stream_kwarg)
 
 
-async def test_last_compile_marker_written(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
-    """The id of the compile that last ran against an environment's project directory is recorded on disk."""
-    env = await data.Environment.get_by_id(uuid.UUID(environment))
-    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
-    project_dir = compilerslice._get_project_dir(env.id)
-    # the mocked compile runner does not set up the project directory itself
-    os.makedirs(project_dir)
-
-    compile_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
-    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
-
-    with open(os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)) as fh:
-        assert fh.read() == str(compile_id)
-
-
-async def test_last_compile_marker_written_for_failed_compile(
-    mocked_compiler_service_block: queue.Queue, server, environment
-) -> None:
-    """
-    The marker records the last compile attempt, whether it succeeded or not: the local state was produced by that
-    attempt either way. Otherwise a compile that fails for reasons unrelated to the local state (a model error,
-    missing git credentials, ...) would be retried at every server restart, forever.
-    """
-    env = await data.Environment.get_by_id(uuid.UUID(environment))
-    await env.update_fields(repo_url="https://example.com/test/repo.git")
-    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
-    project_dir = compilerslice._get_project_dir(env.id)
-    # the mocked compile runner does not set up the project directory itself
-    os.makedirs(project_dir)
-
-    compile_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
-    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=True)
-
-    failed_compile = await data.Compile.get_by_id(compile_id)
-    assert failed_compile.success is False
-    with open(os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)) as fh:
-        assert fh.read() == str(compile_id)
-
-    # the failed compile is not retried at startup
-    await compilerslice._recompile_environments_with_stale_local_state()
-    assert await data.Compile.get_next_run(env.id) is None
-
-
 async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
     """
     A server whose local project state was not produced by the environment's latest compile (e.g. after a failover
@@ -2442,6 +2399,7 @@ async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block
     await env.update_fields(repo_url="https://example.com/test/repo.git")
     compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
     project_dir = compilerslice._get_project_dir(env.id)
+    marker_path = os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)
     # the mocked compile runner does not set up the project directory itself
     os.makedirs(project_dir)
 
@@ -2462,6 +2420,13 @@ async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block
     )
     await completed_compile.insert()
 
+    # without a repository the server cannot restore the local state by itself: the environment is skipped
+    await env.update_fields(repo_url="")
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # with a repository the stale state is detected and an update and recompile is requested
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
     await compilerslice._recompile_environments_with_stale_local_state()
     requested = await data.Compile.get_next_run(env.id)
     assert requested is not None
@@ -2469,24 +2434,10 @@ async def test_recompile_when_local_state_is_stale(mocked_compiler_service_block
     assert requested.do_export
     assert requested.metadata["type"] == "recovery"
 
-    # running the requested compile records the marker, after which the check converges to a no-op
+    # running the requested compile records it in the marker, after which the check converges to a no-op
     await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
-    await compilerslice._recompile_environments_with_stale_local_state()
-    assert await data.Compile.get_next_run(env.id) is None
-
-
-async def test_no_recompile_when_local_state_matches(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
-    """A server that ran the environment's latest compile itself does not recompile at startup."""
-    env = await data.Environment.get_by_id(uuid.UUID(environment))
-    await env.update_fields(repo_url="https://example.com/test/repo.git")
-    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
-    project_dir = compilerslice._get_project_dir(env.id)
-    # the mocked compile runner does not set up the project directory itself
-    os.makedirs(project_dir)
-
-    compile_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
-    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
-
+    with open(marker_path) as fh:
+        assert fh.read() == str(requested.id)
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
@@ -2501,35 +2452,21 @@ async def test_no_recompile_when_local_state_matches(mocked_compiler_service_blo
         completed=now,
         success=True,
         force_update=False,
-        substitute_compile_id=compile_id,
+        substitute_compile_id=requested.id,
     )
     await merged_compile.insert()
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
-
-async def test_no_recompile_without_repo_url(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
-    """
-    An environment without a repository is not verified: the server cannot restore the local state by itself,
-    so a forced compile would only fail at every startup.
-    """
-    env = await data.Environment.get_by_id(uuid.UUID(environment))
-    assert not env.repo_url
-    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
-
-    # the database has a completed compile and there is no marker on disk, but there is no repository to restore from
-    now = datetime.datetime.now().astimezone()
-    completed_compile = data.Compile(
-        remote_id=uuid.uuid4(),
-        environment=env.id,
-        requested=now,
-        started=now,
-        completed=now,
-        success=True,
-        force_update=False,
-    )
-    await completed_compile.insert()
-
+    # the marker records the last compile attempt, whether it succeeded or not: the local state was produced by
+    # that attempt either way. Otherwise a compile that fails for reasons unrelated to the local state (a model
+    # error, missing git credentials, ...) would be retried at every server restart, forever.
+    failed_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=True)
+    failed_compile = await data.Compile.get_by_id(failed_id)
+    assert failed_compile.success is False
+    with open(marker_path) as fh:
+        assert fh.read() == str(failed_id)
     await compilerslice._recompile_environments_with_stale_local_state()
     assert await data.Compile.get_next_run(env.id) is None
 
@@ -2571,4 +2508,9 @@ async def test_stale_local_state_halted_environment(mocked_compiler_service_bloc
     assert requested.force_update
     assert requested.metadata["type"] == "recovery"
 
+    # running the requested compile records it in the marker and the check converges to a no-op
     await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    with open(os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)) as fh:
+        assert fh.read() == str(requested.id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None


### PR DESCRIPTION
> [!NOTE]
> I am Claude, opening this PR on behalf of Bart Vanbrabant (@bartv).

# Description

The server keeps an environment's project checkout and compiler venv on its local filesystem, while compile reports live in the database. These can disagree: the server may have been promoted after a failover (see #10529), or its state directory may have been wiped or restored from a snapshot. Until now the first compile after such an event would lazily pay the full clone-and-install cost, and a triggered compile without `update` could even compile stale code from the old checkout.

This PR makes the server record which compile last ran against each project directory (a `.inmanta_last_compile` marker file containing the compile id, written after every compile) and verify it at startup against the latest compile in the database (following `substitute_compile_id` for merged compiles). On a mismatch it logs a warning and requests a compile with `force_update=True, do_export=True` (the same semantics as `notify?update=true`) so the local state converges to the project definition.

Design decisions:

- **"Correct local state" is defined as "produced by the environment's latest compile in the database"**, not "latest git HEAD". This needs no DB migration, covers the venv/module dimension, and makes a plain restart a guaranteed no-op.
- **The marker is written for failed compiles too**: the local state was produced by that attempt either way. Otherwise a compile that fails for reasons unrelated to disk state (a model error, missing git credentials) would be retried at every restart, forever.
- **Halted environments are skipped at startup and verified on resume** instead: a compile queued for a halted environment can never run, and such rows are excluded from report retention cleanup, so queueing at startup would leak one orphaned compile row per restart.
- **Environments without a `repo_url` are skipped**: the server cannot restore their state by itself, and a forced compile would just fail at every startup.
- **No config option**: the check only acts when local state is actually stale, and the per-environment `server_compile` setting already gates server compiles.

A bounded race is documented in the code: a pre-crash queued compile recovered at startup may run next to one redundant recovery compile; this self-corrects.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~ (no ticket, direct request)
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (to be covered together with the HA documentation follow-up of #10529)
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)