### PR TITLE
Run git non-interactively during server-side compiles

### DIFF
--- a/changelogs/unreleased/git-non-interactive-auth-error.yml
+++ b/changelogs/unreleased/git-non-interactive-auth-error.yml
@@ -1,0 +1,6 @@
+---
+description: "Run git non-interactively during server-side compiles so that a failing checkout of a repository requiring authentication reports the real authentication error instead of the confusing \"could not read Username for '...': No such device or address\"."
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/docs/model_developers/projects.rst
+++ b/docs/model_developers/projects.rst
@@ -20,3 +20,27 @@ A project is the basic unit of orchestration. It contains:
     |__ requirements.txt
     |__ main.cf
 
+
+Server-side checkout and authentication
+---------------------------------------
+
+For server-side compiles, the orchestrator obtains the project from a git repository. Each environment is
+configured with a repository URL and a branch: the orchestrator clones this repository into the environment's
+project directory on the first compile and pulls updates from it on subsequent compiles.
+
+When the repository requires authentication, git takes credentials from its usual sources: a ``.netrc`` file,
+credentials embedded in the repository URL, or a configured git credential helper. The simplest option is a
+``.netrc`` file in the server's home directory (``/var/lib/inmanta/.netrc``). This is the same file that is used
+to authenticate against a :ref:`private Python package repository<setting_up_pip_index_authentication>`, so a
+single file can cover both the project checkout and module installation:
+
+.. code-block:: text
+
+    machine <hostname of the git repository>
+    login <username>
+    password <password>
+
+If a checkout fails to authenticate, the compile report shows the ``Cloning repository`` or ``Pulling updates``
+step failing with an ``Authentication failed`` error. See :ref:`debugging_project_authentication` for how to find
+out which credential source git used.
+

