### PR TITLE
Backport to iso9: verify the local project state at server startup and recompile when it is stale (#10552)

### DIFF
--- a/changelogs/unreleased/recompile-on-stale-local-state.yml
+++ b/changelogs/unreleased/recompile-on-stale-local-state.yml
@@ -1,0 +1,14 @@
+---
+description: >
+  The server keeps an environment's project checkout and compiler venv on its local filesystem, while compile
+  reports live in the database. These can disagree: the server may have been promoted after a failover, or its
+  state directory may have been wiped or restored from a snapshot. The server now records which compile last ran
+  against each project directory and verifies this at startup against the latest compile in the database. On a
+  mismatch it requests an update and recompile so the local state converges to the project definition.
+change-type: minor
+destination-branches: [iso9]
+sections:
+  feature: >
+    At startup the server now verifies for every environment that the project state on its local filesystem was
+    produced by that environment's latest compile (this can be false after a failover to another server or a
+    wiped state directory). If not, it automatically requests an update and recompile to converge the local state.

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -441,6 +441,13 @@ INMANTA_DISK_LAYOUT_VERSION = ".inmanta_disk_layout_version"
 DEFAULT_INMANTA_DISK_LAYOUT_VERSION = 2
 
 
+# File present in the root of an environment's project directory on the server. It contains the id of the last compile
+# that ran against this directory. At server start it is compared to the latest compile in the database to detect that
+# the local project state was not produced by that compile (e.g. after a failover to another server or a wiped state
+# directory), in which case an update and recompile is requested to converge.
+INMANTA_LAST_COMPILE_MARKER = ".inmanta_last_compile"
+
+
 # ID to represent the new scheduler as an agent
 AGENT_SCHEDULER_ID = "$__scheduler"
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -994,14 +994,94 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             self.fully_ready = True
             # start a waiting compile in each environment
             await self._process_next_compile_in_queue()
+            # The call above may restart a compile that was still queued when the server went down. The check
+            # below cannot take the result of that compile into account, so it may request one extra recompile
+            # for such an environment. This is harmless: it happens at most once, at startup.
+            await self._recompile_environments_with_stale_local_state()
 
         self.add_background_task(sub_recovery())
+
+    def _get_project_dir(self, environment_id: uuid.UUID) -> str:
+        """Return the directory that holds the project checkout and compiler venv for the given environment."""
+        return os.path.join(self._server_state_dir, str(environment_id), "compiler")
+
+    def _write_last_compile_marker(self, environment_id: uuid.UUID, compile_id: uuid.UUID) -> None:
+        """
+        Record in the environment's project directory which compile last ran against it. The startup consistency
+        check compares this marker to the latest compile in the database.
+        """
+        project_dir = self._get_project_dir(environment_id)
+        if not os.path.isdir(project_dir):
+            # the compile never got to setting up the project directory
+            return
+        try:
+            with open(os.path.join(project_dir, const.INMANTA_LAST_COMPILE_MARKER), "w") as fh:
+                fh.write(str(compile_id))
+        except OSError:
+            LOGGER.warning("Failed to write the last-compile marker for environment %s", environment_id, exc_info=True)
+
+    async def _recompile_environments_with_stale_local_state(self) -> None:
+        """
+        Verify the local project checkout of every environment and request an update and recompile where it is stale.
+
+        Halted environments are skipped: a compile requested for them cannot run until they are resumed, so it would
+        only accumulate queued compiles across restarts (which the report retention cleanup does not touch for halted
+        environments). They are verified when they are resumed instead.
+        """
+        for env in await data.Environment.get_list():
+            if not env.halted:
+                await self._recompile_environment_with_stale_local_state(env)
+
+    async def _recompile_environment_with_stale_local_state(self, env: data.Environment) -> None:
+        """
+        The project checkout and compiler venv live on the server's local filesystem, while compile reports live in
+        the database. These can disagree: this server may have been promoted after a failover, or its state directory
+        may have been wiped or restored from a snapshot. In that case the project state on disk is not the state that
+        produced the environment's latest compile. Detect this by comparing the last-compile marker on disk to the
+        latest compile in the database, and request an update and recompile to converge the local state.
+        """
+        if not env.repo_url:
+            # without a repository the server cannot restore the local state by itself
+            return
+        last_compile = await data.Compile.get_last_run(env.id)
+        if last_compile is None:
+            # this environment never completed a compile: there is no local state to restore
+            return
+        # a merged compile records the compile that actually ran as its substitute
+        expected_id = last_compile.substitute_compile_id or last_compile.id
+        marker_path = os.path.join(self._get_project_dir(env.id), const.INMANTA_LAST_COMPILE_MARKER)
+        try:
+            with open(marker_path) as fh:
+                if fh.read().strip() == str(expected_id):
+                    return
+        except OSError:
+            pass
+        LOGGER.warning(
+            "The local project checkout of environment %s was not produced by compile %s, the latest compile"
+            " in the database (This can be caused by a failover to another orchestrator server or a wiped state directory)."
+            " Requesting an update and recompile to converge.",
+            env.id,
+            expected_id,
+        )
+        await self.request_recompile(
+            env,
+            force_update=True,
+            do_export=True,
+            remote_id=uuid.uuid4(),
+            metadata={
+                "type": "recovery",
+                "message": "Recompile because the local project checkout does not match the latest compile",
+            },
+        )
 
     async def resume_environment(self, environment: uuid.UUID) -> None:
         """
         Resume compiler service after halt.
         """
         await self._process_next_compile_in_queue(environment=environment)
