### PR TITLE
Add dummy changelog entry

### DIFF
--- a/changelogs/unreleased/fix-compatibility-pg18.yml
+++ b/changelogs/unreleased/fix-compatibility-pg18.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix compatibility with PostgreSQL 18."
+change-type: patch
+destination-branches: [iso8]


### PR DESCRIPTION
# Description

Add dummy changelog entry. https://github.com/inmanta/inmanta-core/pull/10627 Should not be applied on the iso8 branch because database auth doesn't exist in iso8.