### PR TITLE
Document concurrency control in the LSM API docs

### DIFF
--- a/changelogs/unreleased/lsm-concurrency-control-docs.yml
+++ b/changelogs/unreleased/lsm-concurrency-control-docs.yml
@@ -1,0 +1,5 @@
+description: Documented concurrency control (the current_version parameter) in the LSM API documentation
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/docs/lsm/index.rst
+++ b/docs/lsm/index.rst
@@ -116,6 +116,59 @@ The service inventory exposes CRUD operations on service instances in the invent
 The state machine attached to the lifecycle will determine whether the API call is successful or not.
 
 
+.. _lsm_concurrency_control:
+
+Concurrency control
+===================
+
+Every service instance carries an integer ``version`` field, which is returned by every read operation. This version is a
+change counter: it is incremented on every state transfer of the instance. It is **not** a version control mechanism like
+git: older versions are not kept as retrievable snapshots, so the version number cannot be used to check out, diff or
+restore a previous state of the instance. To inspect the history of an instance, use the log endpoint listed under
+`Status operations`_. To revert attribute changes, use a lifecycle transfer with the ``rollback`` operation (see
+:ref:`fsm`).
+
+Instead, the version is used for optimistic concurrency control. A service instance can be modified by multiple actors at
+the same time: operators using the web console, northbound clients such as OSS/BSS systems, and the lifecycle manager
+itself, which moves instances through their lifecycle with automatic state transfers. Any of these can change the instance
+between the moment a client reads it and the moment that client sends a modification.
+
+Every API call that modifies a service instance (attribute updates, state transfers and deletes) therefore takes a
+``current_version`` argument: the version of the instance the caller based its decision on. The call is only executed if
+this value still matches the version of the instance in the inventory. If it does not match, the instance is left
+untouched and the request is rejected with HTTP 409 (Conflict) and an error like::
+
+    The given current version (4) doesn't match the actual current version (5) of service instance
+    8ee3a5e8-... in environment test(f2568cdb-...)
+
+This compare-and-set mechanism prevents lost updates and modifications based on stale data. Clients are expected to
+interact with the API as follows:
+
+1. ``GET`` the service instance and remember its ``version``.
+2. Decide on the modification, based on the attributes and state that were just read.
+3. Send the modifying call with ``current_version`` set to the version from step 1.
+4. On a 409 response, the instance was changed by another actor in the meantime. Read the instance again, verify that the
+   modification still makes sense for the new attributes and state, and retry with the new version. Do not blindly resend
+   the request with the version reported in the error message.
+
+For example, updating the attributes of an instance that is currently at version 4:
+
+.. code-block:: sh
+
+    # 1. read the instance, the response contains "version": 4
+    curl -H "X-Inmanta-tid: $ENV_ID" \
+        "http://<host>:<port>/lsm/v1/service_inventory/vlan_assignment/$INSTANCE_ID"
+
+    # 2. update it, passing the version this update was based on
+    curl -X PATCH -H "X-Inmanta-tid: $ENV_ID" -H "Content-Type: application/json" \
+        "http://<host>:<port>/lsm/v1/service_inventory/vlan_assignment/$INSTANCE_ID" \
+        -d '{"current_version": 4, "attributes": {"description": "updated description"}}'
+
+A successful modification triggers a state transfer, so it increments the version of the instance (possibly multiple
+times, as automatic transfers follow). A read can also assert the version: ``GET`` on a single service instance accepts an
+optional ``current_version`` parameter, which turns a stale read into a 409 error.
+
+
 Configuration operations
 ========================
 
@@ -207,7 +260,8 @@ through the API are stored in candidate_attributes. For all other transitions th
 - ``promote``: Promote the values in candidate to active and active to rollback.
 - ``rollback``: Do a roll back of the attributes by setting the values from rollback to active and active to candidate.
 
-On every state transfer the version of the service instance is incremented.
+On every state transfer the version of the service instance is incremented. This version is used for concurrency control
+on the API (see :ref:`lsm_concurrency_control`).
 
 
 Patterns

--- a/docs/lsm/index.rst
+++ b/docs/lsm/index.rst
@@ -141,6 +141,10 @@ untouched and the request is rejected with HTTP 409 (Conflict) and an error like
     The given current version (4) doesn't match the actual current version (5) of service instance
     8ee3a5e8-... in environment test(f2568cdb-...)
 