+        env: Optional[data.Environment] = await data.Environment.get_by_id(environment)
+        if env is not None:
+            await self._recompile_environment_with_stale_local_state(env)
 
     def is_environment_compiling(self, environment_id: uuid.UUID) -> bool:
         return environment_id in self._env_to_compile_task
@@ -1074,9 +1154,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             if not c.id == compile.id and CompilerService._compile_merge_key(c) == compile_merge_key
         ]
 
-        runner = self._get_compile_runner(
-            compile, project_dir=os.path.join(self._server_state_dir, str(compile.environment), "compiler")
-        )
+        runner = self._get_compile_runner(compile, project_dir=self._get_project_dir(compile.environment))
 
         merged_env_vars = dict(compile.mergeable_environment_variables)
         for merge_candidate in merge_candidates:
@@ -1103,6 +1181,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         end = datetime.datetime.now().astimezone()
         compile_data_json: Optional[dict[str, object]] = None if compile_data is None else compile_data.model_dump()
         await compile.update_fields(completed=end, success=success, version=version, compile_data=compile_data_json)
+        self._write_last_compile_marker(compile.environment, compile.id)
         awaitables = [
             merge_candidate.update_fields(
                 started=compile.started,

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -40,7 +40,7 @@ import inmanta.data.model as model
 import inmanta.util
 import utils
 from inmanta import config, data
-from inmanta.const import INMANTA_REMOVED_SET_ID, ParameterSource
+from inmanta.const import INMANTA_LAST_COMPILE_MARKER, INMANTA_REMOVED_SET_ID, ParameterSource
 from inmanta.data import APILIMIT, Compile, Report
 from inmanta.data.model import PipConfig
 from inmanta.env import PythonEnvironment, VirtualEnv
@@ -2447,3 +2447,139 @@ async def test_drain_multibyte_utf8_at_chunk_boundary(tmp_path, drain_method: st
 
     assert getattr(run.stage, stream_kwarg) == payload
     assert "\u2026" in getattr(run.stage, stream_kwarg)
+
+
+async def test_recompile_when_local_checkout_is_stale(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+    """
+    A server whose local project checkout was not produced by the environment's latest compile (e.g. after a failover
+    to another server or a wiped state directory) requests an update and recompile at startup to converge.
+    """
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    project_dir = compilerslice._get_project_dir(env.id)
+    marker_path = os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)
+    # the mocked compile runner does not set up the project directory itself
+    os.makedirs(project_dir)
+
+    # this environment never compiled: there is no local state to verify
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # a compile records on disk that it ran against the local project directory, so nothing to converge
+    first_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    with open(marker_path) as fh:
+        assert fh.read() == str(first_id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # identical requests queued together are merged: only one compile runs and writes the marker. The disk state
+    # produced by that compile is up to date for the merged request as well. The two identical requests are queued
+    # behind a compile with a different merge key, so that they merge when the first of them starts.
+    await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    merged_into_id, _ = await compilerslice.request_recompile(
+        env=env, force_update=False, do_export=True, remote_id=uuid.uuid4()
+    )
+    merged_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=True, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    merged_compile = await data.Compile.get_by_id(merged_id)
+    assert merged_compile.substitute_compile_id == merged_into_id
+    with open(marker_path) as fh:
+        assert fh.read() == str(merged_into_id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # simulate a failover to a standby that holds an older version of the project: its marker points to an
+    # older compile than the latest one in the database, which ran on the server that is now gone
+    with open(marker_path, "w") as fh:
+        fh.write(str(first_id))
+    await compilerslice._recompile_environments_with_stale_local_state()
+    requested = await data.Compile.get_next_run(env.id)
+    assert requested is not None
+    assert requested.force_update
+    assert requested.metadata["type"] == "recovery"
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    with open(marker_path) as fh:
+        assert fh.read() == str(requested.id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # without a repository the server cannot restore the local checkout by itself: the environment is
+    # skipped even though its state directory is wiped (simulating a failover to a never-active standby)
+    await env.update_fields(repo_url="")
+    shutil.rmtree(project_dir)
+    os.makedirs(project_dir)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # with the repository restored, the stale checkout is detected and an update and recompile is requested
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
+    await compilerslice._recompile_environments_with_stale_local_state()
+    requested = await data.Compile.get_next_run(env.id)
+    assert requested is not None
+    assert requested.force_update
+    assert requested.do_export
+    assert requested.metadata["type"] == "recovery"
+
+    # running the requested compile records it in the marker, after which the check converges to a no-op
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    with open(marker_path) as fh:
+        assert fh.read() == str(requested.id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # the marker records the last compile attempt, whether it succeeded or not: the local state was produced by
+    # that attempt either way. Otherwise a compile that fails for reasons unrelated to the local state (a model
+    # error, missing git credentials, ...) would be retried at every server restart, forever.
+    failed_id, _ = await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=True)
+    failed_compile = await data.Compile.get_by_id(failed_id)
+    assert failed_compile.success is False
+    with open(marker_path) as fh:
+        assert fh.read() == str(failed_id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+
+async def test_stale_local_state_halted_environment(mocked_compiler_service_block: queue.Queue, server, environment) -> None:
+    """
+    A halted environment is not verified at startup: the requested compile could not run anyway and would only
+    accumulate queued compiles across restarts. It is verified when the environment is resumed.
+    """
+    env = await data.Environment.get_by_id(uuid.UUID(environment))
+    await env.update_fields(repo_url="https://example.com/test/repo.git")
+    compilerslice: CompilerService = server.get_slice(SLICE_COMPILER)
+    project_dir = compilerslice._get_project_dir(env.id)
+    # the mocked compile runner does not set up the project directory itself
+    os.makedirs(project_dir)
+
+    # a compile ran normally, then the environment was halted
+    await compilerslice.request_recompile(env=env, force_update=False, do_export=False, remote_id=uuid.uuid4())
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    await env.update_fields(halted=True)
+
+    # simulate a failover: the latest compile in the database ran against the disk of another server, this state
+    # directory is empty
+    shutil.rmtree(project_dir)
+    os.makedirs(project_dir)
+
+    # halted: nothing is requested at startup
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None
+
+    # resuming the environment verifies the local state and requests the recompile
+    await env.update_fields(halted=False)
+    await compilerslice.resume_environment(env.id)
+    requested = await data.Compile.get_next_run(env.id)
+    assert requested is not None
+    assert requested.force_update
+    assert requested.metadata["type"] == "recovery"
+
+    # running the requested compile records it in the marker and the check converges to a no-op
+    await run_compile_and_wait_until_compile_is_done(compilerslice, mocked_compiler_service_block, env.id, fail=False)
+    with open(os.path.join(project_dir, INMANTA_LAST_COMPILE_MARKER)) as fh:
+        assert fh.read() == str(requested.id)
+    await compilerslice._recompile_environments_with_stale_local_state()
+    assert await data.Compile.get_next_run(env.id) is None


### PR DESCRIPTION
> :robot: Opened by Claude on behalf of Bart.

Manual iso9 backport of #10552, which was merged to master only (its changelog entry listed `destination-branches: [master]`), so the merge tool never created an iso9 backport.

The cherry-pick of f111d26d6 applied cleanly, no conflicts. The only change relative to master is the changelog entry's `destination-branches`, set to `[iso9]` following the convention of previous manual backports (e.g. #10554).

Verified on iso9:
- `tests/server/test_compilerservice.py::test_recompile_when_local_checkout_is_stale` and `::test_stale_local_state_halted_environment`: 2 passed
- black/flake8 clean on the changed files
- `make mypy` baseline-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)