### PR TITLE
Use changelog entries of released version as release tag message

### DIFF
--- a/changelogs/unreleased/7893-changelog-in-release-tag-message.yml
+++ b/changelogs/unreleased/7893-changelog-in-release-tag-message.yml
@@ -3,6 +3,6 @@ description: "The `inmanta module release` command now uses the changelog entrie
 issue-nr: 7893
 issue-repo: inmanta-core
 change-type: minor
-destination-branches: [master]
+destination-branches: [master, iso9]
 sections:
   minor-improvement: "{{description}}"

--- a/changelogs/unreleased/7893-changelog-in-release-tag-message.yml
+++ b/changelogs/unreleased/7893-changelog-in-release-tag-message.yml
@@ -1,0 +1,8 @@
+---
+description: "The `inmanta module release` command now uses the changelog entries of the released version as the message of the release tag, instead of the generic \"auto tag by module tool\" message."
+issue-nr: 7893
+issue-repo: inmanta-core
+change-type: minor
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -355,7 +355,7 @@ class GitProvider:
     ) -> None:
         pass
 
-    def tag(self, repo: str, tag: str) -> None:
+    def tag(self, repo: str, tag: str, message: Optional[str] = None) -> None:
         pass
 
     @abstractmethod
@@ -471,9 +471,9 @@ class CLIGitProvider(GitProvider):
                 ["git", "commit", "-a", "-m", message], cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
 
