### PR TITLE
Fix flaky table leakage between tests in test_postgres.py

### DIFF
--- a/changelogs/unreleased/fix-flaky-postgres-locking-order-test.yml
+++ b/changelogs/unreleased/fix-flaky-postgres-locking-order-test.yml
@@ -1,0 +1,6 @@
+description: Prevent the tests in `test_postgres.py` from leaking their tables into one another via the shared session-scoped database by dropping each test's tables when it finishes. This fixes a deadlock on the success code path of the `test_postgres_cascade_locking_order_siblings`test case.
+change-type: patch
+destination-branches:
+  - master
+  - iso9
+  - iso8

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -30,8 +30,25 @@ import asyncpg
 import pytest
 
 
+@pytest.fixture
+async def drop_test_tables(request: pytest.FixtureRequest, postgresql_pool) -> abc.AsyncIterator[None]:
+    """
+    Drop the tables a test creates once it finishes. The tables to drop are passed via parametrization,
+    e.g.::
+
+    @pytest.mark.parametrize("drop_test_tables", [("root", "leaf")], indirect=True)
+    """
+    tables: abc.Sequence[str] = request.param
+    try:
+        yield
+    finally:
+        async with postgresql_pool.acquire() as connection:
+            await connection.execute(f"DROP TABLE IF EXISTS {', '.join(tables)} CASCADE;")
+
+
 @pytest.mark.slowtest
-async def test_postgres_cascade_locking_order(postgresql_pool, run_without_keeping_psql_logs) -> None:
+@pytest.mark.parametrize("drop_test_tables", [("root", "leaf")], indirect=True)
+async def test_postgres_cascade_locking_order(postgresql_pool, drop_test_tables, run_without_keeping_psql_logs) -> None:
     """
     Verifies that Postgres' cascade deletion acquires locks top-down. This is important because in order to avoid deadlocks
     we define a corresponding locking order for all transactions. See `TableLockMode`, `RowLockMode` and `ConfigurationModel`
@@ -39,8 +56,8 @@ async def test_postgres_cascade_locking_order(postgresql_pool, run_without_keepi
     """
     async with postgresql_pool.acquire() as connection:
         await connection.execute("""
-            CREATE TABLE IF NOT EXISTS root (name varchar PRIMARY KEY);
-            CREATE TABLE IF NOT EXISTS leaf (
+            CREATE TABLE root (name varchar PRIMARY KEY);
+            CREATE TABLE leaf (
                 name varchar PRIMARY KEY,
                 myroot varchar REFERENCES root(name) ON DELETE CASCADE
             );
@@ -92,21 +109,22 @@ async def test_postgres_cascade_locking_order(postgresql_pool, run_without_keepi
 
 
 @pytest.mark.slowtest
+@pytest.mark.parametrize("drop_test_tables", [("root", "leafone", "leaftwo")], indirect=True)
 @pytest.mark.parametrize("definition_order_one_two", [True, False])
 async def test_postgres_cascade_locking_order_siblings(
-    postgresql_pool, definition_order_one_two: bool, run_without_keeping_psql_logs
+    postgresql_pool, definition_order_one_two: bool, drop_test_tables, run_without_keeping_psql_logs
 ) -> None:
     """
     Verifies locking order for siblings in the cascade tree. Locking order seems to be based on definition order of the
     referencing columns. Locking order may shift in case of updates to the definition of these columns.
     """
     leaf_definitions: tuple[str] = tuple(
-        f"CREATE TABLE IF NOT EXISTS {name} (name varchar PRIMARY KEY, myroot varchar REFERENCES root(name) ON DELETE CASCADE);"
+        f"CREATE TABLE {name} (name varchar PRIMARY KEY, myroot varchar REFERENCES root(name) ON DELETE CASCADE);"
         for name in ("leafone", "leaftwo")
     )
     async with postgresql_pool.acquire() as connection:
         await connection.execute("""
-            CREATE TABLE IF NOT EXISTS root (name varchar PRIMARY KEY);
+            CREATE TABLE root (name varchar PRIMARY KEY);
             %s
             %s
             """ % (leaf_definitions if definition_order_one_two else tuple(reversed(leaf_definitions))))
@@ -165,7 +183,8 @@ async def test_postgres_cascade_locking_order_siblings(
 
 
 @pytest.mark.slowtest
-async def test_postgres_transaction_re_entry(postgresql_pool) -> None:
+@pytest.mark.parametrize("drop_test_tables", [("root",)], indirect=True)
+async def test_postgres_transaction_re_entry(postgresql_pool, drop_test_tables) -> None:
     """
     When do transaction lock each other out?
 
@@ -174,7 +193,7 @@ async def test_postgres_transaction_re_entry(postgresql_pool) -> None:
 
     # Make a table
     async with postgresql_pool.acquire() as connection:
-        await connection.execute("CREATE TABLE IF NOT EXISTS root (name varchar PRIMARY KEY, released BOOL);")
+        await connection.execute("CREATE TABLE root (name varchar PRIMARY KEY, released BOOL);")
         await connection.execute("""
             INSERT INTO root VALUES
                 ('root1', False),
@@ -223,7 +242,8 @@ async def test_postgres_transaction_re_entry(postgresql_pool) -> None:
 
 
 @pytest.mark.slowtest
-async def test_postgres_index_join_where(postgresql_pool) -> None:
+@pytest.mark.parametrize("drop_test_tables", [("mytable",)], indirect=True)
+async def test_postgres_index_join_where(postgresql_pool, drop_test_tables) -> None:
     """
     Verify that the PG analyzer is sufficiently smart to combine constraints from join and where conditions to select
     appropriate indexes, regardless of ordering.
@@ -231,7 +251,7 @@ async def test_postgres_index_join_where(postgresql_pool) -> None:
 
     async with postgresql_pool.acquire() as connection:
         await connection.execute("""\
-            CREATE TABLE IF NOT EXISTS mytable (x int PRIMARY key, y int, z int);
+            CREATE TABLE mytable (x int PRIMARY key, y int, z int);
             CREATE INDEX mytable_x_y_z_index ON mytable (x, y, z);
             INSERT INTO mytable (x, y, z) VALUES (1, 2, 3), (3, 2, 5);
             """)


### PR DESCRIPTION
# Description

Fixes an intermittent failure in `tests/test_postgres.py`. These tests create throw-away tables directly through `postgresql_pool`, which connects to a **session-scoped** database shared by the whole test session. The tables were created with `CREATE TABLE IF NOT EXISTS` and never dropped, so they leaked between tests and parametrizations.

For `test_postgres_cascade_locking_order_siblings`, this leakage let the foreign-key definition order set by whichever parametrization ran first (test order is randomized by `pytest-randomly`) carry over to the other parametrization, inverting its expected cascade-delete sibling locking order and causing a deadlock **on the code path that is supposed to succeed**. This was observed on PostgreSQL 16 in CI.

Changes:
- Add a `drop_test_tables` fixture, indirect-parametrized with the table names each test creates, that drops those tables when the test finishes so nothing leaks into subsequent tests.
- Create the tables without `IF NOT EXISTS` as a safeguard: a leaked table now makes the test fail loudly instead of silently reusing stale state. This also removes a latent issue in `test_postgres_transaction_re_entry`, whose `root` table has an extra `released` column that a leaked `root` would have masked.

Verified: the module passes under `no:randomly` and under several randomized seeds, including the exact CI seed (`3905442140`) from the failing run. flake8 / black / isort are clean.

closes *N/A (test-suite flakiness)*

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (changelog targets `master`, `iso9`, `iso8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
