### PR TITLE
Make the maximum request body size accepted by the server configurable

### DIFF
--- a/changelogs/unreleased/configurable-max-request-body-size.yml
+++ b/changelogs/unreleased/configurable-max-request-body-size.yml
@@ -1,7 +1,8 @@
 description: "Added the `server.max-request-body-size` config option to configure the maximum size of a request body accepted by the server. It defaults to 100MiB."
-change-type: minor
+change-type: patch
 destination-branches:
   - master
   - iso9
+  - iso8
 sections:
   minor-improvement: "{{description}}"

--- a/changelogs/unreleased/configurable-max-request-body-size.yml
+++ b/changelogs/unreleased/configurable-max-request-body-size.yml
@@ -1,0 +1,7 @@
+description: "Added the `server.max-request-body-size` config option to configure the maximum size of a request body accepted by the server. It defaults to 100MiB."
+change-type: minor
+destination-branches:
+  - master
+  - iso9
+sections:
+  minor-improvement: "{{description}}"

--- a/src/inmanta/protocol/rest/server.py
+++ b/src/inmanta/protocol/rest/server.py
@@ -352,6 +352,8 @@ class RESTServer(RESTBase, AuthnzInterface):
             websocket_ping_interval=ws_ping_interval,
         )
 
+        max_body_size = server_config.server_max_request_body_size.get()
+
         crt = inmanta_config.Config.get("server", "ssl_cert_file", None)
         key = inmanta_config.Config.get("server", "ssl_key_file", None)
 
@@ -366,10 +368,12 @@ class RESTServer(RESTBase, AuthnzInterface):
                     e,
                 )
 
-            self._http_server = httpserver.HTTPServer(application, decompress_request=True, ssl_options=ssl_ctx)
+            self._http_server = httpserver.HTTPServer(
+                application, decompress_request=True, ssl_options=ssl_ctx, max_body_size=max_body_size
+            )
             LOGGER.debug("Created REST transport with SSL")
         else:
-            self._http_server = httpserver.HTTPServer(application, decompress_request=True)
+            self._http_server = httpserver.HTTPServer(application, decompress_request=True, max_body_size=max_body_size)
 
         bind_port = server_config.server_bind_port.get()
         bind_addresses = server_config.server_bind_address.get()

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -178,6 +178,15 @@ server_bind_port = Option(
     is_int,
 )
 
