### PR TITLE
Break the cyclic import between inmanta.data and inmanta.data.model

### DIFF
--- a/changelogs/unreleased/break-dto-dao-cycle.yml
+++ b/changelogs/unreleased/break-dto-dao-cycle.yml
@@ -1,0 +1,5 @@
+description: Broke the cyclic import between inmanta.data and inmanta.data.model. Every moved name stays importable from its old location.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -105,7 +105,9 @@ APILIMIT = 1000
 # Used as the 'default' parameter value for the Field class, when no default value has been set
 default_unset = object()
 
-PRIMITIVE_SQL_TYPES = Union[str, int, bool, datetime.datetime, UUID]
+# Defined in inmanta.types so that code that only needs the alias, such as the DTOs, does not have to import the database
+# access layer. Kept importable here because all its call sites are database code.
+PRIMITIVE_SQL_TYPES = inmanta.types.PRIMITIVE_SQL_TYPES
 
 """
 Locking order rules:
@@ -7044,6 +7046,21 @@ class DiscoveredResource(BaseDocument):
     values: dict[str, object]
 
     __primary_key__ = ("environment", "discovered_resource_id")
+
+    @classmethod
+    def from_dto(cls, dto: m.DiscoveredResourceInput, environment: uuid.UUID) -> "DiscoveredResource":
+        """Build a DAO from the DTO the API received."""
+        parsed_id: resources.Id = resources.Id.parse_id(dto.discovered_resource_id)
+        return cls(
+            discovered_resource_id=dto.discovered_resource_id,
+            resource_type=parsed_id.entity_type,
+            agent=parsed_id.agent_name,
+            resource_id_value=parsed_id.attribute_value,
+            values=dto.values,
+            discovered_at=datetime.datetime.now(),
+            environment=environment,
+            discovery_resource_id=dto.discovery_resource_id,
+        )
 
     def to_dto(self) -> m.DiscoveredResourceOutput:
         return m.DiscoveredResourceOutput(

--- a/src/inmanta/data/model.py
+++ b/src/inmanta/data/model.py
@@ -37,10 +37,10 @@ from pydantic import ConfigDict, Field, SerializationInfo, computed_field, field
 import inmanta
 import inmanta.ast.export as ast_export
 import pydantic_core.core_schema
-from inmanta import const, data, protocol, resources
+from inmanta import const, resources, util
 from inmanta.deploy.state import Blocked, Compliance, HandlerResult
 from inmanta.stable_api import stable_api
-from inmanta.types import ArgumentTypes
+from inmanta.types import PRIMITIVE_SQL_TYPES, ArgumentTypes
 from inmanta.types import BaseModel as BaseModel  # Keep in place for backwards compat with <=ISO8
 from inmanta.types import JsonType
 from inmanta.types import ResourceIdStr as ResourceIdStr  # Keep in place for backwards compat with <=ISO8
@@ -226,7 +226,7 @@ class AttributeStateChange(BaseModel):
         Verify whether the value is serializable (https://github.com/inmanta/inmanta-core/issues/3470)
         """
         try:
-            protocol.common.json_encode(v)
+            util.json_encode(v)
         except TypeError:
             if inmanta.RUNNING_TESTS:
                 # Fail the test when the value is not serializable
@@ -240,7 +240,7 @@ class AttributeStateChange(BaseModel):
         # make pickle use json to keep from leaking stuff
         # Will make the objects into json-like things
         # This method exists only to keep IPC light compatible with the json based RPC
-        return protocol.common.json_encode(self)
+        return util.json_encode(self)
 
     def __setstate__(self, state: str) -> None:
         # This method exists only to keep IPC light compatible with the json based RPC
@@ -615,10 +615,10 @@ class PagingBoundaries:
 
     def __init__(
         self,
-        start: Optional["inmanta.data.PRIMITIVE_SQL_TYPES"],  # Can be none if user selected field is nullable
-        end: Optional["inmanta.data.PRIMITIVE_SQL_TYPES"],  # Can be none if user selected field is nullable
-        first_id: Optional["inmanta.data.PRIMITIVE_SQL_TYPES"],  # Can be none if single keyed
-        last_id: Optional["inmanta.data.PRIMITIVE_SQL_TYPES"],  # Can be none if single keyed
+        start: Optional[PRIMITIVE_SQL_TYPES],  # Can be none if user selected field is nullable
+        end: Optional[PRIMITIVE_SQL_TYPES],  # Can be none if user selected field is nullable
+        first_id: Optional[PRIMITIVE_SQL_TYPES],  # Can be none if single keyed
+        last_id: Optional[PRIMITIVE_SQL_TYPES],  # Can be none if single keyed
     ) -> None:
         self.start = start
         self.end = end
@@ -995,19 +995,6 @@ class DiscoveredResourceInput(DiscoveredResourceABC):
     """
     A discovered resource that is sent to the API.
     """
