### PR TITLE
Defer heavy imports out of the compiler startup path

### DIFF
--- a/changelogs/unreleased/lazy-compiler-startup-imports.yml
+++ b/changelogs/unreleased/lazy-compiler-startup-imports.yml
@@ -1,0 +1,7 @@
+description: Cut compiler startup time by importing strawberry, cookiecutter, tornado, asyncpg, the server bootloader and the resource scheduler only where they are actually used, instead of on every invocation.
+change-type: patch
+destination-branches:
+  - master
+  - iso9
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/agent/__init__.py
+++ b/src/inmanta/agent/__init__.py
@@ -16,8 +16,24 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-from inmanta.agent.agent_new import Agent
+from typing import TYPE_CHECKING
 
 # flake8: noqa: F401
-# Backward compatibility
-from inmanta.agent.reporting import collect_report
+# Agent and collect_report are kept importable from this package for backward compatibility, but are resolved lazily by
+# __getattr__ below. Importing agent_new eagerly pulls the scheduler and the whole server into the import graph of everything
+# that touches inmanta.agent, including the compiler.
+if TYPE_CHECKING:
+    from inmanta.agent.agent_new import Agent
+    from inmanta.agent.reporting import collect_report
+
+
+def __getattr__(name: str) -> object:
+    if name == "Agent":
+        from inmanta.agent import agent_new
+
+        return agent_new.Agent
+    if name == "collect_report":
+        from inmanta.agent import reporting
+
+        return reporting.collect_report
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -50,8 +50,6 @@ from configparser import ConfigParser
 from typing import Optional
 
 import click
-from tornado.httpclient import AsyncHTTPClient
-from tornado.ioloop import IOLoop
 
 import inmanta.compiler as compiler
 from inmanta import const, module, moduletool, protocol, tracing, util
@@ -66,7 +64,6 @@ from inmanta.export import cfg_env
 from inmanta.logging import InmantaLoggerConfig, _is_on_tty
 from inmanta.protocol import common
 from inmanta.server import config as opt
-from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.services.databaseservice import initialize_database_connection_pool
 from inmanta.server.services.metricservice import MetricsService
 from inmanta.signals import safe_shutdown, setup_signal_handlers
@@ -108,6 +105,11 @@ def start_server(options: argparse.Namespace) -> None:
     if options.compatibility_file is not None:
         Config.set("server", "compatibility_file", str(options.compatibility_file))
 
+    # Imported here to keep tornado and the server bootloader out of the import graph of the commands that don't need them.
+    from tornado.ioloop import IOLoop
+
+    from inmanta.server.bootloader import InmantaBootloader
+
     tracing.configure_logfire("server")
     util.ensure_event_loop()
 
@@ -143,6 +145,10 @@ def start_scheduler(options: argparse.Namespace) -> None:
     """
     Start the new agent with the Resource Scheduler
     """
+    # Imported here to keep tornado out of the import graph of the commands that don't need it.
+    from tornado.httpclient import AsyncHTTPClient
+    from tornado.ioloop import IOLoop
+
     from inmanta.agent import agent_new
 
     # The call to configure() should be done as soon as possible.
@@ -963,6 +969,8 @@ def default_logging_config(options: argparse.Namespace) -> None:
 
         if options.config_for_component == "server":
             # Upgrade with extensions
+            from inmanta.server.bootloader import InmantaBootloader
+
             ibl = InmantaBootloader()
             ibl.start_loggers_for_extensions(component_config)
 
@@ -1006,6 +1014,8 @@ def policy_engine(options: argparse.Namespace) -> None:
 def print_versions_installed_components_and_exit() -> None:
     # coroutine to make sure event loop is running for server slices
     async def print_status() -> None:
+        from inmanta.server.bootloader import InmantaBootloader
+
         bootloader = InmantaBootloader()
         app_context = bootloader.load_slices()
         product_metadata = app_context.get_product_metadata()

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -49,7 +49,6 @@ import packaging.version
 from inmanta import const
 from inmanta.ast import CompilerException
 from inmanta.data.model import LEGACY_PIP_DEFAULT, PipConfig
