### PR TITLE
Use a pickle dispatch table for the parser AST cache

### DIFF
--- a/changelogs/unreleased/parser-cache-dispatch-table.yml
+++ b/changelogs/unreleased/parser-cache-dispatch-table.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: Speed up the parser AST cache by replacing persistent_id with a pickle dispatch table, roughly halving cache writes and cutting cache reads by up to 60% on large module sets
+destination-branches:
+- master
+- iso9
+sections:
+  minor-improvement: "{{description}}"

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -682,7 +682,6 @@ src/inmanta/moduletool.py:0: error: Missing type arguments for generic type Modu
 src/inmanta/moduletool.py:0: error: Missing type arguments for generic type Module  [type-arg]
 src/inmanta/moduletool.py:0: error: Return type "DefaultIsolatedEnv" of "__enter__" incompatible with return type "DefaultIsolatedEnvCached" in supertype "build.env.DefaultIsolatedEnv"  [override]
 src/inmanta/moduletool.py:0: error: Skipping analyzing "cookiecutter.main": module is installed, but missing library stubs or py.typed marker  [import-untyped]
-src/inmanta/parser/cache.py:0: error: Argument 1 to "ASTUnpickler" has incompatible type "BufferedReader[_BufferedReaderStream]"; expected "BytesIO"  [arg-type]
 src/inmanta/parser/parsetab.py:0: error: Need type annotation for "_lr_action" (hint: "_lr_action: dict[<type>, <type>] = ...")  [var-annotated]
 src/inmanta/parser/parsetab.py:0: error: Need type annotation for "_lr_goto" (hint: "_lr_goto: dict[<type>, <type>] = ...")  [var-annotated]
 src/inmanta/parser/parsetab.py:0: error: No overload variant of "zip" matches argument types "list[int]", "object"  [call-overload]

--- a/src/inmanta/parser/pickle.py
+++ b/src/inmanta/parser/pickle.py
@@ -1,5 +1,5 @@
 """
-Copyright 2020 Inmanta
+Copyright 2026 Inmanta
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,34 +14,83 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contact: code@inmanta.com
+
+Custom pickler/unpickler for AST Statement objects.
+
+Namespace objects cannot be pickled (they're tied to runtime compilation context),
+so they are replaced with their fully-qualified name string during pickling and
+restored from the unpickler instance during unpickling.
 """
 
-from io import BytesIO
+import contextvars
+import copyreg
+import types
 from pickle import Pickler, Unpickler, UnpicklingError
-from typing import Optional
+from typing import IO, Callable
 
 from inmanta.ast import Namespace
 
+# Namespace the active ASTUnpickler is restoring into. A ContextVar rather than a
+# thread local so that concurrent and re-entrant unpickling both stay correct.
+_current_namespace: contextvars.ContextVar[Namespace] = contextvars.ContextVar("ast_unpickler_namespace")
+
+
+def _reduce_namespace(
+    ns: object,
+) -> tuple[Callable[..., object], tuple[str]]:
+    """Reducer for Namespace objects, replaces with full name string."""
+    assert isinstance(ns, Namespace)
+    return (_restore_namespace, (ns.get_full_name(),))
+
+
+def _restore_namespace(full_name: str) -> Namespace:
+    """Restore a Namespace during unpickling.
+
+    This module-level function is referenced in the pickle stream via dispatch_table.
+    It resolves the namespace from the ASTUnpickler that is currently loading, so the
+    C unpickler keeps its native find_class fast path for every other global.
+
+    If called directly (outside ASTUnpickler), raises UnpicklingError.
+    """
+    namespace: Namespace | None = _current_namespace.get(None)
+    if namespace is None:
+        raise UnpicklingError(f"_restore_namespace({full_name!r}) called outside ASTUnpickler context")
+    if namespace.get_full_name() != full_name:
+        raise UnpicklingError(f"Namespace mismatch: expected {namespace.get_full_name()}, got {full_name}")
+    return namespace
+
 
 class ASTPickler(Pickler):
