### PR TITLE
Use os._exit() in compile command to skip expensive GC shutdown (#10091)

### DIFF
--- a/changelogs/unreleased/fast-compile-exit.yml
+++ b/changelogs/unreleased/fast-compile-exit.yml
@@ -1,0 +1,11 @@
+change-type: minor
+description: >-
+  Improved compile command exit performance by using os._exit() to skip Python's interpreter shutdown.
+  The garbage collector would otherwise spend significant time tearing down the compiler's large cyclic
+  object graph (Namespace trees, Entity hierarchies, Instance/ResultVariable webs), which is unnecessary
+  since the process is terminating. Atexit hooks, which cover log and telemetry flushing, still run
+  and the stdout/stderr buffers are flushed explicitly before exiting.
+destination-branches:
+- master
+- iso9
+sections: {}

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -32,6 +32,7 @@ Entry points
 
 import argparse
 import asyncio
+import atexit
 import contextlib
 import dataclasses
 import enum
@@ -810,9 +811,30 @@ class CompileSummaryReporter:
     def print_summary_and_exit(self, show_stack_traces: bool) -> None:
         """
         Print the compile summary and exit with a 0 status code in case of success or 1 in case of failure.
+
+        Exits with os._exit() to skip Python's interpreter shutdown. The compiler leaves behind a large
+        cyclic object graph (Namespace trees, Entity hierarchies, Instance/ResultVariable webs) and the
+        garbage collector spends seconds tearing it down on shutdown, which is pointless work for a
+        process that is terminating anyway.
+
+        os._exit() skips the cleanup a normal exit performs, so the parts of it that must still happen
+        are done explicitly first:
+
+        - atexit hooks are run via atexit._run_exitfuncs(): the stdlib (logging), the telemetry stack
+          (opentelemetry registers the tracer provider shutdown there and logfire its open-span cleanup)
+          and modules' plugin code (e.g. remote session cleanup) register work there that must not be
+          lost. Hooks run LIFO exactly as on a normal exit, an exception in a hook is printed and
+          ignored, and the hook list is cleared afterwards so hooks cannot run a second time.
+        - the stdout/stderr buffers are flushed
+
+        What remains skipped, by design: __del__ finalizers (the object teardown this method avoids) and
+        joining non-daemon threads.
         """
         self.print_summary(show_stack_traces)
-        exit(1 if self.is_failure() else 0)
+        atexit._run_exitfuncs()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1 if self.is_failure() else 0)
 
 
 def cmd_parser() -> argparse.ArgumentParser:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import atexit
 import json
 import logging
 import os
@@ -568,6 +569,33 @@ def test_compiler_summary_reporter(monkeypatch, capsys) -> None:
     summary_reporter.print_summary(show_stack_traces=True)
     output = capsys.readouterr().err
     assert re.match(r"\n=+ EXCEPTION TRACE =+\n(.|\n)*\n=+ EXPORT FAILURE =+\nError: This is an export failure\n", output)
+
+
+def test_print_summary_and_exit_runs_hooks_before_exit(monkeypatch) -> None:
+    """
+    print_summary_and_exit uses os._exit, which skips the normal exit cleanup. Verify it explicitly
+    runs the atexit hooks (which cover log and telemetry flushing) before exiting, and preserves the
+    exit code semantics.
+
+    atexit._run_exitfuncs is replaced here because really invoking it would run and clear the atexit
+    hooks of the test process itself.
+    """
+    calls: list[object] = []
+    monkeypatch.setattr(atexit, "_run_exitfuncs", lambda: calls.append("atexit"))
+    monkeypatch.setattr(os, "_exit", lambda code: calls.append(("exit", code)))
+
+    summary_reporter = CompileSummaryReporter()
+    with summary_reporter.compiler_exception.capture():
+        pass
+    summary_reporter.print_summary_and_exit(show_stack_traces=False)
+    assert calls == ["atexit", ("exit", 0)]
+
+    calls.clear()
+    summary_reporter = CompileSummaryReporter()
+    with summary_reporter.compiler_exception.capture():
+        raise Exception("This is a compilation failure")
+    summary_reporter.print_summary_and_exit(show_stack_traces=False)
+    assert calls == ["atexit", ("exit", 1)]
 
 
 def test_validate_logging_config(tmpdir, monkeypatch):


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #10091