+On the endpoints listed above, ``current_version`` is mandatory. Endpoints on which it is optional (such as the expert
+variants of these operations) skip the version check when it is not provided: the operation is then applied to the
+instance as it is at the moment the request is processed, regardless of any changes made since the caller last read it.
+
 This compare-and-set mechanism prevents lost updates and modifications based on stale data. Consider a connectivity
 service with a ``bandwidth`` attribute that is managed by a BSS system:
 

--- a/docs/lsm/index.rst
+++ b/docs/lsm/index.rst
@@ -125,8 +125,8 @@ Every service instance carries an integer ``version`` field, which is returned b
 change counter: it is incremented on every state transfer of the instance. It is **not** a version control mechanism like
 git: older versions are not kept as retrievable snapshots, so the version number cannot be used to check out, diff or
 restore a previous state of the instance. To inspect the history of an instance, use the log endpoint listed under
-`Status operations`_. To revert attribute changes, use a lifecycle transfer with the ``rollback`` operation (see
-:ref:`fsm`).
+`Status operations`_. To revert attribute changes, perform a new update with the old attribute values, or use a lifecycle
+transfer with the ``rollback`` operation (see :ref:`fsm`).
 
 Instead, the version is used for optimistic concurrency control. A service instance can be modified by multiple actors at
 the same time: operators using the web console, northbound clients such as OSS/BSS systems, and the lifecycle manager

--- a/docs/lsm/index.rst
+++ b/docs/lsm/index.rst
@@ -141,8 +141,25 @@ untouched and the request is rejected with HTTP 409 (Conflict) and an error like
     The given current version (4) doesn't match the actual current version (5) of service instance
     8ee3a5e8-... in environment test(f2568cdb-...)
 
-This compare-and-set mechanism prevents lost updates and modifications based on stale data. Clients are expected to
-interact with the API as follows:
+This compare-and-set mechanism prevents lost updates and modifications based on stale data. Consider a connectivity
+service with a ``bandwidth`` attribute that is managed by a BSS system:
+
+1. The BSS reads the service instance to prepare a bandwidth upgrade: the instance is in state ``up`` at version 12.
+2. Before the BSS sends its update, a port failure in the network causes a deploy of the instance's resources to fail.
+   The lifecycle manager reacts with an automatic state transfer from ``up`` to ``failed``: the instance is now at
+   version 13.
+3. The BSS sends its update with ``current_version`` set to 12. The instance is no longer at version 12, so the request
+   is rejected with a 409 and the instance is not modified.
+4. The BSS reads the instance again, sees that it is in state ``failed``, and can make an informed decision: raise an
+   alarm, wait for the service to recover, or apply the upgrade anyway with ``current_version`` set to 13.
+
+Without the version check, the update in step 3 would have been accepted, and the BSS would believe it upgraded a healthy
+service while it actually modified a degraded one. The same mechanism protects two API clients that update the same
+instance concurrently: both may base their update on the same version, but only the first update will be accepted.
+Because the v1 update endpoint requires the full tree of attributes, the second update would otherwise silently undo the
+first one (a lost update).
+
+Clients are therefore expected to interact with the API as follows:
 
 1. ``GET`` the service instance and remember its ``version``.
 2. Decide on the modification, based on the attributes and state that were just read.


### PR DESCRIPTION
*This PR was created by Claude Code on behalf of Bart Vanbrabant.*

# Description

Add a dedicated "Concurrency control" section to the LSM service inventory documentation (`docs/lsm/index.rst`), directly after the CRUD operations overview.

The `current_version` parameter on the LSM API is currently only documented in the per-endpoint API reference, and a customer recently mistook the service instance `version` field for git-style version control. The new section explicitly explains that:

- the version is a change counter, not a version control mechanism: it cannot be used to check out, diff or restore older state (the log endpoint and the `rollback` lifecycle operation cover those needs),
- it implements optimistic concurrency control (compare-and-set) to prevent lost updates between concurrent actors (web console operators, northbound clients, the lifecycle manager itself),
- the expected client workflow: read the instance, pass its `version` as `current_version`, and on HTTP 409 Conflict re-read and re-evaluate before retrying, with a curl example.

It also cross-links the "On every state transfer the version of the service instance is incremented" sentence in the lifecycle section to the new section, and quotes the literal 409 error message so users can find this section from the error they see.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] ~~Attached issue to pull request~~ (docs improvement, no ticket)
- [x] Changelog entry
- [x] ~~Type annotations are present~~ (docs only)
- [x] Code is clear and sufficiently documented
- [x] ~~No (preventable) type errors (check using make mypy or make mypy-diff)~~ (docs only)
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~ (docs only)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)