### PR TITLE
Fix venv inheritance pip 26.2 (iso8)

### DIFF
--- a/changelogs/unreleased/fix-venv-inheritance-pip-26-2.yml
+++ b/changelogs/unreleased/fix-venv-inheritance-pip-26-2.yml
@@ -1,4 +1,4 @@
 ---
 description: "Fix incompatibility with pip 26.2 that breaks the venv inheritance. The inmanta-inherit-from-parent-venv.pth now only does addsitedir() calls for directories that are part of the parent venv and no other directories like python stdlib. (reference: https://github.com/pypa/pip/pull/14033)"
 change-type: patch
-destination-branches: [master, iso9, iso8]
+destination-branches: [iso8]

--- a/changelogs/unreleased/fix-venv-inheritance-pip-26-2.yml
+++ b/changelogs/unreleased/fix-venv-inheritance-pip-26-2.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix incompatibility with pip 26.2 that breaks the venv inheritance. The inmanta-inherit-from-parent-venv.pth now only does addsitedir() calls for directories that are part of the parent venv and no other directories like python stdlib. (reference: https://github.com/pypa/pip/pull/14033)"
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/const.py
+++ b/src/inmanta/const.py
@@ -389,6 +389,10 @@ INMANTA_DISK_LAYOUT_VERSION = ".inmanta_disk_layout_version"
 DEFAULT_INMANTA_DISK_LAYOUT_VERSION = 2
 
 
+# File containing the version of the venv. Incremented when an updated is needed to one of the
+# inmanta-maintained files in that venv, like the inmanta-inherit-from-parent-venv.pth file for example.
+VENV_VERSION_FILE = ".inmanta_venv_version"
+
 # ID to represent the new scheduler as an agent
 AGENT_SCHEDULER_ID = "$__scheduler"
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -663,6 +663,8 @@ class PythonEnvironment:
     Inmanta product packages don't change.
     """
 
+    # The version number written into the .inmanta_venv_version file of the venv.
+    VENV_VERSION = 2
     _invalid_chars_in_path_re = re.compile(r'["$`]')
 
     def __init__(self, *, env_path: Optional[str] = None, python_path: Optional[str] = None) -> None:
@@ -685,6 +687,32 @@ class PythonEnvironment:
         self.validate_path(self.env_path)
         self.site_packages_dir: str = self.get_site_dir_for_env_path(self.env_path)
         self._path_pth_file = os.path.join(self.site_packages_dir, "inmanta-inherit-from-parent-venv.pth")
+        self.venv_version_file = os.path.join(self.env_path, const.VENV_VERSION_FILE)
+
+    def write_venv_version_file(self) -> None:
+        """
+        Write the venv version file into the venv.
+        """
+        with open(self.venv_version_file, "w") as fh:
+            fh.write(str(self.VENV_VERSION))
+
+    def update_venv_version(self) -> None:
+        """
+        Update the version of this venv to the latest version.
+        """
+        if not self.is_venv_version_up_to_date():
+            self.write_inmanta_managed_files_in_venv()
+            self.write_venv_version_file()
+
+    def is_venv_version_up_to_date(self) -> bool:
+        """
+        Return True iff the version of this venv is up-to-date.
+        Meaning its version is self.COMPILER_VENV_VERSION
+        """
+        if not os.path.exists(self.venv_version_file):
+            return False
+        with open(self.venv_version_file, "r") as fh:
+            return fh.read().strip() == str(self.VENV_VERSION)
 
     def validate_path(self, path: str) -> None:
         """
@@ -753,8 +781,6 @@ class PythonEnvironment:
             path = os.path.realpath(self.env_path)
             try:
                 venv.create(path, clear=True, with_pip=False)
-                self._write_pip_binary()
-                self._write_pth_file()
             except CalledProcessError as e:
                 raise VenvCreationFailedError(msg=f"Unable to create new virtualenv at {self.env_path} ({e.stdout.decode()})")
             except Exception:
@@ -763,8 +789,13 @@ class PythonEnvironment:
 
         if not os.path.exists(self._path_pth_file):
             # Venv was created using an older version of Inmanta -> Update pip binary and set sitecustomize.py file
-            self._write_pip_binary()
-            self._write_pth_file()
+            self.write_inmanta_managed_files_in_venv()
+
+        self.write_venv_version_file()
+
+    def write_inmanta_managed_files_in_venv(self) -> None:
+        self._write_pip_binary()
+        self._write_pth_file()
 
     def can_activate(self) -> None:
         """
@@ -817,7 +848,13 @@ class PythonEnvironment:
         activate the parent venv. The site directories of the parent venv should appear later in sys.path than the ones of
         this venv.
         """
-        site_dir_strings: list[str] = ['"' + p.replace('"', r"\"") + '"' for p in list(sys.path)]
+        # Path prefix for the currently used venv.
+        venv_dir_prefix = os.path.join(os.path.realpath(sys.prefix), "")
+        # Fetch all paths in sys.path for the currently used venv.
+        site_dir_strings: list[str] = [
+            '"' + p.replace('"', r"\"") + '"' for p in list(sys.path) if os.path.realpath(p).startswith(venv_dir_prefix)
+        ]
+        # Make sure the new venv inherits from the currently used venv by calling into addsitedir().
         add_site_dir_statements: str = "\n".join(
             [f"site.addsitedir({p}) if {p} not in sys.path else None" for p in site_dir_strings]
         )

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -272,22 +272,26 @@ class CompileRun:
 
         async def ensure_venv() -> None:
             """
-            Ensures that a compatible venv exists at .venv-py<version>
+            Ensures that a compatible venv exists at .env-py<version>
             """
             if os.path.exists(versioned_venv_dir_full):
+                virtual_env = VirtualEnv(versioned_venv_dir_full)
+                virtual_env.update_venv_version()
                 return
+
             # migration from old .env
             if os.path.exists(venv_dir) and not os.path.islink(venv_dir):
                 virtual_env = VirtualEnv(venv_dir)
                 if virtual_env.exists():
                     with contextlib.suppress(VenvActivationFailedError):
                         virtual_env.can_activate()  # raises exception
-                        # version matches, move it to the correct folder
+                        virtual_env.update_venv_version()
+                        # python version matches, move it to the correct folder
                         os.rename(venv_dir, versioned_venv_dir_full)
                         await self._info(f"Moving existing venv from {venv_dir} to {versioned_venv_dir_full}")
                         # All done
                         return
-                # version doesn't match
+                # python version doesn't match
                 os.rename(venv_dir, venv_dir + "_old")
                 await self._info(f"Discarding existing venv from {venv_dir} to {venv_dir}_old, Creating new")
 

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -19,6 +19,7 @@ Contact: code@inmanta.com
 import asyncio
 import datetime
 import functools
+import glob
 import logging
 import os
 import platform
@@ -39,7 +40,7 @@ import inmanta.ast.export as ast_export
 import inmanta.data.model as model
 import inmanta.util
 import utils
-from inmanta import config, data
+from inmanta import config, const, data
 from inmanta.const import INMANTA_REMOVED_SET_ID, ParameterSource
 from inmanta.data import APILIMIT, Compile, Report
 from inmanta.data.model import PipConfig
@@ -53,7 +54,7 @@ from inmanta.server.services.compilerservice import CompilerService, CompileRun,
 from inmanta.server.services.notificationservice import NotificationService
 from inmanta.util import ensure_directory_exist
 from server.conftest import EnvironmentFactory
-from utils import LogSequence, log_contains, report_db_index_usage, retry_limited, wait_for_version
+from utils import LogSequence, log_contains, log_doesnt_contain, report_db_index_usage, retry_limited, wait_for_version
 
 logger = logging.getLogger("inmanta.test.server.compilerservice")
 
@@ -2332,6 +2333,77 @@ async def test_venv_upgrade_version_mismatch(tmp_path, caplog):
     await run.ensure_compiler_venv()
     log_contains(caplog, "inmanta.server.services.compilerservice", logging.INFO, "Discarding existing venv from")
     assert (project / ".env").exists()
+
+
+@pytest.mark.parametrize("stale_version", [True, False])
+async def test_venv_upgrade_managed_files(tmp_path, caplog, stale_version: bool):
+    """
+    An existing versioned compiler venv whose version marker is stale (created by a newer/older
+    inmanta) or missing (created by an inmanta predating the version marker) should have its
+    inmanta-managed files regenerated and its version marker bumped, without recreating the venv
+    from scratch.
+
+    :param stale_version: If True, simulate a venv with an outdated version marker. If False,
+        simulate a venv predating the version marker (marker file absent).
+    """
+    caplog.set_level(logging.DEBUG)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    venv = project / ".env"
+    run = CompileRun(None, str(project))
+    run.stage = Mockreport()
+
+    # Create an up-to-date compiler venv
+    await run.ensure_compiler_venv()
+    assert venv.exists()
+
+    python_version = ".".join(platform.python_version_tuple()[0:2])
+    versioned_venv_dir_full = project / (".env-py" + python_version)
+    version_file = versioned_venv_dir_full / const.VENV_VERSION_FILE
+
+    # Sanity check: a freshly created venv is marked with the current version
+    assert version_file.read_text().strip() == str(PythonEnvironment.VENV_VERSION)
+
+    # Locate the inmanta-managed .pth file
+    pth_files = glob.glob(
+        str(versioned_venv_dir_full / "lib" / "python*" / "site-packages" / "inmanta-inherit-from-parent-venv.pth")
+    )
+    assert len(pth_files) == 1
+    pth_file = pth_files[0]
+
+    # Drop a sentinel file to later assert the venv was updated in place rather than recreated
+    sentinel = versioned_venv_dir_full / "sentinel"
+    sentinel.write_text("keep me")
+
+    # Simulate an out-of-date venv: overwrite the managed .pth file with stale content (as produced
+    # by an older inmanta) and either staledate or drop the version marker
+    stale_pth_content = "import site; site.addsitedir('/some/stale/path')"
+    with open(pth_file, "w") as fh:
+        fh.write(stale_pth_content)
+    if stale_version:
+        version_file.write_text("1")
+        assert version_file.read_text().strip() != str(PythonEnvironment.VENV_VERSION)
+    else:
+        version_file.unlink()
+        assert not version_file.exists()
+
+    caplog.clear()
+    await run.ensure_compiler_venv()
+
+    # The venv was upgraded in place, not recreated
+    assert sentinel.exists()
+    log_doesnt_contain(caplog, "inmanta.server.services.compilerservice", logging.INFO, "Creating new venv at")
+    log_contains(caplog, "inmanta.server.services.compilerservice", logging.INFO, "Found existing venv")
+
+    # The stale .pth file was overwritten with freshly generated content and the version marker is
+    # bumped back to the current version
+    assert os.path.exists(pth_file)
+    with open(pth_file) as fh:
+        new_pth_content = fh.read()
+    assert new_pth_content != stale_pth_content
+    assert "/some/stale/path" not in new_pth_content
+    assert version_file.read_text().strip() == str(PythonEnvironment.VENV_VERSION)
 
 
 @pytest.mark.parametrize("use_post_endpoint", [True, False])


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/10636 but on the iso8 branch due to a merge conflict.** 

Fix incompatibility with pip 26.2 that breaks the venv inheritance. The inmanta-inherit-from-parent-venv.pth now only does addsitedir() calls for directories that are part of the parent venv and no other directories like python stdlib. (reference: https://github.com/pypa/pip/pull/14033)

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
