### PR TITLE
Fix compatibility with Python 3.14

### DIFF
--- a/changelogs/unreleased/python-3.14-compatibility.yml
+++ b/changelogs/unreleased/python-3.14-compatibility.yml
@@ -1,4 +1,4 @@
 description: Fix compatibility with Python 3.14.
-change-type: patch
+change-type: minor
 destination-branches:
   - master

--- a/changelogs/unreleased/python-3.14-compatibility.yml
+++ b/changelogs/unreleased/python-3.14-compatibility.yml
@@ -1,0 +1,10 @@
+description: >-
+  Fix compatibility with Python 3.14, where the annotations of a class are evaluated on first access and cached outside
+  of the class dict (PEP 649). Importing inmanta failed with a `RuntimeError: dictionary changed size during iteration`
+  raised by the metaclass of `BaseDocument`, and the GraphQL output types and filters silently lost the fields their
+  mixins declare.
+change-type: patch
+destination-branches:
+  - master
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/python-3.14-compatibility.yml
+++ b/changelogs/unreleased/python-3.14-compatibility.yml
@@ -1,10 +1,4 @@
-description: >-
-  Fix compatibility with Python 3.14, where the annotations of a class are evaluated on first access and cached outside
-  of the class dict (PEP 649). Importing inmanta failed with a `RuntimeError: dictionary changed size during iteration`
-  raised by the metaclass of `BaseDocument`, and the GraphQL output types and filters silently lost the fields their
-  mixins declare.
+description: Fix compatibility with Python 3.14.
 change-type: patch
 destination-branches:
   - master
