### PR TITLE
Only rewrite compiler venv version file when required

### DIFF
--- a/changelogs/unreleased/only-write-venv-version-file-when-required.yml
+++ b/changelogs/unreleased/only-write-venv-version-file-when-required.yml
@@ -1,0 +1,4 @@
+---
+description: "Don't rewrite the .inmanta_venv_version file of the compiler venv if not required. This prevents a race condition in the test suite."
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -693,6 +693,12 @@ class PythonEnvironment:
         """
         Write the venv version file into the venv.
         """
+        if self.is_venv_version_up_to_date():
+            # Only write the venv version file when required to prevent the race condition
+            # where the compiler service and the test suite are performing compiles concurrently.
+            # This happens in the lsm test suite for example by using the combination of the server
+            # fixture and the off_main_thread(partial(project.compile, model)) calls.
+            return
         with open(self.venv_version_file, "w") as fh:
             fh.write(str(self.VENV_VERSION))
 


### PR DESCRIPTION
# Description

Don't rewrite the `.inmanta_venv_version` file of the compiler venv to disk if not required. This prevents a race condition in the test suite (See: https://inmanta.slack.com/archives/CKRF0C8R3/p1786020382780689?thread_ts=1786009506.561809&cid=CKRF0C8R3)

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
