### PR TITLE
Allow deploy/repair to be scoped to a collection of resources

### DIFF
--- a/changelogs/unreleased/deploy-repair-resource-subset.yml
+++ b/changelogs/unreleased/deploy-repair-resource-subset.yml
@@ -1,0 +1,6 @@
+description: >-
+  The resource scheduler's deploy and repair can now be triggered for a specific collection of resources (via
+  the internal agent trigger interface), intersected with the optional agent filter. This is internal groundwork
+  for triggering deploy/repair on the result of a resource filter.
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -21,6 +21,7 @@ import datetime
 import logging
 import os
 import uuid
+from collections.abc import Sequence
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Optional
 
@@ -269,9 +270,12 @@ class Agent(SessionEndpoint):
         await self.stop_working()
 
     @protocol.handle(methods.trigger, env="tid", agent="id")
-    async def trigger_update(self, env: uuid.UUID, agent: None | str, incremental_deploy: bool) -> Apireturn:
+    async def trigger_update(
+        self, env: uuid.UUID, agent: None | str, incremental_deploy: bool, resources: Sequence[ResourceIdStr] | None = None
+    ) -> Apireturn:
         """
         Trigger an update for a specific agent, or for ALL agents in the environment when <agent> param is None.
+        When <resources> is given, only those resources are considered (intersected with the agent filter).
         """
         if agent == const.AGENT_SCHEDULER_ID:
             agent = None
@@ -281,12 +285,16 @@ class Agent(SessionEndpoint):
         else:
             agent_id = f"Agent {agent}"
 
+        # slightly inaccurate in case the resources list contains resources that don't exist (on the given agent),
+        # but we want to keep the log line concise.
+        nb_resources: str = str(len(resources)) if resources is not None else "all"
+
         if incremental_deploy:
-            LOGGER.info("%s got a trigger to run deploy in environment %s", agent_id, env)
-            await self.scheduler.deploy(reason="user requested a deploy", agent=agent)
+            LOGGER.info("%s got a trigger to run deploy for %s resources in environment %s", agent_id, nb_resources, env)
+            await self.scheduler.deploy(reason="user requested a deploy", agent=agent, resources=resources)
         else:
-            LOGGER.info("%s got a trigger to run repair in environment %s", agent_id, env)
-            await self.scheduler.repair(reason="user requested a repair", agent=agent)
+            LOGGER.info("%s got a trigger to run repair for %s resources in environment %s", agent_id, nb_resources, env)
+            await self.scheduler.repair(reason="user requested a repair", agent=agent, resources=resources)
         return 200
 
     @protocol.handle(methods.trigger_read_version, env="tid", agent="id")

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -26,7 +26,7 @@ import logging
 import typing
 import uuid
 from abc import abstractmethod
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Collection, Mapping, Sequence, Set
 from dataclasses import dataclass
 from enum import Enum
 from typing import ClassVar, Optional, Self
@@ -590,19 +590,25 @@ class ResourceScheduler(TaskManager):
         reason: str,
         priority: TaskPriority = TaskPriority.USER_DEPLOY,
         agent: Optional[str] = None,
+        resources: Optional[Collection[ResourceIdStr]] = None,
     ) -> None:
         """
         Trigger a deploy
 
         :param agent: If given, deploy resources only for this agent. Otherwise deploy for all agents.
+        :param resources: If given, deploy only resources in this collection. Otherwise deploy all resources
+            (on the given agent if one is given). Combined with the agent filter as an intersection.
         """
         if not self._running:
             LOGGER.debug("Ignoring deploy request for halted resource scheduler")
             return
         async with self._scheduler_lock:
-            to_deploy: Set[ResourceIdStr] = (
-                self._state.dirty if agent is None else self._state.dirty & self._state.resources_by_agent.get(agent, set())
-            )
+            intersection_filters: list[Collection[ResourceIdStr]] = []
+            if resources is not None:
+                intersection_filters.append(resources)
+            if agent is not None:
+                intersection_filters.append(self._state.resources_by_agent.get(agent, set()))
+            to_deploy: Set[ResourceIdStr] = set.intersection(self._state.dirty, *intersection_filters)
             if agent is not None:
                 LOGGER.debug("Triggering deploy for %d resources on agent %s because %s", len(to_deploy), agent, reason)
             else:
