### PR TITLE
Add a test that verifies the SQLAlchemy models stay in sync with the database schema

### DIFF
--- a/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
+++ b/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
@@ -1,4 +1,4 @@
 ---
-description: "Bring the SQLAlchemy models in sync with the database schema and add a test that verifies they stay in sync."
+description: "Bring the SQLAlchemy models in sync with the database schema and add a test that verifies they stay in sync. The comparison itself lives in inmanta.db.schema_compare, so extensions can verify their own models against their own migration scripts."
 change-type: patch
 destination-branches: [master]

--- a/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
+++ b/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
@@ -1,4 +1,4 @@
 ---
-description: "Bring the SQLAlchemy models in sync with the database schema and add a test that verifies they stay in sync. The comparison itself lives in inmanta.db.schema_compare, so extensions can verify their own models against their own migration scripts."
+description: "Bring the SQLAlchemy models in sync with the database schema and add a test that verifies they stay in sync. The comparison itself is shipped by pytest-inmanta-extensions as inmanta_tests.db.schema_compare, so extensions can verify their own models against their own migration scripts."
 change-type: patch
 destination-branches: [master]

--- a/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
+++ b/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
@@ -1,0 +1,4 @@
+---
+description: "Bring the SQLAlchemy models in sync with the database schema and add a test that verifies they stay in sync."
+change-type: patch
+destination-branches: [master, iso9]

--- a/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
+++ b/changelogs/unreleased/sqlalchemy-models-db-schema-sync.yml
@@ -1,4 +1,4 @@
 ---
 description: "Bring the SQLAlchemy models in sync with the database schema and add a test that verifies they stay in sync."
 change-type: patch
-destination-branches: [master, iso9]
+destination-branches: [master]

--- a/docs/platform_developers/database.rst
+++ b/docs/platform_developers/database.rst
@@ -48,6 +48,18 @@ The test ``tests/db/test_sqlalchemy_model_sync.py`` applies all migration script
 resulting schema against the models, so it fails until the models are updated. Its output names each table and each
 element that differs.
 
+It compares which tables exist, and per table the columns (type, nullability and default), the primary key, the indexes
+(columns, uniqueness, method, operator classes and the condition of a partial one), and the unique, foreign key and
+check constraints, each by name as well, because migration scripts address constraints and indexes by name.
+
+A few things it does not compare, so a model can still be wrong about them and the test will pass:
+
+* the sort order of the columns of an index, so a ``DESC`` in a migration script needs to be carried over to the model
+  by hand;
+* the order of the columns of a table;
+* the comment on a table or a column;
+* whether a constraint is deferrable, or was added ``NOT VALID``.
+
 Executing schema updates
 ########################
 

--- a/docs/platform_developers/database.rst
+++ b/docs/platform_developers/database.rst
@@ -38,6 +38,16 @@ An example is given in the code snippet below:
         await connection.execute(schema)
 
 
+Keeping the SQLAlchemy models in sync with the database
+#######################################################
+
+The tables of the database are also described by the SQLAlchemy models in ``inmanta.data.sqlalchemy``. A migration
+script that changes a table has to be accompanied by the same change to the model of that table.
+
+The test ``tests/db/test_sqlalchemy_model_sync.py`` applies all migration scripts to an empty database and compares the
+resulting schema against the models, so it fails until the models are updated. Its output names each table and each
+element that differs.
+
 Executing schema updates
 ########################
 

--- a/docs/platform_developers/database.rst
+++ b/docs/platform_developers/database.rst
@@ -48,18 +48,6 @@ The test ``tests/db/test_sqlalchemy_model_sync.py`` applies all migration script
 resulting schema against the models, so it fails until the models are updated. Its output names each table and each
 element that differs.
 
-It compares which tables exist, and per table the columns (type, nullability and default), the primary key, the indexes
-(columns, uniqueness, method, operator classes and the condition of a partial one), and the unique, foreign key and
-check constraints, each by name as well, because migration scripts address constraints and indexes by name.
-
-A few things it does not compare, so a model can still be wrong about them and the test will pass:
-
-* the sort order of the columns of an index, so a ``DESC`` in a migration script needs to be carried over to the model
-  by hand;
-* the order of the columns of a table;
-* the comment on a table or a column;
-* whether a constraint is deferrable, or was added ``NOT VALID``.
-
 Executing schema updates
 ########################
 

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -694,7 +694,10 @@ class Environment(Base):
 
 class SchedulerSession(Base):
     __tablename__ = "schedulersession"
-    # This table and its indexes were renamed from agentprocess, its constraints kept their original name.
+    # v202605060 renamed this table and its four indexes from agentprocess but not its primary key or its foreign key,
+    # so those still carry their original name in every database. The names below describe that, rather than the names
+    # the rename would have produced. Renaming them is a metadata-only ALTER TABLE ... RENAME CONSTRAINT, tracked in
+    # inmanta/inmanta-core#10634; the names here have to follow when that lands.
     __table_args__ = (
         ForeignKeyConstraint(["environment"], ["environment.id"], ondelete="CASCADE", name="agentprocess_environment_fkey"),
         PrimaryKeyConstraint("sid", name="agentprocess_pkey"),
@@ -828,7 +831,7 @@ class Discoveredresource(Base):
     discovered_resource_id: Mapped[str] = mapped_column(String, primary_key=True)
     values: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     discovered_at: Mapped[datetime.datetime] = mapped_column(DateTime(True), nullable=False)
-    discovery_resource_id: Mapped[Optional[str]] = mapped_column(String, nullable=False)
+    discovery_resource_id: Mapped[str] = mapped_column(String, nullable=False)
     resource_type: Mapped[str] = mapped_column(String, nullable=False)
     agent: Mapped[str] = mapped_column(String, nullable=False)
     resource_id_value: Mapped[str] = mapped_column(String, nullable=False)
@@ -915,7 +918,7 @@ class Parameter(Base):
         PrimaryKeyConstraint("id", name="parameter_pkey"),
         Index("parameter_env_name_resource_id_index", "environment", "name", "resource_id"),
         Index("parameter_environment_resource_id_index", "environment", "resource_id"),
-        Index("parameter_metadata_index", "metadata"),
+        Index("parameter_metadata_index", "metadata", postgresql_using="gin", postgresql_ops={"metadata": "jsonb_path_ops"}),
         Index("parameter_updated_index", "updated"),
     )
 
@@ -943,6 +946,11 @@ class ResourcePersistentState(Base):
             ["resource_diff.id"],
             ondelete="RESTRICT",
             name="resource_persistent_state_non_compliant_diff_fkey",
+            # This table and resource_diff reference each other, so no order in which the two can be created satisfies
+            # both. Nothing creates the schema from these models, but this keeps the cycle resolvable for whatever
+            # walks them: without it, metadata.sorted_tables warns that it cannot sort them and drops both constraints
+            # from consideration.
+            use_alter=True,
         ),
         PrimaryKeyConstraint("environment", "resource_id", name="resource_persistent_state_pkey"),
         Index("resource_persistent_state_environment_agent_resource_id_idx", "environment", "agent", "resource_id"),
@@ -1072,6 +1080,10 @@ class ResourceDiff(Base):
     )
     created: Mapped[datetime.datetime] = mapped_column(DateTime(True), nullable=False, doc="The moment this diff was observed")
 
+    # Unlike the other tables that carry an environment, this one has no relationship to Environment: its environment
+    # column has no foreign key to that table, only the composite one to resource_persistent_state above. Diffs are
+    # reached through the resource they were observed on.
+
 
 class ResourceSet(Base):
     __tablename__ = "resource_set"
@@ -1179,7 +1191,9 @@ class Resource(Base):
             name="resource_resource_set_id_environment_fkey",
         ),
         PrimaryKeyConstraint("environment", "resource_set", "resource_id", name="resource_pkey"),
-        Index("resource_attributes_index", "attributes"),
+        Index(
+            "resource_attributes_index", "attributes", postgresql_using="gin", postgresql_ops={"attributes": "jsonb_path_ops"}
+        ),
         Index("resource_env_attr_hash_index", "environment", "attribute_hash"),
         Index("resource_environment_agent_idx", "environment", "agent"),
         Index("resource_environment_resource_id_index", "environment", "resource_id"),

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -507,6 +507,7 @@ class Token(SetValidatedMixin, Base):
     __table_args__ = (
         ForeignKeyConstraint(["environment"], ["environment.id"], ondelete="CASCADE", name="token_environment_fkey"),
         PrimaryKeyConstraint("jti", name="token_pkey"),
+        Index("token_environment_index", "environment"),
     )
 
     jti: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, doc="The unique identifier of the token (its jti claim)")
@@ -519,6 +520,9 @@ class Token(SetValidatedMixin, Base):
                 ClientType,
                 native_enum=False,
                 create_constraint=False,
+                # The column is an unbounded varchar array in the database. Without this, the type would default to a
+                # varchar of the length of the longest enum value.
+                length=None,
                 values_callable=lambda enum_cls: [m.value for m in enum_cls],
             )
         ),
@@ -690,12 +694,13 @@ class Environment(Base):
 
 class SchedulerSession(Base):
     __tablename__ = "schedulersession"
+    # This table and its indexes were renamed from agentprocess, its constraints kept their original name.
     __table_args__ = (
-        ForeignKeyConstraint(["environment"], ["environment.id"], ondelete="CASCADE", name="schedulersession_environment_fkey"),
-        PrimaryKeyConstraint("sid", name="schedulersession_pkey"),
+        ForeignKeyConstraint(["environment"], ["environment.id"], ondelete="CASCADE", name="agentprocess_environment_fkey"),
+        PrimaryKeyConstraint("sid", name="agentprocess_pkey"),
         Index("schedulersession_env_expired_index", "environment", "expired"),
         Index("schedulersession_env_hostname_expired_index", "environment", "hostname", "expired"),
-        Index("schedulersession_expired_index", "expired"),
+        Index("schedulersession_expired_index", "expired", postgresql_where=text("expired IS NULL")),
         Index("schedulersession_sid_expired_index", "sid", "expired", unique=True),
     )
 
@@ -732,6 +737,12 @@ class Compile(Base):
     )
     soft_delete: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     links: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    reinstall_project_and_venv: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+        doc="Whether the project and its venv have to be reinstalled from scratch for this compile",
+    )
     started: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime(True))
     completed: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime(True))
     requested: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime(True))
@@ -818,6 +829,9 @@ class Discoveredresource(Base):
     values: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     discovered_at: Mapped[datetime.datetime] = mapped_column(DateTime(True), nullable=False)
     discovery_resource_id: Mapped[Optional[str]] = mapped_column(String, nullable=False)
+    resource_type: Mapped[str] = mapped_column(String, nullable=False)
+    agent: Mapped[str] = mapped_column(String, nullable=False)
+    resource_id_value: Mapped[str] = mapped_column(String, nullable=False)
 
     environment_: Mapped["Environment"] = relationship("Environment", back_populates="discoveredresource")
 
@@ -924,6 +938,12 @@ class ResourcePersistentState(Base):
         ForeignKeyConstraint(
             ["environment"], ["environment.id"], ondelete="CASCADE", name="resource_persistent_state_environment_fkey"
         ),
+        ForeignKeyConstraint(
+            ["non_compliant_diff"],
+            ["resource_diff.id"],
+            ondelete="RESTRICT",
+            name="resource_persistent_state_non_compliant_diff_fkey",
+        ),
         PrimaryKeyConstraint("environment", "resource_id", name="resource_persistent_state_pkey"),
         Index("resource_persistent_state_environment_agent_resource_id_idx", "environment", "agent", "resource_id"),
         Index(
@@ -975,6 +995,9 @@ class ResourcePersistentState(Base):
     current_intent_attribute_hash: Mapped[Optional[str]] = mapped_column(String)
     is_deploying: Mapped[Optional[bool]] = mapped_column(Boolean, server_default=text("false"))
     last_handler_run_compliant: Mapped[Optional[bool]] = mapped_column(Boolean)
+    non_compliant_diff: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID, doc="The diff that made this resource non-compliant, or None if it is not non-compliant"
+    )
 
     environment_: Mapped["Environment"] = relationship("Environment", back_populates="resource_persistent_state")
 
@@ -1023,6 +1046,31 @@ class ResourcePersistentState(Base):
             (cls.last_handler_run_compliant.is_(True), state.Compliance.COMPLIANT.name),
             else_=state.Compliance.NON_COMPLIANT.name,
         )
+
+
+class ResourceDiff(Base):
+    __tablename__ = "resource_diff"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["environment", "resource_id"],
+            ["resource_persistent_state.environment", "resource_persistent_state.resource_id"],
+            ondelete="CASCADE",
+            name="resource_diff_environment_resource_id_fkey",
+        ),
+        PrimaryKeyConstraint("id", name="resource_diff_pkey"),
+        Index("resource_diff_environment_created", "environment", "created"),
+        Index("resource_diff_environment_resource_id", "environment", "resource_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID, primary_key=True, server_default=text("gen_random_uuid()"), doc="The id of this diff"
+    )
+    environment: Mapped[uuid.UUID] = mapped_column(UUID, nullable=False, doc="The environment this diff belongs to")
+    resource_id: Mapped[str] = mapped_column(String, nullable=False, doc="The id of the resource this diff was observed on")
+    diff: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, doc="The current and desired value of each attribute that differs"
+    )
+    created: Mapped[datetime.datetime] = mapped_column(DateTime(True), nullable=False, doc="The moment this diff was observed")
 
 
 class ResourceSet(Base):
@@ -1082,7 +1130,7 @@ class Dryrun(Base):
             ["environment", "model"],
             ["configurationmodel.environment", "configurationmodel.version"],
             ondelete="CASCADE",
-            name="dryrun_environment_fkey",
+            name="dryrun_environment_model_fkey",
         ),
         PrimaryKeyConstraint("id", name="dryrun_pkey"),
         Index("dryrun_env_model_index", "environment", "model"),
@@ -1128,16 +1176,16 @@ class Resource(Base):
             ["resource_set", "environment"],
             ["resource_set.id", "resource_set.environment"],
             ondelete="CASCADE",
-            name="resource_resource_set_environment_fkey",
+            name="resource_resource_set_id_environment_fkey",
         ),
         PrimaryKeyConstraint("environment", "resource_set", "resource_id", name="resource_pkey"),
         Index("resource_attributes_index", "attributes"),
         Index("resource_env_attr_hash_index", "environment", "attribute_hash"),
         Index("resource_environment_agent_idx", "environment", "agent"),
+        Index("resource_environment_resource_id_index", "environment", "resource_id"),
         Index("resource_environment_resource_id_value_index", "environment", "resource_id_value"),
-        Index("resource_environment_resource_set_index", "environment", "resource_set"),
+        Index("resource_environment_resource_set_id_index", "environment", "resource_set"),
         Index("resource_environment_resource_type_index", "environment", "resource_type"),
-        Index("resource_resource_id_index", "resource_id"),
     )
 
     environment: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True)
@@ -1178,10 +1226,10 @@ t_resource_set_configuration_model = Table(
     ForeignKeyConstraint(
         ["environment", "resource_set"],
         ["resource_set.environment", "resource_set.id"],
-        name="resource_set_configuration_mod_environment_resource_set_fkey",
+        name="resource_set_configuration_mod_environment_resource_set_id_fkey",
     ),
     PrimaryKeyConstraint("environment", "model", "resource_set", name="resource_set_configuration_model_pkey"),
-    Index("resource_set_configuration_model_environment_resource_set_in", "environment", "resource_set"),
+    Index("resource_set_configuration_model_environment_resource_set_id_in", "environment", "resource_set"),
 )
 
 
@@ -1192,7 +1240,7 @@ class Resourceaction(Base):
             ["environment", "version"],
             ["configurationmodel.environment", "configurationmodel.version"],
             ondelete="CASCADE",
-            name="resourceaction_environment_fkey",
+            name="resourceaction_environment_version_fkey",
         ),
         PrimaryKeyConstraint("action_id", name="resourceaction_pkey"),
         Index("resourceaction_environment_action_started_index", "environment", "action", "started"),

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -1217,6 +1217,8 @@ class Resource(Base):
 
 class ResourceSetConfigurationModel(Base):
     __tablename__ = "resource_set_configuration_model"