-    def tag(self, repo: str, tag: str) -> None:
+    def tag(self, repo: str, tag: str, message: Optional[str] = None) -> None:
         subprocess.check_call(
-            ["git", "tag", "-a", "-m", "auto tag by module tool", tag],
+            ["git", "tag", "-a", "-m", message if message else "auto tag by module tool", tag],
             cwd=repo,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -614,7 +614,8 @@ class ModuleTool(ModuleLikeTool):
 When a stable release is done, this command:
 
 * Does a commit that changes the current version to a stable version.
-* Adds Git release tag.
+* Adds Git release tag. When a CHANGELOG.md file is present in the root of the module directory, the changelog entries
+  for the released version are used as the tag message.
 * Does a commit that changes the current version to a development version that is one patch increment ahead of the released
   version.
 
@@ -1223,7 +1224,11 @@ version: 0.0.1dev0""" % {"name": name})
                 add=[module.get_metadata_file_path()] + ([changelog.get_path()] if changelog else []),
                 raise_exc_when_nothing_to_commit=False,
             )
-            gitprovider.tag(repo=module_dir, tag=str(release_tag))
+            gitprovider.tag(
+                repo=module_dir,
+                tag=str(release_tag),
+                message=changelog.get_changelog_section_for_version(release_tag) if changelog else None,
+            )
             print(f"Tag created successfully: {release_tag}")
             # bump to the next dev version
             if isinstance(module.metadata, ModuleV2Metadata) and module.metadata.four_digit_version:
@@ -1333,6 +1338,21 @@ class Changelog:
             fh.seek(0, 0)
             fh.write(new_content_changelog)
             fh.truncate()
+
+    def get_changelog_section_for_version(self, version: Version) -> Optional[str]:
+        """
+        Return the content of the changelog section for the given version, without the section header.
+        Returns None if the changelog doesn't contain a section for the given version or if the section is empty.
+        """
+        with open(self.path_changelog_file, encoding="utf-8") as fh:
+            content_changelog = fh.read()
+        match: Optional[re.Match[str]] = self.regex_for_changelog_line(version).search(content_changelog)
+        if match is None:
+            return None
+        # The section ends at the next section header or at the end of the file
+        next_header: Optional[re.Match[str]] = re.compile(r"^#{1,2} ", re.MULTILINE).search(content_changelog, match.end())
+        section_content: str = content_changelog[match.end() : next_header.start() if next_header else None].strip()
+        return section_content if section_content else None
 
     def _has_section_for_version(self, version: Version) -> bool:
         """

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -563,6 +563,17 @@ def test_populate_changelog(tmpdir, modules_dir: str, monkeypatch, top_level_hea
             """,
             "auto tag by module tool",
         ),
+        # The changelog doesn't contain a section for the released version -> fall back to the default tag message
+        (
+            """
+# Changelog
+
+## v1.0.0 - 2023-01-01
+
+- Initial release
+            """,
+            "auto tag by module tool",
+        ),
         # The changelog file is empty -> fall back to the default tag message
         (
             "",

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 import subprocess
+from typing import Optional
 
 import click
 import py
@@ -562,10 +563,24 @@ def test_populate_changelog(tmpdir, modules_dir: str, monkeypatch, top_level_hea
             """,
             "auto tag by module tool",
         ),
+        # The changelog file is empty -> fall back to the default tag message
+        (
+            "",
+            "auto tag by module tool",
+        ),
+        # No changelog file exists -> fall back to the default tag message
+        (
+            None,
+            "auto tag by module tool",
+        ),
     ],
 )
 def test_release_tag_message_contains_changelog_entries(
-    tmpdir: py.path.local, modules_dir: str, monkeypatch: MonkeyPatch, changelog_content: str, expected_tag_message: str
+    tmpdir: py.path.local,
+    modules_dir: str,
+    monkeypatch: MonkeyPatch,
+    changelog_content: Optional[str],
+    expected_tag_message: str,
 ) -> None:
     """
     Verify that the `inmanta module release` command uses the changelog entries of the released version
@@ -579,9 +594,10 @@ def test_release_tag_message_contains_changelog_entries(
         new_version=Version("1.0.1.dev0"),
         new_name=module_name,
     )
-    path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)
-    with open(path_changelog_file, "w", encoding="utf-8") as fh:
-        fh.write(changelog_content.strip())
+    if changelog_content is not None:
+        path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)
+        with open(path_changelog_file, "w", encoding="utf-8") as fh:
+            fh.write(changelog_content.strip())
     gitprovider.git_init(repo=path_module)
     gitprovider.commit(repo=path_module, message="Initial commit", add=["*"], commit_all=True)
 

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -46,6 +46,16 @@ def get_commit_message_x_commits_ago(path: str, nb_previous_commit: int = 0) -> 
     return subprocess.check_output(["git", "log", "-1", f"--skip={nb_previous_commit}", "--pretty=%B"], cwd=path).decode()
 
 
+def get_tag_message(path: str, tag: str) -> str:
+    """
+    Return the message of the given annotated tag.
+
+    :param path: The path to the git repository.
+    :param tag: The name of the tag.
+    """
+    return subprocess.check_output(["git", "tag", "-l", "--format=%(contents)", tag], cwd=path).decode().strip()
+
+
 @pytest.mark.parametrize_any("v1_module", [True, False])
 @pytest.mark.parametrize_any("changelog_file_exists", [True, False])
 @pytest.mark.parametrize_any("previous_stable_version_exists", [True, False])
@@ -144,6 +154,12 @@ def test_release_stable_version(
     # Verify release tags
     expected_tags = [Version("1.2.3")] if not previous_stable_version_exists else [Version("1.2.2"), Version("1.2.3")]
     assert gitprovider.get_version_tags(repo=path_module) == expected_tags
+    # Verify that the tag message contains the changelog entries for the released version
+    release_tag = "1.2.3.0" if four_digits_before_release else "1.2.3"
+    if changelog_file_exists:
+        assert get_tag_message(path=path_module, tag=release_tag) == "- Release"
+    else:
+        assert get_tag_message(path=path_module, tag=release_tag) == "auto tag by module tool"
     # Verify version
     mod = Module.from_path(path_module)
     assert mod.version == Version("1.2.3.1.dev0") if four_digit_version and not v1_module else Version("1.2.4.dev0")
@@ -499,6 +515,43 @@ def test_populate_changelog(tmpdir, modules_dir: str, monkeypatch, top_level_hea
 
 
 """.lstrip()
+
+
+def test_release_tag_message_contains_changelog_entries(tmpdir, modules_dir: str, monkeypatch) -> None:
+    """
+    Verify that the `inmanta module release` command uses the changelog entries of the released version
+    as the message of the release tag (inmanta/inmanta-core#7893).
+    """
+    module_name = "mod"
+    path_module = os.path.join(tmpdir, module_name)
+    v1_module_from_template(
+        source_dir=os.path.join(modules_dir, "minimalv1module"),
+        dest_dir=path_module,
+        new_version=Version("1.0.1.dev0"),
+        new_name=module_name,
+    )
+    path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)
+    with open(path_changelog_file, "w", encoding="utf-8") as fh:
+        fh.write("""
+# Changelog
+
+## v1.0.1 - ?
+
+- Add support for feature X
+- Fix bug in feature Y
+
+## v1.0.0 - 2023-01-01
+
+- Initial release
+            """.strip())
+    gitprovider.git_init(repo=path_module)
+    gitprovider.commit(repo=path_module, message="Initial commit", add=["*"], commit_all=True)
+
+    monkeypatch.chdir(path_module)
+    module_tool = ModuleTool()
+    module_tool.release(dev=False, message="Commit changes")
+
+    assert get_tag_message(path=path_module, tag="1.0.1") == "- Add support for feature X\n- Fix bug in feature Y"
 
 
 def test_too_many_version_bump_arguments() -> None:

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -23,7 +23,9 @@ import re
 import subprocess
 
 import click
