### PR TITLE
Bound the memory cost of the compile-time GC tuning

### DIFF
--- a/changelogs/unreleased/drop-unset-exception-traceback.yml
+++ b/changelogs/unreleased/drop-unset-exception-traceback.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: Stop retaining the traceback of an UnsetException that the compiler reschedules, removing about a fifth of the cyclic garbage a compile produces
+destination-branches:
+- master
+- iso9
+sections:
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/gc-tune-during-compile.yml
+++ b/changelogs/unreleased/gc-tune-during-compile.yml
@@ -1,5 +1,5 @@
 change-type: patch
-description: Relax the cyclic GC thresholds for the duration of a compile, cutting compile time by 8% to 29% depending on the model
+description: Relax the cyclic GC thresholds for the duration of a compile, cutting compile time by 8% to 29% depending on the model. The youngest generation threshold defaults to 1000000 and can be tuned with compiler.gc_gen0_threshold, which bounds the extra memory held while collection is deferred
 destination-branches:
 - master
 - iso9

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -58,8 +58,9 @@ LOGGER: logging.Logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from inmanta.ast import BasicBlock, Statement  # noqa: F401
 
-# GC thresholds applied for the duration of a compile, see relaxed_gc_thresholds().
-COMPILE_GC_THRESHOLDS: tuple[int, int, int] = (5_000_000, 100, 100)
+# gen1/gen2 thresholds applied for the duration of a compile, see relaxed_gc_thresholds().
+# Not configurable: these carry most of the speed-up and cost no memory on any model measured.
+COMPILE_GC_OLD_GEN_THRESHOLDS: tuple[int, int] = (100, 100)
 
 
 @contextlib.contextmanager
@@ -69,14 +70,19 @@ def relaxed_gc_thresholds() -> abc.Iterator[None]:
 
     A compile builds a large object graph that stays almost entirely live until the run ends,
     so the default thresholds make the collector re-traverse it over and over while reclaiming
-    very little. Full collections alone account for roughly 80% of GC time.
+    very little. Full collections alone account for roughly 80% of GC time, which is why the
+    gen1 and gen2 thresholds are raised and are not configurable: they cost no memory.
 