-from inmanta.server.bootloader import InmantaBootloader
 from inmanta.stable_api import stable_api
 from inmanta.util import parse_requirement, strtobool
 from packaging.utils import NormalizedName, canonicalize_name
@@ -1082,6 +1081,9 @@ import sys
         Returns the list of packages that should not be installed/updated by any operation on a Python environment.
         This list of packages will be under the canonical form.
         """
+        # Imported here to keep the server bootloader out of the compiler's import graph.
+        from inmanta.server.bootloader import InmantaBootloader
+
         return [
             # Protect product packages
             packaging.utils.canonicalize_name("inmanta"),

--- a/src/inmanta/graphql/result.py
+++ b/src/inmanta/graphql/result.py
@@ -15,7 +15,10 @@ Contact: code@inmanta.com
 import typing
 
 from inmanta.types import BaseModel
-from strawberry.types.execution import ExecutionResult
+
+if typing.TYPE_CHECKING:
+    # Importing strawberry pulls in the graphql package, which is expensive and not needed to define this model.
+    from strawberry.types.execution import ExecutionResult
 
 
 class GraphQLResult(BaseModel):
@@ -35,7 +38,7 @@ class GraphQLResult(BaseModel):
         return 200 if self.data else 400
 
     @classmethod
-    def from_execution_result(cls, execution_result: ExecutionResult) -> "GraphQLResult":
+    def from_execution_result(cls, execution_result: "ExecutionResult") -> "GraphQLResult":
         """
         Creates a GraphQLResult object from the ExecutionResult returned by strawberry
         """

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -46,7 +46,6 @@ import click
 import more_itertools
 import texttable
 import yaml
-from cookiecutter.main import cookiecutter
 
 import build
 import inmanta
@@ -402,6 +401,9 @@ compatible with the dependencies specified by the updated modules.
         project_path = os.path.join(output_dir, name)
         if os.path.exists(project_path):
             raise Exception(f"Project directory {project_path} already exists")
+        # Imported here because importing cookiecutter is expensive and only the template commands need it.
+        from cookiecutter.main import cookiecutter
+
         cookiecutter(
             "https://github.com/inmanta/inmanta-project-template.git",
             output_dir=output_dir,
@@ -851,6 +853,9 @@ When a development release is done using the \--dev option, this command:
             module_dir: str = name
             if os.path.exists(module_dir):
                 raise Exception(f"Directory {module_dir} already exists")
+            # Imported here because importing cookiecutter is expensive and only the template commands need it.
+            from cookiecutter.main import cookiecutter
+
             cookiecutter(
                 "https://github.com/inmanta/inmanta-module-template.git",
                 no_input=no_input,

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -46,7 +46,6 @@ from logging import Logger
 from types import TracebackType
 from typing import TYPE_CHECKING, BinaryIO, Generic, Optional, TypeVar, Union
 
-import asyncpg
 import click
 import pydantic
 from tornado import gen
@@ -62,6 +61,8 @@ from inmanta.types import JsonType, PrimitiveTypes, ReturnTypes
 from packaging.utils import NormalizedName
 
 if TYPE_CHECKING:
+    import asyncpg
+
     from inmanta.data.model import ResourceId
 
 LOGGER = logging.getLogger(__name__)
@@ -957,10 +958,10 @@ class ExhaustedPoolWatcher:
 
     """
 
-    def __init__(self, pool: asyncpg.pool.Pool) -> None:
+    def __init__(self, pool: "asyncpg.pool.Pool") -> None:
         self._exhausted_pool_events_count: int = 0
         self._last_report: int = 0