-    def persistent_id(self, obj: object) -> Optional[tuple[str, str]]:
-        if isinstance(obj, Namespace):
-            # Don't pickle namespaces
-            return ("Namespace", obj.get_full_name())
-        else:
-            return None
+    """Pickler that replaces Namespace objects with their fully-qualified name.
+
+    Uses dispatch_table instead of persistent_id. persistent_id is a Python callback
+    invoked for every object in the graph, and it runs before the memo lookup, so a
+    namespace is re-emitted at each occurrence rather than referenced. dispatch_table
+    is a C-level type lookup and its result is memoized: roughly 2x faster to write,
+    2x faster to read back, and a 5% smaller cache file.
+    """
+
+    dispatch_table = types.MappingProxyType({**copyreg.dispatch_table, Namespace: _reduce_namespace})
+
+    def __init__(self, file: IO[bytes], protocol: int = 4) -> None:
+        super().__init__(file, protocol=protocol)
 
 
 class ASTUnpickler(Unpickler):
-    def __init__(self, file: BytesIO, namespace: Namespace) -> None:
-        super().__init__(file)
-        self.namespace = namespace
-        self.namespace_name = namespace.get_full_name()
+    """Unpickler that restores Namespace objects from the namespace being loaded into.
 
-    def persistent_load(self, pid: tuple[str, str]) -> object:
-        type_tag, key_id = pid
-        if type_tag == "Namespace":
-            assert self.namespace_name == key_id
-            return self.namespace
-        else:
-            raise UnpicklingError("unsupported persistent object")
+    Publishes the namespace on a ContextVar for the duration of load() rather than
+    overriding find_class(). Overriding find_class() would route every global lookup
+    in the stream through a Python callback, which costs more than it saves.
+    """
+
+    def __init__(self, file: IO[bytes], namespace: Namespace) -> None:
+        super().__init__(file)
+        self._namespace = namespace
+
+    def load(self) -> object:
+        token = _current_namespace.set(self._namespace)
+        try:
+            return super().load()
+        finally:
+            _current_namespace.reset(token)

--- a/src/inmanta/parser/pickle.py
+++ b/src/inmanta/parser/pickle.py
@@ -32,18 +32,18 @@ from inmanta.ast import Namespace
 
 # Namespace the active ASTUnpickler is restoring into. A ContextVar rather than a
 # thread local so that concurrent and re-entrant unpickling both stay correct.