-    Collection stays enabled, and the thresholds are sized so that it self-regulates: a small
-    compile finishes before gen0 ever fills, while a large one still collects periodically.
-    That matches disabling the GC on speed while still reclaiming where it matters.
+    The gen0 threshold is a different trade-off and is configurable. Raising it defers
+    collecting short-lived garbage, so peak memory grows with the threshold, but only for
+    models that produce cyclic garbage. Models that produce none pay nothing for any value,
+    which is the case for every real model measured; a benchmark that produced millions of
+    garbage objects per compile grew by 40%. See compiler.gc_gen0_threshold.
+
+    Collection stays enabled throughout.
     """
     original: tuple[int, int, int] = gc.get_threshold()
-    gc.set_threshold(*COMPILE_GC_THRESHOLDS)
+    gc.set_threshold(compiler_config.gc_gen0_threshold.get(), *COMPILE_GC_OLD_GEN_THRESHOLDS)
     try:
         yield
     finally:

--- a/src/inmanta/compiler/config.py
+++ b/src/inmanta/compiler/config.py
@@ -16,7 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-from inmanta.config import Option, is_bool, is_str
+from inmanta.config import Option, is_bool, is_lower_bounded_int, is_str
 
 datatrace_enable: Option[bool] = Option(
     "compiler",
@@ -56,6 +56,19 @@ export_compile_data: Option[bool] = Option(
     False,
     "Export structured json containing compile data such as occurred errors.",
     is_bool,
+)
+
+
+gc_gen0_threshold: Option[int] = Option(
+    "compiler",
+    "gc_gen0_threshold",
+    1_000_000,
+    "Threshold for the youngest cyclic garbage collector generation, applied for the duration of a compile. "
+    "Raising it defers collection of short-lived garbage, which is faster but keeps that garbage in memory: "
+    "peak memory grows with this value for models that produce cyclic garbage, and not at all for models that "
+    "do not. Lower it if compiles run close to a memory limit. Set it to 700, the CPython default, to opt out "
+    "of the trade-off entirely without giving up the older-generation tuning, which costs no memory.",
+    is_lower_bounded_int(700),
 )
 
 

--- a/src/inmanta/execute/scheduler.py
+++ b/src/inmanta/execute/scheduler.py
@@ -440,9 +440,17 @@ class Scheduler:
                     count = count + 1
                 except UnsetException as e:
                     # some statements don't know all their dependencies up front,...
+                    # This exception is control flow: it is handled here and discarded. Its
+                    # traceback keeps the entire propagation frame stack alive, and
+                    # traceback <-> frame is a reference cycle, so every occurrence becomes
+                    # work for the cyclic collector. Drop it now, while the exception is
+                    # still the only thing referencing it.
+                    e.__traceback__ = None
                     next.requeue_with_additional_requires(object(), e.get_result_variable())
                 except MultiUnsetException as e:
                     # some statements don't know all their dependencies up front,...
+                    # see the comment above on dropping the traceback
+                    e.__traceback__ = None
                     for rv in e.result_variables:
                         next.requeue_with_additional_requires(object(), rv)
 

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -24,6 +24,8 @@ from itertools import groupby
 import pytest
 
 import inmanta.compiler as compiler
+import inmanta.compiler.config as compiler_config
+from inmanta import config
 from inmanta.ast import AttributeException, RuntimeException
 
 
@@ -143,9 +145,10 @@ def test_compile_plugin_typing_invalid(setup_project_for):
 def test_relaxed_gc_thresholds_scoped_to_compile():
     """The relaxed GC thresholds are applied inside the block and always restored."""
     original = gc.get_threshold()
+    expected = (compiler_config.gc_gen0_threshold.get(), *compiler.COMPILE_GC_OLD_GEN_THRESHOLDS)
 
     with compiler.relaxed_gc_thresholds():
-        assert gc.get_threshold() == compiler.COMPILE_GC_THRESHOLDS
+        assert gc.get_threshold() == expected
         # collection must stay enabled, we only make it less frequent
         assert gc.isenabled()
     assert gc.get_threshold() == original
@@ -154,6 +157,31 @@ def test_relaxed_gc_thresholds_scoped_to_compile():
         with compiler.relaxed_gc_thresholds():
             raise RuntimeError("compile failed")
     assert gc.get_threshold() == original
+
+
+def test_relaxed_gc_thresholds_gen0_configurable():
+    """The gen0 threshold follows the config option, the older generations do not."""
+    original = gc.get_threshold()
+
+    config.Config.set("compiler", "gc_gen0_threshold", "700")
+    try:
+        with compiler.relaxed_gc_thresholds():
+            # 700 is the CPython default: opting out of the memory trade-off must still
+            # leave the older generations relaxed, since those are what cost no memory.
+            assert gc.get_threshold() == (700, *compiler.COMPILE_GC_OLD_GEN_THRESHOLDS)
+    finally:
+        config.Config.load_config()
+    assert gc.get_threshold() == original
+
+
+def test_gc_gen0_threshold_rejects_values_below_cpython_default():
+    """Values below 700 are refused: 0 would disable collection entirely."""
+    config.Config.set("compiler", "gc_gen0_threshold", "0")
+    try:
+        with pytest.raises(ValueError):
+            compiler_config.gc_gen0_threshold.get()
+    finally:
+        config.Config.load_config()
 
 
 def test_do_compile_restores_gc_thresholds(snippetcompiler):


### PR DESCRIPTION
Follow-up to #10667, which OOM-killed the compiler scaling test runner. Two related changes: bound the memory cost of the GC tuning, and stop generating the cyclic garbage that the tuning defers.

## What went wrong with #10667

That PR raised all three thresholds to `(5_000_000, 100, 100)` for the duration of a compile. The gen0 value is the wrong trade-off: raising it defers collecting short-lived garbage, so peak memory grows with the threshold for any model that produces cyclic garbage.

`integration-tests/compilerscaling` grew **42%**, from 2082MB to 2951MB at 10000 elines, and build #1602 was SIGKILLed. Bisecting the builds isolates it precisely: the jump appears at `51d001a9b` (post-GC, pre-#10669) and #10669 adds exactly zero.

I validated #10667's memory claim on two production models only. Both happen to produce almost no cyclic garbage, so neither could show the effect. That was too narrow a basis for a change whose entire mechanism is deferring collection.

## The two axes are separable

| thresholds | RSS @10000 el | vs default | wall | vs default |
| --- | ---: | ---: | ---: | ---: |
| `700,10,10` (CPython default) | 2067 MB | - | 95.30s | - |
| `200k,100,100` | 2088 MB | +1.0% | 81.99s | -14.0% |
| **`1M,100,100`** | **2206 MB** | **+6.7%** | **75.15s** | **-21.1%** |
| `5M,100,100` (current) | 2933 MB | +41.9% | 69.26s | -27.3% |

gen1/gen2 at 100 suppress full collections, which are ~80% of GC time, and cost **no memory on any model measured**. gen0 buys the remainder at roughly `threshold × 100 bytes`.

Between 5000 and 10000 elines, the overhead of `1M` stayed flat (+163MB → +139MB) while `5M` **doubled** (+431MB → +866MB). `1M` is bounded by the threshold; `5M` still tracks model size.

## 1M versus 5M, both axes

| model / size | wall 1M | wall 5M | time cost | RSS 1M | RSS 5M | memory saved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| scaling model, 10000 el | 75.15s | 69.26s | **+8.5%** | 2206 MB | 2933 MB | **-727 MB (-24.8%)** |
| scaling model, 5000 el | 34.73s | 33.86s | +2.6% | 1265 MB | 1533 MB | -268 MB (-17.5%) |
| modernized model, 5000 el | 24.42s | 23.88s | +2.3% | 1094 MB | 1094 MB | 0 |
| six production models | — | — | below noise floor | — | — | 0 (identical to 1 MB) |

The trade is 8.5% of compile time for 727 MB at the size that OOMed, and it is concentrated on exactly the model that produces the garbage. Where there is no garbage to defer, `1M` gives up ~2% of time for nothing — but that ~2% is the *entire* exposure of choosing the safe default, which is why it is worth taking.

On the production models both axes are flat: the timing difference is below run-to-run variance (single-run sweep, stated as a bound rather than a figure) and peak RSS is identical to within 1 MB.

## The change

Default gen0 to `1M` and expose it as **`compiler.gc_gen0_threshold`**. How much cyclic garbage a compile produces is a property of the model, not something core can determine, and orchestrator compiles run under memory limits where the only remedy today is a release. Setting it to `700` opts out of the trade-off while keeping the older-generation tuning, which is free. Values below 700 are rejected — `0` disables collection entirely.

gen1/gen2 stay hard-coded: no measured downside, so exposing them is surface area with no use case.

**This costs the real models nothing.** Across the six production models in the benchmark suite, memory is flat for every threshold from 700 to 5M — worst spread 6MB across 24 measurements.

## Also: drop the rescheduled UnsetException's traceback

`UnsetException` is the compiler's lazy-resolution signal. The scheduler catches it, requeues the statement and discards it; the traceback is never read. But it pins the entire propagation frame stack, and traceback ↔ frame is a reference cycle, so every rescheduled statement leaves work for the cyclic collector.

`scheduler.py` is the only site that *consumes* one — the other four handlers (`plugins.py` ×3, `type.py`, `call.py`) re-raise, and `call.py` says so explicitly: *"Don't handle it here! This exception is used by the scheduler to re-queue the unit."*

Measured **~21% less cyclic garbage**, consistent across two unrelated models:

| model | before | after |
| --- | ---: | ---: |
| production model | 197,515 | 156,666 (-20.7%) |
| scaling model @500 el | 588,624 | 467,624 (-20.6%) |

To be clear about what this buys: **it does not change wall time or peak RSS on its own** (both within noise). It reduces the material that the gen0 threshold defers. The production model above aborts zero template renders and still sheds 21%, which confirms this is the generic plugin path rather than anything template-specific.

## Testing

`tests/compiler/` + `tests/test_compilation.py` + `tests/test_parser.py`: **859 passed**, 1 skipped, 2 xfailed. flake8, black, isort and mypy-baseline clean.

Two tests added, both about the new config option: that the gen0 threshold follows it (including `700` still leaving gen1/gen2 relaxed), and that values below 700 are rejected. The existing threshold test is updated for the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7WTQ2SWoC2kgu5wk2LBu4