### PR TITLE
Make revocable tokens the default for environment_create_token

### DIFF
--- a/changelogs/unreleased/token-revocable-default.yml
+++ b/changelogs/unreleased/token-revocable-default.yml
@@ -1,0 +1,16 @@
+description: >-
+  Make revocable tokens the default: environment_create_token (and the v1 create_token) now defaults to
+  idempotent=False, so tokens are registered in the token registry and can be listed and individually
+  revoked. Pass idempotent=true explicitly to keep creating reproducible, stateless tokens.
+issue-nr: 10571
+change-type: minor
+destination-branches:
+  - master
+  - iso9
+sections:
+  upgrade-note: >
+    Tokens created via environment_create_token (API, web console or inmanta-cli token create) without an
+    explicit idempotent argument are now revocable by default: they carry a jti claim, are tracked in the
+    token registry, differ on every call, and expire according to the signing configuration's expire
+    setting. Automation that relies on reproducible, non-expiring tokens must pass idempotent=true
+    explicitly.

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -278,14 +278,15 @@ def delete_setting(tid: uuid.UUID, id: str):
     arg_options=ENV_OPTS,
     client_types=[const.ClientType.api, const.ClientType.compiler],
 )
-def create_token(tid: uuid.UUID, client_types: list, idempotent: bool = True):
+def create_token(tid: uuid.UUID, client_types: list, idempotent: bool = False):
     """
     Create or get a new token for the given client types.
 
     :param tid: The environment id.
     :param client_types: The client types for which this token is valid (api, agent, compiler).
     :param idempotent: Optional. The token should be idempotent, meaning it does not have an expire or issued at set,
-                       so its value will not change.
+                       so its value will not change, but it cannot be individually revoked. By default a unique token
+                       is created that is tracked in the token registry and can be listed and revoked.
     """
 
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -313,7 +313,7 @@ def environment_clear(id: uuid.UUID) -> None:
     client_types=[ClientType.api, ClientType.compiler],
     api_version=2,
 )
-def environment_create_token(tid: uuid.UUID, client_types: Sequence[str], idempotent: bool = True) -> str:
+def environment_create_token(tid: uuid.UUID, client_types: Sequence[str], idempotent: bool = False) -> str:
     """
     Create or get a new token for the given client types. Tokens generated with this call are scoped to the current
     environment.
@@ -321,7 +321,8 @@ def environment_create_token(tid: uuid.UUID, client_types: Sequence[str], idempo
     :param tid: The environment id
     :param client_types: The client types for which this token is valid (api, agent, compiler)
     :param idempotent: The token should be idempotent, such tokens do not have an expire or issued at set so their
-                       value will not change.
+                       value will not change, but they cannot be individually revoked. By default a unique token is
+                       created that is tracked in the token registry and can be listed and revoked.
     """
 
 

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -374,6 +374,13 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     assert claims[const.INMANTA_CREATED_BY_URN] == "admin"
     assert "sub" not in claims
 
+    # By default the token is non-idempotent: it carries a jti and is tracked in the registry so it
+    # can be listed and revoked.
+    assert "jti" in claims
+    response = await auth_client.environment_token_list(tid=env_id)
+    assert response.code == 200
+    assert [t["jti"] for t in response.result["data"]] == [claims["jti"]]
+
     # A call made with that token is attributed to its creator in the access log, instead of user=<>.
     config.Config.set("client_rest_transport", "token", api_token)
     token_client = protocol.Client("client")
@@ -392,6 +399,7 @@ async def test_environment_create_token(server: protocol.Server, auth_client: en
     chained_claims, _ = auth.decode_token(response.result["data"])
     assert chained_claims[const.INMANTA_CREATED_BY_URN] == "admin"
     assert "sub" not in chained_claims
+    assert "jti" in chained_claims
 
 
 async def test_password_max_length(server: protocol.Server, auth_client: endpoints.Client) -> None:


### PR DESCRIPTION
# Description

Claude here, on behalf of @bartv.

Follow-up to the token registry (#10535), from the demo-session feedback: now that tokens can be listed and revoked, a revocable token should be what you get by default.

* Flip the `idempotent` default from `True` to `False` on both the v1 `create_token` and v2 `environment_create_token` methods. Tokens created without an explicit choice now carry a `jti`, are tracked in the token registry, and can be listed and individually revoked.
* Caller audit: `inmanta-cli token bootstrap` encodes its token locally (not affected); `inmanta-cli token create` uses the server default, which is exactly the flow that should produce a revocable token; all in-tree callers that rely on reproducible tokens already pass `idempotent=True` explicitly.
* Behaviour change for API users that omit the argument (noted in the upgrade-note changelog section): the token value differs on every call, and the token expires according to the signing configuration's `expire` setting. Pass `idempotent=true` for the old behaviour.

The web console always sends `idempotent` explicitly; its own default flip is tracked in inmanta/web-console#7102.

closes #10571

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (API docstrings + upgrade note document the change)
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)