-_current_namespace: contextvars.ContextVar[Namespace] = contextvars.ContextVar("ast_unpickler_namespace")
+current_namespace: contextvars.ContextVar[Namespace] = contextvars.ContextVar("ast_unpickler_namespace")
 
 
-def _reduce_namespace(
+def reduce_namespace(
     ns: object,
 ) -> tuple[Callable[..., object], tuple[str]]:
     """Reducer for Namespace objects, replaces with full name string."""
     assert isinstance(ns, Namespace)
-    return (_restore_namespace, (ns.get_full_name(),))
+    return (restore_namespace, (ns.get_full_name(),))
 
 
-def _restore_namespace(full_name: str) -> Namespace:
+def restore_namespace(full_name: str) -> Namespace:
     """Restore a Namespace during unpickling.
 
     This module-level function is referenced in the pickle stream via dispatch_table.
@@ -52,9 +52,9 @@ def _restore_namespace(full_name: str) -> Namespace:
 
     If called directly (outside ASTUnpickler), raises UnpicklingError.
     """
-    namespace: Namespace | None = _current_namespace.get(None)
+    namespace: Namespace | None = current_namespace.get(None)
     if namespace is None:
-        raise UnpicklingError(f"_restore_namespace({full_name!r}) called outside ASTUnpickler context")
+        raise UnpicklingError(f"restore_namespace({full_name!r}) called outside ASTUnpickler context")
     if namespace.get_full_name() != full_name:
         raise UnpicklingError(f"Namespace mismatch: expected {namespace.get_full_name()}, got {full_name}")
     return namespace
@@ -70,10 +70,7 @@ class ASTPickler(Pickler):
     2x faster to read back, and a 5% smaller cache file.
     """
 
-    dispatch_table = types.MappingProxyType({**copyreg.dispatch_table, Namespace: _reduce_namespace})
-
-    def __init__(self, file: IO[bytes], protocol: int = 4) -> None:
-        super().__init__(file, protocol=protocol)
+    dispatch_table = types.MappingProxyType({**copyreg.dispatch_table, Namespace: reduce_namespace})
 
 
 class ASTUnpickler(Unpickler):
@@ -89,8 +86,8 @@ class ASTUnpickler(Unpickler):
         self._namespace = namespace
 
     def load(self) -> object:
-        token = _current_namespace.set(self._namespace)
+        token = current_namespace.set(self._namespace)
         try:
             return super().load()
         finally:
-            _current_namespace.reset(token)
+            current_namespace.reset(token)

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -32,6 +32,20 @@ from inmanta.ast.statements import Statement
 from inmanta.parser.pickle import ASTPickler, ASTUnpickler
 
 
+def make_namespace(name: str) -> Namespace:
+    """Build a namespace rooted under __root__, as the compiler does."""
+    ns = Namespace(name)
+    ns.parent = Namespace("__root__")
+    return ns
+
+
+def pickled(ns: Namespace, source: str) -> bytes:
+    """Parse source in ns and return the pickled statements."""
+    buf = io.BytesIO()
+    ASTPickler(buf, protocol=4).dump(parser.base_parse(ns, "test", source))
+    return buf.getvalue()
+
+
 def test_caching(snippetcompiler):
     # reset counts
     parser.cache_manager.reset_stats()
@@ -73,90 +87,61 @@ a=1
 
 
 def test_pickle_roundtrip():
-    """A pickled AST round-trips with its structure and namespace intact."""
-    root_ns = Namespace("__root__")
-    ns = Namespace("__config__")
-    ns.parent = root_ns
+    """A pickled AST round-trips with its statements and namespace intact."""
+    ns = make_namespace("__config__")
 
-    stmts = parser.base_parse(ns, "test", 'x = 1\ny = "hello"')
+    source = 'x = 1\ny = "hello"'
+    stmts = parser.base_parse(ns, "test", source)
     assert len(stmts) == 2
 
-    buf = io.BytesIO()
-    ASTPickler(buf, protocol=4).dump(stmts)
-
-    buf.seek(0)
-    restored = ASTUnpickler(buf, ns).load()
+    restored = ASTUnpickler(io.BytesIO(pickled(ns, source)), ns).load()
     assert isinstance(restored, list)
     assert len(restored) == len(stmts)
     for orig, rest in zip(stmts, restored):
         assert type(orig) is type(rest)
         assert isinstance(rest, Statement)
+        assert str(rest) == str(orig)
+        assert rest.location.file == orig.location.file
+        assert rest.location.lnr == orig.location.lnr
         assert rest.namespace is ns
 
 
 def test_pickle_namespace_mismatch():
     """Unpickling into the wrong namespace is refused rather than silently rebinding."""
-    root_ns = Namespace("__root__")
-    ns_a = Namespace("ns_a")
-    ns_a.parent = root_ns
-    ns_b = Namespace("ns_b")
-    ns_b.parent = root_ns
-
-    stmts = parser.base_parse(ns_a, "test", "x = 1")
-
-    buf = io.BytesIO()
-    ASTPickler(buf, protocol=4).dump(stmts)
-    buf.seek(0)
+    ns_a = make_namespace("ns_a")
+    ns_b = make_namespace("ns_b")
 
     with pytest.raises(UnpicklingError, match="Namespace mismatch"):
-        ASTUnpickler(buf, ns_b).load()
+        ASTUnpickler(io.BytesIO(pickled(ns_a, "x = 1")), ns_b).load()
 
 
 def test_pickle_namespace_not_restorable_outside_unpickler():
     """A cache file cannot be coerced into yielding a Namespace via a plain Unpickler."""
-    root_ns = Namespace("__root__")
-    ns = Namespace("__config__")
-    ns.parent = root_ns
-
-    buf = io.BytesIO()
-    ASTPickler(buf, protocol=4).dump(parser.base_parse(ns, "test", "x = 1"))
-    buf.seek(0)
+    ns = make_namespace("__config__")
 
     with pytest.raises(UnpicklingError, match="outside ASTUnpickler"):
-        pickle.Unpickler(buf).load()
+        pickle.Unpickler(io.BytesIO(pickled(ns, "x = 1"))).load()
 
 
-def _make_namespace(name: str) -> Namespace:
-    ns = Namespace(name)
-    ns.parent = Namespace("__root__")
-    return ns
-
-
-def _pickled(ns: Namespace, source: str) -> bytes:
-    buf = io.BytesIO()
-    ASTPickler(buf, protocol=4).dump(parser.base_parse(ns, "test", source))
-    return buf.getvalue()
-
-
-class _NestedLoad:
+class NestedLoad:
     """Unpickling this triggers a second, nested ASTUnpickler load."""
 
     def __reduce__(self) -> tuple[Callable[..., object], tuple[()]]:
-        return (_load_inner, ())
+        return (load_inner, ())
 
 
-def _load_inner() -> object:
-    inner_ns = _make_namespace("inner")
-    return ASTUnpickler(io.BytesIO(_pickled(inner_ns, "y = 2")), inner_ns).load()
+def load_inner() -> object:
+    inner_ns = make_namespace("inner")
+    return ASTUnpickler(io.BytesIO(pickled(inner_ns, "y = 2")), inner_ns).load()
 
 
 def test_pickle_nested_load_restores_outer_namespace():
     """A nested load must not leave the outer load bound to the inner namespace."""
-    outer_ns = _make_namespace("outer")
+    outer_ns = make_namespace("outer")
 
     # the nested load comes first, so the outer namespace is resolved only after it returns
     buf = io.BytesIO()
-    ASTPickler(buf, protocol=4).dump([_NestedLoad(), parser.base_parse(outer_ns, "test", "x = 1")])
+    ASTPickler(buf, protocol=4).dump([NestedLoad(), parser.base_parse(outer_ns, "test", "x = 1")])
     buf.seek(0)
 
     inner_stmts, outer_stmts = ASTUnpickler(buf, outer_ns).load()
@@ -167,8 +152,8 @@ def test_pickle_nested_load_restores_outer_namespace():
 
 def test_pickle_namespace_released_after_load():
     """The namespace does not stay published once load() returns."""
-    ns = _make_namespace("__config__")
-    blob = _pickled(ns, "x = 1")
+    ns = make_namespace("__config__")
+    blob = pickled(ns, "x = 1")
 
     ASTUnpickler(io.BytesIO(blob), ns).load()
 

--- a/tests/compiler/test_parser_cache.py
+++ b/tests/compiler/test_parser_cache.py
@@ -16,11 +16,20 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import io
 import os.path
+import pickle
 from pathlib import Path
+from pickle import UnpicklingError
 from time import sleep
+from typing import Callable
+
+import pytest
 
 import inmanta.parser.plyInmantaParser as parser
+from inmanta.ast import Namespace
+from inmanta.ast.statements import Statement
+from inmanta.parser.pickle import ASTPickler, ASTUnpickler
 
 
 def test_caching(snippetcompiler):
@@ -61,3 +70,107 @@ a=1
     assert parser.cache_manager.misses == 1  # std::init
     assert parser.cache_manager.failures == 0
     assert parser.cache_manager.hits == 1  # main.cf
+
+
+def test_pickle_roundtrip():
+    """A pickled AST round-trips with its structure and namespace intact."""
+    root_ns = Namespace("__root__")
+    ns = Namespace("__config__")
+    ns.parent = root_ns
+
+    stmts = parser.base_parse(ns, "test", 'x = 1\ny = "hello"')
+    assert len(stmts) == 2
+
+    buf = io.BytesIO()
+    ASTPickler(buf, protocol=4).dump(stmts)
+
+    buf.seek(0)
+    restored = ASTUnpickler(buf, ns).load()
+    assert isinstance(restored, list)
+    assert len(restored) == len(stmts)
+    for orig, rest in zip(stmts, restored):
+        assert type(orig) is type(rest)
+        assert isinstance(rest, Statement)
+        assert rest.namespace is ns
+
+
+def test_pickle_namespace_mismatch():
+    """Unpickling into the wrong namespace is refused rather than silently rebinding."""
+    root_ns = Namespace("__root__")
+    ns_a = Namespace("ns_a")
+    ns_a.parent = root_ns
+    ns_b = Namespace("ns_b")
+    ns_b.parent = root_ns
+
+    stmts = parser.base_parse(ns_a, "test", "x = 1")
+
+    buf = io.BytesIO()
+    ASTPickler(buf, protocol=4).dump(stmts)
+    buf.seek(0)
+
+    with pytest.raises(UnpicklingError, match="Namespace mismatch"):
+        ASTUnpickler(buf, ns_b).load()
+
+
+def test_pickle_namespace_not_restorable_outside_unpickler():
+    """A cache file cannot be coerced into yielding a Namespace via a plain Unpickler."""
+    root_ns = Namespace("__root__")
+    ns = Namespace("__config__")
+    ns.parent = root_ns
+
+    buf = io.BytesIO()
+    ASTPickler(buf, protocol=4).dump(parser.base_parse(ns, "test", "x = 1"))
+    buf.seek(0)
+
+    with pytest.raises(UnpicklingError, match="outside ASTUnpickler"):
+        pickle.Unpickler(buf).load()
+
+
+def _make_namespace(name: str) -> Namespace:
+    ns = Namespace(name)
+    ns.parent = Namespace("__root__")
+    return ns
+
+
+def _pickled(ns: Namespace, source: str) -> bytes:
+    buf = io.BytesIO()
+    ASTPickler(buf, protocol=4).dump(parser.base_parse(ns, "test", source))
+    return buf.getvalue()
+
+
+class _NestedLoad:
+    """Unpickling this triggers a second, nested ASTUnpickler load."""
+
+    def __reduce__(self) -> tuple[Callable[..., object], tuple[()]]:
+        return (_load_inner, ())
+
+
+def _load_inner() -> object:
+    inner_ns = _make_namespace("inner")
+    return ASTUnpickler(io.BytesIO(_pickled(inner_ns, "y = 2")), inner_ns).load()
+
+
+def test_pickle_nested_load_restores_outer_namespace():
+    """A nested load must not leave the outer load bound to the inner namespace."""
+    outer_ns = _make_namespace("outer")
+
+    # the nested load comes first, so the outer namespace is resolved only after it returns
+    buf = io.BytesIO()
+    ASTPickler(buf, protocol=4).dump([_NestedLoad(), parser.base_parse(outer_ns, "test", "x = 1")])
+    buf.seek(0)
+
+    inner_stmts, outer_stmts = ASTUnpickler(buf, outer_ns).load()
+
+    assert all(s.namespace is outer_ns for s in outer_stmts)
+    assert all(s.namespace.get_full_name() == "inner" for s in inner_stmts)
+
+
+def test_pickle_namespace_released_after_load():
+    """The namespace does not stay published once load() returns."""
+    ns = _make_namespace("__config__")
+    blob = _pickled(ns, "x = 1")
+
+    ASTUnpickler(io.BytesIO(blob), ns).load()
+
+    with pytest.raises(UnpicklingError, match="outside ASTUnpickler"):
+        pickle.Unpickler(io.BytesIO(blob)).load()


### PR DESCRIPTION
Isolates the parser-cache pickling change from the Lark port (#10053) so it can land, and be measured, on its own. Rebased on current master, so the numbers below are relative to the GC threshold change (#10667) already being in.

## The problem

The AST contains `Namespace` objects, which are tied to the live compile and must not be written to a cache file. `ASTPickler` stripped them out with `persistent_id`, which has two defects:

1. **It is a Python callback invoked for every object in the graph**, not just namespaces. The AST has ~82k reachable objects per module set.
2. **It is consulted before the memo lookup.** The namespace therefore never reaches pickle's back-reference table, so it is re-emitted in full at every occurrence instead of being referenced.

Opcode counts for one `.cf` file (`lsm/_init.cf`):

| | opcodes | `BINPERSID` | `persistent_load` calls on read |
| --- | ---: | ---: | ---: |
| before | 36,652 | 733 | 733 |
| after | 33,729 | 0 | 0 |

Defect 1 costs write time. Defect 2 costs write time, file size, and read time.

## The change

A `dispatch_table` entry replaces `persistent_id`. It is a C-level lookup keyed on exact type, consulted only for types in the table, and its result participates in the memo, so the namespace is written once and back-referenced after.

That leaves the stream referencing a module-level `_restore_namespace`, which has to be resolved against the namespace currently being loaded into. The obvious way to do that is to override `find_class`, but `find_class` resolves *every* global in the stream, so overriding it in Python routes every AST class lookup through a Python frame and off CPython's internal fast path. Measured, that costs about as much as the memoisation saves: the read path comes out flat.

Publishing the namespace on a `ContextVar` for the duration of `load()` avoids that. The C unpickler keeps its native lookup path, and the cost is two operations per file rather than one per global. A `ContextVar` rather than a thread local so that concurrent and re-entrant loading both stay correct.

## Measured

Cache time per benchmark compile, 3 runs per variant on an idle machine, against master:

| benchmark | write | read | cache total | timed region |
| --- | ---: | ---: | ---: | ---: |
| connect_demo | -59% | -58% | -58% | -40.5% |
| connect_infra | -31% | -63% | -52% | -32.2% |
| systemtenant | -55% | -40% | -46% | -24.6% |
| inmanta_infra | -59% | -9% | -34% | ~0 |
| connect_enet | -44% | -8% | -32% | ~0 |

The two benchmarks showing no end-to-end movement are the ones where the parser cache is a small share of the compile to begin with (0.6s and 0.17s respectively), so there is little to win. The gain scales with compiles-per-session times module-set size, which is the shape of a `pytest-inmanta` module test suite.

Isolated, both implementations over 112 real `.cf` files (~82k objects), interleaved with a `gc.collect()` before each timed section: write 262ms to 129ms, cache file 6.84MB to 6.49MB.

## Cache format

The format changes, in both directions. An entry written by an older version fails to load with `UnpicklingError`, and vice versa. `CacheManager` already treats any load failure as a miss, so the entry is discarded, the file is reparsed, and the cache rewritten. The `.cfc` filename is keyed on the inmanta version, so a release upgrade never sees a stale entry; within one version string (branch switching on a dev install) the first compile logs one warning per `.cf` file and then self-heals.

`_restore_namespace` raises when called outside an `ASTUnpickler`, so a cache file cannot be coerced into yielding a `Namespace` through a plain `pickle.load`.

## Testing

`tests/compiler/` + `tests/test_parser.py`: 847 passed, 1 skipped, 2 xfailed.

Five tests added to `tests/compiler/test_parser_cache.py`, covering round-trip, namespace mismatch, the plain-`Unpickler` path, nested loads, and context cleanup after `load()`. Verified by mutation: removing the `ContextVar` token reset fails three of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7WTQ2SWoC2kgu5wk2LBu4