### PR TITLE
Relax cyclic GC thresholds during a compile

### DIFF
--- a/changelogs/unreleased/gc-tune-during-compile.yml
+++ b/changelogs/unreleased/gc-tune-during-compile.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Relax the cyclic GC thresholds for the duration of a compile, cutting compile time by 12% to 29% depending on the model
+destination-branches:
+- master
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/gc-tune-during-compile.yml
+++ b/changelogs/unreleased/gc-tune-during-compile.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: Relax the cyclic GC thresholds for the duration of a compile, cutting compile time by 8% to 29% depending on the model
+destination-branches:
+- master
+- iso9
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -16,6 +16,8 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import contextlib
+import gc
 import logging
 import sys
 from collections import abc
@@ -56,6 +58,30 @@ LOGGER: logging.Logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from inmanta.ast import BasicBlock, Statement  # noqa: F401
 
+# GC thresholds applied for the duration of a compile, see relaxed_gc_thresholds().
+COMPILE_GC_THRESHOLDS: tuple[int, int, int] = (5_000_000, 100, 100)
+
+
+@contextlib.contextmanager
+def relaxed_gc_thresholds() -> abc.Iterator[None]:
+    """
+    Scale up the cyclic GC thresholds for the duration of a compile.
+
+    A compile builds a large object graph that stays almost entirely live until the run ends,
+    so the default thresholds make the collector re-traverse it over and over while reclaiming
+    very little. Full collections alone account for roughly 80% of GC time.
+
+    Collection stays enabled, and the thresholds are sized so that it self-regulates: a small
+    compile finishes before gen0 ever fills, while a large one still collects periodically.
+    That matches disabling the GC on speed while still reclaiming where it matters.
+    """
+    original: tuple[int, int, int] = gc.get_threshold()
+    gc.set_threshold(*COMPILE_GC_THRESHOLDS)
+    try:
+        yield
+    finally:
+        gc.set_threshold(*original)
+
 
 def do_compile(refs: Optional[abc.Mapping[object, object]] = None) -> tuple[dict[str, inmanta_type.Type], Namespace]:
     """
@@ -69,22 +95,23 @@ def do_compile(refs: Optional[abc.Mapping[object, object]] = None) -> tuple[dict
     LOGGER.debug("Starting compile")
 
     project = module.Project.get()
-    try:
-        statements, blocks = compiler.compile()
-    except ParserException as e:
-        compiler.handle_exception(e)
-    sched = scheduler.Scheduler(compiler_config.track_dataflow(), project.get_relation_precedence_policy())
-    raised_compile_exception: bool = False
-    try:
-        success = sched.run(compiler, statements, blocks)
-    except CompilerException as e:
-        raised_compile_exception = True
-        if compiler_config.dataflow_graphic_enable.get():
-            show_dataflow_graphic(sched, compiler)
-        compiler.handle_exception(e)
-        success = False
-    finally:
-        Finalizers.call_finalizers(raised_compile_exception)
+    with relaxed_gc_thresholds():
+        try:
+            statements, blocks = compiler.compile()
+        except ParserException as e:
+            compiler.handle_exception(e)
+        sched = scheduler.Scheduler(compiler_config.track_dataflow(), project.get_relation_precedence_policy())
+        raised_compile_exception: bool = False
+        try:
+            success = sched.run(compiler, statements, blocks)
+        except CompilerException as e:
+            raised_compile_exception = True
+            if compiler_config.dataflow_graphic_enable.get():
+                show_dataflow_graphic(sched, compiler)
+            compiler.handle_exception(e)
+            success = False
+        finally:
+            Finalizers.call_finalizers(raised_compile_exception)
     LOGGER.debug("Compile done")
 
     if not success:

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import gc
 import os
 import re
 from itertools import groupby
@@ -137,3 +138,35 @@ def test_compile_plugin_typing_invalid(setup_project_for):
         "\n  Invalid type for value 'a', should be type test::Item (reported in test::badtype(c1.items)"
         " ({dir}/invalid.cf:16:5))"
     ).format(dir=project.project_path)
+
+
+def test_relaxed_gc_thresholds_scoped_to_compile():
+    """The relaxed GC thresholds are applied inside the block and always restored."""
+    original = gc.get_threshold()
+
+    with compiler.relaxed_gc_thresholds():
+        assert gc.get_threshold() == compiler.COMPILE_GC_THRESHOLDS
+        # collection must stay enabled, we only make it less frequent
+        assert gc.isenabled()
+    assert gc.get_threshold() == original
+
+    with pytest.raises(RuntimeError):
+        with compiler.relaxed_gc_thresholds():
+            raise RuntimeError("compile failed")
+    assert gc.get_threshold() == original
+
+
+def test_do_compile_restores_gc_thresholds(snippetcompiler):
+    """A real compile must not leak its GC settings into the calling process."""
+    original = gc.get_threshold()
+    snippetcompiler.setup_for_snippet("""
+        entity A:
+        end
+        implementation a for A:
+        end
+        implement A using a
+        A()
+        """)
+    compiler.do_compile()
+    assert gc.get_threshold() == original
+    assert gc.isenabled()


### PR DESCRIPTION
*Posted by Claude on behalf of @bartv.*

# Description

A compile builds a large object graph that stays almost entirely live until the run ends. Under the default thresholds the cyclic GC re-traverses it repeatedly while reclaiming very little: on the `inmanta_infra` benchmark, GC costs ~4.3s of a ~12.9s compile, ~80% of that in full collections. A forced `gc.collect()` immediately after a compile frees **0** cyclic objects on master, confirming the work is pure re-traversal of live objects rather than reclamation.

This scales the GC thresholds up to `(5_000_000, 100, 100)` for the duration of `do_compile` and restores them in a `finally`. Collection stays **enabled** and self-regulates by workload: a small compile finishes before gen0 fills, a large one still collects periodically.

## Results

Measured with compiler-bench, one compile per process, 3 runs per config:

| Benchmark           | master   | branch   | delta      |
| ------------------- | -------- | -------- | ---------- |
| `athonet_mpn`       | 95.77s   | 67.85s   | **-29.2%** |
| `connect_infra`     | 14.50s   | 10.99s   | -24.2%     |
| `connect_demo`      | 5.70s    | 4.60s    | -19.3%     |
| `systemtenant`      | 7.13s    | 5.87s    | -17.7%     |
| `systemtenant-full` | 140.66s  | 115.99s  | -17.5%     |
| `inmanta_infra`     | 13.68s   | 12.00s   | -12.3%     |
| `connect_enet`      | 14.11s   | 13.00s   | -7.9%      |

Every benchmark in the suite improves, by -8% to -29%.

`inmanta_infra` understates the effect: ~24% of its timed region is pytest-inmanta fixture work outside `do_compile`. Timed on `do_compile` alone it is -17% to -20%.

Module test suites run many compiles in one process, so those were measured separately. On a large model the win is undiminished by repetition; on a small one it washes out but does not regress:

| Benchmark      | compiles | master    | branch    | delta      |
| -------------- | -------- | --------- | --------- | ---------- |
| `athonet_mpn`  | 4        | 412.84s   | 293.73s   | **-28.9%** |
| `connect_demo` | 8        | 53.39s    | 52.55s    | -1.6%      |

## Why these thresholds

Sweep, best of 3 per config, vs default thresholds:

| Strategy         | `inmanta_infra` | `systemtenant-full` |
| ---------------- | --------------- | ------------------- |
| `gc.disable()`   | -19.5%          | -22.9%              |
| `200k,100,100`   | -16.2%          | -20.9%              |
| `1M,100,100`     | -17.9%          | -22.6%              |
| **`5M,100,100`** | **-20.0%**      | **-24.1%**          |

gen1/gen2 at 100 suppress full collections (~80% of GC time); the high gen0 removes the frequent young-generation passes. The chosen values match `gc.disable()` on speed without giving up reclamation.

## Memory

Peak RSS is unchanged on `systemtenant-full` (1216MB vs 1218MB baseline) and +35MB on the much smaller `inmanta_infra`, where the compile ends before any collection triggers. Across repeated compiles it plateaus rather than growing: +15MB on `connect_demo`, +14MB on `athonet_mpn`. Over `tests/compiler/` (hundreds of in-process compiles) peak RSS is byte-identical to master.

## Alternatives rejected

- **`gc.freeze()` after loading** - only reaches objects existing before execution starts, measured **+1.4%** (no effect). The cost is in the graph built *during* execution, which freeze cannot reach.
- **Trailing `gc.collect()` at the end of `do_compile`** - smooths the per-compile curve in multi-compile processes but costs ~1s per compile, cancelling the gain exactly.
- **Config options** - deliberately none. The three integers are not independently meaningful, and bad values (`gen0=0` disables collection entirely) would be actively harmful. The values self-regulate by workload, which is the one thing tuning would otherwise be for. Happy to add a single boolean escape hatch if reviewers want one.

## Relationship to #10091

Complementary, no overlap. #10091 (`os._exit()`) skips interpreter **shutdown** teardown for the CLI only; this reduces collections **during** the compile for all callers (CLI, orchestrator, tests, pytest-inmanta). This change leaves the live graph the same size and the same cost to walk (post-compile `gc.collect()`: 0.37s master vs 0.38s branch), so #10091's win is untouched. One caveat: #10091's "almost 30% of time goes into GC" is very close to what I measured *during* the compile (~33%) - if that figure came from a profile rather than from timing the exit, part of it may be during-compile GC that `os._exit()` cannot recover but this PR does. Worth checking before assuming the wins stack.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (mypy output identical to master, no new errors)
- [x] Sufficient test cases (2 added: thresholds applied/restored incl. on exception; a real compile does not leak settings)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite~~

`tests/compiler/` + `tests/test_compilation.py`: 706 passed, 1 skipped, 2 xfailed, identical to master. Server/agent/moduletool suites were not run locally (need postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7WTQ2SWoC2kgu5wk2LBu4
