### PR TITLE
Add an expire parameter to environment_create_token

### DIFF
--- a/changelogs/unreleased/token-expire-param.yml
+++ b/changelogs/unreleased/token-expire-param.yml
@@ -1,0 +1,13 @@
+description: >-
+  Add an optional expire parameter to environment_create_token that sets the lifetime of the token in
+  seconds, driving both the JWT exp claim and the expiry shown in the token registry.
+issue-nr: 5643
+change-type: minor
+destination-branches:
+  - master
+  - iso9
+sections:
+  feature: >
+    environment_create_token now accepts an optional expire parameter: the lifetime of the created token
+    in seconds. When not set, the expiry configured on the signing configuration applies, as before. The
+    expiry is reflected in the token registry (environment_token_list).

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -313,7 +313,9 @@ def environment_clear(id: uuid.UUID) -> None:
     client_types=[ClientType.api, ClientType.compiler],
     api_version=2,
 )
-def environment_create_token(tid: uuid.UUID, client_types: Sequence[str], idempotent: bool = False) -> str:
+def environment_create_token(
+    tid: uuid.UUID, client_types: Sequence[str], idempotent: bool = False, expire: int | None = None
+) -> str:
     """
     Create or get a new token for the given client types. Tokens generated with this call are scoped to the current
     environment.
@@ -323,6 +325,8 @@ def environment_create_token(tid: uuid.UUID, client_types: Sequence[str], idempo
     :param idempotent: The token should be idempotent, such tokens do not have an expire or issued at set so their
                        value will not change, but they cannot be individually revoked. By default a unique token is
                        created that is tracked in the token registry and can be listed and revoked.
+    :param expire: The lifetime of the token in seconds. When not set, the expiry configured on the signing
+                   configuration applies, if any. Cannot be combined with an idempotent token, which never expires.
     """
 
 

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -587,6 +587,7 @@ class EnvironmentService(protocol.ServerSlice):
         # field is informational (for listing and cleanup); token expiry itself is enforced by the exp
         # claim, not by the registry.
         sign_cfg = auth.AuthJWTConfig.get_sign_config()
+        effective_expire: int | None
         match expire, sign_cfg:
             case int() as explicit_expire, _:
                 effective_expire = explicit_expire

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -290,7 +290,7 @@ class EnvironmentService(protocol.ServerSlice):
         """
         Create a new auth token for this environment
         """
-        return 200, {"token": await self.environment_create_token(env, client_types, idempotent, None, context)}
+        return 200, {"token": await self.environment_create_token(env, client_types, idempotent, expire=None, context=context)}
 
     @handle(methods.list_settings, env="tid")
     async def list_settings(self, env: data.Environment) -> Apireturn:
@@ -581,19 +581,22 @@ class EnvironmentService(protocol.ServerSlice):
         # individually revoked without rotating the signing key.
         jti = uuid.uuid4()
         custom_claims["jti"] = str(jti)
-        token = encode_token(client_types, str(env.id), idempotent, expire=expire, custom_claims=custom_claims)
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
-        # Record when the token stops being valid, mirroring the exp that encode_token derives: an
-        # explicit expire argument wins, otherwise the signing config's expire governs. This field is
-        # informational (for listing and cleanup); token expiry itself is enforced by the JWT exp
+        # Resolve the effective lifetime once and feed it to both the token and the registry, so the JWT
+        # exp claim and the recorded expires_at cannot drift: an explicit expire wins, otherwise the
+        # signing config's expire governs, and if neither applies the token never expires. The expires_at
+        # field is informational (for listing and cleanup); token expiry itself is enforced by the exp
         # claim, not by the registry.
         sign_cfg = auth.AuthJWTConfig.get_sign_config()
