### PR TITLE
Only import logfire when tracing is enabled

### DIFF
--- a/changelogs/unreleased/lazy-logfire-import.yml
+++ b/changelogs/unreleased/lazy-logfire-import.yml
@@ -1,0 +1,7 @@
+description: Only import logfire when a LOGFIRE_TOKEN is set. Importing it pulls in opentelemetry and rich, which costs about 200ms of process startup even though nothing uses it without a token.
+change-type: patch
+destination-branches:
+  - master
+  - iso9
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/lazy-logfire-import.yml
+++ b/changelogs/unreleased/lazy-logfire-import.yml
@@ -1,4 +1,4 @@
-description: Only import logfire when a LOGFIRE_TOKEN is set. Importing it pulls in opentelemetry and rich, which costs about 200ms of process startup even though nothing uses it without a token.
+description: Only import logfire when a LOGFIRE_TOKEN is set, saving about 200ms of process startup in dev and CI.
 change-type: patch
 destination-branches:
   - master

--- a/changelogs/unreleased/lazy-logfire-import.yml
+++ b/changelogs/unreleased/lazy-logfire-import.yml
@@ -3,5 +3,3 @@ change-type: patch
 destination-branches:
   - master
   - iso9
-sections:
-  minor-improvement: "{{description}}"

--- a/src/inmanta/logging.py
+++ b/src/inmanta/logging.py
@@ -42,10 +42,11 @@ from inmanta.server import config as server_config
 from inmanta.stable_api import stable_api
 
 logfire_enabled = os.getenv("LOGFIRE_TOKEN", None) is not None
-try:
-    from logfire.integrations.logging import LogfireLoggingHandler
-except ModuleNotFoundError:
-    logfire_enabled = False
+if logfire_enabled:
+    try:
+        from logfire.integrations.logging import LogfireLoggingHandler
+    except ModuleNotFoundError:
+        logfire_enabled = False
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/inmanta/tracing.py
+++ b/src/inmanta/tracing.py
@@ -25,20 +25,20 @@ LOGGER = logging.getLogger("inmanta")
 
 # We need this early to make @instrument work
 enabled = os.getenv("LOGFIRE_TOKEN", None) is not None
-try:
-    import logfire._internal.config
-    import logfire.integrations
-    import logfire.integrations.pydantic
-    import logfire.propagate
-    from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
+if enabled:
+    # Importing logfire costs ~200ms and pulls in opentelemetry and rich, so only do it when it is actually going to be used.
+    try:
+        import logfire._internal.config
+        import logfire.integrations
+        import logfire.integrations.pydantic
+        import logfire.propagate
+        from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
 
-    # Make sure we don't get warnings when it is off
-    logfire._internal.config.GLOBAL_CONFIG.ignore_no_config = True
-    enabled = os.getenv("LOGFIRE_TOKEN", None) is not None
+        # Make sure we don't get warnings when it is off
+        logfire._internal.config.GLOBAL_CONFIG.ignore_no_config = True
 
-
-except (ModuleNotFoundError, Exception):
-    enabled = False
+    except (ModuleNotFoundError, Exception):
+        enabled = False
 
 # Retaken from Logfire 1.0.1 to make sure tests pass even if logfire is not installed
 LevelName = Literal["trace", "debug", "info", "notice", "warn", "warning", "error", "fatal"]
@@ -184,4 +184,10 @@ def instrument(
 def enable() -> None:
     """Replace dummy instrumentation with the real deal"""
     global enabled
+    # The module level import is skipped when no token is set, so make sure logfire is loaded before anything uses it.
+    import logfire._internal.config
+    import logfire.integrations.pydantic  # noqa: F401
+    import logfire.propagate  # noqa: F401
+
+    logfire._internal.config.GLOBAL_CONFIG.ignore_no_config = True
     enabled = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,14 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import os
+
+if os.getenv("LOGFIRE_TOKEN") is None:
+    # Logfire registers a pydantic entry point plugin, which pydantic autoloads on the first BaseModel subclass. That
+    # pulls in logfire, opentelemetry and rich on every interpreter start, including every subprocess the tests spawn.
+    # Without a token none of it does anything, so suppress it. Must happen before the first pydantic model is created.
+    os.environ.setdefault("PYDANTIC_DISABLE_PLUGINS", "logfire-plugin")
+
 import asyncio
 import concurrent
 import copy
@@ -24,7 +32,6 @@ import datetime
 import json
 import logging
 import logging.config
-import os
 import pathlib
 import queue
 import random


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

This PR takes the stubbing we did a few years ago a bit further so that no loading happens at all. Impact is mostly on faster tests.

Importing `logfire` pulls in `opentelemetry` and `rich`, costing roughly 200 ms of process startup. Without a `LOGFIRE_TOKEN` none of it does anything, so the imports in `tracing.py` and `logging.py` move under the existing token check, and `enable()` imports logfire itself.

Guarding those imports alone achieves nothing: logfire's `logfire-plugin` pydantic entry point is autoloaded on the first `BaseModel` subclass and pulls it straight back in. `tests/conftest.py` therefore sets `PYDANTIC_DISABLE_PLUGINS` when no token is set, where the cost was paid on every spawned subprocess.

On `tests/test_app_cli.py`, 38 of 40 interpreter starts loaded logfire before and 1 after, 52.9 s to 45.7 s. Dev/CI only: logfire ships in the optional `tracing` extra.

For review: a process calling `tracing.enable()` late, rather than setting `LOGFIRE_TOKEN` at startup, now loses pydantic instrumentation. Nothing does that today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