-
-    def to_dao(self, env: uuid.UUID) -> "data.DiscoveredResource":
-        parsed_id: resources.Id = resources.Id.parse_id(self.discovered_resource_id)
-        return data.DiscoveredResource(
-            discovered_resource_id=self.discovered_resource_id,
-            resource_type=parsed_id.entity_type,
-            agent=parsed_id.agent_name,
-            resource_id_value=parsed_id.attribute_value,
-            values=self.values,
-            discovered_at=datetime.datetime.now(),
-            environment=env,
-            discovery_resource_id=self.discovery_resource_id,
-        )
 
 
 def hyphenize(field: str) -> str:

--- a/src/inmanta/protocol/common.py
+++ b/src/inmanta/protocol/common.py
@@ -23,7 +23,6 @@ import gzip
 import importlib
 import inspect
 import io
-import json
 import logging
 import re
 import time
@@ -33,7 +32,6 @@ from collections import defaultdict
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, MutableMapping, Sequence
 from datetime import datetime
 from enum import Enum
-from functools import partial
 from inspect import Parameter
 from typing import TYPE_CHECKING, Any, Generic, Iterator, Optional, Protocol, TypeVar, Union, cast, get_type_hints
 from urllib import parse
@@ -47,7 +45,7 @@ from tornado import web
 from tornado.httpclient import HTTPRequest
 
 import typing_extensions
-from inmanta import const, execute, types, util
+from inmanta import const, types, util
 from inmanta.protocol import exceptions
 from inmanta.protocol.auth import auth
 from inmanta.protocol.auth.decorators import AuthorizationMetadata
@@ -58,6 +56,11 @@ from inmanta.types import ArgumentTypes, BaseModel, DateTimeNormalizerModel, Han
 if TYPE_CHECKING:
     from inmanta.protocol.rest.client import RESTClient
 
+
+# These live in inmanta.util so that low level code, in particular the DTOs, can encode itself without depending on the
+# protocol layer. Kept importable here because that is where they have always been part of the API.
+custom_json_encoder = util.custom_json_encoder
+json_encode = util.json_encode
 
 LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -1156,17 +1159,6 @@ class UrlMethod:
 
 
 # Util functions
-def custom_json_encoder(o: object, tz_aware: bool = True) -> Union[ReturnTypes, util.JSONSerializable]:
-    """
-    A custom json encoder that knows how to encode other types commonly used by Inmanta
-    """
-    if isinstance(o, execute.util.Unknown):
-        return const.UNKNOWN_STRING
-
-    # handle common python types
-    return util.api_boundary_json_encoder(o, tz_aware)
-
-
 def attach_warnings(code: int, value: Optional[JsonType], warnings: Optional[list[str]]) -> tuple[int, JsonType]:
     if value is None:
         value = {}