+    # v202509180 renamed the resource_set_id column of this table to resource_set, but not the foreign key and the
+    # index on it, so both keep the old column in their name.
     __table_args__ = (
         ForeignKeyConstraint(
             ["environment", "model"],
@@ -1227,10 +1229,10 @@ class ResourceSetConfigurationModel(Base):
         ForeignKeyConstraint(
             ["environment", "resource_set"],
             ["resource_set.environment", "resource_set.id"],
-            name="resource_set_configuration_mod_environment_resource_set_fkey",
+            name="resource_set_configuration_mod_environment_resource_set_id_fkey",
         ),
         PrimaryKeyConstraint("environment", "model", "resource_set", name="resource_set_configuration_model_pkey"),
-        Index("resource_set_configuration_model_environment_resource_set_in", "environment", "resource_set"),
+        Index("resource_set_configuration_model_environment_resource_set_id_index", "environment", "resource_set"),
     )
 
     environment: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, doc="The environment this resource set belongs to")

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -40,6 +40,7 @@ from sqlalchemy import (
     UniqueConstraint,
     and_,
     case,
+    column,
     delete,
     event,
     func,
@@ -104,15 +105,15 @@ class SetValidatedMixin:
         """
         mapper = class_mapper(cls)
         for column_property in mapper.column_attrs:
-            column = column_property.columns[0]
+            table_column = column_property.columns[0]
             try:
-                python_type = column.type.python_type
+                python_type = table_column.type.python_type
             except NotImplementedError:
                 continue
             event.listen(
                 getattr(cls, column_property.key),
                 "set",
-                cls._make_column_validator(column_property.key, python_type, column.nullable),
+                cls._make_column_validator(column_property.key, python_type, table_column.nullable),
                 retval=True,
             )
 
@@ -721,7 +722,7 @@ class Compile(Base):
         Index("compile_completed_environment_idx", "completed", "environment"),
         Index("compile_env_remote_id_index", "environment", "remote_id"),
         Index("compile_env_requested_index", "environment", "requested"),
-        Index("compile_env_started_index", "environment", "started"),
+        Index("compile_env_started_index", "environment", column("started").desc()),
         Index("compile_environment_version_index", "environment", "version"),
         Index("compile_substitute_compile_id_index", "substitute_compile_id"),
     )
@@ -781,8 +782,10 @@ class Configurationmodel(Base):
             ["environment"], ["environment.id"], ondelete="CASCADE", name="configurationmodel_environment_fkey"
         ),
         PrimaryKeyConstraint("environment", "version", name="configurationmodel_pkey"),
-        Index("configurationmodel_env_released_version_index", "environment", "released", "version", unique=True),
-        Index("configurationmodel_env_version_total_index", "environment", "version", "total", unique=True),
+        Index(
+            "configurationmodel_env_released_version_index", "environment", "released", column("version").desc(), unique=True
+        ),
+        Index("configurationmodel_env_version_total_index", "environment", column("version").desc(), "total", unique=True),
     )
 
     version: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -884,7 +887,7 @@ class Notification(Base):
         ForeignKeyConstraint(["compile_id"], ["compile.id"], ondelete="CASCADE", name="notification_compile_id_fkey"),
         ForeignKeyConstraint(["environment"], ["environment.id"], ondelete="CASCADE", name="notification_environment_fkey"),
         PrimaryKeyConstraint("environment", "id", name="notification_pkey"),
-        Index("notification_env_created_id_index", "environment", "created", "id"),
+        Index("notification_env_created_id_index", "environment", column("created").desc(), "id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True)
@@ -1250,8 +1253,8 @@ class Resourceaction(Base):
             name="resourceaction_environment_version_fkey",
         ),
         PrimaryKeyConstraint("action_id", name="resourceaction_pkey"),
-        Index("resourceaction_environment_action_started_index", "environment", "action", "started"),
-        Index("resourceaction_environment_version_started_index", "environment", "version", "started"),
+        Index("resourceaction_environment_action_started_index", "environment", "action", column("started").desc()),
+        Index("resourceaction_environment_version_started_index", "environment", "version", column("started").desc()),
         Index("resourceaction_started_index", "started"),
     )
 

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -694,10 +694,6 @@ class Environment(Base):
 
 class SchedulerSession(Base):
     __tablename__ = "schedulersession"
-    # v202605060 renamed this table and its four indexes from agentprocess but not its primary key or its foreign key,
-    # so those still carry their original name in every database. The names below describe that, rather than the names
-    # the rename would have produced. Renaming them is a metadata-only ALTER TABLE ... RENAME CONSTRAINT, tracked in
-    # inmanta/inmanta-core#10634; the names here have to follow when that lands.
     __table_args__ = (
         ForeignKeyConstraint(["environment"], ["environment.id"], ondelete="CASCADE", name="agentprocess_environment_fkey"),
         PrimaryKeyConstraint("sid", name="agentprocess_pkey"),
@@ -1079,10 +1075,6 @@ class ResourceDiff(Base):
         JSONB, nullable=False, doc="The current and desired value of each attribute that differs"
     )
     created: Mapped[datetime.datetime] = mapped_column(DateTime(True), nullable=False, doc="The moment this diff was observed")
-
-    # Unlike the other tables that carry an environment, this one has no relationship to Environment: its environment
-    # column has no foreign key to that table, only the composite one to resource_persistent_state above. Diffs are
-    # reached through the resource they were observed on.
 
 
 class ResourceSet(Base):

--- a/src/inmanta/db/schema_compare.py
+++ b/src/inmanta/db/schema_compare.py
@@ -16,10 +16,14 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import textwrap
+from abc import ABC, abstractmethod
 from collections import abc
+from typing import ClassVar
 
 from sqlalchemy import ARRAY, URL, CheckConstraint, Column, Enum, ForeignKeyConstraint, Index, MetaData, Table, UniqueConstraint
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.schema import DefaultClause
 from sqlalchemy.sql.type_api import TypeEngine
@@ -28,193 +32,312 @@ from sqlalchemy.sql.type_api import TypeEngine
 # truncated in the database. Both sides are truncated before they are compared, to compare what the database sees.
 MAX_IDENTIFIER_LENGTH = 63
 
+# One level of indentation in the report that a comparison produces.
+REPORT_INDENT = "\t"
 
-def _identifier(name: object) -> str | None:
+# SQLAlchemy does not annotate the constructor of a dialect.
+POSTGRESQL_DIALECT: Dialect = postgresql.dialect()  # type: ignore[no-untyped-call]
+
+
+def get_truncated_identifier(name: object) -> str | None:
     """
     The name of a constraint or an index as PostgreSQL stores it, or None if it has none.
-
-    A constraint that was never given a name reports None, while one whose name was computed but resolved to nothing
-    reports SQLAlchemy's _NONE_NAME sentinel, which is not a string (here we resolve it as None anyway).
     """
     return name[:MAX_IDENTIFIER_LENGTH] if isinstance(name, str) else None
 
 
-def _type(column_type: TypeEngine[object]) -> str:
-    """
-    A comparable description of a column type: the type as it appears in DDL, extended with the labels of a native
-    enum type, because those are part of the schema as well.
-    """
-    # SQLAlchemy does not annotate the constructor of a dialect
-    compiled = column_type.compile(postgresql.dialect())  # type: ignore[no-untyped-call]
-    element = column_type.item_type if isinstance(column_type, ARRAY) else column_type
-    if isinstance(element, Enum) and element.native_enum:
-        return f"{compiled} labels=({', '.join(element.enums)})"
-    return compiled
-
-
-def _server_default(column: Column[object]) -> str | None:
-    """The default the database fills in for a column, or None if it has none."""
-    if not isinstance(column.server_default, DefaultClause):
-        # Either no default at all, or one whose value lives outside the schema (a FetchedValue), which neither a
-        # model of this schema nor reflection produces.
-        return None
-    return str(getattr(column.server_default.arg, "text", column.server_default.arg))
-
-
-def _predicate(index: Index) -> str | None:
-    """The condition of a partial index, or None if the index covers all rows."""
-    predicate = index.dialect_options["postgresql"]["where"]
-    if predicate is None:
-        return None
-    # Normalize and parse the entire predicate (e.g. ((n > 0) AND (name IS NULL)))
-    normalized = str(predicate).strip()
-    while normalized.startswith("(") and normalized.endswith(")"):
-        depth = 0
-        in_literal = False
-        for position, character in enumerate(normalized):
-            if character == "'":
-                in_literal = not in_literal
-                continue
-            if in_literal:
-                continue
-            depth += (character == "(") - (character == ")")
-            if depth == 0 and position < len(normalized) - 1:
-                # The parenthesis opened at the start is closed here, so the pair encloses only part of the condition.
-                return normalized
-        normalized = normalized[1:-1].strip()
-    return normalized
-
-
-def _method(index: Index) -> str:
-    """The method of an index (btree, gin, ...)."""
-    # Reflection only reports the method when it is not the default, and a model only declares one when it deviates
-    # from the default, so an absent method on either side means btree.
-    return index.dialect_options["postgresql"]["using"] or "btree"
-
-
-def _operator_classes(index: Index) -> str:
-    """
-    The operator class of each column of an index that does not use the default one for its type.
-    """
-    operator_classes: abc.Mapping[str, str] = index.dialect_options["postgresql"]["ops"]
-    return f"({', '.join(f'{column}={operator_classes[column]}' for column in sorted(operator_classes))})"
-
-
-def _column_names(columns: abc.Iterable[Column[object]]) -> str:
+def column_names_to_str(columns: abc.Iterable[Column[object]]) -> str:
+    """The names of the given columns, in the order they are given."""
     return f"({', '.join(column.name for column in columns)})"
 
 
-def _by_name(elements: abc.Iterable[tuple[str | None, str]]) -> dict[str, str]:
+class ElementDifference(ABC):
     """
-    Key the elements of one kind, of a single table by their name.
-
-    PostgreSQL names every index and constraint, so an element without a name can only come from a sqlalchemy model.
-    We add the description to the key so that multiple unnamed elements can appear in the dictionary
+    A single element of a table (a column, an index, a constraint, ...) that the SQLAlchemy model side and the
+    database side do not describe the same way.
     """
-    return {name if name is not None else f"<unnamed> {description}": description for name, description in elements}
+
+    def __init__(self, element_kind: str, name: str) -> None:
+        """
+        :param element_kind: the kind of element this is, as it appears in the report, e.g. "column" or "index".
+        :param name: the name the element is compared under.
+        """
+        self.element_kind = element_kind
+        self.name = name
+
+    @abstractmethod
+    def format_report(self) -> str:
+        """
+        This difference as one or more report lines, without a trailing newline.
+        """
 
 
-def _columns(table: Table) -> dict[str, str]:
-    return _by_name(
-        (column.name, f"type={_type(column.type)} nullable={column.nullable} default={_server_default(column)}")
-        for column in table.columns
-    )
+class ElementOnlyDeclaredByModel(ElementDifference):
+    """An element that the model declares but that the database does not have."""
+
+    def format_report(self) -> str:
+        return f"{self.element_kind} {self.name}: declared by the model but not present in the database"
 
 
-def _primary_key(table: Table) -> dict[str, str]:
-    return _by_name([(_identifier(table.primary_key.name), f"columns={_column_names(table.primary_key.columns)}")])
+class ElementOnlyPresentInDatabase(ElementDifference):
+    """An element that the database has but that the model does not declare."""
+
+    def format_report(self) -> str:
+        return f"{self.element_kind} {self.name}: present in the database but not declared by the model"
 
 
-def _indexes(table: Table) -> dict[str, str]:
-    return _by_name(
-        (
-            _identifier(index.name),
-            (
-                f"columns={_column_names(index.columns)} unique={bool(index.unique)}"
-                f" method={_method(index)} operator_classes={_operator_classes(index)} where={_predicate(index)}"
-            ),
+class ElementDescribedDifferently(ElementDifference):
+    """An element that both sides have, but that they describe differently."""
+
+    def __init__(self, element_kind: str, name: str, description_in_model: str, description_in_database: str) -> None:
+        super().__init__(element_kind, name)
+        self.description_in_model = description_in_model
+        self.description_in_database = description_in_database
+
+    def format_report(self) -> str:
+        return (
+            f"{self.element_kind} {self.name}:\n"
+            f"{REPORT_INDENT}model:    {self.description_in_model}\n"
+            f"{REPORT_INDENT}database: {self.description_in_database}"
         )
-        for index in table.indexes
-    )
 
 
-def _unique_constraints(table: Table) -> dict[str, str]:
-    return _by_name(
-        (_identifier(constraint.name), f"columns={_column_names(constraint.columns)}")
-        for constraint in table.constraints
-        if isinstance(constraint, UniqueConstraint)
-    )
+class TableDifference(ABC):
+    """
+    A single table that the SQLAlchemy model side and the database side do not describe the same way.
+    """
+
+    def __init__(self, table_name: str) -> None:
+        self.table_name = table_name
+
+    @abstractmethod
+    def format_report(self) -> str:
+        """
+        This difference as one or more report lines, without a trailing newline.
+        """
 
 
-def _foreign_keys(table: Table) -> dict[str, str]:
-    return _by_name(
-        (
-            _identifier(constraint.name),
-            (
-                f"columns={_column_names(constraint.columns)}"
-                f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
-                f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}"
-            ),
+class TableOnlyDeclaredByModel(TableDifference):
+    """A table that a model declares but that the database does not have."""
+
+    def format_report(self) -> str:
+        return f"table {self.table_name}: declared by a model but not present in the database"
+
+
+class TableOnlyPresentInDatabase(TableDifference):
+    """A table that the database has but that no model declares."""
+
+    def format_report(self) -> str:
+        return f"table {self.table_name}: present in the database but not declared by a model"
+
+
+class TableWithDifferingElements(TableDifference):
+    """A table that both sides have, but on whose elements they do not agree."""
+
+    def __init__(self, table_name: str, element_differences: abc.Sequence[ElementDifference]) -> None:
+        super().__init__(table_name)
+        self.element_differences = element_differences
+
+    def format_report(self) -> str:
+        elements = "\n".join(difference.format_report() for difference in self.element_differences)
+        return f"table {self.table_name}:\n{textwrap.indent(elements, REPORT_INDENT)}"
+
+
+class TableElementExtractor(ABC):
+    """
+    Describes one kind of element of a table (its columns, its indexes, ...) in a form that can be compared between
+    the SQLAlchemy model side and the database side.
+
+    Everything that is compared about an element goes into its description, so that comparing the two descriptions
+    decides whether the two sides agree on that element, and the two read next to each other in the report.
+    """
+
+    # The name of the kind of element this extractor handles, as it appears in the report.
+    element_kind: ClassVar[str]
+
+    @abstractmethod
+    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+        """
+        The elements of this kind on the given table, as the name of each element and a description of everything that
+        is compared about it. The name is None for an element that a SQLAlchemy model left for SQLAlchemy to name.
+        """
+
+    def get_descriptions_by_name(self, table: Table) -> abc.Mapping[str, str]:
+        """
+        The description of each element of this kind on the given table, keyed by the name it is compared under.
+
+        PostgreSQL names every index and every constraint, so an element without a name can only come from a
+        SQLAlchemy model. The description is part of the key of such an element, so that several unnamed elements of
+        the same kind on one table do not collapse onto a single key.
+        """
+        return {
+            name if name is not None else f"<unnamed> {description}": description
+            for name, description in self.get_named_elements(table)
+        }
+
+    def compare(self, model_table: Table, database_table: Table) -> abc.Sequence[ElementDifference]:
+        """
+        The differences on the elements of this kind, between the table as a model declares it and the same table as
+        the database has it, ordered by name within each kind of difference.
+        """
+        in_model = self.get_descriptions_by_name(model_table)
+        in_database = self.get_descriptions_by_name(database_table)
+        differences: list[ElementDifference] = [
+            ElementOnlyDeclaredByModel(self.element_kind, name) for name in sorted(in_model.keys() - in_database.keys())
+        ]
+        differences.extend(
+            ElementOnlyPresentInDatabase(self.element_kind, name) for name in sorted(in_database.keys() - in_model.keys())
         )
-        for constraint in table.constraints
-        if isinstance(constraint, ForeignKeyConstraint)
-    )
-
-
-def _check_constraints(table: Table) -> dict[str, str]:
-    return _by_name(
-        (_identifier(constraint.name), f"condition={constraint.sqltext}")
-        for constraint in table.constraints
-        if isinstance(constraint, CheckConstraint)
-    )
-
-
-def _compare(kind: str, in_model: abc.Mapping[str, str], in_db: abc.Mapping[str, str]) -> list[str]:
-    """
-    Compare one kind of schema element (columns, indexes, ...) of a single table.
-
-    :param kind: the name of the kind of element that is compared, used in the reported differences.
-    :param in_model: the elements declared by the SQLAlchemy model, keyed by name.
-    :param in_db: the elements found in the database, keyed by name.
-    :return: a human-readable description of each difference between the two.
-    """
-    differences: list[str] = []
-    for name in sorted(in_model.keys() - in_db.keys()):
-        differences.append(f"{kind} {name}: declared by the model but not present in the database")
-    for name in sorted(in_db.keys() - in_model.keys()):
-        differences.append(f"{kind} {name}: present in the database but not declared by the model")
-    for name in sorted(in_model.keys() & in_db.keys()):
-        if in_model[name] != in_db[name]:
-            differences.append(f"{kind} {name}: model has {in_model[name]}, database has {in_db[name]}")
-    return differences
-
-
-def _compare_tables(model_table: Table, db_table: Table) -> list[str]:
-    """
-    Compare a single table as the model declares it against the table as it exists in the database.
-
-    :return: a human-readable description of each difference between the two.
-    """
-    return [
-        difference
-        for kind, aspect in (
-            ("column", _columns),
-            ("primary key", _primary_key),
-            ("index", _indexes),
-            ("unique constraint", _unique_constraints),
-            ("foreign key", _foreign_keys),
-            ("check constraint", _check_constraints),
+        differences.extend(
+            ElementDescribedDifferently(self.element_kind, name, in_model[name], in_database[name])
+            for name in sorted(in_model.keys() & in_database.keys())
+            if in_model[name] != in_database[name]
         )
-        for difference in _compare(kind, aspect(model_table), aspect(db_table))
-    ]
+        return differences
 
 
-def compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mapping[str, Table]) -> list[str]:
+class ColumnExtractor(TableElementExtractor):
+    element_kind = "column"
+
+    def get_column_type_def_as_str(self, column_type: TypeEngine[object]) -> str:
+        """
+        A comparable description of a column type: the type as it appears in DDL, extended with the labels of a native
+        enum type, because those are part of the schema as well.
+        """
+        compiled_type: str = column_type.compile(POSTGRESQL_DIALECT)
+        element_type = column_type.item_type if isinstance(column_type, ARRAY) else column_type
+        if isinstance(element_type, Enum) and element_type.native_enum:
+            return f"{compiled_type} labels=({', '.join(element_type.enums)})"
+        return compiled_type
+
+    def get_server_default_as_str(self, column: Column[object]) -> str | None:
+        """The default the database fills in for the given column, or None if it has none."""
+        if not isinstance(column.server_default, DefaultClause):
+            # Either no default at all, or one whose value lives outside the schema (a FetchedValue), which neither a
+            # model of this schema nor reflection produces.
+            return None
+        return str(getattr(column.server_default.arg, "text", column.server_default.arg))
+
+    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+        for column in table.columns:
+            yield (
+                column.name,
+                f"type={self.get_column_type_def_as_str(column.type)} nullable={column.nullable}"
+                f" default={self.get_server_default_as_str(column)}",
+            )
+
+
+class PrimaryKeyExtractor(TableElementExtractor):
+    element_kind = "primary key"
+
+    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+        yield (
+            get_truncated_identifier(table.primary_key.name),
+            f"columns={column_names_to_str(table.primary_key.columns)}",
+        )
+
+
+class IndexExtractor(TableElementExtractor):
+    element_kind = "index"
+
+    def get_index_type(self, index: Index) -> str:
+        """The type of an index (btree, gin, ...)."""
+        # Reflection only reports the type when it is not the default, and a model only declares one when it deviates
+        # from the default, so an absent type on either side means btree.
+        index_type: str | None = index.dialect_options["postgresql"]["using"]
+        return index_type or "btree"
+
+    def get_operator_classes_as_str(self, index: Index) -> str:
+        """
+        The operator class of each column of the given index that does not use the default one for its type. The
+        columns that do use the default are absent on both sides, because neither a model nor reflection records those.
+        """
+        operator_classes: abc.Mapping[str, str] = index.dialect_options["postgresql"]["ops"]
+        return f"({', '.join(f'{column}={operator_classes[column]}' for column in sorted(operator_classes))})"
+
+    def get_condition_for_partial_index(self, index: Index) -> str | None:
+        """
+        The condition of a partial index, or None if the index covers all rows.
+
+        A model declares the condition the way a person writes it (``expired IS NULL``), while PostgreSQL reports it
+        back with a pair of parentheses around it (``(expired IS NULL)``). That pair is dropped here, so that the two
+        sides compare equal.
+
+        Telling the two apart takes walking the condition. The parenthesis it opens with encloses the whole condition
+        exactly when it is closed by the very last character. If it is closed earlier, as in ``(n > 0) AND (name IS
+        NULL)``, then the condition merely starts with a parenthesized part and nothing may be dropped. Parentheses
+        within a string literal (``name <> ')'::text``) belong to the literal rather than to the condition and are
+        skipped.
+        """
+        condition = index.dialect_options["postgresql"]["where"]
+        if condition is None:
+            return None
+        condition_as_str = str(condition).strip()
+        while condition_as_str.startswith("(") and condition_as_str.endswith(")"):
+            open_parentheses = 0
+            within_string_literal = False
+            for position, character in enumerate(condition_as_str):
+                if character == "'":
+                    within_string_literal = not within_string_literal
+                    continue
+                if within_string_literal:
+                    continue
+                open_parentheses += (character == "(") - (character == ")")
+                if open_parentheses == 0 and position < len(condition_as_str) - 1:
+                    # The parenthesis the condition opens with is closed before its last character, so the pair encloses
+                    # only part of the condition and neither of the two may be dropped.
+                    return condition_as_str
+            condition_as_str = condition_as_str[1:-1].strip()
+        return condition_as_str
+
+    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+        for index in table.indexes:
+            yield (
+                get_truncated_identifier(index.name),
+                f"columns={column_names_to_str(index.columns)} unique={bool(index.unique)}"
+                f" type={self.get_index_type(index)} operator_classes={self.get_operator_classes_as_str(index)}"
+                f" where={self.get_condition_for_partial_index(index)}",
+            )
+
+
+class UniqueConstraintExtractor(TableElementExtractor):
+    element_kind = "unique constraint"
+
+    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+        for constraint in table.constraints:
+            if isinstance(constraint, UniqueConstraint):
+                yield get_truncated_identifier(constraint.name), f"columns={column_names_to_str(constraint.columns)}"
+
+
+class ForeignKeyExtractor(TableElementExtractor):
+    element_kind = "foreign key"
+
+    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+        for constraint in table.constraints:
+            if isinstance(constraint, ForeignKeyConstraint):
+                yield (
+                    get_truncated_identifier(constraint.name),
+                    f"columns={column_names_to_str(constraint.columns)}"
+                    f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
+                    f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}",
+                )
+
+
+class CheckConstraintExtractor(TableElementExtractor):
+    element_kind = "check constraint"
+
+    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+        for constraint in table.constraints:
+            if isinstance(constraint, CheckConstraint):
+                yield get_truncated_identifier(constraint.name), f"condition={constraint.sqltext}"
+
+
+class DatabaseSchemaComparison:
     """
-    Compare the tables the models declare against the tables the database has.
+    Compares the tables that a set of SQLAlchemy models declares against the tables that a database has.
 
     Compared are: which tables exist, and per table the columns (type, nullability and default), the primary key, the
-    indexes (columns, uniqueness, method, operator classes and the condition of a partial one), and the unique, foreign
+    indexes (columns, uniqueness, type, operator classes and the condition of a partial one), and the unique, foreign
     key and check constraints. Names are compared as well, because migration scripts refer to constraints and indexes
     by name.
 
@@ -225,22 +348,62 @@ def compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mappin
       - the order of the columns of a table, because the columns are compared by name.
       - the comment on a table or a column.
       - whether a constraint is deferrable, or was added NOT VALID.
-
-    :param model_tables: the tables declared by the SQLAlchemy models, keyed by table name.
-    :param db_tables: the tables reflected from the database, keyed by table name.
-    :return: a human-readable description of each difference between the two.
     """
-    differences: list[str] = []
-    for name in sorted(model_tables.keys() - db_tables.keys()):
-        differences.append(f"table {name}: declared by a model but not present in the database")
-    for name in sorted(db_tables.keys() - model_tables.keys()):
-        differences.append(f"table {name}: present in the database but not declared by a model")
-    for name in sorted(model_tables.keys() & db_tables.keys()):
-        differences.extend(f"table {name}: {difference}" for difference in _compare_tables(model_tables[name], db_tables[name]))
-    return differences
+
+    EXTRACTORS: ClassVar[abc.Sequence[TableElementExtractor]] = (
+        ColumnExtractor(),
+        PrimaryKeyExtractor(),
+        IndexExtractor(),
+        UniqueConstraintExtractor(),
+        ForeignKeyExtractor(),
+        CheckConstraintExtractor(),
+    )
+
+    def __init__(self, model_tables: abc.Mapping[str, Table], database_tables: abc.Mapping[str, Table]) -> None:
+        """
+        The two sets of tables are compared here, so that the result describes them as they are at this moment.
+
+        :param model_tables: the tables declared by the SQLAlchemy models, keyed by table name.
+        :param database_tables: the tables reflected from the database, keyed by table name.
+        """
+        self.model_tables = model_tables
+        self.database_tables = database_tables
+        self.differences: abc.Sequence[TableDifference] = self.compare_tables()
+
+    def compare_tables(self) -> abc.Sequence[TableDifference]:
+        """
+        The differences between the two sets of tables, ordered by table name within each kind of difference.
+        """
+        differences: list[TableDifference] = [
+            TableOnlyDeclaredByModel(name) for name in sorted(self.model_tables.keys() - self.database_tables.keys())
+        ]
+        differences.extend(
+            TableOnlyPresentInDatabase(name) for name in sorted(self.database_tables.keys() - self.model_tables.keys())
+        )
+        for name in sorted(self.model_tables.keys() & self.database_tables.keys()):
+            element_differences = self.compare_elements(self.model_tables[name], self.database_tables[name])
+            if element_differences:
+                differences.append(TableWithDifferingElements(name, element_differences))
+        return differences
+
+    def compare_elements(self, model_table: Table, database_table: Table) -> abc.Sequence[ElementDifference]:
+        """
+        The differences on every kind of element of a single table, between the table as a model declares it and the
+        same table as the database has it.
+        """
+        differences: list[ElementDifference] = []
+        for extractor in self.EXTRACTORS:
+            differences.extend(extractor.compare(model_table, database_table))
+        return differences
+
+    def format_report(self) -> str:
+        """
+        The differences as an indented report, one block per table, empty when the two sides agree.
+        """
+        return "\n".join(difference.format_report() for difference in self.differences)
 
 
-async def reflect_database_schema(host: str, port: int, username: str, password: str | None, database: str) -> MetaData:
+async def get_database_schema(host: str, port: int, username: str, password: str | None, database: str) -> MetaData:
     """
     Load the schema of the given database into a new MetaData object.
     """

--- a/src/inmanta/db/schema_compare.py
+++ b/src/inmanta/db/schema_compare.py
@@ -1,0 +1,284 @@
+"""
+Copyright 2026 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+
+
+Compare a set of SQLAlchemy models against the schema that a database holds, so a test can verify that the models of a
+component describe the schema its database migration scripts produce. This lives in inmanta-core so that extensions
+can use it on their own models and their own migration scripts.
+"""
+
+from collections import abc
+from typing import Protocol
+
+from sqlalchemy import ARRAY, URL, CheckConstraint, Column, Enum, ForeignKeyConstraint, Index, MetaData, Table, UniqueConstraint
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.schema import DefaultClause
+from sqlalchemy.sql.type_api import TypeEngine
+
+# PostgreSQL truncates identifiers to NAMEDATALEN - 1 bytes, so a longer name in a model or a migration script ends up
+# truncated in the database. Both sides are truncated before they are compared, to compare what the database sees. An
+# identifier of an Inmanta schema is ASCII, for which a byte is a character.
+MAX_IDENTIFIER_LENGTH = 63
+
+# The dialect that spells column types the way PostgreSQL DDL does. SQLAlchemy does not annotate its constructor.
+_POSTGRESQL_DIALECT = postgresql.dialect()  # type: ignore[no-untyped-call]
+
+
+def _identifier(name: object) -> str | None:
+    """
+    The name of a constraint or an index as PostgreSQL stores it, or None if it has none. SQLAlchemy reports the
+    absence of a name either as None or as a sentinel that is not a name.
+    """
+    return name[:MAX_IDENTIFIER_LENGTH] if isinstance(name, str) else None
+
+
+def _type(column_type: TypeEngine[object]) -> str:
+    """
+    A comparable description of a column type: the type as it appears in DDL, extended with the labels of a native
+    enum type, because those are part of the schema as well.
+    """
+    compiled = column_type.compile(_POSTGRESQL_DIALECT)
+    element = column_type.item_type if isinstance(column_type, ARRAY) else column_type
+    if isinstance(element, Enum) and element.native_enum:
+        return f"{compiled} labels=({', '.join(element.enums)})"
+    return compiled
+
+
+def _server_default(column: Column[object]) -> str | None:
+    """The default the database fills in for a column, or None if it has none."""
+    if not isinstance(column.server_default, DefaultClause):
+        # Either no default at all, or one whose value lives outside the schema (a FetchedValue), which neither a
+        # model of this schema nor reflection produces.
+        return None
+    return str(getattr(column.server_default.arg, "text", column.server_default.arg))
+
+
+def _predicate(index: Index) -> str | None:
+    """The condition of a partial index, or None if the index covers all rows."""
+    predicate = index.dialect_options["postgresql"]["where"]
+    if predicate is None:
+        return None
+    # Normalize and parse the entire predicate (e.g. ((n > 0) AND (name IS NULL)))
+    normalized = str(predicate).strip()
+    while normalized.startswith("(") and normalized.endswith(")"):
+        depth = 0
+        in_literal = False
+        for position, character in enumerate(normalized):
+            if character == "'":
+                in_literal = not in_literal
+                continue
+            if in_literal:
+                continue
+            depth += (character == "(") - (character == ")")
+            if depth == 0 and position < len(normalized) - 1:
+                # The parenthesis opened at the start is closed here, so the pair encloses only part of the condition.
+                return normalized
+        normalized = normalized[1:-1].strip()
+    return normalized
+
+
+def _method(index: Index) -> str:
+    """The method of an index (btree, gin, ...)."""
+    # Reflection only reports the method when it is not the default, and a model only declares one when it deviates
+    # from the default, so an absent method on either side means btree.
+    return index.dialect_options["postgresql"]["using"] or "btree"
+
+
+def _operator_classes(index: Index) -> str:
+    """
+    The operator class of each column of an index that does not use the default one for its type.
+    """
+    operator_classes: abc.Mapping[str, str] = index.dialect_options["postgresql"]["ops"]
+    return f"({', '.join(f'{column}={operator_classes[column]}' for column in sorted(operator_classes))})"
+
+
+def _column_names(columns: abc.Iterable[Column[object]]) -> str:
+    return f"({', '.join(column.name for column in columns)})"
+
+
+def _by_name(elements: abc.Iterable[tuple[str | None, str]]) -> dict[str, str]:
+    """
+    Key the elements of one kind of a single table by their name, to be compared by name.
+
+    PostgreSQL names every index and constraint, so an element without a name can only come from a model, and it is
+    reported as a difference whatever the database holds. Its description is part of its key so that several unnamed
+    elements of the same kind do not collapse onto a single entry, and so that the keys are ordered.
+    """
+    return {name if name is not None else f"<unnamed> {description}": description for name, description in elements}
+
+
+def _columns(table: Table) -> dict[str, str]:
+    return _by_name(
+        (column.name, f"type={_type(column.type)} nullable={column.nullable} default={_server_default(column)}")
+        for column in table.columns
+    )
+
+
+def _primary_key(table: Table) -> dict[str, str]:
+    return _by_name([(_identifier(table.primary_key.name), f"columns={_column_names(table.primary_key.columns)}")])
+
+
+def _indexes(table: Table) -> dict[str, str]:
+    return _by_name(
+        (
+            _identifier(index.name),
+            (
+                f"columns={_column_names(index.columns)} unique={bool(index.unique)}"
+                f" method={_method(index)} operator_classes={_operator_classes(index)} where={_predicate(index)}"
+            ),
+        )
+        for index in table.indexes
+    )
+
+
+def _unique_constraints(table: Table) -> dict[str, str]:
+    return _by_name(
+        (_identifier(constraint.name), f"columns={_column_names(constraint.columns)}")
+        for constraint in table.constraints
+        if isinstance(constraint, UniqueConstraint)
+    )
+
+
+def _foreign_keys(table: Table) -> dict[str, str]:
+    return _by_name(
+        (
+            _identifier(constraint.name),
+            (
+                f"columns={_column_names(constraint.columns)}"
+                f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
+                f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}"
+            ),
+        )
+        for constraint in table.constraints
+        if isinstance(constraint, ForeignKeyConstraint)
+    )
+
+
+def _check_constraints(table: Table) -> dict[str, str]:
+    return _by_name(
+        (_identifier(constraint.name), f"condition={constraint.sqltext}")
+        for constraint in table.constraints
+        if isinstance(constraint, CheckConstraint)
+    )
+
+
+def _compare(kind: str, in_model: abc.Mapping[str, str], in_db: abc.Mapping[str, str]) -> list[str]:
+    """
+    Compare one kind of schema element (columns, indexes, ...) of a single table.
+
+    :param kind: the name of the kind of element that is compared, used in the reported differences.
+    :param in_model: the elements declared by the SQLAlchemy model, keyed by name.
+    :param in_db: the elements found in the database, keyed by name.
+    :return: a human-readable description of each difference between the two.
+    """
+    differences: list[str] = []
+    for name in sorted(in_model.keys() - in_db.keys()):
+        differences.append(f"{kind} {name}: declared by the model but not present in the database")
+    for name in sorted(in_db.keys() - in_model.keys()):
+        differences.append(f"{kind} {name}: present in the database but not declared by the model")
+    for name in sorted(in_model.keys() & in_db.keys()):
+        if in_model[name] != in_db[name]:
+            differences.append(f"{kind} {name}: model has {in_model[name]}, database has {in_db[name]}")
+    return differences
+
+
+def _compare_tables(model_table: Table, db_table: Table) -> list[str]:
+    """
+    Compare a single table as the model declares it against the table as it exists in the database.
+
+    :return: a human-readable description of each difference between the two.
+    """
+    return [
+        difference
+        for kind, aspect in (
+            ("column", _columns),
+            ("primary key", _primary_key),
+            ("index", _indexes),
+            ("unique constraint", _unique_constraints),
+            ("foreign key", _foreign_keys),
+            ("check constraint", _check_constraints),
+        )
+        for difference in _compare(kind, aspect(model_table), aspect(db_table))
+    ]
+
+
+def compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mapping[str, Table]) -> list[str]:
+    """
+    Compare the tables the models declare against the tables the database has.
+
+    Compared are: which tables exist, and per table the columns (type, nullability and default), the primary key, the
+    indexes (columns, uniqueness, method, operator classes and the condition of a partial one), and the unique, foreign
+    key and check constraints. Names are compared as well, because migration scripts refer to constraints and indexes
+    by name.
+
+    Not compared, all of which the models can express, so each is a way for a model to be wrong that this comparison
+    does not catch:
+      - the sort order of the columns of an index, because the indexes are compared on index.columns, which reports the
+        columns without the modifier that carries the order.
+      - the order of the columns of a table, because the columns are compared by name.
+      - the comment on a table or a column.
+      - whether a constraint is deferrable, or was added NOT VALID.
+
+    :param model_tables: the tables declared by the SQLAlchemy models, keyed by table name.
+    :param db_tables: the tables reflected from the database, keyed by table name. A component whose tables share a
+        database with those of another component passes only its own, otherwise the tables of the other component are
+        reported as undeclared.
+    :return: a human-readable description of each difference between the two.
+    """
+    differences: list[str] = []
+    for name in sorted(model_tables.keys() - db_tables.keys()):
+        differences.append(f"table {name}: declared by a model but not present in the database")
+    for name in sorted(db_tables.keys() - model_tables.keys()):
+        differences.append(f"table {name}: present in the database but not declared by a model")
+    for name in sorted(model_tables.keys() & db_tables.keys()):
+        differences.extend(f"table {name}: {difference}" for difference in _compare_tables(model_tables[name], db_tables[name]))
+    return differences
+
+
+class DatabaseConnectionDetails(Protocol):
+    """
+    How to reach the database. Both executors the postgres_db fixture can yield, for an embedded and for an external
+    database, provide these.
+    """
+
+    host: str
+    port: int
+    user: str
+    password: str | None
+
+
+async def reflect_database_schema(postgres_db: DatabaseConnectionDetails, database_name: str) -> MetaData:
+    """
+    Load the schema of the given database into a new MetaData object.
+    """
+    url = URL.create(
+        drivername="postgresql+asyncpg",
+        username=postgres_db.user,
+        password=postgres_db.password or None,
+        host=postgres_db.host,
+        port=postgres_db.port,
+        database=database_name,
+    )
+    engine = create_async_engine(url)
+    try:
+        metadata = MetaData()
+        async with engine.connect() as connection:
+            await connection.run_sync(metadata.reflect)
+        return metadata
+    finally:
+        await engine.dispose()

--- a/src/inmanta/db/schema_compare.py
+++ b/src/inmanta/db/schema_compare.py
@@ -21,7 +21,19 @@ from abc import ABC, abstractmethod
 from collections import abc
 from typing import ClassVar
 
-from sqlalchemy import ARRAY, URL, CheckConstraint, Column, Enum, ForeignKeyConstraint, Index, MetaData, Table, UniqueConstraint
+from sqlalchemy import (
+    ARRAY,
+    URL,
+    CheckConstraint,
+    Column,
+    Constraint,
+    Enum,
+    ForeignKeyConstraint,
+    Index,
+    MetaData,
+    Table,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -39,10 +51,13 @@ REPORT_INDENT = "\t"
 POSTGRESQL_DIALECT: Dialect = postgresql.dialect()  # type: ignore[no-untyped-call]
 
 
-def get_truncated_identifier(name: object) -> str | None:
+def get_truncated_identifier(element: Constraint | Index) -> str | None:
     """
-    The name of a constraint or an index as PostgreSQL stores it, or None if it has none.
+    The name of the given constraint or index as PostgreSQL stores it, or None if it has none.
+
+    A nameless element carries either None or _NoneName, so only a string counts as a name here.
     """
+    name = element.name
     return name[:MAX_IDENTIFIER_LENGTH] if isinstance(name, str) else None
 
 
@@ -232,7 +247,7 @@ class PrimaryKeyExtractor(TableElementExtractor):
 
     def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
         yield (
-            get_truncated_identifier(table.primary_key.name),
+            get_truncated_identifier(table.primary_key),
             f"columns={column_names_to_str(table.primary_key.columns)}",
         )
 
@@ -293,7 +308,7 @@ class IndexExtractor(TableElementExtractor):
     def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
         for index in table.indexes:
             yield (
-                get_truncated_identifier(index.name),
+                get_truncated_identifier(index),
                 f"columns={column_names_to_str(index.columns)} unique={bool(index.unique)}"
                 f" type={self.get_index_type(index)} operator_classes={self.get_operator_classes_as_str(index)}"
                 f" where={self.get_condition_for_partial_index(index)}",
@@ -306,7 +321,7 @@ class UniqueConstraintExtractor(TableElementExtractor):
     def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
         for constraint in table.constraints:
             if isinstance(constraint, UniqueConstraint):
-                yield get_truncated_identifier(constraint.name), f"columns={column_names_to_str(constraint.columns)}"
+                yield get_truncated_identifier(constraint), f"columns={column_names_to_str(constraint.columns)}"
 
 
 class ForeignKeyExtractor(TableElementExtractor):
@@ -316,7 +331,7 @@ class ForeignKeyExtractor(TableElementExtractor):
         for constraint in table.constraints:
             if isinstance(constraint, ForeignKeyConstraint):
                 yield (
-                    get_truncated_identifier(constraint.name),
+                    get_truncated_identifier(constraint),
                     f"columns={column_names_to_str(constraint.columns)}"
                     f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
                     f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}",
@@ -329,7 +344,7 @@ class CheckConstraintExtractor(TableElementExtractor):
     def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
         for constraint in table.constraints:
             if isinstance(constraint, CheckConstraint):
-                yield get_truncated_identifier(constraint.name), f"condition={constraint.sqltext}"
+                yield get_truncated_identifier(constraint), f"condition={constraint.sqltext}"
 
 
 class DatabaseSchemaComparison:

--- a/src/inmanta/db/schema_compare.py
+++ b/src/inmanta/db/schema_compare.py
@@ -14,15 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contact: code@inmanta.com
-
-
-Compare a set of SQLAlchemy models against the schema that a database holds, so a test can verify that the models of a
-component describe the schema its database migration scripts produce. This lives in inmanta-core so that extensions
-can use it on their own models and their own migration scripts.
 """
 
 from collections import abc
-from typing import Protocol
 
 from sqlalchemy import ARRAY, URL, CheckConstraint, Column, Enum, ForeignKeyConstraint, Index, MetaData, Table, UniqueConstraint
 from sqlalchemy.dialects import postgresql
@@ -31,18 +25,16 @@ from sqlalchemy.schema import DefaultClause
 from sqlalchemy.sql.type_api import TypeEngine
 
 # PostgreSQL truncates identifiers to NAMEDATALEN - 1 bytes, so a longer name in a model or a migration script ends up
-# truncated in the database. Both sides are truncated before they are compared, to compare what the database sees. An
-# identifier of an Inmanta schema is ASCII, for which a byte is a character.
+# truncated in the database. Both sides are truncated before they are compared, to compare what the database sees.
 MAX_IDENTIFIER_LENGTH = 63
-
-# The dialect that spells column types the way PostgreSQL DDL does. SQLAlchemy does not annotate its constructor.
-_POSTGRESQL_DIALECT = postgresql.dialect()  # type: ignore[no-untyped-call]
 
 
 def _identifier(name: object) -> str | None:
     """
-    The name of a constraint or an index as PostgreSQL stores it, or None if it has none. SQLAlchemy reports the
-    absence of a name either as None or as a sentinel that is not a name.
+    The name of a constraint or an index as PostgreSQL stores it, or None if it has none.
+
+    A constraint that was never given a name reports None, while one whose name was computed but resolved to nothing
+    reports SQLAlchemy's _NONE_NAME sentinel, which is not a string (here we resolve it as None anyway).
     """
     return name[:MAX_IDENTIFIER_LENGTH] if isinstance(name, str) else None
 
@@ -52,7 +44,8 @@ def _type(column_type: TypeEngine[object]) -> str:
     A comparable description of a column type: the type as it appears in DDL, extended with the labels of a native
     enum type, because those are part of the schema as well.
     """
-    compiled = column_type.compile(_POSTGRESQL_DIALECT)
+    # SQLAlchemy does not annotate the constructor of a dialect
+    compiled = column_type.compile(postgresql.dialect())  # type: ignore[no-untyped-call]
     element = column_type.item_type if isinstance(column_type, ARRAY) else column_type
     if isinstance(element, Enum) and element.native_enum:
         return f"{compiled} labels=({', '.join(element.enums)})"
@@ -113,11 +106,10 @@ def _column_names(columns: abc.Iterable[Column[object]]) -> str:
 
 def _by_name(elements: abc.Iterable[tuple[str | None, str]]) -> dict[str, str]:
     """
-    Key the elements of one kind of a single table by their name, to be compared by name.
+    Key the elements of one kind, of a single table by their name.
 
-    PostgreSQL names every index and constraint, so an element without a name can only come from a model, and it is
-    reported as a difference whatever the database holds. Its description is part of its key so that several unnamed
-    elements of the same kind do not collapse onto a single entry, and so that the keys are ordered.
+    PostgreSQL names every index and constraint, so an element without a name can only come from a sqlalchemy model.
+    We add the description to the key so that multiple unnamed elements can appear in the dictionary
     """
     return {name if name is not None else f"<unnamed> {description}": description for name, description in elements}
 
@@ -235,9 +227,7 @@ def compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mappin
       - whether a constraint is deferrable, or was added NOT VALID.
 
     :param model_tables: the tables declared by the SQLAlchemy models, keyed by table name.
-    :param db_tables: the tables reflected from the database, keyed by table name. A component whose tables share a
-        database with those of another component passes only its own, otherwise the tables of the other component are
-        reported as undeclared.
+    :param db_tables: the tables reflected from the database, keyed by table name.
     :return: a human-readable description of each difference between the two.
     """
     differences: list[str] = []
@@ -250,29 +240,17 @@ def compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mappin
     return differences
 
 
-class DatabaseConnectionDetails(Protocol):
-    """
-    How to reach the database. Both executors the postgres_db fixture can yield, for an embedded and for an external
-    database, provide these.
-    """
-
-    host: str
-    port: int
-    user: str
-    password: str | None
-
-
-async def reflect_database_schema(postgres_db: DatabaseConnectionDetails, database_name: str) -> MetaData:
+async def reflect_database_schema(host: str, port: int, username: str, password: str | None, database: str) -> MetaData:
     """
     Load the schema of the given database into a new MetaData object.
     """
     url = URL.create(
         drivername="postgresql+asyncpg",
-        username=postgres_db.user,
-        password=postgres_db.password or None,
-        host=postgres_db.host,
-        port=postgres_db.port,
-        database=database_name,
+        username=username,
+        password=password or None,
+        host=host,
+        port=port,
+        database=database,
     )
     engine = create_async_engine(url)
     try:

--- a/src/inmanta/db/schema_compare.py
+++ b/src/inmanta/db/schema_compare.py
@@ -32,6 +32,7 @@ from sqlalchemy import (
     Index,
     MetaData,
     Table,
+    TextClause,
     UniqueConstraint,
 )
 from sqlalchemy.dialects import postgresql
@@ -61,7 +62,7 @@ def get_truncated_identifier(element: Constraint | Index) -> str | None:
     return name[:MAX_IDENTIFIER_LENGTH] if isinstance(name, str) else None
 
 
-def column_names_to_str(columns: abc.Iterable[Column[object]]) -> str:
+def column_names_to_str[T](columns: abc.Iterable[Column[T]]) -> str:
     """The names of the given columns, in the order they are given."""
     return f"({', '.join(column.name for column in columns)})"
 
@@ -214,7 +215,8 @@ class TableElementExtractor(ABC):
 class ColumnExtractor(TableElementExtractor):
     element_kind = "column"
 
-    def get_column_type_def_as_str(self, column_type: TypeEngine[object]) -> str:
+    @staticmethod
+    def get_column_type_def_as_str[T](column_type: TypeEngine[T]) -> str:
         """
         A comparable description of a column type: the type as it appears in DDL, extended with the labels of a native
         enum type, because those are part of the schema as well.
@@ -225,13 +227,17 @@ class ColumnExtractor(TableElementExtractor):
             return f"{compiled_type} labels=({', '.join(element_type.enums)})"
         return compiled_type
 
-    def get_server_default_as_str(self, column: Column[object]) -> str | None:
+    @staticmethod
+    def get_server_default_as_str[T](column: Column[T]) -> str | None:
         """The default the database fills in for the given column, or None if it has none."""
         if not isinstance(column.server_default, DefaultClause):
             # Either no default at all, or one whose value lives outside the schema (a FetchedValue), which neither a
             # model of this schema nor reflection produces.
             return None
-        return str(getattr(column.server_default.arg, "text", column.server_default.arg))
+        default = column.server_default.arg
+        # A text clause is taken apart rather than rendered, because rendering it turns the parameter markers it may
+        # hold back into a form that no longer matches what the other side reports.
+        return default.text if isinstance(default, TextClause) else str(default)
 
     def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
         for column in table.columns:
@@ -255,14 +261,16 @@ class PrimaryKeyExtractor(TableElementExtractor):
 class IndexExtractor(TableElementExtractor):
     element_kind = "index"
 
-    def get_index_type(self, index: Index) -> str:
+    @staticmethod
+    def get_index_type(index: Index) -> str:
         """The type of an index (btree, gin, ...)."""
         # Reflection only reports the type when it is not the default, and a model only declares one when it deviates
         # from the default, so an absent type on either side means btree.
         index_type: str | None = index.dialect_options["postgresql"]["using"]
         return index_type or "btree"
 
-    def get_operator_classes_as_str(self, index: Index) -> str:
+    @staticmethod
+    def get_operator_classes_as_str(index: Index) -> str:
         """
         The operator class of each column of the given index that does not use the default one for its type. The
         columns that do use the default are absent on both sides, because neither a model nor reflection records those.
@@ -270,7 +278,8 @@ class IndexExtractor(TableElementExtractor):
         operator_classes: abc.Mapping[str, str] = index.dialect_options["postgresql"]["ops"]
         return f"({', '.join(f'{column}={operator_classes[column]}' for column in sorted(operator_classes))})"
 
-    def get_condition_for_partial_index(self, index: Index) -> str | None:
+    @staticmethod
+    def get_condition_for_partial_index(index: Index) -> str | None:
         """
         The condition of a partial index, or None if the index covers all rows.
 

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -957,6 +957,9 @@ class ResourceOrder(StrawberryOrder):
 @mapper.type(models.ResourcePersistentState)
 class ResourcePersistentState:
     __tablename__ = "resource_persistent_state"
+    # non_compliant_diff is the foreign key to the resource_diff table. Exposing it would put a bare id in the API that
+    # nothing can resolve, because resource_diff has no GraphQL type of its own. Exposing the diff itself is a separate
+    # decision, to be made when there is a consumer for it.
     __exclude__ = ["resource_set_", "environment_", "non_compliant_diff"]
 
 

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -957,9 +957,6 @@ class ResourceOrder(StrawberryOrder):
 @mapper.type(models.ResourcePersistentState)
 class ResourcePersistentState:
     __tablename__ = "resource_persistent_state"
-    # non_compliant_diff is the foreign key to the resource_diff table. Exposing it would put a bare id in the API that
-    # nothing can resolve, because resource_diff has no GraphQL type of its own. Exposing the diff itself is a separate
-    # decision, to be made when there is a consumer for it.
     __exclude__ = ["resource_set_", "environment_", "non_compliant_diff"]
 
 

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -971,7 +971,7 @@ class ResourceOrder(StrawberryOrder):
 @mapper.type(models.ResourcePersistentState)
 class ResourcePersistentState:
     __tablename__ = "resource_persistent_state"
-    __exclude__ = ["resource_set_", "environment_"]
+    __exclude__ = ["resource_set_", "environment_", "non_compliant_diff"]
 
 
 @strawberry.type

--- a/tests/db/schema_compare.py
+++ b/tests/db/schema_compare.py
@@ -444,15 +444,15 @@ class DatabaseSchemaComparison:
     the unique, foreign key and check constraints. Names are compared as well, because migration scripts refer to
     constraints and indexes by name.
 
-    Not compared, all of which the models can express, so each is a way for a model to be wrong that this comparison
-    does not catch:
+    Not compared, so a model can get any of these wrong without this comparison noticing:
       - the expression a functional index indexes, only that it indexes one, because PostgreSQL normalizes the
         expression it stores and reports back something no model spells the same way.
-      - the collation of an index column, which PostgreSQL does not report back at all. A model that declares one is
-        reported as differing from the database, and there is no way to declare it so that the two agree.
       - the order of the columns of a table, because the columns are compared by name.
       - the comment on a table or a column.
       - whether a constraint is deferrable, or was added NOT VALID.
+
+    The collation of an index column is the reverse: PostgreSQL never reports it back, so a model that declares one is
+    always reported as differing, with no way to make the two agree.
     """
 
     EXTRACTORS: ClassVar[abc.Sequence[TableElementExtractor]] = (

--- a/tests/db/schema_compare.py
+++ b/tests/db/schema_compare.py
@@ -39,6 +39,8 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.schema import DefaultClause
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.elements import ClauseElement, ColumnClause, ColumnElement, UnaryExpression
 from sqlalchemy.sql.type_api import TypeEngine
 
 # PostgreSQL truncates identifiers to NAMEDATALEN - 1 bytes, so a longer name in a model or a migration script ends up
@@ -67,6 +69,40 @@ def column_names_to_str[T](columns: abc.Iterable[Column[T]]) -> str:
     return f"({', '.join(column.name for column in columns)})"
 
 
+class TableElement:
+    """
+    A single element of a table (a column, an index, a constraint, ...) as it is compared: the name it carries and a
+    description of everything that is compared about it.
+    """
+
+    # The name which an unnamed element will be reported as.
+    UNNAMED = "<unnamed>"
+
+    def __init__(self, name: str | None, description: str) -> None:
+        """
+        :param name: the name of the element, None for an element for which no explicit name was defined in the
+            SQLAlchemy model.
+        :param description: everything that is compared about the element, so that comparing two descriptions decides
+            whether the two sides agree on the element.
+        """
+        self.name = name
+        self.description = description
+
+    @property
+    def comparison_key(self) -> str:
+        """
+        The key the model side and the database side are matched on.
+
+        PostgreSQL names every index and every constraint, so an element without a name can only come from a SQLAlchemy model.
+        """
+        return self.name if self.name is not None else f"{self.UNNAMED} {self.description}"
+
+    @property
+    def reported_name(self) -> str:
+        """The name this element is reported under."""
+        return self.name if self.name is not None else self.UNNAMED
+
+
 class ElementDifference(ABC):
     """
     A single element of a table (a column, an index, a constraint, ...) that the SQLAlchemy model side and the
@@ -76,7 +112,7 @@ class ElementDifference(ABC):
     def __init__(self, element_kind: str, name: str) -> None:
         """
         :param element_kind: the kind of element this is, as it appears in the report, e.g. "column" or "index".
-        :param name: the name the element is compared under.
+        :param name: the name the element is reported under.
         """
         self.element_kind = element_kind
         self.name = name
@@ -91,30 +127,44 @@ class ElementDifference(ABC):
 class ElementOnlyDeclaredByModel(ElementDifference):
     """An element that the model declares but that the database does not have."""
 
+    def __init__(self, element_kind: str, element: TableElement) -> None:
+        super().__init__(element_kind, element.reported_name)
+        self.element = element
+
     def format_report(self) -> str:
-        return f"{self.element_kind} {self.name}: declared by the model but not present in the database"
+        return (
+            f"{self.element_kind} {self.name}: declared by the model but not present in the database\n"
+            f"{REPORT_INDENT}model:    {self.element.description}"
+        )
 
 
 class ElementOnlyPresentInDatabase(ElementDifference):
     """An element that the database has but that the model does not declare."""
 
+    def __init__(self, element_kind: str, element: TableElement) -> None:
+        super().__init__(element_kind, element.reported_name)
+        self.element = element
+
     def format_report(self) -> str:
-        return f"{self.element_kind} {self.name}: present in the database but not declared by the model"
+        return (
+            f"{self.element_kind} {self.name}: present in the database but not declared by the model\n"
+            f"{REPORT_INDENT}database: {self.element.description}"
+        )
 
 
 class ElementDescribedDifferently(ElementDifference):
     """An element that both sides have, but that they describe differently."""
 
-    def __init__(self, element_kind: str, name: str, description_in_model: str, description_in_database: str) -> None:
-        super().__init__(element_kind, name)
-        self.description_in_model = description_in_model
-        self.description_in_database = description_in_database
+    def __init__(self, element_kind: str, element_in_model: TableElement, element_in_database: TableElement) -> None:
+        super().__init__(element_kind, element_in_model.reported_name)
+        self.element_in_model = element_in_model
+        self.element_in_database = element_in_database
 
     def format_report(self) -> str:
         return (
             f"{self.element_kind} {self.name}:\n"
-            f"{REPORT_INDENT}model:    {self.description_in_model}\n"
-            f"{REPORT_INDENT}database: {self.description_in_database}"
+            f"{REPORT_INDENT}model:    {self.element_in_model.description}\n"
+            f"{REPORT_INDENT}database: {self.element_in_database.description}"
         )
 
 
@@ -172,42 +222,35 @@ class TableElementExtractor(ABC):
     element_kind: ClassVar[str]
 
     @abstractmethod
-    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+    def get_table_elements(self, table: Table) -> abc.Iterator[TableElement]:
         """
-        The elements of this kind on the given table, as the name of each element and a description of everything that
-        is compared about it. The name is None for an element that a SQLAlchemy model left for SQLAlchemy to name.
+        The elements of this kind on the given table.
         """
 
-    def get_descriptions_by_name(self, table: Table) -> abc.Mapping[str, str]:
+    def get_table_elements_by_comparison_key(self, table: Table) -> abc.Mapping[str, TableElement]:
         """
-        The description of each element of this kind on the given table, keyed by the name it is compared under.
-
-        PostgreSQL names every index and every constraint, so an element without a name can only come from a
-        SQLAlchemy model. The description is part of the key of such an element, so that several unnamed elements of
-        the same kind on one table do not collapse onto a single key.
+        The elements of this kind on the given table, keyed by the comparison_key.
         """
-        return {
-            name if name is not None else f"<unnamed> {description}": description
-            for name, description in self.get_named_elements(table)
-        }
+        return {element.comparison_key: element for element in self.get_table_elements(table)}
 
     def compare(self, model_table: Table, database_table: Table) -> abc.Sequence[ElementDifference]:
         """
         The differences on the elements of this kind, between the table as a model declares it and the same table as
         the database has it, ordered by name within each kind of difference.
         """
-        in_model = self.get_descriptions_by_name(model_table)
-        in_database = self.get_descriptions_by_name(database_table)
+        in_model = self.get_table_elements_by_comparison_key(model_table)
+        in_database = self.get_table_elements_by_comparison_key(database_table)
         differences: list[ElementDifference] = [
-            ElementOnlyDeclaredByModel(self.element_kind, name) for name in sorted(in_model.keys() - in_database.keys())
+            ElementOnlyDeclaredByModel(self.element_kind, in_model[key]) for key in sorted(in_model.keys() - in_database.keys())
         ]
         differences.extend(
-            ElementOnlyPresentInDatabase(self.element_kind, name) for name in sorted(in_database.keys() - in_model.keys())
+            ElementOnlyPresentInDatabase(self.element_kind, in_database[key])
+            for key in sorted(in_database.keys() - in_model.keys())
         )
         differences.extend(
-            ElementDescribedDifferently(self.element_kind, name, in_model[name], in_database[name])
-            for name in sorted(in_model.keys() & in_database.keys())
-            if in_model[name] != in_database[name]
+            ElementDescribedDifferently(self.element_kind, in_model[key], in_database[key])
+            for key in sorted(in_model.keys() & in_database.keys())
+            if in_model[key].description != in_database[key].description
         )
         return differences
 
@@ -239,9 +282,9 @@ class ColumnExtractor(TableElementExtractor):
         # hold back into a form that no longer matches what the other side reports.
         return default.text if isinstance(default, TextClause) else str(default)
 
-    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+    def get_table_elements(self, table: Table) -> abc.Iterator[TableElement]:
         for column in table.columns:
-            yield (
+            yield TableElement(
                 column.name,
                 f"type={self.get_column_type_def_as_str(column.type)} nullable={column.nullable}"
                 f" default={self.get_server_default_as_str(column)}",
@@ -251,8 +294,8 @@ class ColumnExtractor(TableElementExtractor):
 class PrimaryKeyExtractor(TableElementExtractor):
     element_kind = "primary key"
 
-    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
-        yield (
+    def get_table_elements(self, table: Table) -> abc.Iterator[TableElement]:
+        yield TableElement(
             get_truncated_identifier(table.primary_key),
             f"columns={column_names_to_str(table.primary_key.columns)}",
         )
@@ -314,11 +357,47 @@ class IndexExtractor(TableElementExtractor):
             condition_as_str = condition_as_str[1:-1].strip()
         return condition_as_str
 
-    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+    # What an index that indexes an expression rather than a column reports for that expression.
+    INDEXED_EXPRESSION = "<expression>"
+
+    @classmethod
+    def get_indexed_column_as_str(cls, expression: ColumnElement[object]) -> str:
+        """
+        One column of an index, followed by the sort order it is indexed in (if it is not the PostgreSQL default).
+
+        PostgreSQL indexes a column ascending, and a descending column with its nulls first, unless it is told
+        otherwise, and it reports the sort order of a column back only where it deviates from that. A model may spell
+        out a sort order that is the default anyway, so the defaults are dropped from both sides here.
+
+        An index may index an expression instead of a column. PostgreSQL stores such an expression the way it reads it
+        rather than the way it was written (``lower(name)`` comes back as ``lower(name::text)``), which no model spells
+        the same way, we only report that we detected an expression, not which one.
+        """
+        modifiers: list[object] = []
+        element: ClauseElement = expression
+        while isinstance(element, UnaryExpression) and element.modifier is not None:
+            modifiers.append(element.modifier)
+            element = element.element
+        descending = operators.desc_op in modifiers
+        if operators.nulls_first_op in modifiers or operators.nulls_last_op in modifiers:
+            nulls_first = operators.nulls_first_op in modifiers
+        else:
+            nulls_first = descending
+        sort_order = " DESC" if descending else ""
+        if nulls_first != descending:
+            sort_order += " NULLS FIRST" if nulls_first else " NULLS LAST"
+        indexed = element.name if isinstance(element, ColumnClause) else cls.INDEXED_EXPRESSION
+        return f"{indexed}{sort_order}"
+
+    def get_indexed_columns_as_str(self, index: Index) -> str:
+        """The columns of the given index, in the order the index holds them, each with the sort order it is indexed in."""
+        return f"({', '.join(self.get_indexed_column_as_str(expression) for expression in index.expressions)})"
+
+    def get_table_elements(self, table: Table) -> abc.Iterator[TableElement]:
         for index in table.indexes:
-            yield (
+            yield TableElement(
                 get_truncated_identifier(index),
-                f"columns={column_names_to_str(index.columns)} unique={bool(index.unique)}"
+                f"columns={self.get_indexed_columns_as_str(index)} unique={bool(index.unique)}"
                 f" type={self.get_index_type(index)} operator_classes={self.get_operator_classes_as_str(index)}"
                 f" where={self.get_condition_for_partial_index(index)}",
             )
@@ -327,19 +406,19 @@ class IndexExtractor(TableElementExtractor):
 class UniqueConstraintExtractor(TableElementExtractor):
     element_kind = "unique constraint"
 
-    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+    def get_table_elements(self, table: Table) -> abc.Iterator[TableElement]:
         for constraint in table.constraints:
             if isinstance(constraint, UniqueConstraint):
-                yield get_truncated_identifier(constraint), f"columns={column_names_to_str(constraint.columns)}"
+                yield TableElement(get_truncated_identifier(constraint), f"columns={column_names_to_str(constraint.columns)}")
 
 
 class ForeignKeyExtractor(TableElementExtractor):
     element_kind = "foreign key"
 
-    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+    def get_table_elements(self, table: Table) -> abc.Iterator[TableElement]:
         for constraint in table.constraints:
             if isinstance(constraint, ForeignKeyConstraint):
-                yield (
+                yield TableElement(
                     get_truncated_identifier(constraint),
                     f"columns={column_names_to_str(constraint.columns)}"
                     f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
@@ -350,10 +429,10 @@ class ForeignKeyExtractor(TableElementExtractor):
 class CheckConstraintExtractor(TableElementExtractor):
     element_kind = "check constraint"
 
-    def get_named_elements(self, table: Table) -> abc.Iterator[tuple[str | None, str]]:
+    def get_table_elements(self, table: Table) -> abc.Iterator[TableElement]:
         for constraint in table.constraints:
             if isinstance(constraint, CheckConstraint):
-                yield get_truncated_identifier(constraint), f"condition={constraint.sqltext}"
+                yield TableElement(get_truncated_identifier(constraint), f"condition={constraint.sqltext}")
 
 
 class DatabaseSchemaComparison:
@@ -361,14 +440,16 @@ class DatabaseSchemaComparison:
     Compares the tables that a set of SQLAlchemy models declares against the tables that a database has.
 
     Compared are: which tables exist, and per table the columns (type, nullability and default), the primary key, the
-    indexes (columns, uniqueness, type, operator classes and the condition of a partial one), and the unique, foreign
-    key and check constraints. Names are compared as well, because migration scripts refer to constraints and indexes
-    by name.
+    indexes (columns with their sort order, uniqueness, type, operator classes and the condition of a partial one), and
+    the unique, foreign key and check constraints. Names are compared as well, because migration scripts refer to
+    constraints and indexes by name.
 
     Not compared, all of which the models can express, so each is a way for a model to be wrong that this comparison
     does not catch:
-      - the sort order of the columns of an index, because the indexes are compared on index.columns, which reports the
-        columns without the modifier that carries the order.
+      - the expression a functional index indexes, only that it indexes one, because PostgreSQL normalizes the
+        expression it stores and reports back something no model spells the same way.
+      - the collation of an index column, which PostgreSQL does not report back at all. A model that declares one is
+        reported as differing from the database, and there is no way to declare it so that the two agree.
       - the order of the columns of a table, because the columns are compared by name.
       - the comment on a table or a column.
       - whether a constraint is deferrable, or was added NOT VALID.

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -81,15 +81,10 @@ def _predicate(index: Index) -> str | None:
     predicate = index.dialect_options["postgresql"]["where"]
     if predicate is None:
         return None
-    # The database reports the condition wrapped in parentheses, a model typically declares it without. Only a pair
-    # that encloses the whole condition is dropped: stripping both ends of "((n > 0) AND (name IS NULL))" until they
-    # are no longer parentheses would leave the mangled "n > 0) AND (name IS NULL".
+    # Normalize and parse the entire predicate (e.g. ((n > 0) AND (name IS NULL)))
     normalized = str(predicate).strip()
     while normalized.startswith("(") and normalized.endswith(")"):
         depth = 0
-        # A parenthesis within a string literal is part of that literal and does not open or close a pair, so
-        # "name = ')'::text" keeps the pair the database wraps it in. Two consecutive quotes are an escaped quote
-        # within a literal, which toggles this flag twice and so leaves it inside the literal.
         in_literal = False
         for position, character in enumerate(normalized):
             if character == "'":
@@ -115,9 +110,6 @@ def _method(index: Index) -> str:
 def _operator_classes(index: Index) -> str:
     """
     The operator class of each column of an index that does not use the default one for its type.
-
-    Reflection only reports the non-default ones, so a model that declares a default operator class explicitly reads
-    as a difference. Declaring it is pointless, which makes that acceptable.
     """
     operator_classes: abc.Mapping[str, str] = index.dialect_options["postgresql"]["ops"]
     return f"({', '.join(f'{column}={operator_classes[column]}' for column in sorted(operator_classes))})"
@@ -268,11 +260,8 @@ async def _reflect_database_schema(postgres_db: DatabaseConnectionDetails, datab
     Load the schema of the given database into a new MetaData object.
     """
     url = URL.create(
-        # The engine of the server uses the asyncpgnoi dialect, which drives its own connection pool. Reflection needs
-        # neither, so it uses a plain engine on the stock dialect.
         drivername="postgresql+asyncpg",
         username=postgres_db.user,
-        # An embedded database reports an empty password rather than none at all, which asyncpg rejects.
         password=postgres_db.password or None,
         host=postgres_db.host,
         port=postgres_db.port,
@@ -290,7 +279,7 @@ async def _reflect_database_schema(postgres_db: DatabaseConnectionDetails, datab
 
 def _drift(model_elements: abc.Sequence[SchemaItem], db_elements: abc.Sequence[SchemaItem]) -> list[str]:
     """
-    Compare one table as the model side declares it against the same table as the database side declares it.
+    Compare one table as the sqlalchemy model side declares it against the same table as the postgres database side declares it.
 
     Both sides are declared by hand instead of one of them being reflected, so that a case can set up a single
     difference and nothing else. That the database really reports a given property the way a model declares it is

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -23,9 +23,25 @@ import asyncpg
 import inmanta.db.versions
 from inmanta.data import CORE_SCHEMA_NAME, schema
 from inmanta.data.sqlalchemy import Base
-from sqlalchemy import ARRAY, URL, CheckConstraint, Column, Enum, ForeignKeyConstraint, Index, MetaData, Table, UniqueConstraint
+from sqlalchemy import (
+    ARRAY,
+    URL,
+    CheckConstraint,
+    Column,
+    Enum,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    MetaData,
+    PrimaryKeyConstraint,
+    String,
+    Table,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.schema import SchemaItem
 from sqlalchemy.sql.type_api import TypeEngine
 
 # PostgreSQL truncates identifiers to NAMEDATALEN - 1 bytes, so a longer name in a model or a migration script ends up
@@ -169,6 +185,24 @@ def _compare_tables(model_table: Table, db_table: Table) -> list[str]:
     ]
 
 
+def _compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mapping[str, Table]) -> list[str]:
+    """
+    Compare the tables the models declare against the tables the database has.
+
+    :param model_tables: the tables declared by the SQLAlchemy models, keyed by table name.
+    :param db_tables: the tables reflected from the database, keyed by table name.
+    :return: a human-readable description of each difference between the two.
+    """
+    differences: list[str] = []
+    for name in sorted(model_tables.keys() - db_tables.keys()):
+        differences.append(f"table {name}: declared by a model but not present in the database")
+    for name in sorted(db_tables.keys() - model_tables.keys()):
+        differences.append(f"table {name}: present in the database but not declared by a model")
+    for name in sorted(model_tables.keys() & db_tables.keys()):
+        differences.extend(f"table {name}: {difference}" for difference in _compare_tables(model_tables[name], db_tables[name]))
+    return differences
+
+
 async def _reflect_database_schema(postgres_db, database_name: str) -> MetaData:
     """
     Load the schema of the given database into a new MetaData object.
@@ -189,6 +223,283 @@ async def _reflect_database_schema(postgres_db, database_name: str) -> MetaData:
         return metadata
     finally:
         await engine.dispose()
+
+
+def _drift(model_elements: abc.Sequence[SchemaItem], db_elements: abc.Sequence[SchemaItem]) -> list[str]:
+    """
+    Compare one table as the model side declares it against the same table as the database side declares it.
+
+    Both sides are declared by hand instead of one of them being reflected, so that a case can set up a single
+    difference and nothing else. That the database really reports a given property the way a model declares it is
+    covered by test_sqlalchemy_models_in_sync_with_database_schema, which compares the two for real.
+
+    :param model_elements: the columns and constraints of the table on the model side.
+    :param db_elements: the columns and constraints of the same table on the database side.
+    :return: the differences reported between the two.
+    """
+    model, database = MetaData(), MetaData()
+    Table("tab", model, *model_elements)
+    Table("tab", database, *db_elements)
+    return _compare_schemas(model.tables, database.tables)
+
+
+def test_detects_table_drift() -> None:
+    """
+    Verify that a table that only one side has is reported.
+    """
+    model, database = MetaData(), MetaData()
+    Table("only_in_model", model, Column("id", Integer, primary_key=True))
+    Table("only_in_db", database, Column("id", Integer, primary_key=True))
+    assert _compare_schemas(model.tables, database.tables) == [
+        "table only_in_model: declared by a model but not present in the database",
+        "table only_in_db: present in the database but not declared by a model",
+    ]
+
+
+def test_detects_column_drift() -> None:
+    """
+    Verify that every property of a column that the models express is reported when it differs.
+    """
+    # a column that only one side has
+    assert _drift([], [Column("extra", String)]) == [
+        "table tab: column extra: present in the database but not declared by the model"
+    ]
+    assert _drift([Column("extra", String)], []) == [
+        "table tab: column extra: declared by the model but not present in the database"
+    ]
+    # the type of a column
+    assert _drift([Column("val", String)], [Column("val", Integer)]) == [
+        "table tab: column val: model has type=VARCHAR nullable=True default=None,"
+        " database has type=INTEGER nullable=True default=None"
+    ]
+    # the length of a varchar
+    assert _drift([Column("val", String(8))], [Column("val", String)]) == [
+        "table tab: column val: model has type=VARCHAR(8) nullable=True default=None,"
+        " database has type=VARCHAR nullable=True default=None"
+    ]
+    # the labels of a native enum type
+    assert _drift([Column("val", Enum("a", "b", name="my_enum"))], [Column("val", Enum("a", "b", "c", name="my_enum"))]) == [
+        "table tab: column val: model has type=my_enum labels=(a, b) nullable=True default=None,"
+        " database has type=my_enum labels=(a, b, c) nullable=True default=None"
+    ]
+    # whether a column accepts NULL
+    assert _drift([Column("val", String, nullable=False)], [Column("val", String)]) == [
+        "table tab: column val: model has type=VARCHAR nullable=False default=None,"
+        " database has type=VARCHAR nullable=True default=None"
+    ]
+    # the default the database fills in
+    assert _drift(
+        [Column("val", String, server_default=text("'a'::character varying"))],
+        [Column("val", String, server_default=text("'b'::character varying"))],
+    ) == [
+        "table tab: column val: model has type=VARCHAR nullable=True default='a'::character varying,"
+        " database has type=VARCHAR nullable=True default='b'::character varying"
+    ]
+    # a default that only one side has
+    assert _drift([Column("val", String)], [Column("val", String, server_default=text("''::character varying"))]) == [
+        "table tab: column val: model has type=VARCHAR nullable=True default=None,"
+        " database has type=VARCHAR nullable=True default=''::character varying"
+    ]
+
+
+def test_detects_primary_key_drift() -> None:
+    """
+    Verify that the columns and the name of a primary key are reported when they differ.
+    """
+    # the columns of the primary key. Both columns are declared NOT NULL on both sides, because a column being part
+    # of the primary key makes it NOT NULL, which would be a second difference.
+    assert _drift(
+        [Column("a", Integer), Column("b", Integer, nullable=False), PrimaryKeyConstraint("a", name="tab_pkey")],
+        [Column("a", Integer), Column("b", Integer, nullable=False), PrimaryKeyConstraint("a", "b", name="tab_pkey")],
+    ) == ["table tab: primary key tab_pkey: model has columns=(a), database has columns=(a, b)"]
+    # the name of the primary key, which a migration script needs to address it
+    assert _drift(
+        [Column("a", Integer), PrimaryKeyConstraint("a", name="tab_pkey")],
+        [Column("a", Integer), PrimaryKeyConstraint("a", name="old_name_pkey")],
+    ) == [
+        "table tab: primary key tab_pkey: declared by the model but not present in the database",
+        "table tab: primary key old_name_pkey: present in the database but not declared by the model",
+    ]
+
+
+def test_detects_index_drift() -> None:
+    """
+    Verify that every property of an index that the models express is reported when it differs.
+    """
+    # an index that only one side has
+    assert _drift([Column("a", Integer)], [Column("a", Integer), Index("tab_a_index", "a")]) == [
+        "table tab: index tab_a_index: present in the database but not declared by the model"
+    ]
+    # the name of an index
+    assert _drift(
+        [Column("a", Integer), Index("tab_new_name_index", "a")],
+        [Column("a", Integer), Index("tab_old_name_index", "a")],
+    ) == [
+        "table tab: index tab_new_name_index: declared by the model but not present in the database",
+        "table tab: index tab_old_name_index: present in the database but not declared by the model",
+    ]
+    # the columns of an index
+    assert _drift(
+        [Column("a", Integer), Column("b", Integer), Index("tab_index", "a")],
+        [Column("a", Integer), Column("b", Integer), Index("tab_index", "a", "b")],
+    ) == [
+        "table tab: index tab_index: model has columns=(a) unique=False where=None,"
+        " database has columns=(a, b) unique=False where=None"
+    ]
+    # the order of the columns of an index, which decides the queries it serves
+    assert _drift(
+        [Column("a", Integer), Column("b", Integer), Index("tab_index", "a", "b")],
+        [Column("a", Integer), Column("b", Integer), Index("tab_index", "b", "a")],
+    ) == [
+        "table tab: index tab_index: model has columns=(a, b) unique=False where=None,"
+        " database has columns=(b, a) unique=False where=None"
+    ]
+    # whether an index is unique
+    assert _drift(
+        [Column("a", Integer), Index("tab_index", "a")],
+        [Column("a", Integer), Index("tab_index", "a", unique=True)],
+    ) == [
+        "table tab: index tab_index: model has columns=(a) unique=False where=None,"
+        " database has columns=(a) unique=True where=None"
+    ]
+    # the condition of a partial index
+    assert _drift(
+        [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
+        [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NOT NULL"))],
+    ) == [
+        "table tab: index tab_index: model has columns=(a) unique=False where=a IS NULL,"
+        " database has columns=(a) unique=False where=a IS NOT NULL"
+    ]
+    # a condition that only one side has, so an index covers all rows on one side and some on the other
+    assert _drift(
+        [Column("a", Integer), Index("tab_index", "a")],
+        [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
+    ) == [
+        "table tab: index tab_index: model has columns=(a) unique=False where=None,"
+        " database has columns=(a) unique=False where=a IS NULL"
+    ]
+
+
+def test_detects_unique_constraint_drift() -> None:
+    """
+    Verify that the columns and the name of a unique constraint are reported when they differ.
+    """
+    # a unique constraint that only one side has
+    assert _drift([Column("a", Integer)], [Column("a", Integer), UniqueConstraint("a", name="tab_a_key")]) == [
+        "table tab: unique constraint tab_a_key: present in the database but not declared by the model"
+    ]
+    # the columns of a unique constraint
+    assert _drift(
+        [Column("a", Integer), Column("b", Integer), UniqueConstraint("a", name="tab_key")],
+        [Column("a", Integer), Column("b", Integer), UniqueConstraint("a", "b", name="tab_key")],
+    ) == ["table tab: unique constraint tab_key: model has columns=(a), database has columns=(a, b)"]
+
+
+def test_detects_foreign_key_drift() -> None:
+    """
+    Verify that every property of a foreign key that the models express is reported when it differs.
+    """
+    # a foreign key that only one side has
+    assert _drift(
+        [Column("a", Integer)],
+        [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_a_fkey")],
+    ) == ["table tab: foreign key tab_a_fkey: present in the database but not declared by the model"]
+    # the columns a foreign key is on
+    assert _drift(
+        [Column("a", Integer), Column("b", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_fkey")],
+        [Column("a", Integer), Column("b", Integer), ForeignKeyConstraint(["b"], ["other.id"], name="tab_fkey")],
+    ) == [
+        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=None onupdate=None,"
+        " database has columns=(b) references=(other.id) ondelete=None onupdate=None"
+    ]
+    # the columns a foreign key references
+    assert _drift(
+        [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_fkey")],
+        [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.name"], name="tab_fkey")],
+    ) == [
+        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=None onupdate=None,"
+        " database has columns=(a) references=(other.name) ondelete=None onupdate=None"
+    ]
+    # what happens to a referencing row when the row it references is deleted
+    assert _drift(
+        [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], ondelete="CASCADE", name="tab_fkey")],
+        [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], ondelete="RESTRICT", name="tab_fkey")],
+    ) == [
+        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=CASCADE onupdate=None,"
+        " database has columns=(a) references=(other.id) ondelete=RESTRICT onupdate=None"
+    ]
+    # and when it is updated
+    assert _drift(
+        [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_fkey")],
+        [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], onupdate="CASCADE", name="tab_fkey")],
+    ) == [
+        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=None onupdate=None,"
+        " database has columns=(a) references=(other.id) ondelete=None onupdate=CASCADE"
+    ]
+
+
+def test_detects_check_constraint_drift() -> None:
+    """
+    Verify that the condition and the name of a check constraint are reported when they differ.
+    """
+    # a check constraint that only one side has
+    assert _drift([Column("n", Integer)], [Column("n", Integer), CheckConstraint(text("n > 0"), name="tab_n_check")]) == [
+        "table tab: check constraint tab_n_check: present in the database but not declared by the model"
+    ]
+    # the condition of a check constraint
+    assert _drift(
+        [Column("n", Integer), CheckConstraint(text("n > 0"), name="tab_check")],
+        [Column("n", Integer), CheckConstraint(text("n > 1"), name="tab_check")],
+    ) == ["table tab: check constraint tab_check: model has condition=n > 0, database has condition=n > 1"]
+
+
+def test_reports_no_drift_for_equal_declarations() -> None:
+    """
+    Verify the other side of the comparison: a model that describes the same table as the database is not reported,
+    including where the two sides spell the same thing differently and the comparison normalizes it.
+    """
+    # the same table, declared the same way
+    assert (
+        _drift(
+            [Column("a", Integer), PrimaryKeyConstraint("a", name="tab_pkey"), Index("tab_a_index", "a")],
+            [Column("a", Integer), PrimaryKeyConstraint("a", name="tab_pkey"), Index("tab_a_index", "a")],
+        )
+        == []
+    )
+    # a name longer than PostgreSQL keeps, against the truncated name the database ends up with
+    long_name = "tab_" + "x" * 60
+    assert len(long_name) == MAX_IDENTIFIER_LENGTH + 1
+    assert (
+        _drift(
+            [Column("a", Integer), Index(long_name, "a")],
+            [Column("a", Integer), Index(long_name[:MAX_IDENTIFIER_LENGTH], "a")],
+        )
+        == []
+    )
+    # the parentheses PostgreSQL puts around the condition of a partial index
+    assert (
+        _drift(
+            [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
+            [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("(a IS NULL)"))],
+        )
+        == []
+    )
+    # only those, the parentheses within a compound condition are part of it and are kept on both sides
+    assert (
+        _drift(
+            [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("(n > 0) AND (a IS NULL)"))],
+            [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("((n > 0) AND (a IS NULL))"))],
+        )
+        == []
+    )
+    # the labels of a non-native enum, which the database holds as the varchar it is
+    assert (
+        _drift(
+            [Column("val", ARRAY(Enum("a", "b", name="my_enum", native_enum=False, create_constraint=False, length=None)))],
+            [Column("val", ARRAY(String))],
+        )
+        == []
+    )
 
 
 async def test_sqlalchemy_models_in_sync_with_database_schema(
@@ -213,16 +524,7 @@ async def test_sqlalchemy_models_in_sync_with_database_schema(
     await schema.DBSchema(CORE_SCHEMA_NAME, inmanta.db.versions, postgresql_client).ensure_db_schema()
     database_schema: MetaData = await _reflect_database_schema(postgres_db, database_name_internal)
 
-    model_tables: dict[str, Table] = Base.metadata.tables
-    db_tables: dict[str, Table] = database_schema.tables
-
-    differences: list[str] = []
-    for name in sorted(model_tables.keys() - db_tables.keys()):
-        differences.append(f"table {name}: declared by a model but not present in the database")
-    for name in sorted(db_tables.keys() - model_tables.keys()):
-        differences.append(f"table {name}: present in the database but not declared by a model")
-    for name in sorted(model_tables.keys() & db_tables.keys()):
-        differences.extend(f"table {name}: {difference}" for difference in _compare_tables(model_tables[name], db_tables[name]))
+    differences: list[str] = _compare_schemas(Base.metadata.tables, database_schema.tables)
 
     assert not differences, (
         "The SQLAlchemy models in inmanta.data.sqlalchemy are out of sync with the schema created by the database "

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -17,16 +17,15 @@ Contact: code@inmanta.com
 """
 
 from collections import abc
-from typing import Protocol
 
 import asyncpg
 
 import inmanta.db.versions
 from inmanta.data import CORE_SCHEMA_NAME, schema
 from inmanta.data.sqlalchemy import Base
+from inmanta.db.schema_compare import MAX_IDENTIFIER_LENGTH, DatabaseConnectionDetails, compare_schemas, reflect_database_schema
 from sqlalchemy import (
     ARRAY,
-    URL,
     CheckConstraint,
     Column,
     Enum,
@@ -40,241 +39,8 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.schema import SchemaItem
-from sqlalchemy.sql.type_api import TypeEngine
-
-# PostgreSQL truncates identifiers to NAMEDATALEN - 1 bytes, so a longer name in a model or a migration script ends up
-# truncated in the database. Both sides are truncated before they are compared, to compare what the database sees. The
-# identifiers of this schema are ASCII, for which a byte is a character.
-MAX_IDENTIFIER_LENGTH = 63
-
-
-def _identifier(name: str | None) -> str | None:
-    """The name of a constraint or an index as PostgreSQL stores it."""
-    return name if name is None else name[:MAX_IDENTIFIER_LENGTH]
-
-
-def _type(column_type: TypeEngine[object]) -> str:
-    """
-    A comparable description of a column type: the type as it appears in DDL, extended with the labels of a native
-    enum type, because those are part of the schema as well.
-    """
-    compiled = column_type.compile(postgresql.dialect())
-    element = column_type.item_type if isinstance(column_type, ARRAY) else column_type
-    if isinstance(element, Enum) and element.native_enum:
-        return f"{compiled} labels=({', '.join(element.enums)})"
-    return compiled
-
-
-def _server_default(column: Column[object]) -> str | None:
-    """The default the database fills in for a column, or None if it has none."""
-    if column.server_default is None:
-        return None
-    return str(getattr(column.server_default.arg, "text", column.server_default.arg))
-
-
-def _predicate(index: Index) -> str | None:
-    """The condition of a partial index, or None if the index covers all rows."""
-    predicate = index.dialect_options["postgresql"]["where"]
-    if predicate is None:
-        return None
-    # Normalize and parse the entire predicate (e.g. ((n > 0) AND (name IS NULL)))
-    normalized = str(predicate).strip()
-    while normalized.startswith("(") and normalized.endswith(")"):
-        depth = 0
-        in_literal = False
-        for position, character in enumerate(normalized):
-            if character == "'":
-                in_literal = not in_literal
-                continue
-            if in_literal:
-                continue
-            depth += (character == "(") - (character == ")")
-            if depth == 0 and position < len(normalized) - 1:
-                # The parenthesis opened at the start is closed here, so the pair encloses only part of the condition.
-                return normalized
-        normalized = normalized[1:-1].strip()
-    return normalized
-
-
-def _method(index: Index) -> str:
-    """The method of an index (btree, gin, ...)."""
-    # Reflection only reports the method when it is not the default, and a model only declares one when it deviates
-    # from the default, so an absent method on either side means btree.
-    return index.dialect_options["postgresql"]["using"] or "btree"
-
-
-def _operator_classes(index: Index) -> str:
-    """
-    The operator class of each column of an index that does not use the default one for its type.
-    """
-    operator_classes: abc.Mapping[str, str] = index.dialect_options["postgresql"]["ops"]
-    return f"({', '.join(f'{column}={operator_classes[column]}' for column in sorted(operator_classes))})"
-
-
-def _column_names(columns: abc.Iterable[Column[object]]) -> str:
-    return f"({', '.join(column.name for column in columns)})"
-
-
-def _by_name(elements: abc.Iterable[tuple[str | None, str]]) -> dict[str, str]:
-    """
-    Key the elements of one kind of a single table by their name, to be compared by name.
-
-    PostgreSQL names every index and constraint, so an element without a name can only come from a model, and it is
-    reported as a difference whatever the database holds. Its description is part of its key so that several unnamed
-    elements of the same kind do not collapse onto a single entry, and so that the keys are ordered.
-    """
-    return {name if name is not None else f"<unnamed> {description}": description for name, description in elements}
-
-
-def _columns(table: Table) -> dict[str, str]:
-    return _by_name(
-        (column.name, f"type={_type(column.type)} nullable={column.nullable} default={_server_default(column)}")
-        for column in table.columns
-    )
-
-
-def _primary_key(table: Table) -> dict[str, str]:
-    return _by_name([(_identifier(table.primary_key.name), f"columns={_column_names(table.primary_key.columns)}")])
-
-
-def _indexes(table: Table) -> dict[str, str]:
-    return _by_name(
-        (
-            _identifier(index.name),
-            (
-                f"columns={_column_names(index.columns)} unique={bool(index.unique)}"
-                f" method={_method(index)} operator_classes={_operator_classes(index)} where={_predicate(index)}"
-            ),
-        )
-        for index in table.indexes
-    )
-
-
-def _unique_constraints(table: Table) -> dict[str, str]:
-    return _by_name(
-        (_identifier(constraint.name), f"columns={_column_names(constraint.columns)}")
-        for constraint in table.constraints
-        if isinstance(constraint, UniqueConstraint)
-    )
-
-
-def _foreign_keys(table: Table) -> dict[str, str]:
-    return _by_name(
-        (
-            _identifier(constraint.name),
-            (
-                f"columns={_column_names(constraint.columns)}"
-                f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
-                f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}"
-            ),
-        )
-        for constraint in table.constraints
-        if isinstance(constraint, ForeignKeyConstraint)
-    )
-
-
-def _check_constraints(table: Table) -> dict[str, str]:
-    return _by_name(
-        (_identifier(constraint.name), f"condition={constraint.sqltext}")
-        for constraint in table.constraints
-        if isinstance(constraint, CheckConstraint)
-    )
-
-
-def _compare(kind: str, in_model: abc.Mapping[str, str], in_db: abc.Mapping[str, str]) -> list[str]:
-    """
-    Compare one kind of schema element (columns, indexes, ...) of a single table.
-
-    :param kind: the name of the kind of element that is compared, used in the reported differences.
-    :param in_model: the elements declared by the SQLAlchemy model, keyed by name.
-    :param in_db: the elements found in the database, keyed by name.
-    :return: a human-readable description of each difference between the two.
-    """
-    differences: list[str] = []
-    for name in sorted(in_model.keys() - in_db.keys()):
-        differences.append(f"{kind} {name}: declared by the model but not present in the database")
-    for name in sorted(in_db.keys() - in_model.keys()):
-        differences.append(f"{kind} {name}: present in the database but not declared by the model")
-    for name in sorted(in_model.keys() & in_db.keys()):
-        if in_model[name] != in_db[name]:
-            differences.append(f"{kind} {name}: model has {in_model[name]}, database has {in_db[name]}")
-    return differences
-
-
-def _compare_tables(model_table: Table, db_table: Table) -> list[str]:
-    """
-    Compare a single table as the model declares it against the table as it exists in the database.
-
-    :return: a human-readable description of each difference between the two.
-    """
-    return [
-        difference
-        for kind, aspect in (
-            ("column", _columns),
-            ("primary key", _primary_key),
-            ("index", _indexes),
-            ("unique constraint", _unique_constraints),
-            ("foreign key", _foreign_keys),
-            ("check constraint", _check_constraints),
-        )
-        for difference in _compare(kind, aspect(model_table), aspect(db_table))
-    ]
-
-
-def _compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mapping[str, Table]) -> list[str]:
-    """
-    Compare the tables the models declare against the tables the database has.
-
-    :param model_tables: the tables declared by the SQLAlchemy models, keyed by table name.
-    :param db_tables: the tables reflected from the database, keyed by table name.
-    :return: a human-readable description of each difference between the two.
-    """
-    differences: list[str] = []
-    for name in sorted(model_tables.keys() - db_tables.keys()):
-        differences.append(f"table {name}: declared by a model but not present in the database")
-    for name in sorted(db_tables.keys() - model_tables.keys()):
-        differences.append(f"table {name}: present in the database but not declared by a model")
-    for name in sorted(model_tables.keys() & db_tables.keys()):
-        differences.extend(f"table {name}: {difference}" for difference in _compare_tables(model_tables[name], db_tables[name]))
-    return differences
-
-
-class DatabaseConnectionDetails(Protocol):
-    """
-    How to reach the test database. Both executors the postgres_db fixture can yield, for an embedded and for an
-    external database, provide these.
-    """
-
-    host: str
-    port: int
-    user: str
-    password: str | None
-
-
-async def _reflect_database_schema(postgres_db: DatabaseConnectionDetails, database_name: str) -> MetaData:
-    """
-    Load the schema of the given database into a new MetaData object.
-    """
-    url = URL.create(
-        drivername="postgresql+asyncpg",
-        username=postgres_db.user,
-        password=postgres_db.password or None,
-        host=postgres_db.host,
-        port=postgres_db.port,
-        database=database_name,
-    )
-    engine = create_async_engine(url)
-    try:
-        metadata = MetaData()
-        async with engine.connect() as connection:
-            await connection.run_sync(metadata.reflect)
-        return metadata
-    finally:
-        await engine.dispose()
 
 
 def _drift(model_elements: abc.Sequence[SchemaItem], db_elements: abc.Sequence[SchemaItem]) -> list[str]:
@@ -292,7 +58,7 @@ def _drift(model_elements: abc.Sequence[SchemaItem], db_elements: abc.Sequence[S
     model, database = MetaData(), MetaData()
     Table("tab", model, *model_elements)
     Table("tab", database, *db_elements)
-    return _compare_schemas(model.tables, database.tables)
+    return compare_schemas(model.tables, database.tables)
 
 
 def test_detects_table_drift() -> None:
@@ -302,7 +68,7 @@ def test_detects_table_drift() -> None:
     model, database = MetaData(), MetaData()
     Table("only_in_model", model, Column("id", Integer, primary_key=True))
     Table("only_in_db", database, Column("id", Integer, primary_key=True))
-    assert _compare_schemas(model.tables, database.tables) == [
+    assert compare_schemas(model.tables, database.tables) == [
         "table only_in_model: declared by a model but not present in the database",
         "table only_in_db: present in the database but not declared by a model",
     ]
@@ -615,23 +381,12 @@ async def test_sqlalchemy_models_in_sync_with_database_schema(
     scripts produce. A migration that changes a table has to be accompanied by a change to the model of that table,
     and this test fails until it is.
 
-    Compared are: which tables exist, and per table the columns (type, nullability and default), the primary key, the
-    indexes (columns, uniqueness, method, operator classes and the condition of a partial one), and the unique,
-    foreign key and check constraints. Names are compared as well, because migration scripts refer to constraints and
-    indexes by name.
-
-    Not compared, all of which the models can express, so each is a way for a model to be wrong that this test does
-    not catch:
-      - the sort order of the columns of an index, because the indexes are compared on index.columns, which reports
-        the columns without the modifier that carries the order.
-      - the order of the columns of a table, because the columns are compared by name.
-      - the comment on a table or a column, of which this schema has none.
-      - whether a constraint is deferrable, or was added NOT VALID.
+    What is and is not compared is documented on inmanta.db.schema_compare.compare_schemas.
     """
     await schema.DBSchema(CORE_SCHEMA_NAME, inmanta.db.versions, postgresql_client).ensure_db_schema()
-    database_schema: MetaData = await _reflect_database_schema(postgres_db, database_name_internal)
+    database_schema: MetaData = await reflect_database_schema(postgres_db, database_name_internal)
 
-    differences: list[str] = _compare_schemas(Base.metadata.tables, database_schema.tables)
+    differences: list[str] = compare_schemas(Base.metadata.tables, database_schema.tables)
 
     assert not differences, (
         "The SQLAlchemy models in inmanta.data.sqlalchemy are out of sync with the schema created by the database "

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -17,6 +17,7 @@ Contact: code@inmanta.com
 """
 
 from collections import abc
+from typing import Protocol
 
 import asyncpg
 
@@ -40,12 +41,14 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.schema import SchemaItem
 from sqlalchemy.sql.type_api import TypeEngine
 
 # PostgreSQL truncates identifiers to NAMEDATALEN - 1 bytes, so a longer name in a model or a migration script ends up
-# truncated in the database. Both sides are truncated before they are compared, to compare what the database sees.
+# truncated in the database. Both sides are truncated before they are compared, to compare what the database sees. The
+# identifiers of this schema are ASCII, for which a byte is a character.
 MAX_IDENTIFIER_LENGTH = 63
 
 
@@ -84,7 +87,16 @@ def _predicate(index: Index) -> str | None:
     normalized = str(predicate).strip()
     while normalized.startswith("(") and normalized.endswith(")"):
         depth = 0
+        # A parenthesis within a string literal is part of that literal and does not open or close a pair, so
+        # "name = ')'::text" keeps the pair the database wraps it in. Two consecutive quotes are an escaped quote
+        # within a literal, which toggles this flag twice and so leaves it inside the literal.
+        in_literal = False
         for position, character in enumerate(normalized):
+            if character == "'":
+                in_literal = not in_literal
+                continue
+            if in_literal:
+                continue
             depth += (character == "(") - (character == ")")
             if depth == 0 and position < len(normalized) - 1:
                 # The parenthesis opened at the start is closed here, so the pair encloses only part of the condition.
@@ -93,59 +105,95 @@ def _predicate(index: Index) -> str | None:
     return normalized
 
 
+def _method(index: Index) -> str:
+    """The method of an index (btree, gin, ...)."""
+    # Reflection only reports the method when it is not the default, and a model only declares one when it deviates
+    # from the default, so an absent method on either side means btree.
+    return index.dialect_options["postgresql"]["using"] or "btree"
+
+
+def _operator_classes(index: Index) -> str:
+    """
+    The operator class of each column of an index that does not use the default one for its type.
+
+    Reflection only reports the non-default ones, so a model that declares a default operator class explicitly reads
+    as a difference. Declaring it is pointless, which makes that acceptable.
+    """
+    operator_classes: abc.Mapping[str, str] = index.dialect_options["postgresql"]["ops"]
+    return f"({', '.join(f'{column}={operator_classes[column]}' for column in sorted(operator_classes))})"
+
+
 def _column_names(columns: abc.Iterable[Column[object]]) -> str:
     return f"({', '.join(column.name for column in columns)})"
 
 
-def _columns(table: Table) -> dict[str | None, str]:
-    return {
-        column.name: f"type={_type(column.type)} nullable={column.nullable} default={_server_default(column)}"
+def _by_name(elements: abc.Iterable[tuple[str | None, str]]) -> dict[str, str]:
+    """
+    Key the elements of one kind of a single table by their name, to be compared by name.
+
+    PostgreSQL names every index and constraint, so an element without a name can only come from a model, and it is
+    reported as a difference whatever the database holds. Its description is part of its key so that several unnamed
+    elements of the same kind do not collapse onto a single entry, and so that the keys are ordered.
+    """
+    return {name if name is not None else f"<unnamed> {description}": description for name, description in elements}
+
+
+def _columns(table: Table) -> dict[str, str]:
+    return _by_name(
+        (column.name, f"type={_type(column.type)} nullable={column.nullable} default={_server_default(column)}")
         for column in table.columns
-    }
+    )
 
 
-def _primary_key(table: Table) -> dict[str | None, str]:
-    return {_identifier(table.primary_key.name): f"columns={_column_names(table.primary_key.columns)}"}
+def _primary_key(table: Table) -> dict[str, str]:
+    return _by_name([(_identifier(table.primary_key.name), f"columns={_column_names(table.primary_key.columns)}")])
 
 
-def _indexes(table: Table) -> dict[str | None, str]:
-    return {
-        _identifier(index.name): (
-            f"columns={_column_names(index.columns)} unique={bool(index.unique)} where={_predicate(index)}"
+def _indexes(table: Table) -> dict[str, str]:
+    return _by_name(
+        (
+            _identifier(index.name),
+            (
+                f"columns={_column_names(index.columns)} unique={bool(index.unique)}"
+                f" method={_method(index)} operator_classes={_operator_classes(index)} where={_predicate(index)}"
+            ),
         )
         for index in table.indexes
-    }
+    )
 
 
-def _unique_constraints(table: Table) -> dict[str | None, str]:
-    return {
-        _identifier(constraint.name): f"columns={_column_names(constraint.columns)}"
+def _unique_constraints(table: Table) -> dict[str, str]:
+    return _by_name(
+        (_identifier(constraint.name), f"columns={_column_names(constraint.columns)}")
         for constraint in table.constraints
         if isinstance(constraint, UniqueConstraint)
-    }
+    )
 
 
-def _foreign_keys(table: Table) -> dict[str | None, str]:
-    return {
-        _identifier(constraint.name): (
-            f"columns={_column_names(constraint.columns)}"
-            f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
-            f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}"
+def _foreign_keys(table: Table) -> dict[str, str]:
+    return _by_name(
+        (
+            _identifier(constraint.name),
+            (
+                f"columns={_column_names(constraint.columns)}"
+                f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
+                f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}"
+            ),
         )
         for constraint in table.constraints
         if isinstance(constraint, ForeignKeyConstraint)
-    }
+    )
 
 
-def _check_constraints(table: Table) -> dict[str | None, str]:
-    return {
-        _identifier(constraint.name): f"condition={constraint.sqltext}"
+def _check_constraints(table: Table) -> dict[str, str]:
+    return _by_name(
+        (_identifier(constraint.name), f"condition={constraint.sqltext}")
         for constraint in table.constraints
         if isinstance(constraint, CheckConstraint)
-    }
+    )
 
 
-def _compare(kind: str, in_model: dict[str | None, str], in_db: dict[str | None, str]) -> list[str]:
+def _compare(kind: str, in_model: abc.Mapping[str, str], in_db: abc.Mapping[str, str]) -> list[str]:
     """
     Compare one kind of schema element (columns, indexes, ...) of a single table.
 
@@ -203,13 +251,28 @@ def _compare_schemas(model_tables: abc.Mapping[str, Table], db_tables: abc.Mappi
     return differences
 
 
-async def _reflect_database_schema(postgres_db, database_name: str) -> MetaData:
+class DatabaseConnectionDetails(Protocol):
+    """
+    How to reach the test database. Both executors the postgres_db fixture can yield, for an embedded and for an
+    external database, provide these.
+    """
+
+    host: str
+    port: int
+    user: str
+    password: str | None
+
+
+async def _reflect_database_schema(postgres_db: DatabaseConnectionDetails, database_name: str) -> MetaData:
     """
     Load the schema of the given database into a new MetaData object.
     """
     url = URL.create(
+        # The engine of the server uses the asyncpgnoi dialect, which drives its own connection pool. Reflection needs
+        # neither, so it uses a plain engine on the stock dialect.
         drivername="postgresql+asyncpg",
         username=postgres_db.user,
+        # An embedded database reports an empty password rather than none at all, which asyncpg rejects.
         password=postgres_db.password or None,
         host=postgres_db.host,
         port=postgres_db.port,
@@ -282,6 +345,14 @@ def test_detects_column_drift() -> None:
         "table tab: column val: model has type=my_enum labels=(a, b) nullable=True default=None,"
         " database has type=my_enum labels=(a, b, c) nullable=True default=None"
     ]
+    # and the labels of a native enum that an array holds, which sit on the element type
+    assert _drift(
+        [Column("val", ARRAY(Enum("a", "b", name="my_enum")))],
+        [Column("val", ARRAY(Enum("a", "b", "c", name="my_enum")))],
+    ) == [
+        "table tab: column val: model has type=my_enum[] labels=(a, b) nullable=True default=None,"
+        " database has type=my_enum[] labels=(a, b, c) nullable=True default=None"
+    ]
     # whether a column accepts NULL
     assert _drift([Column("val", String, nullable=False)], [Column("val", String)]) == [
         "table tab: column val: model has type=VARCHAR nullable=False default=None,"
@@ -343,40 +414,56 @@ def test_detects_index_drift() -> None:
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "a")],
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "a", "b")],
     ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False where=None,"
-        " database has columns=(a, b) unique=False where=None"
+        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
+        " database has columns=(a, b) unique=False method=btree operator_classes=() where=None"
     ]
     # the order of the columns of an index, which decides the queries it serves
     assert _drift(
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "a", "b")],
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "b", "a")],
     ) == [
-        "table tab: index tab_index: model has columns=(a, b) unique=False where=None,"
-        " database has columns=(b, a) unique=False where=None"
+        "table tab: index tab_index: model has columns=(a, b) unique=False method=btree operator_classes=() where=None,"
+        " database has columns=(b, a) unique=False method=btree operator_classes=() where=None"
     ]
     # whether an index is unique
     assert _drift(
         [Column("a", Integer), Index("tab_index", "a")],
         [Column("a", Integer), Index("tab_index", "a", unique=True)],
     ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False where=None,"
-        " database has columns=(a) unique=True where=None"
+        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
+        " database has columns=(a) unique=True method=btree operator_classes=() where=None"
     ]
     # the condition of a partial index
     assert _drift(
         [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
         [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NOT NULL"))],
     ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False where=a IS NULL,"
-        " database has columns=(a) unique=False where=a IS NOT NULL"
+        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=a IS NULL,"
+        " database has columns=(a) unique=False method=btree operator_classes=() where=a IS NOT NULL"
     ]
     # a condition that only one side has, so an index covers all rows on one side and some on the other
     assert _drift(
         [Column("a", Integer), Index("tab_index", "a")],
         [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
     ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False where=None,"
-        " database has columns=(a) unique=False where=a IS NULL"
+        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
+        " database has columns=(a) unique=False method=btree operator_classes=() where=a IS NULL"
+    ]
+    # the method of an index, which decides which operators it can serve at all
+    assert _drift(
+        [Column("a", JSONB), Index("tab_index", "a")],
+        [Column("a", JSONB), Index("tab_index", "a", postgresql_using="gin")],
+    ) == [
+        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
+        " database has columns=(a) unique=False method=gin operator_classes=() where=None"
+    ]
+    # the operator class of a column of an index, which decides which operators it serves and what it costs
+    assert _drift(
+        [Column("a", JSONB), Index("tab_index", "a", postgresql_using="gin")],
+        [Column("a", JSONB), Index("tab_index", "a", postgresql_using="gin", postgresql_ops={"a": "jsonb_path_ops"})],
+    ) == [
+        "table tab: index tab_index: model has columns=(a) unique=False method=gin operator_classes=() where=None,"
+        " database has columns=(a) unique=False method=gin operator_classes=(a=jsonb_path_ops) where=None"
     ]
 
 
@@ -492,6 +579,23 @@ def test_reports_no_drift_for_equal_declarations() -> None:
         )
         == []
     )
+    # a parenthesis within a string literal, which closes no pair, so the pair around the whole condition is still
+    # the one that is dropped
+    assert (
+        _drift(
+            [Column("name", String), Index("tab_index", "name", postgresql_where=text("name <> ')'::text"))],
+            [Column("name", String), Index("tab_index", "name", postgresql_where=text("(name <> ')'::text)"))],
+        )
+        == []
+    )
+    # the default method of an index, which the database only reports when it is not the default
+    assert (
+        _drift(
+            [Column("a", Integer), Index("tab_index", "a", postgresql_using="btree")],
+            [Column("a", Integer), Index("tab_index", "a")],
+        )
+        == []
+    )
     # the labels of a non-native enum, which the database holds as the varchar it is
     assert (
         _drift(
@@ -500,10 +604,18 @@ def test_reports_no_drift_for_equal_declarations() -> None:
         )
         == []
     )
+    # the labels of a native enum in an array, which the database reports on the element type
+    assert (
+        _drift(
+            [Column("val", ARRAY(Enum("a", "b", name="my_enum")))],
+            [Column("val", ARRAY(Enum("a", "b", name="my_enum")))],
+        )
+        == []
+    )
 
 
 async def test_sqlalchemy_models_in_sync_with_database_schema(
-    postgres_db,
+    postgres_db: DatabaseConnectionDetails,
     database_name_internal: str,
     postgresql_client: asyncpg.Connection,
     hard_clean_db,
@@ -514,12 +626,18 @@ async def test_sqlalchemy_models_in_sync_with_database_schema(
     scripts produce. A migration that changes a table has to be accompanied by a change to the model of that table,
     and this test fails until it is.
 
-    Everything the models express is compared: which tables exist, and per table the columns (type, nullability and
-    default), the primary key, the indexes, and the unique, foreign key and check constraints. Names are compared as
-    well, because migration scripts refer to constraints and indexes by name.
+    Compared are: which tables exist, and per table the columns (type, nullability and default), the primary key, the
+    indexes (columns, uniqueness, method, operator classes and the condition of a partial one), and the unique,
+    foreign key and check constraints. Names are compared as well, because migration scripts refer to constraints and
+    indexes by name.
 
-    Details that the models do not express are out of scope: the index method (btree, gin, ...), operator classes and
-    the sort order of an index are not compared.
+    Not compared, all of which the models can express, so each is a way for a model to be wrong that this test does
+    not catch:
+      - the sort order of the columns of an index, because the indexes are compared on index.columns, which reports
+        the columns without the modifier that carries the order.
+      - the order of the columns of a table, because the columns are compared by name.
+      - the comment on a table or a column, of which this schema has none.
+      - whether a constraint is deferrable, or was added NOT VALID.
     """
     await schema.DBSchema(CORE_SCHEMA_NAME, inmanta.db.versions, postgresql_client).ensure_db_schema()
     database_schema: MetaData = await _reflect_database_schema(postgres_db, database_name_internal)

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -21,9 +21,9 @@ from collections import abc
 import asyncpg
 
 import inmanta.db.versions
+from db.schema_compare import MAX_IDENTIFIER_LENGTH, DatabaseSchemaComparison, get_database_schema
 from inmanta.data import CORE_SCHEMA_NAME, schema
 from inmanta.data.sqlalchemy import Base
-from inmanta.db.schema_compare import MAX_IDENTIFIER_LENGTH, DatabaseSchemaComparison, get_database_schema
 from sqlalchemy import (
     ARRAY,
     CheckConstraint,
@@ -37,6 +37,8 @@ from sqlalchemy import (
     String,
     Table,
     UniqueConstraint,
+    column,
+    func,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -80,10 +82,14 @@ def test_detects_column_drift() -> None:
     """
     # a column that only one side has
     assert get_drift_report([], [Column("extra", String)]) == (
-        "table tab:\n\tcolumn extra: present in the database but not declared by the model"
+        "table tab:\n"
+        "\tcolumn extra: present in the database but not declared by the model\n"
+        "\t\tdatabase: type=VARCHAR nullable=True default=None"
     )
     assert get_drift_report([Column("extra", String)], []) == (
-        "table tab:\n\tcolumn extra: declared by the model but not present in the database"
+        "table tab:\n"
+        "\tcolumn extra: declared by the model but not present in the database\n"
+        "\t\tmodel:    type=VARCHAR nullable=True default=None"
     )
     # the type of a column
     assert get_drift_report([Column("val", String)], [Column("val", Integer)]) == (
@@ -161,7 +167,9 @@ def test_detects_primary_key_drift() -> None:
     ) == (
         "table tab:\n"
         "\tprimary key tab_pkey: declared by the model but not present in the database\n"
-        "\tprimary key old_name_pkey: present in the database but not declared by the model"
+        "\t\tmodel:    columns=(a)\n"
+        "\tprimary key old_name_pkey: present in the database but not declared by the model\n"
+        "\t\tdatabase: columns=(a)"
     )
 
 
@@ -171,7 +179,9 @@ def test_detects_index_drift() -> None:
     """
     # an index that only one side has
     assert get_drift_report([Column("a", Integer)], [Column("a", Integer), Index("tab_a_index", "a")]) == (
-        "table tab:\n\tindex tab_a_index: present in the database but not declared by the model"
+        "table tab:\n"
+        "\tindex tab_a_index: present in the database but not declared by the model\n"
+        "\t\tdatabase: columns=(a) unique=False type=btree operator_classes=() where=None"
     )
     # the name of an index
     assert get_drift_report(
@@ -180,7 +190,9 @@ def test_detects_index_drift() -> None:
     ) == (
         "table tab:\n"
         "\tindex tab_new_name_index: declared by the model but not present in the database\n"
-        "\tindex tab_old_name_index: present in the database but not declared by the model"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=None\n"
+        "\tindex tab_old_name_index: present in the database but not declared by the model\n"
+        "\t\tdatabase: columns=(a) unique=False type=btree operator_classes=() where=None"
     )
     # the columns of an index
     assert get_drift_report(
@@ -201,6 +213,26 @@ def test_detects_index_drift() -> None:
         "\tindex tab_index:\n"
         "\t\tmodel:    columns=(a, b) unique=False type=btree operator_classes=() where=None\n"
         "\t\tdatabase: columns=(b, a) unique=False type=btree operator_classes=() where=None"
+    )
+    # the sort order a column is indexed in, which decides whether the index serves an ORDER BY without a sort
+    assert get_drift_report(
+        [Column("a", Integer), Index("tab_index", "a")],
+        [Column("a", Integer), Index("tab_index", column("a").desc())],
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(a DESC) unique=False type=btree operator_classes=() where=None"
+    )
+    # and where the nulls of a column sit within that sort order
+    assert get_drift_report(
+        [Column("a", Integer), Index("tab_index", "a")],
+        [Column("a", Integer), Index("tab_index", column("a").nullsfirst())],
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(a NULLS FIRST) unique=False type=btree operator_classes=() where=None"
     )
     # whether an index is unique
     assert get_drift_report(
@@ -260,7 +292,9 @@ def test_detects_unique_constraint_drift() -> None:
     """
     # a unique constraint that only one side has
     assert get_drift_report([Column("a", Integer)], [Column("a", Integer), UniqueConstraint("a", name="tab_a_key")]) == (
-        "table tab:\n\tunique constraint tab_a_key: present in the database but not declared by the model"
+        "table tab:\n"
+        "\tunique constraint tab_a_key: present in the database but not declared by the model\n"
+        "\t\tdatabase: columns=(a)"
     )
     # the columns of a unique constraint
     assert get_drift_report(
@@ -277,7 +311,11 @@ def test_detects_foreign_key_drift() -> None:
     assert get_drift_report(
         [Column("a", Integer)],
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_a_fkey")],
-    ) == ("table tab:\n\tforeign key tab_a_fkey: present in the database but not declared by the model")
+    ) == (
+        "table tab:\n"
+        "\tforeign key tab_a_fkey: present in the database but not declared by the model\n"
+        "\t\tdatabase: columns=(a) references=(other.id) ondelete=None onupdate=None"
+    )
     # the columns a foreign key is on
     assert get_drift_report(
         [Column("a", Integer), Column("b", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_fkey")],
@@ -327,7 +365,11 @@ def test_detects_check_constraint_drift() -> None:
     # a check constraint that only one side has
     assert get_drift_report(
         [Column("n", Integer)], [Column("n", Integer), CheckConstraint(text("n > 0"), name="tab_n_check")]
-    ) == ("table tab:\n\tcheck constraint tab_n_check: present in the database but not declared by the model")
+    ) == (
+        "table tab:\n"
+        "\tcheck constraint tab_n_check: present in the database but not declared by the model\n"
+        "\t\tdatabase: condition=n > 0"
+    )
     # the condition of a check constraint
     assert get_drift_report(
         [Column("n", Integer), CheckConstraint(text("n > 0"), name="tab_check")],
@@ -391,6 +433,33 @@ def test_reports_no_drift_for_equal_declarations() -> None:
         )
         == ""
     )
+    # the default sort order of an indexed column, which the database only reports when it is not the default
+    assert (
+        get_drift_report(
+            [Column("a", Integer), Index("tab_index", column("a").asc().nullslast())],
+            [Column("a", Integer), Index("tab_index", "a")],
+        )
+        == ""
+    )
+    # the expression of a functional index, which the database reports back normalized: PostgreSQL stores lower(name)
+    # as lower(name::text), so comparing the expression itself would report a difference no model can resolve
+    assert (
+        get_drift_report(
+            [Column("name", String), Index("tab_index", func.lower(column("name")))],
+            [Column("name", String), Index("tab_index", text("lower(name::text)"))],
+        )
+        == ""
+    )
+    # but an index on an expression is still told apart from an index on a column
+    assert get_drift_report(
+        [Column("name", String), Index("tab_index", "name")],
+        [Column("name", String), Index("tab_index", text("lower(name::text)"))],
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(name) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(<expression>) unique=False type=btree operator_classes=() where=None"
+    )
     # the labels of a non-native enum, which the database holds as the varchar it is
     assert (
         get_drift_report(
@@ -421,7 +490,7 @@ async def test_sqlalchemy_models_in_sync_with_database_schema(
     scripts produce. A migration that changes a table has to be accompanied by a change to the model of that table,
     and this test fails until it is.
 
-    What is and is not compared is documented on inmanta.db.schema_compare.DatabaseSchemaComparison.
+    What is and is not compared is documented on db.schema_compare.DatabaseSchemaComparison.
     """
     await schema.DBSchema(CORE_SCHEMA_NAME, inmanta.db.versions, postgresql_client).ensure_db_schema()
     database_schema: MetaData = await get_database_schema(

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -1,0 +1,230 @@
+"""
+Copyright 2026 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+from collections import abc
+
+import asyncpg
+
+import inmanta.db.versions
+from inmanta.data import CORE_SCHEMA_NAME, schema
+from inmanta.data.sqlalchemy import Base
+from sqlalchemy import ARRAY, URL, CheckConstraint, Column, Enum, ForeignKeyConstraint, Index, MetaData, Table, UniqueConstraint
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.sql.type_api import TypeEngine
+
+# PostgreSQL truncates identifiers to NAMEDATALEN - 1 bytes, so a longer name in a model or a migration script ends up
+# truncated in the database. Both sides are truncated before they are compared, to compare what the database sees.
+MAX_IDENTIFIER_LENGTH = 63
+
+
+def _identifier(name: str | None) -> str | None:
+    """The name of a constraint or an index as PostgreSQL stores it."""
+    return name if name is None else name[:MAX_IDENTIFIER_LENGTH]
+
+
+def _type(column_type: TypeEngine[object]) -> str:
+    """
+    A comparable description of a column type: the type as it appears in DDL, extended with the labels of a native
+    enum type, because those are part of the schema as well.
+    """
+    compiled = column_type.compile(postgresql.dialect())
+    element = column_type.item_type if isinstance(column_type, ARRAY) else column_type
+    if isinstance(element, Enum) and element.native_enum:
+        return f"{compiled} labels=({', '.join(element.enums)})"
+    return compiled
+
+
+def _server_default(column: Column[object]) -> str | None:
+    """The default the database fills in for a column, or None if it has none."""
+    if column.server_default is None:
+        return None
+    return str(getattr(column.server_default.arg, "text", column.server_default.arg))
+
+
+def _predicate(index: Index) -> str | None:
+    """The condition of a partial index, or None if the index covers all rows."""
+    predicate = index.dialect_options["postgresql"]["where"]
+    if predicate is None:
+        return None
+    # The database reports the condition wrapped in parentheses, a model typically declares it without. Only a pair
+    # that encloses the whole condition is dropped: stripping both ends of "((n > 0) AND (name IS NULL))" until they
+    # are no longer parentheses would leave the mangled "n > 0) AND (name IS NULL".
+    normalized = str(predicate).strip()
+    while normalized.startswith("(") and normalized.endswith(")"):
+        depth = 0
+        for position, character in enumerate(normalized):
+            depth += (character == "(") - (character == ")")
+            if depth == 0 and position < len(normalized) - 1:
+                # The parenthesis opened at the start is closed here, so the pair encloses only part of the condition.
+                return normalized
+        normalized = normalized[1:-1].strip()
+    return normalized
+
+
+def _column_names(columns: abc.Iterable[Column[object]]) -> str:
+    return f"({', '.join(column.name for column in columns)})"
+
+
+def _columns(table: Table) -> dict[str | None, str]:
+    return {
+        column.name: f"type={_type(column.type)} nullable={column.nullable} default={_server_default(column)}"
+        for column in table.columns
+    }
+
+
+def _primary_key(table: Table) -> dict[str | None, str]:
+    return {_identifier(table.primary_key.name): f"columns={_column_names(table.primary_key.columns)}"}
+
+
+def _indexes(table: Table) -> dict[str | None, str]:
+    return {
+        _identifier(index.name): (
+            f"columns={_column_names(index.columns)} unique={bool(index.unique)} where={_predicate(index)}"
+        )
+        for index in table.indexes
+    }
+
+
+def _unique_constraints(table: Table) -> dict[str | None, str]:
+    return {
+        _identifier(constraint.name): f"columns={_column_names(constraint.columns)}"
+        for constraint in table.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+
+
+def _foreign_keys(table: Table) -> dict[str | None, str]:
+    return {
+        _identifier(constraint.name): (
+            f"columns={_column_names(constraint.columns)}"
+            f" references=({', '.join(element.target_fullname for element in constraint.elements)})"
+            f" ondelete={constraint.ondelete} onupdate={constraint.onupdate}"
+        )
+        for constraint in table.constraints
+        if isinstance(constraint, ForeignKeyConstraint)
+    }
+
+
+def _check_constraints(table: Table) -> dict[str | None, str]:
+    return {
+        _identifier(constraint.name): f"condition={constraint.sqltext}"
+        for constraint in table.constraints
+        if isinstance(constraint, CheckConstraint)
+    }
+
+
+def _compare(kind: str, in_model: dict[str | None, str], in_db: dict[str | None, str]) -> list[str]:
+    """
+    Compare one kind of schema element (columns, indexes, ...) of a single table.
+
+    :param kind: the name of the kind of element that is compared, used in the reported differences.
+    :param in_model: the elements declared by the SQLAlchemy model, keyed by name.
+    :param in_db: the elements found in the database, keyed by name.
+    :return: a human-readable description of each difference between the two.
+    """
+    differences: list[str] = []
+    for name in sorted(in_model.keys() - in_db.keys()):
+        differences.append(f"{kind} {name}: declared by the model but not present in the database")
+    for name in sorted(in_db.keys() - in_model.keys()):
+        differences.append(f"{kind} {name}: present in the database but not declared by the model")
+    for name in sorted(in_model.keys() & in_db.keys()):
+        if in_model[name] != in_db[name]:
+            differences.append(f"{kind} {name}: model has {in_model[name]}, database has {in_db[name]}")
+    return differences
+
+
+def _compare_tables(model_table: Table, db_table: Table) -> list[str]:
+    """
+    Compare a single table as the model declares it against the table as it exists in the database.
+
+    :return: a human-readable description of each difference between the two.
+    """
+    return [
+        difference
+        for kind, aspect in (
+            ("column", _columns),
+            ("primary key", _primary_key),
+            ("index", _indexes),
+            ("unique constraint", _unique_constraints),
+            ("foreign key", _foreign_keys),
+            ("check constraint", _check_constraints),
+        )
+        for difference in _compare(kind, aspect(model_table), aspect(db_table))
+    ]
+
+
+async def _reflect_database_schema(postgres_db, database_name: str) -> MetaData:
+    """
+    Load the schema of the given database into a new MetaData object.
+    """
+    url = URL.create(
+        drivername="postgresql+asyncpg",
+        username=postgres_db.user,
+        password=postgres_db.password or None,
+        host=postgres_db.host,
+        port=postgres_db.port,
+        database=database_name,
+    )
+    engine = create_async_engine(url)
+    try:
+        metadata = MetaData()
+        async with engine.connect() as connection:
+            await connection.run_sync(metadata.reflect)
+        return metadata
+    finally:
+        await engine.dispose()
+
+
+async def test_sqlalchemy_models_in_sync_with_database_schema(
+    postgres_db,
+    database_name_internal: str,
+    postgresql_client: asyncpg.Connection,
+    hard_clean_db,
+    hard_clean_db_post,
+) -> None:
+    """
+    Verify that the SQLAlchemy models in inmanta.data.sqlalchemy describe the schema that the database migration
+    scripts produce. A migration that changes a table has to be accompanied by a change to the model of that table,
+    and this test fails until it is.
+
+    Everything the models express is compared: which tables exist, and per table the columns (type, nullability and
+    default), the primary key, the indexes, and the unique, foreign key and check constraints. Names are compared as
+    well, because migration scripts refer to constraints and indexes by name.
+
+    Details that the models do not express are out of scope: the index method (btree, gin, ...), operator classes and
+    the sort order of an index are not compared.
+    """
+    await schema.DBSchema(CORE_SCHEMA_NAME, inmanta.db.versions, postgresql_client).ensure_db_schema()
+    database_schema: MetaData = await _reflect_database_schema(postgres_db, database_name_internal)
+
+    model_tables: dict[str, Table] = Base.metadata.tables
+    db_tables: dict[str, Table] = database_schema.tables
+
+    differences: list[str] = []
+    for name in sorted(model_tables.keys() - db_tables.keys()):
+        differences.append(f"table {name}: declared by a model but not present in the database")
+    for name in sorted(db_tables.keys() - model_tables.keys()):
+        differences.append(f"table {name}: present in the database but not declared by a model")
+    for name in sorted(model_tables.keys() & db_tables.keys()):
+        differences.extend(f"table {name}: {difference}" for difference in _compare_tables(model_tables[name], db_tables[name]))
+
+    assert not differences, (
+        "The SQLAlchemy models in inmanta.data.sqlalchemy are out of sync with the schema created by the database "
+        "migration scripts. Update the models to match the database:\n  " + "\n  ".join(differences)
+    )

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -23,7 +23,7 @@ import asyncpg
 import inmanta.db.versions
 from inmanta.data import CORE_SCHEMA_NAME, schema
 from inmanta.data.sqlalchemy import Base
-from inmanta.db.schema_compare import MAX_IDENTIFIER_LENGTH, DatabaseConnectionDetails, compare_schemas, reflect_database_schema
+from inmanta.db.schema_compare import MAX_IDENTIFIER_LENGTH, compare_schemas, reflect_database_schema
 from sqlalchemy import (
     ARRAY,
     CheckConstraint,
@@ -370,7 +370,7 @@ def test_reports_no_drift_for_equal_declarations() -> None:
 
 
 async def test_sqlalchemy_models_in_sync_with_database_schema(
-    postgres_db: DatabaseConnectionDetails,
+    postgres_db,
     database_name_internal: str,
     postgresql_client: asyncpg.Connection,
     hard_clean_db,
@@ -384,7 +384,13 @@ async def test_sqlalchemy_models_in_sync_with_database_schema(
     What is and is not compared is documented on inmanta.db.schema_compare.compare_schemas.
     """
     await schema.DBSchema(CORE_SCHEMA_NAME, inmanta.db.versions, postgresql_client).ensure_db_schema()
-    database_schema: MetaData = await reflect_database_schema(postgres_db, database_name_internal)
+    database_schema: MetaData = await reflect_database_schema(
+        host=postgres_db.host,
+        port=postgres_db.port,
+        username=postgres_db.user,
+        password=postgres_db.password,
+        database=database_name_internal,
+    )
 
     differences: list[str] = compare_schemas(Base.metadata.tables, database_schema.tables)
 

--- a/tests/db/test_sqlalchemy_model_sync.py
+++ b/tests/db/test_sqlalchemy_model_sync.py
@@ -23,7 +23,7 @@ import asyncpg
 import inmanta.db.versions
 from inmanta.data import CORE_SCHEMA_NAME, schema
 from inmanta.data.sqlalchemy import Base
-from inmanta.db.schema_compare import MAX_IDENTIFIER_LENGTH, compare_schemas, reflect_database_schema
+from inmanta.db.schema_compare import MAX_IDENTIFIER_LENGTH, DatabaseSchemaComparison, get_database_schema
 from sqlalchemy import (
     ARRAY,
     CheckConstraint,
@@ -43,22 +43,22 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.schema import SchemaItem
 
 
-def _drift(model_elements: abc.Sequence[SchemaItem], db_elements: abc.Sequence[SchemaItem]) -> list[str]:
+def get_drift_report(model_elements: abc.Sequence[SchemaItem], database_elements: abc.Sequence[SchemaItem]) -> str:
     """
-    Compare one table as the sqlalchemy model side declares it against the same table as the postgres database side declares it.
+    Compare one table as the SQLAlchemy model side declares it against the same table as the database side declares it.
 
     Both sides are declared by hand instead of one of them being reflected, so that a case can set up a single
     difference and nothing else. That the database really reports a given property the way a model declares it is
     covered by test_sqlalchemy_models_in_sync_with_database_schema, which compares the two for real.
 
     :param model_elements: the columns and constraints of the table on the model side.
-    :param db_elements: the columns and constraints of the same table on the database side.
-    :return: the differences reported between the two.
+    :param database_elements: the columns and constraints of the same table on the database side.
+    :return: the report of the differences between the two.
     """
     model, database = MetaData(), MetaData()
     Table("tab", model, *model_elements)
-    Table("tab", database, *db_elements)
-    return compare_schemas(model.tables, database.tables)
+    Table("tab", database, *database_elements)
+    return DatabaseSchemaComparison(model.tables, database.tables).format_report()
 
 
 def test_detects_table_drift() -> None:
@@ -68,10 +68,10 @@ def test_detects_table_drift() -> None:
     model, database = MetaData(), MetaData()
     Table("only_in_model", model, Column("id", Integer, primary_key=True))
     Table("only_in_db", database, Column("id", Integer, primary_key=True))
-    assert compare_schemas(model.tables, database.tables) == [
-        "table only_in_model: declared by a model but not present in the database",
-        "table only_in_db: present in the database but not declared by a model",
-    ]
+    assert DatabaseSchemaComparison(model.tables, database.tables).format_report() == (
+        "table only_in_model: declared by a model but not present in the database\n"
+        "table only_in_db: present in the database but not declared by a model"
+    )
 
 
 def test_detects_column_drift() -> None:
@@ -79,53 +79,69 @@ def test_detects_column_drift() -> None:
     Verify that every property of a column that the models express is reported when it differs.
     """
     # a column that only one side has
-    assert _drift([], [Column("extra", String)]) == [
-        "table tab: column extra: present in the database but not declared by the model"
-    ]
-    assert _drift([Column("extra", String)], []) == [
-        "table tab: column extra: declared by the model but not present in the database"
-    ]
+    assert get_drift_report([], [Column("extra", String)]) == (
+        "table tab:\n\tcolumn extra: present in the database but not declared by the model"
+    )
+    assert get_drift_report([Column("extra", String)], []) == (
+        "table tab:\n\tcolumn extra: declared by the model but not present in the database"
+    )
     # the type of a column
-    assert _drift([Column("val", String)], [Column("val", Integer)]) == [
-        "table tab: column val: model has type=VARCHAR nullable=True default=None,"
-        " database has type=INTEGER nullable=True default=None"
-    ]
+    assert get_drift_report([Column("val", String)], [Column("val", Integer)]) == (
+        "table tab:\n"
+        "\tcolumn val:\n"
+        "\t\tmodel:    type=VARCHAR nullable=True default=None\n"
+        "\t\tdatabase: type=INTEGER nullable=True default=None"
+    )
     # the length of a varchar
-    assert _drift([Column("val", String(8))], [Column("val", String)]) == [
-        "table tab: column val: model has type=VARCHAR(8) nullable=True default=None,"
-        " database has type=VARCHAR nullable=True default=None"
-    ]
+    assert get_drift_report([Column("val", String(8))], [Column("val", String)]) == (
+        "table tab:\n"
+        "\tcolumn val:\n"
+        "\t\tmodel:    type=VARCHAR(8) nullable=True default=None\n"
+        "\t\tdatabase: type=VARCHAR nullable=True default=None"
+    )
     # the labels of a native enum type
-    assert _drift([Column("val", Enum("a", "b", name="my_enum"))], [Column("val", Enum("a", "b", "c", name="my_enum"))]) == [
-        "table tab: column val: model has type=my_enum labels=(a, b) nullable=True default=None,"
-        " database has type=my_enum labels=(a, b, c) nullable=True default=None"
-    ]
+    assert get_drift_report(
+        [Column("val", Enum("a", "b", name="my_enum"))], [Column("val", Enum("a", "b", "c", name="my_enum"))]
+    ) == (
+        "table tab:\n"
+        "\tcolumn val:\n"
+        "\t\tmodel:    type=my_enum labels=(a, b) nullable=True default=None\n"
+        "\t\tdatabase: type=my_enum labels=(a, b, c) nullable=True default=None"
+    )
     # and the labels of a native enum that an array holds, which sit on the element type
-    assert _drift(
+    assert get_drift_report(
         [Column("val", ARRAY(Enum("a", "b", name="my_enum")))],
         [Column("val", ARRAY(Enum("a", "b", "c", name="my_enum")))],
-    ) == [
-        "table tab: column val: model has type=my_enum[] labels=(a, b) nullable=True default=None,"
-        " database has type=my_enum[] labels=(a, b, c) nullable=True default=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tcolumn val:\n"
+        "\t\tmodel:    type=my_enum[] labels=(a, b) nullable=True default=None\n"
+        "\t\tdatabase: type=my_enum[] labels=(a, b, c) nullable=True default=None"
+    )
     # whether a column accepts NULL
-    assert _drift([Column("val", String, nullable=False)], [Column("val", String)]) == [
-        "table tab: column val: model has type=VARCHAR nullable=False default=None,"
-        " database has type=VARCHAR nullable=True default=None"
-    ]
+    assert get_drift_report([Column("val", String, nullable=False)], [Column("val", String)]) == (
+        "table tab:\n"
+        "\tcolumn val:\n"
+        "\t\tmodel:    type=VARCHAR nullable=False default=None\n"
+        "\t\tdatabase: type=VARCHAR nullable=True default=None"
+    )
     # the default the database fills in
-    assert _drift(
+    assert get_drift_report(
         [Column("val", String, server_default=text("'a'::character varying"))],
         [Column("val", String, server_default=text("'b'::character varying"))],
-    ) == [
-        "table tab: column val: model has type=VARCHAR nullable=True default='a'::character varying,"
-        " database has type=VARCHAR nullable=True default='b'::character varying"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tcolumn val:\n"
+        "\t\tmodel:    type=VARCHAR nullable=True default='a'::character varying\n"
+        "\t\tdatabase: type=VARCHAR nullable=True default='b'::character varying"
+    )
     # a default that only one side has
-    assert _drift([Column("val", String)], [Column("val", String, server_default=text("''::character varying"))]) == [
-        "table tab: column val: model has type=VARCHAR nullable=True default=None,"
-        " database has type=VARCHAR nullable=True default=''::character varying"
-    ]
+    assert get_drift_report([Column("val", String)], [Column("val", String, server_default=text("''::character varying"))]) == (
+        "table tab:\n"
+        "\tcolumn val:\n"
+        "\t\tmodel:    type=VARCHAR nullable=True default=None\n"
+        "\t\tdatabase: type=VARCHAR nullable=True default=''::character varying"
+    )
 
 
 def test_detects_primary_key_drift() -> None:
@@ -134,18 +150,19 @@ def test_detects_primary_key_drift() -> None:
     """
     # the columns of the primary key. Both columns are declared NOT NULL on both sides, because a column being part
     # of the primary key makes it NOT NULL, which would be a second difference.
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Column("b", Integer, nullable=False), PrimaryKeyConstraint("a", name="tab_pkey")],
         [Column("a", Integer), Column("b", Integer, nullable=False), PrimaryKeyConstraint("a", "b", name="tab_pkey")],
-    ) == ["table tab: primary key tab_pkey: model has columns=(a), database has columns=(a, b)"]
+    ) == ("table tab:\n\tprimary key tab_pkey:\n\t\tmodel:    columns=(a)\n\t\tdatabase: columns=(a, b)")
     # the name of the primary key, which a migration script needs to address it
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), PrimaryKeyConstraint("a", name="tab_pkey")],
         [Column("a", Integer), PrimaryKeyConstraint("a", name="old_name_pkey")],
-    ) == [
-        "table tab: primary key tab_pkey: declared by the model but not present in the database",
-        "table tab: primary key old_name_pkey: present in the database but not declared by the model",
-    ]
+    ) == (
+        "table tab:\n"
+        "\tprimary key tab_pkey: declared by the model but not present in the database\n"
+        "\tprimary key old_name_pkey: present in the database but not declared by the model"
+    )
 
 
 def test_detects_index_drift() -> None:
@@ -153,73 +170,88 @@ def test_detects_index_drift() -> None:
     Verify that every property of an index that the models express is reported when it differs.
     """
     # an index that only one side has
-    assert _drift([Column("a", Integer)], [Column("a", Integer), Index("tab_a_index", "a")]) == [
-        "table tab: index tab_a_index: present in the database but not declared by the model"
-    ]
+    assert get_drift_report([Column("a", Integer)], [Column("a", Integer), Index("tab_a_index", "a")]) == (
+        "table tab:\n\tindex tab_a_index: present in the database but not declared by the model"
+    )
     # the name of an index
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Index("tab_new_name_index", "a")],
         [Column("a", Integer), Index("tab_old_name_index", "a")],
-    ) == [
-        "table tab: index tab_new_name_index: declared by the model but not present in the database",
-        "table tab: index tab_old_name_index: present in the database but not declared by the model",
-    ]
+    ) == (
+        "table tab:\n"
+        "\tindex tab_new_name_index: declared by the model but not present in the database\n"
+        "\tindex tab_old_name_index: present in the database but not declared by the model"
+    )
     # the columns of an index
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "a")],
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "a", "b")],
-    ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
-        " database has columns=(a, b) unique=False method=btree operator_classes=() where=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(a, b) unique=False type=btree operator_classes=() where=None"
+    )
     # the order of the columns of an index, which decides the queries it serves
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "a", "b")],
         [Column("a", Integer), Column("b", Integer), Index("tab_index", "b", "a")],
-    ) == [
-        "table tab: index tab_index: model has columns=(a, b) unique=False method=btree operator_classes=() where=None,"
-        " database has columns=(b, a) unique=False method=btree operator_classes=() where=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a, b) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(b, a) unique=False type=btree operator_classes=() where=None"
+    )
     # whether an index is unique
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Index("tab_index", "a")],
         [Column("a", Integer), Index("tab_index", "a", unique=True)],
-    ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
-        " database has columns=(a) unique=True method=btree operator_classes=() where=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(a) unique=True type=btree operator_classes=() where=None"
+    )
     # the condition of a partial index
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
         [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NOT NULL"))],
-    ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=a IS NULL,"
-        " database has columns=(a) unique=False method=btree operator_classes=() where=a IS NOT NULL"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=a IS NULL\n"
+        "\t\tdatabase: columns=(a) unique=False type=btree operator_classes=() where=a IS NOT NULL"
+    )
     # a condition that only one side has, so an index covers all rows on one side and some on the other
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Index("tab_index", "a")],
         [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
-    ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
-        " database has columns=(a) unique=False method=btree operator_classes=() where=a IS NULL"
-    ]
-    # the method of an index, which decides which operators it can serve at all
-    assert _drift(
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(a) unique=False type=btree operator_classes=() where=a IS NULL"
+    )
+    # the type of an index, which decides which operators it can serve at all
+    assert get_drift_report(
         [Column("a", JSONB), Index("tab_index", "a")],
         [Column("a", JSONB), Index("tab_index", "a", postgresql_using="gin")],
-    ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False method=btree operator_classes=() where=None,"
-        " database has columns=(a) unique=False method=gin operator_classes=() where=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=btree operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(a) unique=False type=gin operator_classes=() where=None"
+    )
     # the operator class of a column of an index, which decides which operators it serves and what it costs
-    assert _drift(
+    assert get_drift_report(
         [Column("a", JSONB), Index("tab_index", "a", postgresql_using="gin")],
         [Column("a", JSONB), Index("tab_index", "a", postgresql_using="gin", postgresql_ops={"a": "jsonb_path_ops"})],
-    ) == [
-        "table tab: index tab_index: model has columns=(a) unique=False method=gin operator_classes=() where=None,"
-        " database has columns=(a) unique=False method=gin operator_classes=(a=jsonb_path_ops) where=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tindex tab_index:\n"
+        "\t\tmodel:    columns=(a) unique=False type=gin operator_classes=() where=None\n"
+        "\t\tdatabase: columns=(a) unique=False type=gin operator_classes=(a=jsonb_path_ops) where=None"
+    )
 
 
 def test_detects_unique_constraint_drift() -> None:
@@ -227,14 +259,14 @@ def test_detects_unique_constraint_drift() -> None:
     Verify that the columns and the name of a unique constraint are reported when they differ.
     """
     # a unique constraint that only one side has
-    assert _drift([Column("a", Integer)], [Column("a", Integer), UniqueConstraint("a", name="tab_a_key")]) == [
-        "table tab: unique constraint tab_a_key: present in the database but not declared by the model"
-    ]
+    assert get_drift_report([Column("a", Integer)], [Column("a", Integer), UniqueConstraint("a", name="tab_a_key")]) == (
+        "table tab:\n\tunique constraint tab_a_key: present in the database but not declared by the model"
+    )
     # the columns of a unique constraint
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Column("b", Integer), UniqueConstraint("a", name="tab_key")],
         [Column("a", Integer), Column("b", Integer), UniqueConstraint("a", "b", name="tab_key")],
-    ) == ["table tab: unique constraint tab_key: model has columns=(a), database has columns=(a, b)"]
+    ) == ("table tab:\n\tunique constraint tab_key:\n\t\tmodel:    columns=(a)\n\t\tdatabase: columns=(a, b)")
 
 
 def test_detects_foreign_key_drift() -> None:
@@ -242,42 +274,50 @@ def test_detects_foreign_key_drift() -> None:
     Verify that every property of a foreign key that the models express is reported when it differs.
     """
     # a foreign key that only one side has
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer)],
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_a_fkey")],
-    ) == ["table tab: foreign key tab_a_fkey: present in the database but not declared by the model"]
+    ) == ("table tab:\n\tforeign key tab_a_fkey: present in the database but not declared by the model")
     # the columns a foreign key is on
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), Column("b", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_fkey")],
         [Column("a", Integer), Column("b", Integer), ForeignKeyConstraint(["b"], ["other.id"], name="tab_fkey")],
-    ) == [
-        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=None onupdate=None,"
-        " database has columns=(b) references=(other.id) ondelete=None onupdate=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tforeign key tab_fkey:\n"
+        "\t\tmodel:    columns=(a) references=(other.id) ondelete=None onupdate=None\n"
+        "\t\tdatabase: columns=(b) references=(other.id) ondelete=None onupdate=None"
+    )
     # the columns a foreign key references
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_fkey")],
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.name"], name="tab_fkey")],
-    ) == [
-        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=None onupdate=None,"
-        " database has columns=(a) references=(other.name) ondelete=None onupdate=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tforeign key tab_fkey:\n"
+        "\t\tmodel:    columns=(a) references=(other.id) ondelete=None onupdate=None\n"
+        "\t\tdatabase: columns=(a) references=(other.name) ondelete=None onupdate=None"
+    )
     # what happens to a referencing row when the row it references is deleted
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], ondelete="CASCADE", name="tab_fkey")],
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], ondelete="RESTRICT", name="tab_fkey")],
-    ) == [
-        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=CASCADE onupdate=None,"
-        " database has columns=(a) references=(other.id) ondelete=RESTRICT onupdate=None"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tforeign key tab_fkey:\n"
+        "\t\tmodel:    columns=(a) references=(other.id) ondelete=CASCADE onupdate=None\n"
+        "\t\tdatabase: columns=(a) references=(other.id) ondelete=RESTRICT onupdate=None"
+    )
     # and when it is updated
