### PR TITLE
Move select_method to MethodProperties

### DIFF
--- a/changelogs/unreleased/move-select-method.yml
+++ b/changelogs/unreleased/move-select-method.yml
@@ -1,0 +1,4 @@
+---
+description: "Move the select_method to MethodProperties"
+change-type: patch
+destination-branches: [iso9]

--- a/src/inmanta/protocol/__init__.py
+++ b/src/inmanta/protocol/__init__.py
@@ -55,9 +55,9 @@ to REST transport with Tornado, together with the code in :module:`~inmanta.serv
 
 from inmanta.protocol import methods, methods_v2
 from inmanta.protocol.auth.auth import decode_token, encode_token
-from inmanta.protocol.common import Response, Result, gzipped_json, json_encode
+from inmanta.protocol.common import Response, Result, VersionMatch, gzipped_json, json_encode
 from inmanta.protocol.decorators import handle, method, typedmethod
-from inmanta.protocol.endpoints import Client, SessionClient, SessionEndpoint, SyncClient, TypedClient, VersionMatch
+from inmanta.protocol.endpoints import Client, SessionClient, SessionEndpoint, SyncClient, TypedClient
 
 __all__ = [
     "Response",

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -380,6 +380,18 @@ VALID_SIMPLE_ARG_TYPES = (
 )
 
 
+class VersionMatch(str, Enum):
+    lowest = "lowest"
+    """ Select the lowest available version of the method
+    """
+    highest = "highest"
+    """ Select the highest available version of the method
+    """
+    exact = "exact"
+    """ Select the exact version of the method
+    """
+
+
 class MethodProperties(Generic[R]):
     """
     This class stores the information from a method definition
@@ -523,6 +535,24 @@ class MethodProperties(Generic[R]):
 
         self.authorization_metadata: AuthorizationMetadata | None = None
         self.allow_env_scoped_tokens: bool = allow_env_scoped_tokens
+
+    @classmethod
+    def select_method(
+        cls, name: str, match_constraint: VersionMatch = VersionMatch.lowest, exact_version: int = 0
+    ) -> Optional["MethodProperties"]:
+        if name not in cls.methods:
+            return None
+
+        methods = cls.methods[name]
+
+        if match_constraint is VersionMatch.lowest:
+            return min(methods, key=lambda x: x.api_version)
+        elif match_constraint is VersionMatch.highest:
+            return max(methods, key=lambda x: x.api_version)
+        elif match_constraint is VersionMatch.exact:
+            return next((m for m in methods if m.api_version == exact_version), None)
+
+        return None
 
     @classmethod
     def get_open_policy_agent_data(cls) -> dict[str, object]:

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -24,7 +24,6 @@ import uuid
 from asyncio import CancelledError, sleep
 from collections import defaultdict
 from collections.abc import Awaitable, Sequence
-from enum import Enum
 from typing import Callable, Optional
 from urllib import parse
 
@@ -323,18 +322,6 @@ class SessionEndpoint(Endpoint, CallTarget):
             )
 
 
-class VersionMatch(str, Enum):
-    lowest = "lowest"
-    """ Select the lowest available version of the method
-    """
-    highest = "highest"
-    """ Select the highest available version of the method
-    """
-    exact = "exact"
-    """ Select the exact version of the method
-    """
-
-
 class Client(Endpoint):
     """
     A client that communicates with end-point based on its configuration
@@ -344,7 +331,7 @@ class Client(Endpoint):
         self,
         name: str,
         timeout: int = 120,
-        version_match: VersionMatch = VersionMatch.lowest,
+        version_match: common.VersionMatch = common.VersionMatch.lowest,
         exact_version: int = 0,
         with_rest_client: bool = True,
         force_instance: bool = False,
@@ -376,26 +363,13 @@ class Client(Endpoint):
         """
         return await self._transport_instance.call(method_properties, args, kwargs)
 
-    def _select_method(self, name: str) -> Optional[common.MethodProperties]:
-        if name not in common.MethodProperties.methods:
-            return None
-
-        methods = common.MethodProperties.methods[name]
-
-        if self._version_match is VersionMatch.lowest:
-            return min(methods, key=lambda x: x.api_version)
-        elif self._version_match is VersionMatch.highest:
-            return max(methods, key=lambda x: x.api_version)
-        elif self._version_match is VersionMatch.exact:
-            return next((m for m in methods if m.api_version == self._exact_version), None)
-
-        return None
-
     def __getattr__(self, name: str) -> Callable[..., common.ClientCall]:
         """
         Return a function that will call self._call with the correct method properties associated
         """
-        method = self._select_method(name)
+        method = common.MethodProperties.select_method(
+            name, match_constraint=self._version_match, exact_version=self._exact_version
+        )
 
         if method is None:
             raise AttributeError("Method with name %s is not defined for this client" % name)
@@ -486,7 +460,7 @@ class TypedClient(Client):
         self,
         name: str,
         timeout: int = 120,
-        version_match: VersionMatch = VersionMatch.lowest,
+        version_match: common.VersionMatch = common.VersionMatch.lowest,
         exact_version: int = 0,
         with_rest_client: bool = True,
         force_instance: bool = False,


### PR DESCRIPTION
# Description

This PR moves the `_select_method()` method from the `Client` class to the `MethodProperties` class. This change makes the location of this method consistent between master and iso9. This is required, because [this change](https://github.com/inmanta/inmanta-support/pull/1034) on the support extension is applied on master and iso9. On the support extension these branches are currently aligned. This change makes sure we can keep them aligned.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