@@ -1175,12 +1167,6 @@ def attach_warnings(code: int, value: Optional[JsonType], warnings: Optional[lis
         warns = meta.setdefault("warnings", [])
         warns.extend(warnings)
     return code, value
-
-
-def json_encode(value: object, tz_aware: bool = True) -> str:
-    """Our json encode is able to also serialize other types than a dict."""
-    # see json_encode in tornado.escape
-    return json.dumps(value, default=partial(custom_json_encoder, tz_aware=tz_aware)).replace("</", "<\\/")
 
 
 def gzipped_json(value: JsonType) -> tuple[bool, Union[bytes, str]]:

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -449,14 +449,14 @@ class ResourceService(protocol.ServerSlice):
             LOGGER.exception(error_msg)
             raise BadRequest(error_msg, {"validation_errors": e.errors()})
 
-        dao = discovered_resource.to_dao(env.id)
+        dao = data.DiscoveredResource.from_dto(discovered_resource, env.id)
         await dao.insert_with_overwrite()
 
     @handle(methods_v2.discovered_resource_create_batch, env="tid")
     async def discovered_resources_create_batch(
         self, env: data.Environment, discovered_resources: list[model.DiscoveredResourceInput]
     ) -> None:
-        dao_list = [res.to_dao(env.id) for res in discovered_resources]
+        dao_list = [data.DiscoveredResource.from_dto(res, env.id) for res in discovered_resources]
         await data.DiscoveredResource.insert_many_with_overwrite(dao_list)
 
     @handle(methods_v2.discovered_resources_get, env="tid")

--- a/src/inmanta/types.py
+++ b/src/inmanta/types.py
@@ -100,6 +100,11 @@ def issubclass(sub: type, super: Union[type, tuple[type, ...]]) -> bool:
 
 
 PrimitiveTypes = Optional[uuid.UUID | bool | int | float | datetime.datetime | str]
+
+PRIMITIVE_SQL_TYPES = Union[str, int, bool, datetime.datetime, uuid.UUID]
+"""
+    The primitive types that can be stored in, and ordered by, a database column.
+"""
 type SimpleTypes = BaseModel | PrimitiveTypes
 
 JsonType = dict[str, Any]

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -555,6 +555,26 @@ def api_boundary_json_encoder(o: object, tz_aware: bool = True) -> Union[ReturnT
     return _custom_json_encoder(o)
 
 
+@stable_api
+def custom_json_encoder(o: object, tz_aware: bool = True) -> Union[ReturnTypes, "JSONSerializable"]:
+    """
+    A custom json encoder that knows how to encode other types commonly used by Inmanta, including compiler Unknown values.
+    """
+    from inmanta.execute.util import Unknown
+
+    if isinstance(o, Unknown):
+        return const.UNKNOWN_STRING
+
+    return api_boundary_json_encoder(o, tz_aware)
+
+
+@stable_api
+def json_encode(value: object, tz_aware: bool = True) -> str:
+    """Our json encode is able to also serialize other types than a dict."""
+    # see json_encode in tornado.escape
+    return json.dumps(value, default=functools.partial(custom_json_encoder, tz_aware=tz_aware)).replace("</", "<\\/")
+
+
 def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
     """
     A custom json encoder that knows how to encode other types commonly used by Inmanta from standard python libraries
@@ -1099,8 +1119,6 @@ def make_attribute_hash(resource_id: "ResourceId", attributes: Mapping[str, obje
     """
     This method returns the attribute hash for the attributes of the given resource.
     """
-    from inmanta.protocol.common import custom_json_encoder
-
     character = json.dumps(
         {k: v for k, v in attributes.items() if k not in ["id", "requires", "provides", "version"]},
         default=custom_json_encoder,


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

First step of the import cleanup train. `inmanta/data/__init__.py` imports `inmanta.data.model`, and `inmanta/data/model.py` imported `inmanta.data` and `inmanta.protocol` straight back:

```
data/__init__.py:56   from inmanta.data import model as m
data/model.py:40      from inmanta import const, data, protocol, resources
```

That cycle only resolves because Python hands out a partially initialised module. It also blocks moving the DTOs out of the database package, since the move would push the same edge one level out.

Exactly three uses kept it alive, and each gets the treatment its subject calls for rather than the cheapest one available:

| use | treatment | why |
| --- | --------- | --- |
| `PRIMITIVE_SQL_TYPES` (4 annotations in `PagingBoundaries`) | definition moves down to `inmanta.types` | a plain `Union` alias with no database semantics; it lived in the DAO only because the paging code did |
| `protocol.common.json_encode` (2 calls) | definition moves down to `inmanta.util` | serialising yourself is a utility, not a protocol concern, and it already delegated to `util.api_boundary_json_encoder` |
| `DiscoveredResourceInput.to_dao` | inverted to `data.DiscoveredResource.from_dto` | a DTO constructing a DAO is a genuine layering violation; no relocation fixes the direction |

`inmanta/data/model.py` now imports `const`, `resources` and `util` only.

The `json_encode` move also removes the function-level `from inmanta.protocol.common import custom_json_encoder` inside `util.make_attribute_hash`, which existed purely to dodge this same loop.

## Nothing downstream changes

Every moved name stays importable where it was, verified to be the same object:

- `inmanta.protocol.common.json_encode`, `inmanta.protocol.json_encode` and `inmanta.protocol.common.custom_json_encoder` all still resolve. The top-level `inmanta.protocol` re-export matters: `pytest-inmanta` uses it.
- `inmanta.data.PRIMITIVE_SQL_TYPES` still resolves, and `is inmanta.types.PRIMITIVE_SQL_TYPES`.
- `inmanta.data.json_encode` is deliberately untouched. It is a **different** function from `protocol.common.json_encode`: it encodes with `util.internal_json_encoder` rather than `custom_json_encoder`. Only the protocol one was in the cycle. inmanta-lsm uses both, separately.

`DiscoveredResourceInput.to_dao` is the only removal. It is not `@stable_api`, and a search across every checkout in my workspace found no user outside the two `resourceservice.py` call sites updated here.

## What this deliberately does not do

No files move and no DTO is touched. That is the next PR in the stack, which introduces the `inmanta.dto` package; this one only makes that move possible. As a result there is no measurable change here: `inmanta/data/model.py` still lives inside the `data` package, so importing it still executes the database layer.

## Verification

- CI mypy and the fast test suite both pass on this branch. Locally, `mypy-baseline filter` with a cold cache reports `new: 9` here and the identical set on master, so this PR introduces no violations either tool sees. Those 9 are pre-existing drift against the committed baseline; CI's mypy is green on master and here, so its mypy version resolves them differently.
- black, isort and flake8 clean, under the `profile=black` isort config that landed on master in #10428.
- 158 tests pass across `tests/protocol/`, `tests/forking_agent/`, `tests/test_resource.py`, `tests/test_data_model.py` and `tests/deploy/e2e/test_discovered_resources.py`. Two failures are pre-existing and reproduce on pristine master: `test_2151_method_header_parameter_in_body` (a local port clash on 127.0.0.1:8888) and `test_max_request_body_size_decompressed` (new in #10687, asserts 400 and gets 200).
