### PR TITLE
Add reusable resolver from resource filter to resource ids

### DIFF
--- a/changelogs/unreleased/resource-filter-resolver.yml
+++ b/changelogs/unreleased/resource-filter-resolver.yml
@@ -1,0 +1,6 @@
+description: >-
+  Add a reusable resolver that turns a resource filter into the set of matching resource ids, reusing the
+  version-selection logic of the GraphQL `resources` query. This is internal groundwork for triggering resource
+  actions (deploy/dryrun) on the result of a filter.
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -30,6 +30,7 @@ from inmanta import data
 from inmanta.data import get_session, get_session_factory, model
 from inmanta.deploy import state
 from inmanta.server.services.compilerservice import CompilerService
+from inmanta.types import ResourceIdStr
 from sqlakeyset import Marker, unserialize_bookmark
 from sqlakeyset.asyncio import select_page
 from sqlalchemy import Boolean, Select, UnaryExpression, and_, asc, desc, func, not_, select
@@ -856,6 +857,97 @@ def add_filter_and_sort[*Ts](
     return stmt
 
 
+def join_latest_version[*Ts](
+    stmt: Select[tuple[*Ts]],
+    environment: uuid.UUID,
+    *,
+    include_orphans: bool,
+) -> Select[tuple[*Ts]]:
+    """
+    Restrict a statement that selects from (or joins on) ``models.Resource`` to the resources as present in their
+    latest version. Logic based on ``src/inmanta/data/dataview.py::ResourceView``.
+
+    - When ``include_orphans`` is True, an orphaned resource is returned in the latest version it was present in,
+      and every other resource in the latest scheduled version.
+    - When ``include_orphans`` is False, only resources in the latest scheduled version are returned.
+
+    Extracted from the ``resources`` query so the exact same version-selection logic can be reused to resolve a
+    ``ResourceFilter`` into a set of resource ids (see ``resolve_resource_ids``).
+    """
+    # CTE that fetches the latest scheduled version
+    latest_scheduled_version_cte = (
+        select(models.Scheduler.last_processed_model_version.label("version"))
+        .where(models.Scheduler.environment == environment)
+        .cte()
+    )
+
+    if include_orphans:
+        # CTE that checks if a resource is orphaned or not and returns the appropriate version
+        # - If it is not orphaned, return the resource in the latest released version
+        # - If it is orphaned, return the resource in the latest version that it was present in.
+        included_orphans_cte = (
+            select(
+                models.ResourcePersistentState.environment,
+                models.ResourcePersistentState.resource_id,
+                func.coalesce(
+                    models.ResourcePersistentState.orphaned_after,
+                    latest_scheduled_version_cte.c.version,
+                ).label("version"),
+            )
+            .where(
+                models.ResourcePersistentState.environment == environment,
+            )
+            .cte()
+        )
+        return stmt.join(
+            models.t_resource_set_configuration_model,
+            and_(
+                models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
+                models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
+            ),
+        ).join(
+            included_orphans_cte,
+            and_(
+                models.Resource.environment == included_orphans_cte.c.environment,
+                models.Resource.resource_id == included_orphans_cte.c.resource_id,
+                models.t_resource_set_configuration_model.c.model == included_orphans_cte.c.version,
+            ),
+        )
+    return stmt.join(
+        models.t_resource_set_configuration_model,
+        and_(
+            models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
+            models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
+            models.t_resource_set_configuration_model.c.model
+            == select(latest_scheduled_version_cte.c.version).scalar_subquery(),
+        ),
+    )
+
+
+async def resolve_resource_ids(filter: ResourceFilter) -> set[ResourceIdStr]:
+    """
+    Resolve a ``ResourceFilter`` into the set of resource ids matching it, using the exact same version-selection
+    and filtering logic as the ``resources`` query, but without pagination, sorting or extension output columns.
+
+    This is the shared building block used to trigger resource actions (deploy/dryrun) on the result of a filter:
+    the same set of resources the user sees in the ``resources`` query is the set the action operates on.
+    """
+    # Mirrors the include_orphans logic of the `resources` resolver.
+    include_orphans = filter.is_orphan is not False
+    stmt = select(models.Resource.resource_id).join(
+        models.ResourcePersistentState,
+        and_(
+            models.Resource.resource_id == models.ResourcePersistentState.resource_id,
+            models.Resource.environment == models.ResourcePersistentState.environment,
+        ),
+    )
+    stmt = join_latest_version(stmt, filter.environment, include_orphans=include_orphans)
+    stmt = filter.apply_filters(stmt)
+    async with get_session() as session:
+        result = await session.execute(stmt)
+        return {ResourceIdStr(resource_id) for resource_id in result.scalars().all()}
+
+
 def encode_cursor(cursor: str) -> str:
     """
     :param cursor: The cursor received from sqlakeyset without direction information ('<'/'>').
@@ -1214,13 +1306,10 @@ def get_schema(
             before: typing.Optional[str] = strawberry.UNSET,
             order_by: typing.Optional[Sequence[ResourceOrder]] = strawberry.UNSET,
         ) -> CustomListConnection[Resource]:
-            if filter.is_orphan is False:
-                include_orphans = False
-            else:
-                include_orphans = True
+            # Mirrors resolve_resource_ids: is_orphan=False excludes orphans, otherwise they are included.
+            include_orphans = filter.is_orphan is not False
 
-            # Only fetch resources in their latest version
-            # Logic based on src/inmanta/data/dataview.py::ResourceView
+            # Only fetch resources in their latest version, honouring the is_orphan filter (see join_latest_version).
             # We select `resource_model` (a subclass of models.Resource carrying the extensions' extra columns when
             # there are any, models.Resource otherwise) so each row is a single ORM object that can carry them.
             stmt = select(resource_model).join(
@@ -1230,56 +1319,7 @@ def get_schema(
                     models.Resource.environment == models.ResourcePersistentState.environment,
                 ),
             )
-
-            # CTE that fetches the latest scheduled version
-            latest_scheduled_version_cte = (
-                select(models.Scheduler.last_processed_model_version.label("version"))
-                .where(models.Scheduler.environment == filter.environment)
-                .cte()
-            )
-
-            if include_orphans:
-                # CTE that checks if a resource is orphaned or not and returns the appropriate version
-                # - If it is not orphaned, return the resource in the latest released version
-                # - If it is orphaned, return the resource in the latest version that it was present in.
-                included_orphans_cte = (
-                    select(
-                        models.ResourcePersistentState.environment,
-                        models.ResourcePersistentState.resource_id,
-                        func.coalesce(
-                            models.ResourcePersistentState.orphaned_after,
-                            latest_scheduled_version_cte.c.version,
-                        ).label("version"),
-                    )
-                    .where(
-                        models.ResourcePersistentState.environment == filter.environment,
-                    )
-                    .cte()
-                )
-                stmt = stmt.join(
-                    models.t_resource_set_configuration_model,
-                    and_(
-                        models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
-                        models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
-                    ),
-                ).join(
-                    included_orphans_cte,
-                    and_(
-                        models.Resource.environment == included_orphans_cte.c.environment,
-                        models.Resource.resource_id == included_orphans_cte.c.resource_id,
-                        models.t_resource_set_configuration_model.c.model == included_orphans_cte.c.version,
-                    ),
-                )
-            else:
-                stmt = stmt.join(
-                    models.t_resource_set_configuration_model,
-                    and_(
-                        models.t_resource_set_configuration_model.c.environment == models.Resource.environment,
-                        models.t_resource_set_configuration_model.c.resource_set == models.Resource.resource_set,
-                        models.t_resource_set_configuration_model.c.model
-                        == select(latest_scheduled_version_cte.c.version).scalar_subquery(),
-                    ),
-                )
+            stmt = join_latest_version(stmt, filter.environment, include_orphans=include_orphans)
             stmt = populate_extension_columns(stmt, models.Resource, resource_model, info)
 
             stmt = add_filter_and_sort(stmt, ResourceOrder.default_order(), filter, order_by)

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -27,10 +27,14 @@ from inmanta.data import model
 from inmanta.deploy import state
 from inmanta.graphql.graphql import GraphQLSlice
 from inmanta.graphql.schema import (
+    EnumFilter,
     GraphQLContribution,
+    ResourceFilter,
+    StrFilter,
     _docstring_param_cache,
     build_composed_sqlalchemy_model,
     mapper,
+    resolve_resource_ids,
     to_snake_case,
 )
 from inmanta.protocol import Result
@@ -752,6 +756,76 @@ async def test_notifications(server, client, setup_database):
         created = datetime.datetime.fromisoformat(edge["node"]["created"])
         assert created < previous_time
         previous_time = created
+
+
+async def test_resolve_resource_ids(server, client, environment, setup_database, mixed_resource_generator):
+    """
+    ``resolve_resource_ids`` must return exactly the set of resource ids that the equivalent ``resources`` GraphQL
+    query returns for the same filter. This is the contract the filtered resource actions rely on: a deploy/dryrun
+    on a filter operates on precisely the resources the user sees in the ``resources`` view.
+
+    We include ``setup_database`` so there are resources in other environments, to make sure the resolver does not
+    leak resources across environments.
+    """
+    instances = 2
+    resources_per_version = 10
+    await mixed_resource_generator(environment, instances, resources_per_version)
+    env_uuid = uuid.UUID(environment)
+
+    async def ids_from_graphql(filter_fragment: str) -> set[str]:
+        query = """
+        {
+            resources (filter: {environment: "%s" %s}) {
+                edges { node { resourceId } }
+            }
+        }
+        """ % (
+            environment,
+            filter_fragment,
+        )
+        result = await client.graphql(query=query)
+        check_correct_graphql_response(result)
+        return {edge["node"]["resourceId"] for edge in result.result["data"]["data"]["resources"]["edges"]}
+
+    # (graphql filter fragment, equivalent ResourceFilter built in python)
+    cases: list[tuple[str, ResourceFilter]] = [
+        ("", ResourceFilter(environment=env_uuid)),
+        ('agent: {eq: ["agent1"]}', ResourceFilter(environment=env_uuid, agent=StrFilter(eq=["agent1"]))),
+        (
+            'agent: {eq: ["agent1"]} isOrphan: false',
+            ResourceFilter(environment=env_uuid, agent=StrFilter(eq=["agent1"]), is_orphan=False),
+        ),
+        ("isOrphan: true", ResourceFilter(environment=env_uuid, is_orphan=True)),
+        ('resourceIdValue: {eq: ["0"]}', ResourceFilter(environment=env_uuid, resource_id_value=StrFilter(eq=["0"]))),
+        (
+            'resourceType: {contains: ["%XResource0%"]}',
+            ResourceFilter(environment=env_uuid, resource_type=StrFilter(contains=["%XResource0%"])),
+        ),
+        (
+            "blocked: {eq: BLOCKED}",
+            ResourceFilter(environment=env_uuid, blocked=EnumFilter[state.Blocked](eq=[state.Blocked.BLOCKED])),
+        ),
+        ("isDeploying: true", ResourceFilter(environment=env_uuid, is_deploying=True)),
+        (
+            "lastHandlerRun: {eq: NEW}",
+            ResourceFilter(
+                environment=env_uuid, last_handler_run=EnumFilter[state.HandlerResult](eq=[state.HandlerResult.NEW])
+            ),
+        ),
+        ("purged: false", ResourceFilter(environment=env_uuid, purged=False)),
+    ]
+
+    saw_non_empty = False
+    for fragment, filter_obj in cases:
+        expected = await ids_from_graphql(fragment)
+        actual = await resolve_resource_ids(filter_obj)
+        assert actual == expected, fragment
+        saw_non_empty = saw_non_empty or bool(expected)
+    # sanity check: the fixtures actually produced resources that match at least one filter
+    assert saw_non_empty
+
+    # An empty match yields an empty set (not an error).
+    assert await resolve_resource_ids(ResourceFilter(environment=env_uuid, agent=StrFilter(eq=["does-not-exist"]))) == set()
 
 
 async def test_query_resources(server, client, environment, setup_database, mixed_resource_generator):


### PR DESCRIPTION
_Claude opened this PR on behalf of @bartv._

# Description

Groundwork for triggering resource actions (deploy/dryrun) on the result of a resource filter.

Extracts the version-selection logic of the GraphQL `resources` query into a reusable `join_latest_version` helper and adds `resolve_resource_ids(filter)`, which turns a `ResourceFilter` into the set of matching resource ids (no pagination, sorting or extension output columns). A follow-up PR uses this to trigger a deploy/repair on exactly the set of resources a filter matches.

The `resources` query resolver is refactored to reuse `join_latest_version`, so its behaviour is unchanged (covered by the existing `test_query_resources`).

This is the first of a stack of 3 PRs:
1. **This PR** - filter -> resource ids resolver
2. Deploy/repair scoped to a collection of resources (internal plumbing)
3. `deploy_filtered` REST endpoint (ties 1 and 2 together)

## Tests
- `test_resolve_resource_ids` asserts the resolver returns exactly the same set of resource ids as the equivalent `resources` GraphQL query, across agent / resource_type / resource_id_value / orphan / enum / bool filters, plus environment scoping and the empty-match case.
- `test_query_resources` (existing) covers the refactored resolver.

# Self Check:

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~ (internal helper, no user-facing change)
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)