+import py
 import pytest
+from pytest import MonkeyPatch
 
 from inmanta import const
 from inmanta.module import Module, UntrackedFilesMode
@@ -563,7 +565,7 @@ def test_populate_changelog(tmpdir, modules_dir: str, monkeypatch, top_level_hea
     ],
 )
 def test_release_tag_message_contains_changelog_entries(
-    tmpdir, modules_dir: str, monkeypatch, changelog_content: str, expected_tag_message: str
+    tmpdir: py.path.local, modules_dir: str, monkeypatch: MonkeyPatch, changelog_content: str, expected_tag_message: str
 ) -> None:
     """
     Verify that the `inmanta module release` command uses the changelog entries of the released version

--- a/tests/moduletool/test_release.py
+++ b/tests/moduletool/test_release.py
@@ -517,7 +517,54 @@ def test_populate_changelog(tmpdir, modules_dir: str, monkeypatch, top_level_hea
 """.lstrip()
 
 
-def test_release_tag_message_contains_changelog_entries(tmpdir, modules_dir: str, monkeypatch) -> None:
+@pytest.mark.parametrize_any(
+    "changelog_content, expected_tag_message",
+    [
+        # The changelog contains a section for the released version, followed by sections for older versions
+        (
+            """
+# Changelog
+
+## v1.0.1 - ?
+
+- Add support for feature X
+- Fix bug in feature Y
+
+## v1.0.0 - 2023-01-01
+
+- Initial release
+            """,
+            "- Add support for feature X\n- Fix bug in feature Y",
+        ),
+        # The section for the released version is the only section in the changelog file
+        (
+            """
+# Changelog
+
+## v1.0.1 - ?
+
+- Add support for feature X
+            """,
+            "- Add support for feature X",
+        ),
+        # The section for the released version is empty -> fall back to the default tag message
+        (
+            """
+# Changelog
+
+## v1.0.1 - ?
+
+## v1.0.0 - 2023-01-01
+
+- Initial release
+            """,
+            "auto tag by module tool",
+        ),
+    ],
+)
+def test_release_tag_message_contains_changelog_entries(
+    tmpdir, modules_dir: str, monkeypatch, changelog_content: str, expected_tag_message: str
+) -> None:
     """
     Verify that the `inmanta module release` command uses the changelog entries of the released version
     as the message of the release tag (inmanta/inmanta-core#7893).
@@ -532,18 +579,7 @@ def test_release_tag_message_contains_changelog_entries(tmpdir, modules_dir: str
     )
     path_changelog_file = os.path.join(path_module, const.MODULE_CHANGELOG_FILE)
     with open(path_changelog_file, "w", encoding="utf-8") as fh:
-        fh.write("""
-# Changelog
-
-## v1.0.1 - ?
-
-- Add support for feature X
-- Fix bug in feature Y
-
-## v1.0.0 - 2023-01-01
-
-- Initial release
-            """.strip())
+        fh.write(changelog_content.strip())
     gitprovider.git_init(repo=path_module)
     gitprovider.commit(repo=path_module, message="Initial commit", add=["*"], commit_all=True)
 
@@ -551,7 +587,7 @@ def test_release_tag_message_contains_changelog_entries(tmpdir, modules_dir: str
     module_tool = ModuleTool()
     module_tool.release(dev=False, message="Commit changes")
 
-    assert get_tag_message(path=path_module, tag="1.0.1") == "- Add support for feature X\n- Fix bug in feature Y"
+    assert get_tag_message(path=path_module, tag="1.0.1") == expected_tag_message
 
 
 def test_too_many_version_bump_arguments() -> None:


### PR DESCRIPTION
# Description

The `inmanta module release` command previously always tagged stable releases with the generic message "auto tag by module tool". The tag message now contains the changelog entries of the released version when a CHANGELOG.md file is present (falls back to the old message when there is no changelog or the section is empty).

closes #7893

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: ) — the `inmanta module release` command help text was updated
- ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