-    assert _drift(
+    assert get_drift_report(
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], name="tab_fkey")],
         [Column("a", Integer), ForeignKeyConstraint(["a"], ["other.id"], onupdate="CASCADE", name="tab_fkey")],
-    ) == [
-        "table tab: foreign key tab_fkey: model has columns=(a) references=(other.id) ondelete=None onupdate=None,"
-        " database has columns=(a) references=(other.id) ondelete=None onupdate=CASCADE"
-    ]
+    ) == (
+        "table tab:\n"
+        "\tforeign key tab_fkey:\n"
+        "\t\tmodel:    columns=(a) references=(other.id) ondelete=None onupdate=None\n"
+        "\t\tdatabase: columns=(a) references=(other.id) ondelete=None onupdate=CASCADE"
+    )
 
 
 def test_detects_check_constraint_drift() -> None:
@@ -285,14 +325,14 @@ def test_detects_check_constraint_drift() -> None:
     Verify that the condition and the name of a check constraint are reported when they differ.
     """
     # a check constraint that only one side has
-    assert _drift([Column("n", Integer)], [Column("n", Integer), CheckConstraint(text("n > 0"), name="tab_n_check")]) == [
-        "table tab: check constraint tab_n_check: present in the database but not declared by the model"
-    ]
+    assert get_drift_report(
+        [Column("n", Integer)], [Column("n", Integer), CheckConstraint(text("n > 0"), name="tab_n_check")]
+    ) == ("table tab:\n\tcheck constraint tab_n_check: present in the database but not declared by the model")
     # the condition of a check constraint
-    assert _drift(
+    assert get_drift_report(
         [Column("n", Integer), CheckConstraint(text("n > 0"), name="tab_check")],
         [Column("n", Integer), CheckConstraint(text("n > 1"), name="tab_check")],
-    ) == ["table tab: check constraint tab_check: model has condition=n > 0, database has condition=n > 1"]
+    ) == ("table tab:\n\tcheck constraint tab_check:\n\t\tmodel:    condition=n > 0\n\t\tdatabase: condition=n > 1")
 
 
 def test_reports_no_drift_for_equal_declarations() -> None:
@@ -302,70 +342,70 @@ def test_reports_no_drift_for_equal_declarations() -> None:
     """
     # the same table, declared the same way
     assert (
-        _drift(
+        get_drift_report(
             [Column("a", Integer), PrimaryKeyConstraint("a", name="tab_pkey"), Index("tab_a_index", "a")],
             [Column("a", Integer), PrimaryKeyConstraint("a", name="tab_pkey"), Index("tab_a_index", "a")],
         )
-        == []
+        == ""
     )
     # a name longer than PostgreSQL keeps, against the truncated name the database ends up with
     long_name = "tab_" + "x" * 60
     assert len(long_name) == MAX_IDENTIFIER_LENGTH + 1
     assert (
-        _drift(
+        get_drift_report(
             [Column("a", Integer), Index(long_name, "a")],
             [Column("a", Integer), Index(long_name[:MAX_IDENTIFIER_LENGTH], "a")],
         )
-        == []
+        == ""
     )
     # the parentheses PostgreSQL puts around the condition of a partial index
     assert (
-        _drift(
+        get_drift_report(
             [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("a IS NULL"))],
             [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("(a IS NULL)"))],
         )
-        == []
+        == ""
     )
     # only those, the parentheses within a compound condition are part of it and are kept on both sides
     assert (
-        _drift(
+        get_drift_report(
             [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("(n > 0) AND (a IS NULL)"))],
             [Column("a", Integer), Index("tab_index", "a", postgresql_where=text("((n > 0) AND (a IS NULL))"))],
         )
-        == []
+        == ""
     )
     # a parenthesis within a string literal, which closes no pair, so the pair around the whole condition is still
     # the one that is dropped
     assert (
-        _drift(
+        get_drift_report(
             [Column("name", String), Index("tab_index", "name", postgresql_where=text("name <> ')'::text"))],
             [Column("name", String), Index("tab_index", "name", postgresql_where=text("(name <> ')'::text)"))],
         )
-        == []
+        == ""
     )
-    # the default method of an index, which the database only reports when it is not the default
+    # the default type of an index, which the database only reports when it is not the default
     assert (
-        _drift(
+        get_drift_report(
             [Column("a", Integer), Index("tab_index", "a", postgresql_using="btree")],
             [Column("a", Integer), Index("tab_index", "a")],
         )
-        == []
+        == ""
     )
     # the labels of a non-native enum, which the database holds as the varchar it is
     assert (
-        _drift(
+        get_drift_report(
             [Column("val", ARRAY(Enum("a", "b", name="my_enum", native_enum=False, create_constraint=False, length=None)))],
             [Column("val", ARRAY(String))],
         )
-        == []
+        == ""
     )
     # the labels of a native enum in an array, which the database reports on the element type
     assert (
-        _drift(
+        get_drift_report(
             [Column("val", ARRAY(Enum("a", "b", name="my_enum")))],
             [Column("val", ARRAY(Enum("a", "b", name="my_enum")))],
         )
-        == []
+        == ""
     )
 
 
@@ -381,10 +421,10 @@ async def test_sqlalchemy_models_in_sync_with_database_schema(
     scripts produce. A migration that changes a table has to be accompanied by a change to the model of that table,
     and this test fails until it is.
 
-    What is and is not compared is documented on inmanta.db.schema_compare.compare_schemas.
+    What is and is not compared is documented on inmanta.db.schema_compare.DatabaseSchemaComparison.
     """
     await schema.DBSchema(CORE_SCHEMA_NAME, inmanta.db.versions, postgresql_client).ensure_db_schema()
-    database_schema: MetaData = await reflect_database_schema(
+    database_schema: MetaData = await get_database_schema(
         host=postgres_db.host,
         port=postgres_db.port,
         username=postgres_db.user,
@@ -392,9 +432,9 @@ async def test_sqlalchemy_models_in_sync_with_database_schema(
         database=database_name_internal,
     )
 
-    differences: list[str] = compare_schemas(Base.metadata.tables, database_schema.tables)
+    comparison = DatabaseSchemaComparison(Base.metadata.tables, database_schema.tables)
 
-    assert not differences, (
+    assert not comparison.differences, (
         "The SQLAlchemy models in inmanta.data.sqlalchemy are out of sync with the schema created by the database "
-        "migration scripts. Update the models to match the database:\n  " + "\n  ".join(differences)
+        "migration scripts. Update the models to match the database:\n" + comparison.format_report()
     )

--- a/tests_common/copy_files_from_core.py
+++ b/tests_common/copy_files_from_core.py
@@ -53,6 +53,8 @@ enduser_certs_dir = os.path.join(data_dir, "ca", "enduser-certs")
 simple_project_dir = os.path.join(data_dir, "simple_project")
 db_common_py = os.path.join(db_dir, "common.py")
 dest_db_common_py = os.path.join(dest_db_dir, "common.py")
+db_schema_compare_py = os.path.join(db_dir, "schema_compare.py")
+dest_db_schema_compare_py = os.path.join(dest_db_dir, "schema_compare.py")
 dest_simple_project_dir = os.path.join(dest_db_dir, "simple_project")
 
 
@@ -64,6 +66,7 @@ def remove_file_if_exists(filename: str):
 remove_file_if_exists(dest_conftest_py)
 remove_file_if_exists(dest_utils_py)
 remove_file_if_exists(dest_db_common_py)
+remove_file_if_exists(dest_db_schema_compare_py)
 
 # Copy files
 shutil.copy(conftest_py, dest_dir)
@@ -72,4 +75,5 @@ shutil.copy(server_crt_file, dest_data_dir)
 shutil.copy(server_open_key_file, dest_data_dir)
 shutil.copytree(enduser_certs_dir, os.path.join(dest_data_dir, "ca", "enduser-certs"))
 shutil.copy(db_common_py, dest_db_common_py)
+shutil.copy(db_schema_compare_py, dest_db_schema_compare_py)
 shutil.copytree(simple_project_dir, dest_simple_project_dir)

--- a/tests_common/setup.py
+++ b/tests_common/setup.py
@@ -32,6 +32,8 @@ requires = [
     "pytest-env",
     "pytest-postgresql>=4",
     "psycopg>=3",
+    # inmanta_tests.db.schema_compare compares SQLAlchemy models against a reflected schema
+    "SQLAlchemy~=2.0",
     "tornado",
 ]
 


### PR DESCRIPTION
*This PR was created by Claude on behalf of @jptrindade.*

Note: This was mostly Claude logic, but I asked it for the specific drift tests. It is mostly to serve as a guardrail against drifting schemas. 

# Description

The SQLAlchemy models in `inmanta.data.sqlalchemy` describe the same tables as the database migration scripts, but nothing enforced that. This adds a test that applies all migration scripts to an empty database and compares the result against the models, and fixes the drift it found.

Example output:

```
The SQLAlchemy models in inmanta.data.sqlalchemy are out of sync with the schema created by the database migration
scripts. Update the models to match the database:
table parameter:
	index parameter_metadata_index:
		model:    columns=(metadata) unique=False type=btree operator_classes=() where=None
		database: columns=(metadata) unique=False type=gin operator_classes=(metadata=jsonb_path_ops) where=None
table token:
	index token_environment_index: present in the database but not declared by the model
```

Compared per table: columns (type, nullability, default), primary key, indexes (columns, uniqueness, type, operator classes, condition of a partial one) and the unique, foreign key and check constraints, names included. Not compared: the sort order of the columns of an index, the expressions of a functional index, column order, comments, constraint deferrability.

## Drift fixed

* Missing from the models: `compile.reinstall_project_and_venv`, three `discoveredresource` columns, the `resource_diff` table, `resource_persistent_state.non_compliant_diff`, `token_environment_index`, and the partial condition of `schedulersession_expired_index`.
* `parameter_metadata_index` and `resource_attributes_index` were declared as plain btree indexes where the database has `gin (... jsonb_path_ops)`.
* Eight constraint and index names the models had guessed instead of taking from the database. Two of those are on `resource_set_configuration_model`, where `v202509180` renamed the `resource_set_id` column but not the foreign key and the index that carry it in their name.
* `schedulersession` keeps the constraint names of `agentprocess`, because `v202605060` renamed the table but not its primary key or foreign key. Renaming those needs a migration: #10634.
* `non_compliant_diff` is not exposed via GraphQL, since `resource_diff` has no GraphQL type to resolve it against.

`iso9` has a different schema (no `v202605060`) and different drift, so it is ported separately in #10635.

## Reusable by extensions

The comparison lives in `inmanta.db.schema_compare` rather than in the test, so an extension can verify its own models against the schema its own migration scripts produce without repeating any of it. Exposed are `DatabaseSchemaComparison`, which compares two sets of tables and reports the differences, and `get_database_schema`, which loads the schema of a database into a `MetaData`. The test in `tests/db` keeps the drift cases, which now exercise the shared code, and the comparison against the real database.

`src/` is type checked where `tests/` is not, which surfaced three typing issues in the moved code. They are fixed rather than baselined: the dialect is built once at module level (SQLAlchemy does not annotate its constructor), `get_server_default_as_str` narrows to `DefaultClause` instead of reading `.arg` off a `FetchedValue`, and `get_truncated_identifier` also handles the sentinel SQLAlchemy reports for an unnamed constraint. `make mypy` needs no baseline change.

inmanta/inmanta-lsm#2468 is the LSM side, and consists of a single 50-line test that calls into this module.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