-sections:
-  bugfix: "{{description}}"

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ version = "19.1.0"
 
 setup(
     version=version,
-    python_requires=">=3.14",  # also update classifiers
+    python_requires=">=3.13",  # also update classifiers
     # Meta data
     name="inmanta-core",
     description="Inmanta deployment tool",
@@ -75,7 +75,7 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",
-        "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.13",
     ],
     keywords="orchestrator orchestration configurationmanagement",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ version = "19.1.0"
 
 setup(
     version=version,
-    python_requires=">=3.13",  # also update classifiers
+    python_requires=">=3.14",  # also update classifiers
     # Meta data
     name="inmanta-core",
     description="Inmanta deployment tool",
@@ -75,7 +75,7 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",
-        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     keywords="orchestrator orchestration configurationmanagement",
     project_urls={

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -20,6 +20,7 @@ import asyncio
 import copy
 import datetime
 import enum
+import inspect
 import itertools
 import json
 import logging
@@ -1355,14 +1356,20 @@ class BaseDocument(metaclass=DocumentMeta):
         if "__ignore_fields__" in cls.__dict__:
             ignore = cls.__ignore_fields__
 
+        # Resolve the annotations this class declares itself before iterating over the class dict. As of Python 3.14 the
+        # annotations of a class are evaluated on the first read and cached in the class dict (PEP 649), so reading them
+        # from within the loop below would add a key to the very dict that loop is iterating over, and the iteration
+        # would fail with `RuntimeError: dictionary changed size during iteration`.
+        annotations = inspect.get_annotations(cls)
+
         for attribute, value in cls.__dict__.items():
             if attribute.startswith("_"):
                 continue
             elif isinstance(value, Field):
                 warnings.warn(f"Field {attribute} should be defined using annotations instead of Field.")
                 cls._fields_metadata[attribute] = value
-            elif cls.__annotations__ and attribute in cls.__annotations__:
-                annotation = cls.__annotations__[attribute]
+            elif annotations and attribute in annotations:
+                annotation = annotations[attribute]
                 cls._fields_metadata[attribute] = cls._annotation_to_field(
                     attribute,
                     annotation,
@@ -1373,7 +1380,7 @@ class BaseDocument(metaclass=DocumentMeta):
                 )
 
         # attributes that do not have a default value will only be present in __annotations__ and not in __dict__
-        for attribute, annotation in cls.__annotations__.items():
+        for attribute, annotation in annotations.items():
             if not attribute.startswith("_") and attribute not in cls._fields_metadata:
                 cls._fields_metadata[attribute] = cls._annotation_to_field(
                     attribute,

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -1356,10 +1356,8 @@ class BaseDocument(metaclass=DocumentMeta):
         if "__ignore_fields__" in cls.__dict__:
             ignore = cls.__ignore_fields__
 
-        # Resolve the annotations this class declares itself before iterating over the class dict. As of Python 3.14 the
-        # annotations of a class are evaluated on the first read and cached in the class dict (PEP 649), so reading them
-        # from within the loop below would add a key to the very dict that loop is iterating over, and the iteration
-        # would fail with `RuntimeError: dictionary changed size during iteration`.
+        # Read the annotations before the loop below: as of Python 3.14 the first read caches them in the class dict
+        # (PEP 649), which would resize the dict that loop iterates over.
         annotations = inspect.get_annotations(cls)
 
         for attribute, value in cls.__dict__.items():

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1241,7 +1241,11 @@ def build_strawberry_output_type(
     attrs: dict[str, object] = {}
     excludes: list[str] = []
     for base in (core_mixin, *mixins):
-        annotations.update(base.__dict__.get("__annotations__", {}))
+        # inspect.get_annotations() returns the annotations the class declares itself, without the ones of its parents,
+        # which is what this type composition needs. It is read through inspect because as of Python 3.14 a class no
+        # longer carries its annotations under __annotations__ in its own dict: they are evaluated on first access and
+        # cached elsewhere (PEP 649), so reading that key directly would find nothing and drop every field.
+        annotations.update(inspect.get_annotations(base))
         excludes += base.__dict__.get("__exclude__", [])
         for k, v in base.__dict__.items():
             if not k.startswith("__"):  # Exclude private attributes. Annotations and exclude are dealt separately
@@ -1293,12 +1297,14 @@ def build_composed_filter_input(
     """
     components = get_filter_components(core_filter, contributions)
     # Guard against multiple components having the same field that is not shared
-    # __annotations__ is used because it doesn't contain the fields of the parent class so those are excluded for the comparison
+    # The annotations a component declares itself are used because they don't contain the fields of the parent class, so
+    # those are excluded for the comparison. They are read through inspect because as of Python 3.14 a class no longer
+    # carries them under __annotations__ in its own dict (PEP 649, see build_strawberry_output_type).
     seen_fields: set[str] = set()
     for component in components:
         if not issubclass(component, base_filter):
             raise Exception(f"{component.__name__} must subclass {base_filter} to filter on {type_name}.")
-        for field_name in component.__dict__.get("__annotations__", {}):
+        for field_name in inspect.get_annotations(component):
             if field_name in seen_fields:
                 raise Exception(f"{field_name} defined more than once in {type_name} filters.")
             seen_fields.add(field_name)

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1241,10 +1241,8 @@ def build_strawberry_output_type(
     attrs: dict[str, object] = {}
     excludes: list[str] = []
     for base in (core_mixin, *mixins):
-        # inspect.get_annotations() returns the annotations the class declares itself, without the ones of its parents,
-        # which is what this type composition needs. It is read through inspect because as of Python 3.14 a class no
-        # longer carries its annotations under __annotations__ in its own dict: they are evaluated on first access and
-        # cached elsewhere (PEP 649), so reading that key directly would find nothing and drop every field.
+        # The annotations the class declares itself, without the ones of its parents. Read through inspect because as of
+        # Python 3.14 a class no longer carries them in its own dict (PEP 649).
         annotations.update(inspect.get_annotations(base))
         excludes += base.__dict__.get("__exclude__", [])
         for k, v in base.__dict__.items():
@@ -1297,9 +1295,7 @@ def build_composed_filter_input(
     """
     components = get_filter_components(core_filter, contributions)
     # Guard against multiple components having the same field that is not shared
-    # The annotations a component declares itself are used because they don't contain the fields of the parent class, so
-    # those are excluded for the comparison. They are read through inspect because as of Python 3.14 a class no longer
-    # carries them under __annotations__ in its own dict (PEP 649, see build_strawberry_output_type).
+    # The annotations a component declares itself are used because they exclude the fields of the parent class.
     seen_fields: set[str] = set()
     for component in components:
         if not issubclass(component, base_filter):

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1457,11 +1457,9 @@ class ProjectPipConfig(inmanta.data.model.PipConfig):
 
 _RELATION_PRECEDENCE_RULE_PATTERN: str = r"^(?P<ft>[^\s.]+)\.(?P<fr>[^\s.]+)\s+before\s+(?P<tt>[^\s.]+)\.(?P<tr>[^\s.]+)$"
 """
-The pattern a rule of the relation precedence policy has to match.
-
-It lives at module level because the annotation of the relation_precedence_policy field below constrains that field with
-it. As of Python 3.14 the annotations of a class are evaluated lazily, in a scope that does not include the namespace of
-the class (PEP 649), so a name defined on the class itself would reach pydantic as an unusable ForwardRef.
+The pattern a rule of the relation precedence policy has to match. It lives at module level because the annotation of
+the relation_precedence_policy field below constrains that field with it, and as of Python 3.14 annotations are
+evaluated in a scope that does not see the class namespace (PEP 649).
 """
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -1455,6 +1455,16 @@ class ProjectPipConfig(inmanta.data.model.PipConfig):
         return values
 
 
+_RELATION_PRECEDENCE_RULE_PATTERN: str = r"^(?P<ft>[^\s.]+)\.(?P<fr>[^\s.]+)\s+before\s+(?P<tt>[^\s.]+)\.(?P<tr>[^\s.]+)$"
+"""
+The pattern a rule of the relation precedence policy has to match.
+
+It lives at module level because the annotation of the relation_precedence_policy field below constrains that field with
+it. As of Python 3.14 the annotations of a class are evaluated lazily, in a scope that does not include the namespace of
+the class (PEP 649), so a name defined on the class itself would reach pydantic as an unusable ForwardRef.
+"""
+
+
 @stable_api
 class ProjectMetadata(Metadata, MetadataFieldRequires):
     """
@@ -1519,8 +1529,7 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
 
     _raw_parser: typing.ClassVar[type[YamlParser]] = YamlParser
 
-    _re_relation_precedence_rule: str = r"^(?P<ft>[^\s.]+)\.(?P<fr>[^\s.]+)\s+before\s+(?P<tt>[^\s.]+)\.(?P<tr>[^\s.]+)$"
-    _re_relation_precedence_rule_compiled: ClassVar[re.Pattern[str]] = re.compile(_re_relation_precedence_rule)
+    _re_relation_precedence_rule_compiled: ClassVar[re.Pattern[str]] = re.compile(_RELATION_PRECEDENCE_RULE_PATTERN)
 
     author: Optional[str] = None
     author_email: Optional[NameEmail] = None
@@ -1531,7 +1540,7 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
     downloadpath: Optional[str] = None
     install_mode: InstallMode = InstallMode.release
     relation_precedence_policy: list[
-        Annotated[str, StringConstraints(strip_whitespace=True, pattern=_re_relation_precedence_rule, min_length=1)]
+        Annotated[str, StringConstraints(strip_whitespace=True, pattern=_RELATION_PRECEDENCE_RULE_PATTERN, min_length=1)]
     ] = []
     agent_install_dependency_modules: bool = True
     pip: ProjectPipConfig = ProjectPipConfig()


### PR DESCRIPTION
# Description

*Claude here, opening this on behalf of @jptrindade.*

`import inmanta` fails on Python 3.14, which blocks
[irt#update-to-python-3.14](https://jenkins.inmanta.com/job/integration-tests/job/irt-test/job/update-to-python-3.14/1/).
As of 3.14 the annotations of a class are evaluated on first read and cached outside of the class dict, in a scope that
does not see the class namespace (PEP 649). Three places depended on the old behaviour:

* `BaseDocument.load_fields` read `cls.__annotations__` from within a loop over `cls.__dict__`, so caching them resized
  the dict being iterated: `RuntimeError: dictionary changed size during iteration`.
* `ProjectMetadata.relation_precedence_policy` constrained itself with a pattern defined on the class body, which the
  lazily evaluated annotation can no longer resolve, so pydantic got a `ForwardRef`. The pattern moved to module level.
* `build_strawberry_output_type` and `build_composed_filter_input` read the annotations of their mixins out of
  `__dict__`, where they no longer are. That returned nothing, silently: the fields extensions contribute were dropped
  from the GraphQL types and the duplicate field guard on filters stopped guarding.

All three now read them through `inspect.get_annotations()`, which behaves the same on 3.13 and on 3.14.

Verified on both interpreters: every `inmanta.*` module imports, `tests/test_data.py` passes (68 tests), and the
`BaseDocument` field metadata and generated GraphQL SDL are identical. `make mypy` is clean on 3.13. No tests are added
because the existing suite already covers this on 3.14: with only the `schema.py` hunk reverted,
`test_custom_extension_contributions` and `test_resolved_model_version_available_to_contributions` fail with
`MissingFieldAnnotationError`, and the other two issues break `import inmanta` outright.

# Self Check:

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~