--- a/docs/model_developers/projects.rst
+++ b/docs/model_developers/projects.rst
@@ -34,7 +34,10 @@ credentials the same way you would for a local ``git clone``. The most common me
 
 * **SSH keys**: use a ``git@host:...`` (or ``ssh://``) repository URL and place the private key and a matching
   ``known_hosts`` entry in the SSH configuration of the ``inmanta`` user (the user the orchestrator runs as),
-  under ``~/.ssh`` in its home directory (``/var/lib/inmanta/.ssh``).
+  under ``~/.ssh`` in its home directory (``/var/lib/inmanta/.ssh``). Make sure the key files and the ``.ssh``
+  directory are owned by the ``inmanta`` user with sufficiently strict permissions (private key ``600``, ``.ssh``
+  directory ``700``); otherwise OpenSSH silently ignores the key and authentication fails. See the
+  `GitHub SSH documentation <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_ for details.
 * **A ``.netrc`` file** for HTTP(S) repositories: create a ``.netrc`` file in the home directory of the
   ``inmanta`` user (``/var/lib/inmanta/.netrc``). This is the same file used to authenticate against a
   :ref:`private Python package repository<setting_up_pip_index_authentication>`, so a single file can cover both

--- a/docs/model_developers/projects.rst
+++ b/docs/model_developers/projects.rst
@@ -32,7 +32,7 @@ The orchestrator invokes ``git`` for these operations, so it transparently suppo
 mechanism that ``git`` itself supports. No extra configuration is needed on the orchestrator side; you set up
 credentials the same way you would for a local ``git clone``. The most common mechanisms are:
 
-* **SSH keys**: use an ``ssh://`` (or ``git@host:...``) repository URL and place the private key and a matching
+* **SSH keys**: use a ``git@host:...`` (or ``ssh://``) repository URL and place the private key and a matching
   ``known_hosts`` entry in the SSH configuration of the ``inmanta`` user (the user the orchestrator runs as),
   under ``~/.ssh`` in its home directory (``/var/lib/inmanta/.ssh``).
 * **A ``.netrc`` file** for HTTP(S) repositories: create a ``.netrc`` file in the home directory of the

--- a/docs/model_developers/projects.rst
+++ b/docs/model_developers/projects.rst
@@ -28,17 +28,25 @@ For server-side compiles, the orchestrator obtains the project from a git reposi
 configured with a repository URL and a branch: the orchestrator clones this repository into the environment's
 project directory on the first compile and pulls updates from it on subsequent compiles.
 
-When the repository requires authentication, git takes credentials from its usual sources: a ``.netrc`` file,
-credentials embedded in the repository URL, or a configured git credential helper. The simplest option is a
-``.netrc`` file in the server's home directory (``/var/lib/inmanta/.netrc``). This is the same file that is used
-to authenticate against a :ref:`private Python package repository<setting_up_pip_index_authentication>`, so a
-single file can cover both the project checkout and module installation:
+The orchestrator invokes ``git`` for these operations, so it transparently supports any authentication
+mechanism that ``git`` itself supports. No extra configuration is needed on the orchestrator side; you set up
+credentials the same way you would for a local ``git clone``. The most common mechanisms are:
 
-.. code-block:: text
+* **SSH keys**: use an ``ssh://`` (or ``git@host:...``) repository URL and place the private key and a matching
+  ``known_hosts`` entry in the SSH configuration of the ``inmanta`` user (the user the orchestrator runs as),
+  under ``~/.ssh`` in its home directory (``/var/lib/inmanta/.ssh``).
+* **A ``.netrc`` file** for HTTP(S) repositories: create a ``.netrc`` file in the home directory of the
+  ``inmanta`` user (``/var/lib/inmanta/.netrc``). This is the same file used to authenticate against a
+  :ref:`private Python package repository<setting_up_pip_index_authentication>`, so a single file can cover both
+  the project checkout and module installation:
 
-    machine <hostname of the git repository>
-    login <username>
-    password <password>
+  .. code-block:: text
+
+      machine <hostname of the git repository>
+      login <username>
+      password <password>
+
+* **Credentials in the repository URL**, or a configured **git credential helper**.
 
 If a checkout fails to authenticate, the compile report shows the ``Cloning repository`` or ``Pulling updates``
 step failing with an ``Authentication failed`` error. See :ref:`debugging_project_authentication` for how to find

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -213,6 +213,25 @@ generated or the compile report doesn't show any errors, check the server logs a
    :align: center
 
 
+Debugging project authentication issues
+---------------------------------------
+
+When the ``Cloning repository`` or ``Pulling updates`` step fails with ``Authentication failed``, the orchestrator
+could not authenticate against the git repository of the project. Git looks for credentials in several places (the
+repository URL, a ``.netrc`` file, and configured git credential helpers), so it is not always obvious which source
+was used or why it was rejected.
+
+To find out which credential source git consulted, set the ``GIT_TRACE_CURL`` (or ``GIT_CURL_VERBOSE``) environment
+variable to ``1`` as an :ref:`orchestrator environment variable<env_vars>` and trigger a new compile. The extra
+output is added to the git step of the compile report and shows, among other things, whether a ``.netrc`` file was
+read and which username was sent. The actual secret is redacted (``Authorization: Basic <redacted>``).
+
+.. note::
+    This tracing is verbose, so only enable it while investigating and remove it afterwards. Prefer ``GIT_TRACE_CURL``
+    over ``GIT_TRACE``: the latter prints the full repository URL on every line, which leaks any credentials embedded
+    in the URL into the compile report.
+
+
 Logs show "empty model" after export
 ====================================
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -233,6 +233,13 @@ read and which username was sent. The actual secret is redacted (``Authorization
     over ``GIT_TRACE``: the latter prints the full repository URL on every line, which leaks any credentials embedded
     in the URL into the compile report.
 
+``GIT_TRACE_CURL`` only traces the HTTP(S) transport, so it produces no useful output for SSH (``git@host:...`` or
+``ssh://``) repositories. To debug an SSH checkout, make git run ``ssh`` in verbose mode by setting the
+``GIT_SSH_COMMAND`` environment variable to ``ssh -vvv`` instead and trigger a new compile. The output shows which
+identity files ``ssh`` loaded, which keys it offered, and the outcome of host-key verification. A key that the
+``inmanta`` user cannot read is skipped silently (``no identity pubkey loaded``), which then surfaces as
+``Permission denied (publickey)``.
+
 
 Logs show "empty model" after export
 ====================================

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -213,6 +213,8 @@ generated or the compile report doesn't show any errors, check the server logs a
    :align: center
 
 
+.. _debugging_project_authentication:
+
 Debugging project authentication issues
 ---------------------------------------
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -64,6 +64,14 @@ from inmanta.util import TaskMethod, ensure_directory_exist
 RETURNCODE_INTERNAL_ERROR = -1
 BUFFER_SIZE: int = 8192
 
+# Environment variables that force git to be non-interactive. The compiler runs git in a subprocess
+# whose stdin is not a terminal, so git can never read an answer to a credential prompt. Without these,
+# git blocks trying to prompt and then fails with the confusing
+# "could not read Username for '...': No such device or address" instead of the real error.
+# GIT_ASKPASS=true feeds empty credentials, so a private repo answers with its actual authentication
+# error. GIT_TERMINAL_PROMPT=0 disables any remaining interactive prompt as a safety net.
+GIT_NON_INTERACTIVE_ENV: dict[str, str] = {"GIT_ASKPASS": "true", "GIT_TERMINAL_PROMPT": "0"}
+
 LOGGER: Logger = logging.getLogger(__name__)
 COMPILER_LOGGER: Logger = LOGGER.getChild("report")
 
@@ -188,7 +196,11 @@ class CompileRun:
         sub_process: Process | None = None
         try:
             sub_process = await asyncio.create_subprocess_exec(
-                *cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._project_dir
+                *cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self._project_dir,
+                env={**os.environ, **GIT_NON_INTERACTIVE_ENV},
             )
             out, _ = await sub_process.communicate()
         finally:
@@ -229,6 +241,7 @@ class CompileRun:
         sub_process: Optional[Process] = None
         try:
             env_all = os.environ.copy()
+            env_all.update(GIT_NON_INTERACTIVE_ENV)
             if env is not None:
                 env_all.update(env)
 

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -64,12 +64,14 @@ from inmanta.util import TaskMethod, ensure_directory_exist
 RETURNCODE_INTERNAL_ERROR = -1
 BUFFER_SIZE: int = 8192
 
-# Environment variables that force git to be non-interactive. The compiler runs git in a subprocess
+# Default environment variables that make git non-interactive. The compiler runs git in a subprocess
 # whose stdin is not a terminal, so git can never read an answer to a credential prompt. Without these,
 # git blocks trying to prompt and then fails with the confusing
 # "could not read Username for '...': No such device or address" instead of the real error.
 # GIT_ASKPASS=true feeds empty credentials, so a private repo answers with its actual authentication
 # error. GIT_TERMINAL_PROMPT=0 disables any remaining interactive prompt as a safety net.
+# These are only defaults: they are applied below the process environment, so an operator can override
+# them (e.g. point GIT_ASKPASS at a real credential helper) through the orchestrator's environment.
 GIT_NON_INTERACTIVE_ENV: dict[str, str] = {"GIT_ASKPASS": "true", "GIT_TERMINAL_PROMPT": "0"}
 
 LOGGER: Logger = logging.getLogger(__name__)
@@ -200,7 +202,7 @@ class CompileRun:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=self._project_dir,
-                env={**os.environ, **GIT_NON_INTERACTIVE_ENV},
+                env={**GIT_NON_INTERACTIVE_ENV, **os.environ},
             )
             out, _ = await sub_process.communicate()
         finally:
@@ -240,8 +242,7 @@ class CompileRun:
 
         sub_process: Optional[Process] = None
         try:
-            env_all = os.environ.copy()
-            env_all.update(GIT_NON_INTERACTIVE_ENV)
+            env_all = {**GIT_NON_INTERACTIVE_ENV, **os.environ}
             if env is not None:
                 env_all.update(env)
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -584,19 +584,13 @@ async def test_compile_runner_repo_url_changed(environment_factory: EnvironmentF
     assert remote_url == env_other.repo_url
 
 
-@pytest.mark.slowtest
-@pytest.mark.parametrize("no_agent", [True])
-async def test_compile_runner_clone_auth_failure(server, client, tmpdir) -> None:
+@pytest.fixture
+def unauthenticated_git_repo() -> abc.Iterator[str]:
     """
-    When cloning a repository that requires authentication and no credentials are available, git must
-    not block trying to prompt for a username. The compiler subprocess has no terminal, so an interactive
-    prompt fails with the confusing "could not read Username for '...': No such device or address".
-
-    The compiler service must run git non-interactively so that the real authentication error surfaces
-    instead. See GIT_NON_INTERACTIVE_ENV in the compiler service.
+    Serve a local HTTP endpoint that rejects every request with a 401, mimicking a git repository that
+    requires authentication. Yields a repository URL pointing at it.
     """
 
-    # Minimal HTTP server that rejects every request with a 401, mimicking a private repository.
     class _Unauthorized(http.server.BaseHTTPRequestHandler):
         def do_GET(self) -> None:
             self.send_response(401)
@@ -611,42 +605,54 @@ async def test_compile_runner_clone_auth_failure(server, client, tmpdir) -> None
     server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     server_thread.start()
     try:
-        repo_url = f"http://127.0.0.1:{httpd.server_address[1]}/repo.git"
-
-        project = data.Project(name="test_clone_auth")
-        await project.insert()
-        env = data.Environment(name="dev", project=project.id, repo_url=repo_url, repo_branch="")
-        await env.insert()
-
-        compile = data.Compile(
-            remote_id=uuid.uuid4(),
-            environment=env.id,
-            do_export=False,
-            requested_environment_variables={},
-            used_environment_variables={},
-        )
-        await compile.insert()
-
-        project_work_dir = os.path.join(tmpdir, "work")
-        ensure_directory_exist(project_work_dir)
-
-        cr = CompileRun(compile, project_work_dir)
-        await cr.run()
-
-        result = await client.get_report(compile.id)
-        assert result.code == 200
-        stages = {stage["name"]: stage for stage in result.result["report"]["reports"]}
-
-        clone_stage = stages["Cloning repository"]
-        assert clone_stage["returncode"] != 0
-        errstream = clone_stage["errstream"]
-        # The real authentication error is surfaced ...
-        assert "Authentication failed" in errstream
-        # ... instead of the confusing message caused by git trying to prompt without a terminal.
-        assert "could not read Username" not in errstream
+        yield f"http://127.0.0.1:{httpd.server_address[1]}/repo.git"
     finally:
         httpd.shutdown()
         server_thread.join()
+
+
+@pytest.mark.slowtest
+@pytest.mark.parametrize("no_agent", [True])
+async def test_compile_runner_clone_auth_failure(server, client, tmpdir, unauthenticated_git_repo: str) -> None:
+    """
+    When cloning a repository that requires authentication and no credentials are available, git must
+    not block trying to prompt for a username. The compiler subprocess has no terminal, so an interactive
+    prompt fails with the confusing "could not read Username for '...': No such device or address".
+
+    The compiler service must run git non-interactively so that the real authentication error surfaces
+    instead. See GIT_NON_INTERACTIVE_ENV in the compiler service.
+    """
+    project = data.Project(name="test_clone_auth")
+    await project.insert()
+    env = data.Environment(name="dev", project=project.id, repo_url=unauthenticated_git_repo, repo_branch="")
+    await env.insert()
+
+    compile = data.Compile(
+        remote_id=uuid.uuid4(),
+        environment=env.id,
+        do_export=False,
+        requested_environment_variables={},
+        used_environment_variables={},
+    )
+    await compile.insert()
+
+    project_work_dir = os.path.join(tmpdir, "work")
+    ensure_directory_exist(project_work_dir)
+
+    cr = CompileRun(compile, project_work_dir)
+    await cr.run()
+
+    result = await client.get_report(compile.id)
+    assert result.code == 200
+    stages = {stage["name"]: stage for stage in result.result["report"]["reports"]}
+
+    clone_stage = stages["Cloning repository"]
+    assert clone_stage["returncode"] != 0
+    errstream = clone_stage["errstream"]
+    # The real authentication error is surfaced ...
+    assert "Authentication failed" in errstream
+    # ... instead of the confusing message caused by git trying to prompt without a terminal.
+    assert "could not read Username" not in errstream
 
 
 @pytest.mark.slowtest

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -613,7 +613,9 @@ def unauthenticated_git_repo() -> abc.Iterator[str]:
 
 @pytest.mark.slowtest
 @pytest.mark.parametrize("no_agent", [True])
-async def test_compile_runner_clone_auth_failure(server, client, tmpdir, unauthenticated_git_repo: str) -> None:
+async def test_compile_runner_clone_auth_failure(
+    server: Server, client: protocol.Client, tmpdir: py.path.local, unauthenticated_git_repo: str
+) -> None:
     """
     When cloning a repository that requires authentication and no credentials are available, git must
     not block trying to prompt for a username. The compiler subprocess has no terminal, so an interactive

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -19,6 +19,7 @@ Contact: code@inmanta.com
 import asyncio
 import datetime
 import functools
+import http.server
 import logging
 import os
 import platform
@@ -26,6 +27,7 @@ import queue
 import re
 import shutil
 import subprocess
+import threading
 import uuid
 from asyncio import Semaphore
 from collections import abc
@@ -580,6 +582,71 @@ async def test_compile_runner_repo_url_changed(environment_factory: EnvironmentF
     # The checkout in the project directory now points at the new repository.
     remote_url = subprocess.check_output(["git", "remote", "get-url", "origin"], cwd=project_work_dir, encoding="utf-8").strip()
     assert remote_url == env_other.repo_url
+
+
+@pytest.mark.slowtest
+@pytest.mark.parametrize("no_agent", [True])
+async def test_compile_runner_clone_auth_failure(server, client, tmpdir) -> None:
+    """
+    When cloning a repository that requires authentication and no credentials are available, git must
+    not block trying to prompt for a username. The compiler subprocess has no terminal, so an interactive
+    prompt fails with the confusing "could not read Username for '...': No such device or address".
+
+    The compiler service must run git non-interactively so that the real authentication error surfaces
+    instead. See GIT_NON_INTERACTIVE_ENV in the compiler service.
+    """
+
+    # Minimal HTTP server that rejects every request with a 401, mimicking a private repository.
+    class _Unauthorized(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="git"')
+            self.end_headers()
+            self.wfile.write(b"denied\n")
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), _Unauthorized)
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        repo_url = f"http://127.0.0.1:{httpd.server_address[1]}/repo.git"
+
+        project = data.Project(name="test_clone_auth")
+        await project.insert()
+        env = data.Environment(name="dev", project=project.id, repo_url=repo_url, repo_branch="")
+        await env.insert()
+
+        compile = data.Compile(
+            remote_id=uuid.uuid4(),
+            environment=env.id,
+            do_export=False,
+            requested_environment_variables={},
+            used_environment_variables={},
+        )
+        await compile.insert()
+
+        project_work_dir = os.path.join(tmpdir, "work")
+        ensure_directory_exist(project_work_dir)
+
+        cr = CompileRun(compile, project_work_dir)
+        await cr.run()
+
+        result = await client.get_report(compile.id)
+        assert result.code == 200
+        stages = {stage["name"]: stage for stage in result.result["report"]["reports"]}
+
+        clone_stage = stages["Cloning repository"]
+        assert clone_stage["returncode"] != 0
+        errstream = clone_stage["errstream"]
+        # The real authentication error is surfaced ...
+        assert "Authentication failed" in errstream
+        # ... instead of the confusing message caused by git trying to prompt without a terminal.
+        assert "could not read Username" not in errstream
+    finally:
+        httpd.shutdown()
+        server_thread.join()
 
 
 @pytest.mark.slowtest

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -17,6 +17,7 @@ Contact: code@inmanta.com
 """
 
 import asyncio
+import base64
 import datetime
 import functools
 import http.server
@@ -655,6 +656,106 @@ async def test_compile_runner_clone_auth_failure(
     assert "Authentication failed" in errstream
     # ... instead of the confusing message caused by git trying to prompt without a terminal.
     assert "could not read Username" not in errstream
+
+
+@pytest.fixture
+def netrc_authenticated_git_repo(tmp_path_factory) -> abc.Iterator[tuple[str, str]]:
+    """
+    Serve a git repository over HTTP behind HTTP Basic authentication. Yields a tuple of the repository
+    URL and the path to a HOME directory that contains a .netrc file with valid credentials for it.
+    """
+    user, password = "user", "pass"
+    repo_root = str(tmp_path_factory.mktemp("git_repo"))
+    src_dir = os.path.join(repo_root, "src")
+    bare_dir = os.path.join(repo_root, "repo.git")
+    subprocess.check_call(["git", "init", "-q", src_dir])
+    subprocess.check_call(["git", "-C", src_dir, "config", "user.email", "unit@test.example"])
+    subprocess.check_call(["git", "-C", src_dir, "config", "user.name", "Unit"])
+    with open(os.path.join(src_dir, "marker.txt"), "w") as fd:
+        fd.write("content")
+    subprocess.check_call(["git", "-C", src_dir, "add", "marker.txt"])
+    subprocess.check_call(["git", "-C", src_dir, "commit", "-q", "-m", "init"])
+    # A bare checkout with server info can be cloned over plain (dumb) HTTP by a static file server.
+    subprocess.check_call(["git", "clone", "-q", "--bare", src_dir, bare_dir])
+    subprocess.check_call(["git", "-C", bare_dir, "update-server-info"])
+
+    expected_auth = "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+    class _AuthHandler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, directory=bare_dir, **kwargs)
+
+        def do_GET(self) -> None:
+            if self.headers.get("Authorization") != expected_auth:
+                self.send_response(401)
+                self.send_header("WWW-Authenticate", 'Basic realm="git"')
+                self.end_headers()
+                self.wfile.write(b"denied\n")
+                return
+            super().do_GET()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    httpd = http.server.HTTPServer(("127.0.0.1", 0), _AuthHandler)
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+
+    home_dir = str(tmp_path_factory.mktemp("git_home"))
+    netrc_file = os.path.join(home_dir, ".netrc")
+    with open(netrc_file, "w") as fd:
+        fd.write(f"machine 127.0.0.1 login {user} password {password}\n")
+    os.chmod(netrc_file, 0o600)
+
+    try:
+        yield f"http://127.0.0.1:{httpd.server_address[1]}/", home_dir
+    finally:
+        httpd.shutdown()
+        server_thread.join()
+
+
+@pytest.mark.slowtest
+@pytest.mark.parametrize("no_agent", [True])
+async def test_compile_runner_clone_with_netrc(
+    server: Server,
+    client: protocol.Client,
+    tmpdir: py.path.local,
+    monkeypatch: pytest.MonkeyPatch,
+    netrc_authenticated_git_repo: tuple[str, str],
+) -> None:
+    """
+    A server-side checkout of a repository that requires authentication succeeds when the credentials
+    are provided through a .netrc file. The empty credentials fed by the GIT_ASKPASS=true default (see
+    GIT_NON_INTERACTIVE_ENV) must not shadow the credentials found in the .netrc file.
+    """
+    repo_url, home_dir = netrc_authenticated_git_repo
+    # git (through curl) reads .netrc from $HOME; point it at the directory holding our test .netrc.
+    monkeypatch.setenv("HOME", home_dir)
+
+    project = data.Project(name="test_clone_netrc")
+    await project.insert()
+    env = data.Environment(name="dev", project=project.id, repo_url=repo_url, repo_branch="")
+    await env.insert()
+
+    compile = data.Compile(
+        remote_id=uuid.uuid4(),
+        environment=env.id,
+        do_export=False,
+        requested_environment_variables={},
+        used_environment_variables={},
+    )
+    await compile.insert()
+
+    project_work_dir = os.path.join(tmpdir, "work")
+    ensure_directory_exist(project_work_dir)
+
+    # Exercise the clone stage directly: this is the git command the compiler service runs, and it is
+    # the only stage that needs to authenticate against the repository.
+    cr = CompileRun(compile, project_work_dir)
+    report = await cr._run_compile_stage("Cloning repository", ["git", "clone", repo_url, "."], project_work_dir)
+
+    assert report.returncode == 0, report.errstream
+    assert os.path.exists(os.path.join(project_work_dir, "marker.txt"))
 
 
 @pytest.mark.slowtest


### PR DESCRIPTION
> Created by Claude on behalf of Guillaume.

# Description

When a server-side compile clones or pulls a project repository that requires authentication and no credentials are available, git tries to prompt for a username. The compiler runs git in a subprocess with no terminal attached, so the prompt fails with the confusing:

```
fatal: could not read Username for 'https://code.inmanta.com': No such device or address
```

which hides the actual problem (wrong/missing credentials).

The git subprocesses spawned by the compiler service (`_run_compile_stage` and `_run_cmd_async`) now run with `GIT_ASKPASS=true` and `GIT_TERMINAL_PROMPT=0` by default:

- `GIT_ASKPASS=true` feeds empty credentials, so the remote answers with its **real** authentication error (`fatal: Authentication failed for '...'`).
- `GIT_TERMINAL_PROMPT=0` disables any remaining interactive prompt as a safety net.

These are applied *below* the process environment, so they act as defaults an operator can override through the orchestrator environment (e.g. pointing `GIT_ASKPASS` at a real credential helper). This matches what `CLIGitProvider` already does for its own clone/fetch.

Verified locally against a minimal 401 HTTP server:

| env                     | git output                                                          |
| ----------------------- | ------------------------------------------------------------------- |
| none (before)           | `fatal: could not read Username ... No such device or address`      |
| `GIT_ASKPASS=true`      | `fatal: Authentication failed ...` ← real error                     |
| `GIT_TERMINAL_PROMPT=0` | `fatal: could not read Username ... terminal prompts disabled`      |

# Documentation

Added a "Debugging project authentication issues" subsection to `docs/troubleshooting.rst` explaining how to set `GIT_TRACE_CURL` / `GIT_CURL_VERBOSE` as orchestrator environment variables to see which credential source git consulted (`.netrc`, URL, credential helper) when a checkout fails to authenticate. The secret itself is redacted; the docs warn against `GIT_TRACE`, which prints the full repository URL and would leak URL-embedded credentials into the compile report.

closes N/A

# Self Check:

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included
- [ ] ~~If this PR fixes a race condition in the test suite~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)