### PR TITLE
Fix compatibility with PostgreSQL 18

### DIFF
--- a/changelogs/unreleased/fix-compatibility-pg18.yml
+++ b/changelogs/unreleased/fix-compatibility-pg18.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix compatibility with PostgreSQL 18."
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -7014,7 +7014,7 @@ class Role(BaseDocument):
         """
         try:
             result = await cls._fetchrow(query, name)
-        except asyncpg.ForeignKeyViolationError:
+        except (asyncpg.ForeignKeyViolationError, asyncpg.RestrictViolationError):
             # Role is still assigned to a certain user
             raise RoleStillAssignedException()
         else:


### PR DESCRIPTION
# Description

This PR fixes an incompatibility with PostgreSQL 18. In PG18 an `asyncpg.RestrictViolationError` exception is raised when trying to delete a record that is referenced by a foreign key constraint with ON DELETE RESTICT set, instead of an `asyncpg.ForeignKeyViolationError` exception in order versions.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