-        if expire is not None:
-            expires_at = now + datetime.timedelta(seconds=expire)
-        elif sign_cfg is not None and sign_cfg.expire > 0:
-            expires_at = now + datetime.timedelta(seconds=sign_cfg.expire)
-        else:
-            expires_at = None
+        match expire, sign_cfg:
+            case int() as explicit_expire, _:
+                effective_expire = explicit_expire
+            case None, cfg if cfg is not None and cfg.expire > 0:
+                effective_expire = cfg.expire
+            case _:
+                effective_expire = None
+        token = encode_token(client_types, str(env.id), idempotent, expire=effective_expire, custom_claims=custom_claims)
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        expires_at = now + datetime.timedelta(seconds=effective_expire) if effective_expire is not None else None
         async with data.get_session() as session:
             await TokenRepository(session).add(
                 Token(

--- a/src/inmanta/server/services/environmentservice.py
+++ b/src/inmanta/server/services/environmentservice.py
@@ -290,7 +290,7 @@ class EnvironmentService(protocol.ServerSlice):
         """
         Create a new auth token for this environment
         """
-        return 200, {"token": await self.environment_create_token(env, client_types, idempotent, context)}
+        return 200, {"token": await self.environment_create_token(env, client_types, idempotent, None, context)}
 
     @handle(methods.list_settings, env="tid")
     async def list_settings(self, env: data.Environment) -> Apireturn:
@@ -546,13 +546,17 @@ class EnvironmentService(protocol.ServerSlice):
 
     @handle(methods_v2.environment_create_token, env="tid")
     async def environment_create_token(
-        self, env: data.Environment, client_types: list[str], idempotent: bool, context: CallContext
+        self, env: data.Environment, client_types: list[str], idempotent: bool, expire: int | None, context: CallContext
     ) -> str:
         """
         Create a new auth token for this environment
         """
         if not config.Config.getboolean("server", "auth", False):
             raise BadRequest("Authentication is disabled, generating a token is not allowed")
+        if expire is not None and expire <= 0:
+            raise BadRequest("expire must be a positive number of seconds")
+        if expire is not None and idempotent:
+            raise BadRequest("An idempotent token cannot have an expiry: such tokens carry no time-based claims")
         # Attribute the token to the user that created it so that actions performed with it are not
         # anonymous in the access log. When the token is minted using another attributed token rather
         # than an interactive session, carry over its creator so attribution survives token chains.
@@ -577,14 +581,19 @@ class EnvironmentService(protocol.ServerSlice):
         # individually revoked without rotating the signing key.
         jti = uuid.uuid4()
         custom_claims["jti"] = str(jti)
-        token = encode_token(client_types, str(env.id), idempotent, custom_claims=custom_claims)
+        token = encode_token(client_types, str(env.id), idempotent, expire=expire, custom_claims=custom_claims)
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        # Record when the token stops being valid, mirroring the exp that encode_token derived from the
-        # signing config (this call passes no explicit expire, so cfg.expire governs both). This field
-        # is informational (for listing and cleanup); token expiry itself is enforced by the JWT exp
+        # Record when the token stops being valid, mirroring the exp that encode_token derives: an
+        # explicit expire argument wins, otherwise the signing config's expire governs. This field is
+        # informational (for listing and cleanup); token expiry itself is enforced by the JWT exp
         # claim, not by the registry.
         sign_cfg = auth.AuthJWTConfig.get_sign_config()
-        expires_at = now + datetime.timedelta(seconds=sign_cfg.expire) if sign_cfg is not None and sign_cfg.expire > 0 else None
+        if expire is not None:
+            expires_at = now + datetime.timedelta(seconds=expire)
+        elif sign_cfg is not None and sign_cfg.expire > 0:
+            expires_at = now + datetime.timedelta(seconds=sign_cfg.expire)
+        else:
+            expires_at = None
         async with data.get_session() as session:
             await TokenRepository(session).add(
                 Token(

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -614,6 +614,58 @@ async def test_token_registry(server: protocol.Server, auth_client: endpoints.Cl
     assert response.code == 403
 
 
+async def test_token_expire_param(server: protocol.Server, auth_client: endpoints.Client) -> None:
+    """
+    An explicit expire on environment_create_token drives both the JWT exp claim and the registry
+    expires_at; a non-positive expire and the idempotent+expire combination are rejected.
+    """
+    user = data.User(
+        username="admin",
+        password_hash=nacl.pwhash.str("adminadmin".encode()).decode(),
+        auth_method=AuthMethod.database,
+    )
+    await user.insert()
+    response = await auth_client.login("admin", "adminadmin")
+    assert response.code == 200
+    config.Config.set("client_rest_transport", "token", response.result["data"]["token"])
+    admin_client = protocol.Client("client")
+
+    response = await admin_client.project_create(name="test")
+    assert response.code == 200
+    response = await admin_client.environment_create(project_id=response.result["data"]["id"], name="test")
+    assert response.code == 200
+    env_id = response.result["data"]["id"]
+
+    # The expire argument drives the exp claim and the registry expires_at.
+    response = await admin_client.environment_create_token(tid=env_id, client_types=["api"], expire=3600)
+    assert response.code == 200
+    expiring_token = response.result["data"]
+    claims = jwt.decode(expiring_token, options={"verify_signature": False})
+    assert claims["exp"] == claims["iat"] + 3600
+    response = await admin_client.environment_token_list(tid=env_id)
+    assert response.code == 200
+    [entry] = response.result["data"]
+    issued_at = datetime.datetime.fromisoformat(entry["issued_at"])
+    expires_at = datetime.datetime.fromisoformat(entry["expires_at"])
+    assert expires_at - issued_at == datetime.timedelta(seconds=3600)
+
+    # The expiring token authenticates as long as it has not expired.
+    config.Config.set("client_rest_transport", "token", expiring_token)
+    token_client = protocol.Client("client")
+    response = await token_client.environment_token_list(tid=env_id)
+    assert response.code == 200
+
+    # A non-positive expire is rejected.
+    response = await admin_client.environment_create_token(tid=env_id, client_types=["api"], expire=0)
+    assert response.code == 400
+    response = await admin_client.environment_create_token(tid=env_id, client_types=["api"], expire=-5)
+    assert response.code == 400
+
+    # An idempotent token carries no time-based claims, so it cannot have an expiry.
+    response = await admin_client.environment_create_token(tid=env_id, client_types=["api"], idempotent=True, expire=3600)
+    assert response.code == 400
+
+
 async def test_token_registry_cleanup(server: protocol.Server) -> None:
     """
     delete_stale removes entries that expired or were revoked before the retention cutoff, while keeping

--- a/tests/server/test_user.py
+++ b/tests/server/test_user.py
@@ -621,11 +621,11 @@ async def test_token_expire_param(server: protocol.Server, auth_client: endpoint
     """
     user = data.User(
         username="admin",
-        password_hash=nacl.pwhash.str("adminadmin".encode()).decode(),
+        password_hash=nacl.pwhash.str("Str0ng-Pass!".encode()).decode(),
         auth_method=AuthMethod.database,
     )
     await user.insert()
-    response = await auth_client.login("admin", "adminadmin")
+    response = await auth_client.login("admin", "Str0ng-Pass!")
     assert response.code == 200
     config.Config.set("client_rest_transport", "token", response.result["data"]["token"])
     admin_client = protocol.Client("client")


### PR DESCRIPTION
# Description

Claude here, on behalf of @bartv.

Follow-up to the token registry (#10535), from the demo-session feedback: tokens can now be given an explicit lifetime at creation time.

* `environment_create_token` gets an optional `expire` parameter (seconds). It drives both the JWT `exp` claim (via `encode_token`, which already supported an explicit expire for the login endpoint) and the `expires_at` recorded in the token registry, so the expiry shows up in `environment_token_list` and the expired token is eventually purged by the registry cleanup.
* When `expire` is not set, the signing configuration's `expire` setting governs, as before.
* Validation: a non-positive `expire` is rejected, and so is combining `expire` with `idempotent=true` (idempotent tokens carry no time-based claims by definition).

Stacked on #10577 (both change the `environment_create_token` signature); the base is set to that branch and I'll retarget/rebase onto master once it merges. The web-console companion (expiry input + column in the Tokens tab) is tracked in inmanta/web-console#7104.

closes #5643

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (API docstring documents the parameter)
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)