-        self._pool: asyncpg.pool.Pool = pool
+        self._pool: "asyncpg.pool.Pool" = pool
 
     def report_and_reset(self, logger: logging.Logger) -> None:
         """

--- a/tests/compiler/test_plugin_types.py
+++ b/tests/compiler/test_plugin_types.py
@@ -41,6 +41,23 @@ def test_conversion(caplog):
     def to_dsl_type_simple(python_type: type[object]) -> inmanta_type.Type:
         return to_dsl_type(python_type, location, namespace)
 
+    def unordered(dsl_type: inmanta_type.Type) -> object:
+        """
+        Canonical form of a type, with the members of a union unordered. to_dsl_type follows the member order of
+        typing.get_args(), which is not stable across processes: typing caches subscriptions in a bounded LRU whose key
+        considers Union[int, str] and Union[str, int] equal, so the order that comes back depends on what else the process
+        has subscripted and on what has been evicted.
+        """
+        if isinstance(dsl_type, inmanta_type.Union):
+            return frozenset(unordered(tp) for tp in dsl_type.types)
+        if isinstance(dsl_type, inmanta_type.NullableType):
+            return ("nullable", unordered(dsl_type.element_type))
+        return dsl_type.type_string_internal()
+
+    def assert_union(expected: inmanta_type.Type, python_type: type[object]) -> None:
+        """Assert to_dsl_type(python_type) == expected, ignoring the order of union members."""
+        assert unordered(expected) == unordered(to_dsl_type_simple(python_type))
+
     assert inmanta_type.NullableType(inmanta_type.Integer()) == to_dsl_type_simple(Annotated[int | None, "something"])
     # Union type should be ignored in favor of our ModelType
     assert inmanta_type.TypedDict(inmanta_type.Any()) == to_dsl_type_simple(Annotated[dict[str, int], ModelType["dict"]])
@@ -63,45 +80,50 @@ def test_conversion(caplog):
 
     # Union types
     assert inmanta_type.Integer() == to_dsl_type_simple(Union[int])
-    assert inmanta_type.Union(
-        [inmanta_type.Integer(), inmanta_type.String(), inmanta_type.TypedDict(inmanta_type.Any())]
-    ) == to_dsl_type_simple(Union[int, str, GenericDict])
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        Union[None, int, str]
+    assert_union(
+        inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String(), inmanta_type.TypedDict(inmanta_type.Any())]),
+        Union[int, str, GenericDict],
     )
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        Optional[Union[int, str]]
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])), Union[None, int, str]
     )
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        Union[int, str] | None
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])),
+        Optional[Union[int, str]],
     )
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        None | Union[int, str]
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])), Union[int, str] | None
+    )
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])), None | Union[int, str]
     )
     # verify that nested unions are flattened and nested None values are considered for NullableType
-    assert inmanta_type.NullableType(
-        inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String(), inmanta_type.Float()])
-    ) == to_dsl_type_simple(Union[int, Union[str, Union[float, None]]])
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String(), inmanta_type.Float()])),
+        Union[int, Union[str, Union[float, None]]],
+    )
 
     # Union types
     assert inmanta_type.Integer() == to_dsl_type_simple(Union[int])
-    assert inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()]) == to_dsl_type_simple(Union[int, str])
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        Union[None, int, str]
+    assert_union(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()]), Union[int, str])
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])), Union[None, int, str]
     )
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        Optional[Union[int, str]]
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])),
+        Optional[Union[int, str]],
     )
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        Union[int, str] | None
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])), Union[int, str] | None
     )
-    assert inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])) == to_dsl_type_simple(
-        None | Union[int, str]
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String()])), None | Union[int, str]
     )
     # verify that nested unions are flattened and nested None values are considered for NullableType
-    assert inmanta_type.NullableType(
-        inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String(), inmanta_type.Float()])
-    ) == to_dsl_type_simple(Union[int, Union[str, Union[float, None]]])
+    assert_union(
+        inmanta_type.NullableType(inmanta_type.Union([inmanta_type.Integer(), inmanta_type.String(), inmanta_type.Float()])),
+        Union[int, Union[str, Union[float, None]]],
+    )
 
     assert Null() == to_dsl_type_simple(Union[None])
     assert inmanta_type.TypedDict(inmanta_type.String()) == to_dsl_type_simple(collections.abc.Mapping[str, str])


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

Every `inmanta` invocation, including a plain `inmanta compile`, imported strawberry, cookiecutter, the server bootloader and the resource scheduler. The compiler uses none of them. This imports them where they are actually needed.

## Effect

`import inmanta.app`, measured as the min of 5 `-X importtime` runs:

| | modules | import work |
| ------- | ------- | ----------- |
| master  | 1738    | 793.2 ms    |
| this PR | 1385    | 696.7 ms    |

**-96.5 ms and -353 modules**; wall-clock min drops by roughly 140 ms. Removed self-time by package: strawberry 23.8 ms, graphql 20.7 ms, inmanta 17.6 ms, jinja2 11.5 ms, pydantic 9.2 ms, cookiecutter 2.0 ms, plus assorted smaller ones.

## Changes

- **`graphql/result.py`** only needs strawberry for one annotation on a classmethod, so it moves under `TYPE_CHECKING`. On master this single import pulled strawberry and graphql into every compile, via `inmanta.protocol.methods_v2`.
- **`moduletool.py`** imported cookiecutter at module scope but only uses it in the two template commands.
- **`agent/__init__.py`** eagerly re-exported `Agent` from `agent_new`, which dragged in `deploy.scheduler` -> `server.services.resourceservice` -> `server.agentmanager` -> `server.server`. `Agent` and `collect_report` are now resolved lazily through a module `__getattr__`, with a `TYPE_CHECKING` re-export so type checking is unaffected. **Deliberately not deleted**: `from inmanta.agent import Agent` is used by inmanta-lsm and lsm test suites, so removing it would be a cross-repo break.
- **`app.py`** imported tornado and `InmantaBootloader` at module scope; both are only used inside function bodies. All three `InmantaBootloader` sites are deferred, not just one, otherwise the `env.py` change below has no effect for the CLI.
- **`env.py`** imported `InmantaBootloader` at module scope for a single use inside a method. This also drops a compiler -> server layering edge.
- **`util/__init__.py`** imported asyncpg only for two annotations.

**The tornado and asyncpg moves have no effect yet.** Both are still pulled in regardless, tornado by `inmanta/util/__init__.py` (`from tornado import gen`) and asyncpg by `inmanta.data`. They are included because they are correct on their own terms and become effective once `inmanta/data/__init__.py` is thinned out, which is the next and much larger step.

## The test change

`tests/compiler/test_plugin_types.py::test_conversion` asserted an exact member order for the unions returned by `to_dsl_type`. That order comes from `typing.get_args`, and `typing._tp_cache` is a **bounded LRU (maxsize 128) whose key treats `Union[int, str]` and `Union[str, int]` as equal** - they compare equal and hash equal. So the ordering you get back depends on what else the process has subscripted and on what has been evicted since. Changing the import graph shifted the eviction and flipped it, making the test fail deterministically at `--randomly-seed=12345`.

This is pre-existing fragility rather than a regression here: **the test fails on master in exactly the same way**, same line and same repr, once `Optional[Union[str, int]]` is resident in the cache at test time (reproducible with a plugin that subscripts it in `pytest_runtest_setup`). The assertions now compare union members without regard to order. `Union.__eq__` is left alone, since member order is semantically meaningful for its `to_python` dispatch.

## Verification

`inmanta compile` succeeds; `--version`, `module`, `project`, `export` and `list-commands` behave and exit as before; `GraphQLResult.from_execution_result` still works against a real strawberry `ExecutionResult`; `from inmanta.agent import Agent` and attribute access both still resolve, and an unknown attribute still raises `AttributeError`.

black, isort and flake8 are clean. Full mypy produces a new-violation set byte-identical to master (the repo's baseline has some pre-existing drift, unchanged by this PR). `tests/compiler` passes at seeds 12345, 777 and 20260810; `tests/test_app.py`, `tests/util` and `tests/moduletool/test_module_tool_basics.py` pass (223 tests). The DB-backed suites could not be run locally, so `tests/deploy` and `tests/server` coverage of `scheduler_mocks`, `ExhaustedPoolWatcher` and `get_protected_inmanta_packages` rests on CI.

Branched off `master`, so it does not include #10672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)