### PR TITLE
Update default access policy

### DIFF
--- a/changelogs/unreleased/update-default-access-policy.yml
+++ b/changelogs/unreleased/update-default-access-policy.yml
@@ -1,0 +1,6 @@
+---
+description: "Updated the default access policy: Downloading a support archive now requires the user to be global admin."
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  upgrade-note: "{{description}}"

--- a/src/inmanta/protocol/auth/default_policy.rego
+++ b/src/inmanta/protocol/auth/default_policy.rego
@@ -23,10 +23,16 @@ allow if {
     input.token.sub == input.request.parameters.username
 }
 
-# Any authenticated user is allowed read-only access on the environment independent endpoints.
+# Label for the endpoints that expose support archives. These archives contain server-wide
+# troubleshooting information and are therefore restricted to global admins only (see below).
+download_support_archive_label := "support.support-archive.read"
+
+# Any authenticated user is allowed read-only access on the environment independent endpoints,
+# except for the endpoints that expose support archives.
 allow if {
     endpoint_data.read_only
     endpoint_data.environment_param == null
+    endpoint_data.auth_label != download_support_archive_label
 }
 
 # Any authenticated user can use the file storage.
@@ -64,7 +70,6 @@ read_only_labels := {
     "lsm.docs.read",
     "lsm.instance.read",
     "lsm.order.read",
-    "support.support-archive.read",
 }
 
 allow if {

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -298,9 +298,7 @@ async def test_policy_evaluation(server_with_test_slice: protocol.Server) -> Non
     "access_policy",
     [
         utils.read_file(
-            os.path.join(
-                os.path.dirname(__file__), "..", "..", "src", "inmanta", "protocol", "auth", "default_policy.rego"
-            )
+            os.path.join(os.path.dirname(__file__), "..", "..", "src", "inmanta", "protocol", "auth", "default_policy.rego")
         )
     ],
 )

--- a/tests/server/test_auth.py
+++ b/tests/server/test_auth.py
@@ -37,6 +37,15 @@ from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import Server, SliceStartupException
 
 
+class SupportAuthorizationLabel(const.AuthorizationLabel):
+    """
+    Mirrors the AuthorizationLabel enum defined by the inmanta-support extension. It's redefined here so that the
+    default policy can be tested against a support-archive-like endpoint without depending on that extension.
+    """
+
+    SUPPORT_SUPPORT_ARCHIVE_READ = "support.support-archive.read"
+
+
 @pytest.fixture
 async def server_with_test_slice(
     tmpdir,
@@ -99,6 +108,13 @@ async def server_with_test_slice(
     def admin_only_method() -> None:  # NOQA
         pass
 
+    # An environment-independent, read-only endpoint that carries the support-archive label,
+    # mimicking the download-support-archive endpoints of the inmanta-support extension.
+    @decorators.auth(auth_label=SupportAuthorizationLabel.SUPPORT_SUPPORT_ARCHIVE_READ, read_only=True)
+    @typedmethod(path="/support-archive", operation="GET", client_types=[const.ClientType.api])
+    def support_archive_method() -> None:  # NOQA
+        pass
+
     @decorators.auth(auth_label=const.CoreAuthorizationLabel.TEST, read_only=False)
     @typedmethod(path="/enforce-auth-disabled", operation="GET", client_types=[const.ClientType.api], enforce_auth=False)
     def enforce_auth_disabled_method() -> None:  # NOQA
@@ -135,6 +151,10 @@ async def server_with_test_slice(
 
         @handle(admin_only_method)
         async def handle_admin_only_method(self, context: common.CallContext) -> None:  # NOQA
+            return
+
+        @handle(support_archive_method)
+        async def handle_support_archive_method(self) -> None:  # NOQA
             return
 
         @handle(enforce_auth_disabled_method)
@@ -272,6 +292,43 @@ async def test_policy_evaluation(server_with_test_slice: protocol.Server) -> Non
     assert os.path.isfile(policy_engine_log_file)
     with open(policy_engine_log_file, "r") as fh:
         assert fh.read(1)
+
+
+@pytest.mark.parametrize(
+    "access_policy",
+    [
+        utils.read_file(
+            os.path.join(
+                os.path.dirname(__file__), "..", "..", "src", "inmanta", "protocol", "auth", "default_policy.rego"
+            )
+        )
+    ],
+)
+async def test_default_policy_support_archive(
+    init_dataclasses_and_load_schema, server_with_test_slice: protocol.Server
+) -> None:
+    """
+    Verify that the default policy only allows global admins to download the support archive. The support-archive
+    endpoints are environment-independent, read-only endpoints, but unlike other such endpoints they must not be
+    accessible to regular (even environment-admin) users.
+    """
+    env_id = "11111111-1111-1111-1111-111111111111"
+
+    # A user with the read-only role cannot download the support archive, even though it's a read-only endpoint.
+    client = utils.get_auth_client(env_to_role_dct={env_id: ["read-only"]}, is_admin=False)
+    result = await client.support_archive_method()
+    assert result.code == 403
+
+    # Not even a user with the environment-admin or environment-expert-admin role can download the support archive.
+    for role in ["environment-admin", "environment-expert-admin"]:
+        client = utils.get_auth_client(env_to_role_dct={env_id: [role]}, is_admin=False)
+        result = await client.support_archive_method()
+        assert result.code == 403
+
+    # Only a global admin can download the support archive.
+    client = utils.get_auth_client(env_to_role_dct={}, is_admin=True)
+    result = await client.support_archive_method()
+    assert result.code == 200
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Updated the default access policy: Downloading a support archive now requires the user to be global admin.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~