+server_max_request_body_size = Option(
+    "server",
+    "max-request-body-size",
+    100 * 1024 * 1024,
+    "The maximum size in bytes of the body of a request accepted by the server. Requests with a larger body are "
+    "rejected. When a request is compressed, this limit applies to the compressed body.",
+    is_lower_bounded_int(1),
+)
+
 server_tz_aware_timestamps = Option(
     "server",
     "tz_aware_timestamps",

--- a/src/inmanta/server/config.py
+++ b/src/inmanta/server/config.py
@@ -183,7 +183,7 @@ server_max_request_body_size = Option(
     "max-request-body-size",
     100 * 1024 * 1024,
     "The maximum size in bytes of the body of a request accepted by the server. Requests with a larger body are "
-    "rejected. When a request is compressed, this limit applies to the compressed body.",
+    "rejected. This limit is applied to both compressed and decompressed bodies.",
     is_lower_bounded_int(1),
 )
 

--- a/tests/protocol/test_max_request_body_size.py
+++ b/tests/protocol/test_max_request_body_size.py
@@ -60,7 +60,7 @@ async def test_max_request_body_size_decompressed(server) -> None:
     """
     file_hash, _, file_content = make_random_file(size=MAX_REQUEST_BODY_SIZE)
     is_zipped, body = protocol.gzipped_json({"content": file_content})
-    assert zipped
+    assert is_zipped
     # The request only makes it past the limit on the compressed body because it is this much smaller than the
     # decompressed one it carries.
     assert len(body) < MAX_REQUEST_BODY_SIZE < len(json.dumps({"content": file_content}))

--- a/tests/protocol/test_max_request_body_size.py
+++ b/tests/protocol/test_max_request_body_size.py
@@ -21,7 +21,7 @@ import json
 import pytest
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
-from inmanta import config
+from inmanta import config, protocol
 from inmanta.server import config as opt
 from utils import make_random_file
 
@@ -51,3 +51,27 @@ async def test_max_request_body_size(server, above_limit: bool) -> None:
     response = await AsyncHTTPClient().fetch(request, raise_error=False)
 
     assert response.code == (400 if above_limit else 200)
+
+
+async def test_max_request_body_size_decompressed(server) -> None:
+    """
+    Verify that the limit is applied to the decompressed body as well: a request that stays below the limit while
+    compressed is still rejected when it inflates beyond it.
+    """
+    file_hash, _, file_content = make_random_file(size=MAX_REQUEST_BODY_SIZE)
+    zipped, body = protocol.gzipped_json({"content": file_content})
+    assert zipped
+    # The request only makes it past the limit on the compressed body because it is this much smaller than the
+    # decompressed one it carries.
+    assert len(body) < MAX_REQUEST_BODY_SIZE < len(json.dumps({"content": file_content}))
+
+    port = opt.server_bind_port.get()
+    request = HTTPRequest(
+        url=f"http://localhost:{port}/api/v1/file/{file_hash}",
+        method="PUT",
+        headers={"Content-Encoding": "gzip"},
+        body=body,
+    )
+    response = await AsyncHTTPClient().fetch(request, raise_error=False)
+
+    assert response.code == 400

--- a/tests/protocol/test_max_request_body_size.py
+++ b/tests/protocol/test_max_request_body_size.py
@@ -1,0 +1,53 @@
+"""
+Copyright 2026 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+import json
+
+import pytest
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+
+from inmanta import config
+from inmanta.server import config as opt
+from utils import make_random_file
+
+MAX_REQUEST_BODY_SIZE = 1024
+
+
+@pytest.fixture
+def server_pre_start(server_config):
+    config.Config.set("server", "max-request-body-size", str(MAX_REQUEST_BODY_SIZE))
+
+
+def test_max_request_body_size_default() -> None:
+    assert opt.server_max_request_body_size.get() == 100 * 1024 * 1024
+
+
+@pytest.mark.parametrize("above_limit", [True, False])
+async def test_max_request_body_size(server, above_limit: bool) -> None:
+    """
+    Verify that the server rejects requests with a body larger than the configured maximum and accepts smaller ones.
+    """
+    file_hash, _, file_content = make_random_file(size=MAX_REQUEST_BODY_SIZE if above_limit else 1)
+    body = json.dumps({"content": file_content}).encode()
+    assert (len(body) > MAX_REQUEST_BODY_SIZE) == above_limit
+
+    port = opt.server_bind_port.get()
+    request = HTTPRequest(url=f"http://localhost:{port}/api/v1/file/{file_hash}", method="PUT", body=body)
+    response = await AsyncHTTPClient().fetch(request, raise_error=False)
+
+    assert response.code == (400 if above_limit else 200)

--- a/tests/protocol/test_max_request_body_size.py
+++ b/tests/protocol/test_max_request_body_size.py
@@ -59,7 +59,7 @@ async def test_max_request_body_size_decompressed(server) -> None:
     compressed is still rejected when it inflates beyond it.
     """
     file_hash, _, file_content = make_random_file(size=MAX_REQUEST_BODY_SIZE)
-    zipped, body = protocol.gzipped_json({"content": file_content})
+    is_zipped, body = protocol.gzipped_json({"content": file_content})
     assert zipped
     # The request only makes it past the limit on the compressed body because it is this much smaller than the
     # decompressed one it carries.


### PR DESCRIPTION
# Description

The server relied on Tornado's implicit default for `max_body_size`: `HTTPServer` was constructed without it, so `HTTP1Connection` fell back to `stream.max_buffer_size`, which is 100MiB. This surfaced when the addition of the `send_event`/`receive_event` flags on inmanta-performance pushed an export of 200k resources over that limit.

This exposes the limit as the `server.max-request-body-size` config option, keeping the default at 100MiB so behaviour is unchanged unless the option is set.

Discussed [here](https://inmanta.slack.com/archives/CKRF0C8R3/p1786519779489309).

# Self Check:

- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [x] If this PR fixes a race condition in the test suite, also block the sha of the improvement on normal test suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)