@@ -616,11 +622,14 @@ class ResourceScheduler(TaskManager):
         reason: str,
         priority: TaskPriority = TaskPriority.USER_REPAIR,
         agent: Optional[str] = None,
+        resources: Optional[Collection[ResourceIdStr]] = None,
     ) -> None:
         """
         Trigger a repair, i.e. mark all unblocked resources as dirty, then trigger a deploy.
 
         :param agent: If given, repair resources only for this agent. Otherwise repair for all agents.
+        :param resources: If given, repair only resources in this collection. Otherwise repair all resources
+            (on the given agent if one is given). Combined with the agent filter as an intersection.
         """
 
         def should_deploy_resource(resource: ResourceIdStr) -> bool:
@@ -636,9 +645,10 @@ class ResourceScheduler(TaskManager):
             LOGGER.debug("Ignoring repair request for halted resource scheduler")
             return
         async with self._scheduler_lock:
-            in_scope: Set[ResourceIdStr] = (
+            base_in_scope: Set[ResourceIdStr] = (
                 self._state.intent.keys() if agent is None else self._state.resources_by_agent.get(agent, set())
             )
+            in_scope: Set[ResourceIdStr] = base_in_scope & set(resources) if resources is not None else base_in_scope
 
             to_deploy: Set[ResourceIdStr] = {resource for resource in in_scope if should_deploy_resource(resource)}
             if agent is not None:

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -945,14 +945,19 @@ def set_state(agent: Optional[str], enabled: bool):
     arg_options=AGENT_ENV_OPTS,
     client_types=[],
 )
-def trigger(tid: uuid.UUID, id: None | str, incremental_deploy: bool):
+def trigger(tid: uuid.UUID, id: None | str, incremental_deploy: bool, resources: Sequence[ResourceIdStr] | None = None):
     """
-    When the <id> parameter is set: request this specific agent to reload resources.
-    Otherwise, request ALL agents in the environment to reload resources.
+    Request the resource scheduler to schedule resources for deploy. The agent and resources parameters may be used as
+    filters to limit the set of resources to schedule for deploy. If both are given, only resources that match both
+    filters are considered.
 
     :param tid: The environment this agent is defined in
-    :param id: The name of the agent
-    :param incremental_deploy: Indicates whether the agent should perform an incremental deploy or a full deploy
+    :param id: The name of the agent for which to deploy. When None, all agents in the environment are considered.
+    :param incremental_deploy: Indicates whether the agent should perform an incremental deploy or a full deploy.
+        For an incremental deploy, only non-compliant resources and resources with an outstanding update are triggered
+        for deploy (even if they are part of the ``resources`` list). A full deploy (repair) triggers a deploy for all
+        resources (for the given agent / in the given resources list).
+    :param resources: Optional, the resources to consider for deploy. When omitted, all resources are considered.
     """
 
 

--- a/tests/deploy/e2e/test_deploy_trigger.py
+++ b/tests/deploy/e2e/test_deploy_trigger.py
@@ -62,7 +62,7 @@ async def test_deploy_trigger(server, client, clienthelper, resource_container, 
                 caplog,
                 "inmanta.scheduler",
                 logging.INFO,
-                f"All agents got a trigger to run repair in environment {environment}",
+                f"All agents got a trigger to run repair for all resources in environment {environment}",
             )
             agents = ["agent1", "agent2", "agent3"]  # this also includes paused agents
         else:
@@ -70,10 +70,13 @@ async def test_deploy_trigger(server, client, clienthelper, resource_container, 
                 caplog,
                 "inmanta.scheduler",
                 logging.INFO,
-                f"Agent agent1 got a trigger to run repair in environment {environment}",
+                f"Agent agent1 got a trigger to run repair for all resources in environment {environment}",
             )
         log_doesnt_contain(
-            caplog, "inmanta.scheduler", logging.INFO, f"Agent agent5 got a trigger to run repair in environment {environment}"
+            caplog,
+            "inmanta.scheduler",
+            logging.INFO,
+            f"Agent agent5 got a trigger to run repair for all resources in environment {environment}",
         )
 
         assert result.result["agents"] == agents

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -963,6 +963,130 @@ async def test_deploy_single_agent(agent: TestAgent, make_resource_minimal) -> N
     assert agent.scheduler._state.resource_state[r3_fail].last_deployed > before_trigger
 
 
+async def test_deploy_specific_resources(agent: TestAgent, make_resource_minimal) -> None:
+    """
+    Verify the behavior of deploy and repair when a specific collection of resources is given. This is the
+    internal plumbing the filtered deploy endpoint relies on:
+    - deploy (incremental): only dirty resources that are also in the collection are deployed
+    - repair (full): only resources in the collection are deployed, even if they are compliant
+    - combined with an agent filter, only the intersection is deployed
+    """
+    r1_success = ResourceIdStr("test::Resource[agent1,name=1]")
+    r1_fail = ResourceIdStr("test::Resource[agent1,name=2]")
+    r2_success = ResourceIdStr("test::Resource[agent2,name=1]")
+    r2_fail = ResourceIdStr("test::Resource[agent2,name=2]")
+
+    resources: Mapping[ResourceIdStr, state.ResourceIntent] = {
+        r1_success: make_resource_minimal(r1_success, values={FAIL_DEPLOY: False}, requires=[]),
+        r1_fail: make_resource_minimal(r1_fail, values={FAIL_DEPLOY: True}, requires=[]),
+        r2_success: make_resource_minimal(r2_success, values={FAIL_DEPLOY: False}, requires=[]),
+        r2_fail: make_resource_minimal(r2_fail, values={FAIL_DEPLOY: True}, requires=[]),
+    }
+    await agent.scheduler._new_version([model_version(version=1, resources=resources, requires={})])
+
+    await wait_until_done(agent)
+    assert agent.executor_manager.executors["agent1"].execute_count == 2
+    assert agent.executor_manager.executors["agent2"].execute_count == 2
+
+    before_trigger: datetime.datetime
+
+    # deploy only r1_fail: only that resource should redeploy (it is dirty/non-compliant)
+    agent.executor_manager.reset_executor_counters()
+    before_trigger = datetime.datetime.now().astimezone()
+    await agent.scheduler.deploy(reason="Test deploy specific resource", resources=[r1_fail])
+    await wait_until_done(agent)
+
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 0
+    assert agent.scheduler._state.resource_state[r1_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r1_fail].last_deployed > before_trigger
+    assert agent.scheduler._state.resource_state[r2_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_fail].last_deployed < before_trigger
+
+    # deploy only r1_success: it is already compliant so nothing should redeploy
+    agent.executor_manager.reset_executor_counters()
+    before_trigger = datetime.datetime.now().astimezone()
+    await agent.scheduler.deploy(reason="Test deploy compliant resource", resources=[r1_success])
+    await wait_until_done(agent)
+
+    assert agent.executor_manager.executors["agent1"].execute_count == 0
+    assert agent.executor_manager.executors["agent2"].execute_count == 0
+    assert agent.scheduler._state.resource_state[r1_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r1_fail].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_fail].last_deployed < before_trigger
+
+    # deploy r1_fail and r2_fail: both should redeploy
+    agent.executor_manager.reset_executor_counters()
+    before_trigger = datetime.datetime.now().astimezone()
+    await agent.scheduler.deploy(reason="Test deploy specific resources across agents", resources=[r1_fail, r2_fail])
+    await wait_until_done(agent)
+
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 1
+    assert agent.scheduler._state.resource_state[r1_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r1_fail].last_deployed > before_trigger
+    assert agent.scheduler._state.resource_state[r2_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_fail].last_deployed > before_trigger
+
+    # repair only r1_success: that resource should redeploy even though it is compliant
+    agent.executor_manager.reset_executor_counters()
+    before_trigger = datetime.datetime.now().astimezone()
+    await agent.scheduler.repair(reason="Test repair specific resource", resources=[r1_success])
+    await wait_until_done(agent)
+
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 0
+    assert agent.scheduler._state.resource_state[r1_success].last_deployed > before_trigger
+    assert agent.scheduler._state.resource_state[r1_fail].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_fail].last_deployed < before_trigger
+
+    # repair r1_success and r2_success: both compliant resources should be re-deployed
+    agent.executor_manager.reset_executor_counters()
+    before_trigger = datetime.datetime.now().astimezone()
+    await agent.scheduler.repair(reason="Test repair specific resources across agents", resources=[r1_success, r2_success])
+    await wait_until_done(agent)
+
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 1
+    assert agent.scheduler._state.resource_state[r1_success].last_deployed > before_trigger
+    assert agent.scheduler._state.resource_state[r1_fail].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_success].last_deployed > before_trigger
+    assert agent.scheduler._state.resource_state[r2_fail].last_deployed < before_trigger
+
+    # deploy with both agent and resources filters: only the intersection should be deployed
+    agent.executor_manager.reset_executor_counters()
+    before_trigger = datetime.datetime.now().astimezone()
+    await agent.scheduler.deploy(
+        reason="Test deploy with agent and resource filter", agent="agent1", resources=[r1_fail, r2_fail]
+    )
+    await wait_until_done(agent)
+
+    # r2_fail is on agent2, so it should not be deployed (filtered out by agent filter)
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 0
+    assert agent.scheduler._state.resource_state[r1_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r1_fail].last_deployed > before_trigger
+    assert agent.scheduler._state.resource_state[r2_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_fail].last_deployed < before_trigger
+
+    # repair with both agent and resources filters: only r1_success is on agent1
+    agent.executor_manager.reset_executor_counters()
+    before_trigger = datetime.datetime.now().astimezone()
+    await agent.scheduler.repair(
+        reason="Test repair with agent and resource filter", agent="agent1", resources=[r1_success, r2_success]
+    )
+    await wait_until_done(agent)
+
+    assert agent.executor_manager.executors["agent1"].execute_count == 1
+    assert agent.executor_manager.executors["agent2"].execute_count == 0
+    assert agent.scheduler._state.resource_state[r1_success].last_deployed > before_trigger
+    assert agent.scheduler._state.resource_state[r1_fail].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_success].last_deployed < before_trigger
+    assert agent.scheduler._state.resource_state[r2_fail].last_deployed < before_trigger
+
+
 async def test_deploy_event_propagation(agent: TestAgent, make_resource_minimal):
     """
     Ensure that events are propagated when a deploy finishes


### PR DESCRIPTION
_Claude opened this PR on behalf of @bartv._

# Description

Internal execution layer for filtered deploy/repair actions.

Threads an optional `resources` collection through `scheduler.deploy` and `scheduler.repair` (intersected with the existing agent filter) and exposes it on the internal agent-facing `trigger` RPC and `Agent.trigger_update`. The public `/deploy` server interface is intentionally left unchanged: the resolved set of resources is fed in through the agent interface only, so the user-facing surface stays a single filter-based endpoint (see the follow-up PR).

Reuses the scheduler/agent approach from the unmerged #10259, restricted to the agent interface (no public server-interface change), following the direction in #10479.

Second of a stack of 3 PRs (independent of PR 1):
1. Filter -> resource ids resolver
2. **This PR** - deploy/repair scoped to a collection of resources
3. `deploy_filtered` REST endpoint (ties 1 and 2 together)

Relates to #10479.

## Tests
- `test_deploy_specific_resources` (scheduler level): deploy only touches dirty resources within the collection, repair touches all in the collection (even compliant), and both intersect correctly with the agent filter.
- Updated the existing `test_deploy_trigger` log assertions for the new (resource-count) log message.

# Self Check:

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~ (internal interface only)
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)