### PR TITLE
Import the DTOs from their thematic inmanta.dto modules

### DIFF
--- a/changelogs/unreleased/migrate-dto-imports.yml
+++ b/changelogs/unreleased/migrate-dto-imports.yml
@@ -1,0 +1,5 @@
+description: inmanta-core now imports the data transfer objects from their thematic inmanta.dto modules instead of the inmanta.data.model re-export.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -31,8 +31,8 @@ from inmanta.agent import config as cfg
 from inmanta.agent import executor, forking_executor
 from inmanta.agent.reporting import collect_report
 from inmanta.const import AGENT_SCHEDULER_ID
-from inmanta.data.model import DataBaseReport, SchedulerStatusReport
 from inmanta.deploy import scheduler
+from inmanta.dto.scheduler import DataBaseReport, SchedulerStatusReport
 from inmanta.protocol import SessionEndpoint, methods, methods_v2
 from inmanta.resources import Id
 from inmanta.server.services.databaseservice import DatabaseMonitor

--- a/src/inmanta/agent/code_manager.py
+++ b/src/inmanta/agent/code_manager.py
@@ -25,7 +25,8 @@ import inmanta.data.sqlalchemy as models
 from inmanta import data
 from inmanta.agent import executor
 from inmanta.agent.executor import ModuleInstallSpec
-from inmanta.data.model import LEGACY_PIP_DEFAULT, ModuleSource, ModuleSourceMetadata, PipConfig
+from inmanta.dto.code import ModuleSource, ModuleSourceMetadata
+from inmanta.dto.pip import LEGACY_PIP_DEFAULT, PipConfig
 from inmanta.util.async_lru import async_lru_cache
 from sqlalchemy import and_, select
 

--- a/src/inmanta/agent/executor.py
+++ b/src/inmanta/agent/executor.py
@@ -43,7 +43,9 @@ from inmanta.agent import resourcepool
 from inmanta.agent.handler import HandlerContext
 from inmanta.const import Change
 from inmanta.data import LogLine
-from inmanta.data.model import AttributeStateChange, ModuleSource, PipConfig
+from inmanta.dto.code import ModuleSource
+from inmanta.dto.pip import PipConfig
+from inmanta.dto.resource import AttributeStateChange
 from inmanta.env import PythonEnvironment
 from inmanta.resources import Id
 from inmanta.types import JsonType, ResourceIdStr, ResourceVersionIdStr

--- a/src/inmanta/agent/forking_executor.py
+++ b/src/inmanta/agent/forking_executor.py
@@ -88,6 +88,7 @@ import inmanta.agent.in_process_executor
 import inmanta.config
 import inmanta.const
 import inmanta.data
+import inmanta.dto.code
 import inmanta.env
 import inmanta.loader
 import inmanta.logging
@@ -395,7 +396,7 @@ class InitCommand(inmanta.protocol.ipc_light.IPCMethod[ExecutorContext, FailedIn
         self,
         venv_path: str,
         storage_folder: str,
-        sources: Sequence[inmanta.data.model.ModuleSource],
+        sources: Sequence[inmanta.dto.code.ModuleSource],
         venv_touch_interval: float = 60.0,
     ):
         """
@@ -428,7 +429,7 @@ class InitCommand(inmanta.protocol.ipc_light.IPCMethod[ExecutorContext, FailedIn
         loader = inmanta.loader.CodeLoader(self.storage_folder)
 
         failed: FailedInmantaModules = defaultdict(dict)
-        in_place: list[inmanta.data.model.ModuleSource] = []
+        in_place: list[inmanta.dto.code.ModuleSource] = []
         # First put all files on disk
         for module_source in self.sources:
             try:

--- a/src/inmanta/agent/handler.py
+++ b/src/inmanta/agent/handler.py
@@ -35,10 +35,11 @@ import inmanta
 from inmanta import const, data, protocol, resources, tracing
 from inmanta.agent.cache import AgentCache
 from inmanta.const import ParameterSource, ResourceState
-from inmanta.data.model import AttributeStateChange, BaseModel, DiscoveredResourceInput
+from inmanta.dto.discovery import DiscoveredResourceInput
+from inmanta.dto.resource import AttributeStateChange
 from inmanta.protocol import Result, json_encode
 from inmanta.stable_api import stable_api
-from inmanta.types import ResourceIdStr, SimpleTypes
+from inmanta.types import BaseModel, ResourceIdStr, SimpleTypes
 from inmanta.util import hash_file
 
 if typing.TYPE_CHECKING:

--- a/src/inmanta/agent/in_process_executor.py
+++ b/src/inmanta/agent/in_process_executor.py
@@ -33,7 +33,7 @@ from inmanta.agent import executor, handler
 from inmanta.agent.executor import DeployReport, DryrunReport, FailedInmantaModules, GetFactReport, ResourceDetails
 from inmanta.agent.handler import HandlerAPI, SkipResource, SkipResourceForDependencies
 from inmanta.const import NAME_RESOURCE_ACTION_LOGGER, ParameterSource
-from inmanta.data.model import AttributeStateChange
+from inmanta.dto.resource import AttributeStateChange
 from inmanta.references import MutatorMissingError, ReferenceMissingError
 from inmanta.resources import Resource
 from inmanta.types import ResourceIdStr, ResourceVersionIdStr

--- a/src/inmanta/compiler/data.py
+++ b/src/inmanta/compiler/data.py
@@ -17,8 +17,8 @@ Contact: code@inmanta.com
 """
 
 import inmanta.ast.export as ast_export
-import inmanta.data.model as model
 from inmanta.ast import CompilerException
+from inmanta.dto import compile as dto_compile
 
 
 class CompileData(ast_export.Exportable):
@@ -28,5 +28,5 @@ class CompileData(ast_export.Exportable):
     def add_error(self, error: CompilerException) -> None:
         self.errors.append(error)
 
-    def export(self) -> "model.CompileData":
-        return model.CompileData(errors=[e.export() for e in self.errors])
+    def export(self) -> "dto_compile.CompileData":
+        return dto_compile.CompileData(errors=[e.export() for e in self.errors])

--- a/src/inmanta/data/dataview.py
+++ b/src/inmanta/data/dataview.py
@@ -53,19 +53,19 @@ from inmanta.data import (
     Scheduler,
     SimpleQueryBuilder,
     VersionedResourceOrder,
-    model,
 )
-from inmanta.data.model import (
-    BaseModel,
-    CompileReport,
-    DesiredStateLabel,
-    DesiredStateVersion,
-    Fact,
-    LatestReleasedResource,
-    PagingBoundaries,
-    ResourceHistory,
-    ResourceLog,
-)
+from inmanta.dto import agent as dto_agent
+from inmanta.dto import compile as dto_compile
+from inmanta.dto import discovery as dto_discovery
+from inmanta.dto import notification as dto_notification
+from inmanta.dto import parameter as dto_parameter
+from inmanta.dto import resource as dto_resource
+from inmanta.dto.compile import CompileReport
+from inmanta.dto.desiredstate import DesiredStateLabel, DesiredStateVersion
+from inmanta.dto.log import ResourceLog
+from inmanta.dto.paging import PagingBoundaries
+from inmanta.dto.parameter import Fact
+from inmanta.dto.resource import LatestReleasedResource, ResourceHistory
 from inmanta.protocol.exceptions import BadRequest
 from inmanta.protocol.return_value_meta import ReturnValueWithMeta
 from inmanta.resources import Id
@@ -84,7 +84,7 @@ from inmanta.server.validate_filter import (
     InvalidFilter,
     LogLevelFilter,
 )
-from inmanta.types import ResourceIdStr, ResourceVersionIdStr, SimpleTypes
+from inmanta.types import BaseModel, ResourceIdStr, ResourceVersionIdStr, SimpleTypes
 from inmanta.util import datetime_iso_format
 
 T_ORDER = TypeVar("T_ORDER", bound=DatabaseOrderV2)
@@ -475,7 +475,7 @@ class DataView(FilterValidator, Generic[T_ORDER, T_DTO], ABC):
         return limit
 
 
-class ResourceView(DataView[ResourceStatusOrder, model.LatestReleasedResource]):
+class ResourceView(DataView[ResourceStatusOrder, dto_resource.LatestReleasedResource]):
     def __init__(
         self,
         env: data.Environment,
@@ -552,9 +552,9 @@ class ResourceView(DataView[ResourceStatusOrder, model.LatestReleasedResource]):
         )
         return new_query_builder
 
-    def construct_dtos(self, records: Sequence[Record]) -> Sequence[model.LatestReleasedResource]:
+    def construct_dtos(self, records: Sequence[Record]) -> Sequence[dto_resource.LatestReleasedResource]:
         dtos: Sequence[LatestReleasedResource] = [
-            model.LatestReleasedResource(
+            dto_resource.LatestReleasedResource(
                 resource_id=resource["resource_id"],
                 resource_version_id=resource["resource_id"] + ",v=" + str(resource["model"]),
                 id_details=data.Resource.get_details_from_resource_id(resource["resource_id"]),
@@ -567,7 +567,7 @@ class ResourceView(DataView[ResourceStatusOrder, model.LatestReleasedResource]):
         return dtos
 
 
-class ResourcesInVersionView(DataView[VersionedResourceOrder, model.VersionedResource]):
+class ResourcesInVersionView(DataView[VersionedResourceOrder, dto_resource.VersionedResource]):
     def __init__(
         self,
         environment: data.Environment,
@@ -616,9 +616,9 @@ class ResourcesInVersionView(DataView[VersionedResourceOrder, model.VersionedRes
         )
         return query_builder
 
-    def construct_dtos(self, records: Sequence[Record]) -> Sequence[model.VersionedResource]:
+    def construct_dtos(self, records: Sequence[Record]) -> Sequence[dto_resource.VersionedResource]:
         return [
-            model.VersionedResource(
+            dto_resource.VersionedResource(
                 resource_id=versioned_resource["resource_id"],
                 resource_version_id=versioned_resource["resource_id"] + f",v={self.version}",
                 id_details=data.Resource.get_details_from_resource_id(versioned_resource["resource_id"]),
@@ -677,7 +677,7 @@ class CompileReportView(DataView[CompileReportOrder, CompileReport]):
         )
         return query_builder
 
-    def construct_dtos(self, records: Sequence[Record]) -> Sequence[model.CompileReport]:
+    def construct_dtos(self, records: Sequence[Record]) -> Sequence[dto_compile.CompileReport]:
         return [
             CompileReport(
                 id=compile["id"],
@@ -1019,7 +1019,7 @@ class FactsView(DataView[FactOrder, Fact]):
         ]
 
 
-class NotificationsView(DataView[NotificationOrder, model.Notification]):
+class NotificationsView(DataView[NotificationOrder, dto_notification.Notification]):
     def __init__(
         self,
         environment: data.Environment,
@@ -1063,9 +1063,9 @@ class NotificationsView(DataView[NotificationOrder, model.Notification]):
             values=[self.environment.id],
         )
 
-    def construct_dtos(self, records: Sequence[Record]) -> Sequence[model.Notification]:
+    def construct_dtos(self, records: Sequence[Record]) -> Sequence[dto_notification.Notification]:
         return [
-            model.Notification(
+            dto_notification.Notification(
                 id=notification["id"],
                 title=notification["title"],
                 message=notification["message"],
@@ -1081,7 +1081,7 @@ class NotificationsView(DataView[NotificationOrder, model.Notification]):
         ]
 
 
-class ParameterView(DataView[ParameterOrder, model.Parameter]):
+class ParameterView(DataView[ParameterOrder, dto_parameter.Parameter]):
     def __init__(
         self,
         environment: data.Environment,
@@ -1123,9 +1123,9 @@ class ParameterView(DataView[ParameterOrder, model.Parameter]):
             values=[self.environment.id],
         )
 
-    def construct_dtos(self, records: Sequence[Record]) -> Sequence[model.Parameter]:
+    def construct_dtos(self, records: Sequence[Record]) -> Sequence[dto_parameter.Parameter]:
         return [
-            model.Parameter(
+            dto_parameter.Parameter(
                 id=parameter["id"],
                 name=parameter["name"],
                 value=parameter["value"],
@@ -1138,7 +1138,7 @@ class ParameterView(DataView[ParameterOrder, model.Parameter]):
         ]
 
 
-class AgentView(DataView[AgentOrder, model.Agent]):
+class AgentView(DataView[AgentOrder, dto_agent.Agent]):
     def __init__(
         self,
         environment: data.Environment,
@@ -1220,9 +1220,9 @@ class AgentView(DataView[AgentOrder, model.Agent]):
             )
         return base
 
-    def construct_dtos(self, records: Sequence[Record]) -> Sequence[model.Agent]:
+    def construct_dtos(self, records: Sequence[Record]) -> Sequence[dto_agent.Agent]:
         return [
-            model.Agent(
+            dto_agent.Agent(
                 name=agent["name"],
                 environment=agent["environment"],
                 paused=agent["paused"],
@@ -1235,7 +1235,7 @@ class AgentView(DataView[AgentOrder, model.Agent]):
         ]
 
 
-class DiscoveredResourceView(DataView[DiscoveredResourceOrder, model.DiscoveredResourceOutput]):
+class DiscoveredResourceView(DataView[DiscoveredResourceOrder, dto_discovery.DiscoveredResourceOutput]):
     def __init__(
         self,
         environment: data.Environment,
@@ -1302,7 +1302,7 @@ class DiscoveredResourceView(DataView[DiscoveredResourceOrder, model.DiscoveredR
 
     def construct_dtos(self, records: Sequence[Record]) -> Sequence[dict[str, str]]:
         return [
-            model.DiscoveredResourceOutput(
+            dto_discovery.DiscoveredResourceOutput(
                 discovered_resource_id=rid.resource_str(),
                 resource_type=rid.entity_type,
                 agent=rid.agent_name,

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -19,11 +19,11 @@ from typing import Any, Callable, Optional, Sequence
 import asyncpg
 
 from inmanta.const import ClientType
-from inmanta.data.model import AgentName
-from inmanta.data.model import InmantaModule as InmantaModuleDTO
-from inmanta.data.model import InmantaModuleName, InmantaModuleVersion
-from inmanta.data.model import Token as TokenDTO
 from inmanta.deploy import state
+from inmanta.dto.agent import AgentName
+from inmanta.dto.auth import Token as TokenDTO
+from inmanta.dto.code import InmantaModule as InmantaModuleDTO
+from inmanta.dto.code import InmantaModuleName, InmantaModuleVersion
 from sqlalchemy import (
     ARRAY,
     Boolean,

--- a/src/inmanta/db/versions/v202503030.py
+++ b/src/inmanta/db/versions/v202503030.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 
 from asyncpg import Connection
 
-from inmanta.data.model import ModuleSourceMetadata
+from inmanta.dto.code import ModuleSourceMetadata
 from inmanta.loader import CodeManager
 
 LOGGER = logging.getLogger("databaseservice")

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -38,12 +38,12 @@ from inmanta.agent import executor
 from inmanta.agent.code_manager import CodeManager
 from inmanta.const import HandlerResourceState
 from inmanta.data import Environment
-from inmanta.data.model import Discrepancy, SchedulerStatusReport
 from inmanta.deploy import timers, work
 from inmanta.deploy.persistence import ToDbUpdateManager
 from inmanta.deploy.state import AgentStatus, Blocked, Compliance, HandlerResult, ModelState, ResourceIntent, ResourceState
 from inmanta.deploy.tasks import Deploy, DryRun, RefreshFact, Task
 from inmanta.deploy.work import TaskPriority
+from inmanta.dto.scheduler import Discrepancy, SchedulerStatusReport
 from inmanta.protocol import Client
 from inmanta.resources import Id
 from inmanta.server.extensions import BoolFeature

--- a/src/inmanta/deploy/tasks.py
+++ b/src/inmanta/deploy/tasks.py
@@ -27,8 +27,8 @@ from dataclasses import dataclass
 from inmanta import data, resources
 from inmanta.agent import executor, resourcepool
 from inmanta.agent.executor import DeployReport, ModuleLoadingException
-from inmanta.data.model import AttributeStateChange
 from inmanta.deploy import scheduler, state
+from inmanta.dto.resource import AttributeStateChange
 from inmanta.types import ResourceIdStr, ResourceVersionIdStr
 from inmanta.vendor import pyformance
 

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -48,7 +48,7 @@ import packaging.utils
 import packaging.version
 from inmanta import const
 from inmanta.ast import CompilerException
-from inmanta.data.model import LEGACY_PIP_DEFAULT, PipConfig
+from inmanta.dto.pip import LEGACY_PIP_DEFAULT, PipConfig
 from inmanta.server.bootloader import InmantaBootloader
 from inmanta.stable_api import stable_api
 from inmanta.util import parse_requirement, strtobool

--- a/src/inmanta/export.py
+++ b/src/inmanta/export.py
@@ -34,7 +34,7 @@ from inmanta.agent.handler import Commander
 from inmanta.ast import CompilerException, Namespace, UnknownException
 from inmanta.ast.entity import Entity
 from inmanta.config import Option, is_list, is_uuid_opt
-from inmanta.data import model
+from inmanta.dto.environment import ProtectedBy
 from inmanta.execute import proxy
 from inmanta.execute.proxy import DynamicProxy, ProxyContext
 from inmanta.execute.runtime import Instance
@@ -427,7 +427,7 @@ class Exporter:
             result = self.client.protected_environment_settings_set_batch(
                 tid=self._get_env_id(),
                 settings=project.metadata.environment_settings or {},
-                protected_by=model.ProtectedBy.project_yml,
+                protected_by=ProtectedBy.project_yml,
             )
             if result.code != 200:
                 raise Exception("Failed to update the environment settings, defined in the project.yml file, on the server.")

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -28,8 +28,9 @@ import inmanta.data.sqlalchemy as models
 import strawberry
 from graphql import GraphQLInputObjectType
 from inmanta import data
-from inmanta.data import get_session, get_session_factory, model
+from inmanta.data import get_session, get_session_factory
 from inmanta.deploy import state
+from inmanta.dto import environment as dto_environment
 from inmanta.graphql.rest_filter import ResolvedFilter, strip_input_field
 from inmanta.server.services.compilerservice import CompilerService
 from inmanta.types import ResourceIdStr
@@ -615,10 +616,10 @@ def get_settings(root: "CoreEnvironmentMixin") -> scalars.JSON:
     assert isinstance(root.settings, dict)
     modified_settings = root.settings["settings"]
     assert modified_settings is not None
-    setting_values: dict[str, model.EnvironmentSettingDetails] = {}
+    setting_values: dict[str, dto_environment.EnvironmentSettingDetails] = {}
     for key, setting_info in data.Environment._settings.items():
         if stored_setting := modified_settings.get(key, None):
-            setting_values[key] = model.EnvironmentSettingDetails(
+            setting_values[key] = dto_environment.EnvironmentSettingDetails(
                 value=stored_setting["value"],
                 protected=stored_setting.get("protected", False),
                 protected_by=stored_setting.get("protected_by", None),
@@ -626,7 +627,7 @@ def get_settings(root: "CoreEnvironmentMixin") -> scalars.JSON:
         else:
             default_value = setting_info.default
             assert default_value is not None  # Should never happen but setting_info.default is Optional
-            setting_values[key] = model.EnvironmentSettingDetails(value=default_value)
+            setting_values[key] = dto_environment.EnvironmentSettingDetails(value=default_value)
     setting_definitions = dict(sorted(data.Environment.get_setting_definitions_for_api(setting_values).items()))
     return scalars.JSON({"settings": setting_values, "definition": setting_definitions})
 
@@ -967,7 +968,7 @@ class ResourcePersistentState:
 @strawberry.type
 class ComposedResourceSummary:
     """
-    Modeled after inmanta.data.model.ComposedResourceSummary.
+    Modeled after inmanta.dto.resource.ComposedResourceSummary.
 
     Summary of the composed status of all resources in an environment.
     """

--- a/src/inmanta/loader.py
+++ b/src/inmanta/loader.py
@@ -34,7 +34,7 @@ from itertools import chain
 from typing import TYPE_CHECKING, Optional
 
 from inmanta import const, module
-from inmanta.data.model import InmantaModule, ModuleSource
+from inmanta.dto.code import InmantaModule, ModuleSource
 from inmanta.stable_api import stable_api
 from inmanta.util import hash_file_streaming
 
@@ -45,7 +45,7 @@ PLUGIN_DIR = "plugins"
 LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from inmanta.data.model import ModuleSourceMetadata
+    from inmanta.dto.code import ModuleSourceMetadata
     from inmanta.resources import Id, Resource
 
 

--- a/src/inmanta/module.py
+++ b/src/inmanta/module.py
@@ -53,7 +53,7 @@ import pydantic
 import yaml
 from pydantic import BaseModel, Field, NameEmail, StringConstraints, ValidationError, field_validator
 
-import inmanta.data.model
+import inmanta.util
 import packaging.requirements
 import packaging.utils
 import packaging.version
@@ -62,6 +62,8 @@ from inmanta.ast import CompilerException, LocatableString, Location, Namespace,
 from inmanta.ast.blocks import BasicBlock
 from inmanta.ast.statements import BiStatement, DefinitionStatement, DynamicStatement, Statement
 from inmanta.ast.statements.define import DefineImport
+from inmanta.dto.environment import EnvSettingType
+from inmanta.dto.pip import PipConfig
 from inmanta.file_parser import PreservativeYamlParser, RequirementsTxtParser
 from inmanta.parser import plyInmantaParser
 from inmanta.parser.plyInmantaParser import cache_manager
@@ -1418,7 +1420,7 @@ class RelationPrecedenceRule:
 
 
 @stable_api
-class ProjectPipConfig(inmanta.data.model.PipConfig):
+class ProjectPipConfig(PipConfig):
     """
     :param index_url: one pip index url for this project.
     :param extra_index_url:  additional pip index urls for this project. This is generally only
@@ -1535,7 +1537,7 @@ class ProjectMetadata(Metadata, MetadataFieldRequires):
     ] = []
     agent_install_dependency_modules: bool = True
     pip: ProjectPipConfig = ProjectPipConfig()
-    environment_settings: dict[str, inmanta.data.model.EnvSettingType] | None = None
+    environment_settings: dict[str, EnvSettingType] | None = None
 
     @field_validator("modulepath", mode="before")
     @classmethod

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -57,7 +57,7 @@ from build.env import DefaultIsolatedEnv
 from inmanta import const, env, util
 from inmanta.command import CLIException, ShowUsageException
 from inmanta.const import CF_CACHE_DIR
-from inmanta.data import model
+from inmanta.dto.pip import PipConfig
 from inmanta.module import (
     DummyProject,
     FreezeOperator,
@@ -1919,7 +1919,7 @@ class PythonPackageToSourceConverter:
         dependencies: Sequence[util.CanonicalRequirement],
         ignore_transitive_dependencies: bool,
         constraints: Sequence[util.CanonicalRequirement] | None = None,
-        pip_config: model.PipConfig | None = None,
+        pip_config: PipConfig | None = None,
         override_if_already_exists: bool = False,
     ) -> list[str]:
         """
@@ -1972,7 +1972,7 @@ class PythonPackageToSourceConverter:
         constraints: Sequence[util.CanonicalRequirement] | None,
         ignore_transitive_dependencies: bool,
         download_dir: str,
-        pip_config: model.PipConfig | None,
+        pip_config: PipConfig | None,
     ) -> list[str]:
         """
         Download the source distribution packages for the given requirements into the download_dir.

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -25,8 +25,10 @@ from typing import Any, Literal, Optional, Union
 import inmanta.types
 from inmanta import const, data, resources
 from inmanta.const import ResourceState
-from inmanta.data import model
-from inmanta.data.model import InmantaModule, PipConfig
+from inmanta.dto.code import InmantaModule
+from inmanta.dto.compile import CompileRun
+from inmanta.dto.pip import PipConfig
+from inmanta.dto.status import StatusResponse
 from inmanta.protocol import exceptions
 from inmanta.protocol.auth.decorators import auth
 from inmanta.protocol.common import ArgOption
@@ -1003,7 +1005,7 @@ def get_state(tid: uuid.UUID, agent: str) -> dict[str, bool]:
 
 @auth(auth_label=const.CoreAuthorizationLabel.STATUS_READ, read_only=True)
 @typedmethod(path="/serverstatus", operation="GET", client_types=[const.ClientType.api])
-def get_server_status() -> model.StatusResponse:
+def get_server_status() -> StatusResponse:
     """
     Get the status of the server
     """
@@ -1018,7 +1020,7 @@ def get_server_status() -> model.StatusResponse:
     api_version=1,
     envelope_key="queue",
 )
-def get_compile_queue(tid: uuid.UUID) -> list[model.CompileRun]:
+def get_compile_queue(tid: uuid.UUID) -> list[CompileRun]:
     """
     Get the current compiler queue on the server, ordered by increasing `requested` timestamp.
 

--- a/src/inmanta/protocol/methods_v2.py
+++ b/src/inmanta/protocol/methods_v2.py
@@ -28,8 +28,35 @@ from pydantic import SecretStr
 import inmanta.types
 from inmanta import const
 from inmanta.const import AgentAction, AllAgentAction, ApiDocsFormat, Change, ClientType, ParameterSource, ResourceState
-from inmanta.data import model
-from inmanta.data.model import DataBaseReport, PipConfig, ResourceComplianceDiff
+from inmanta.dto.agent import Agent, AgentProcess
+from inmanta.dto.auth import CurrentUser, LoginReturn, RoleAssignmentsPerEnvironment, Token, User, UserWithRoles
+from inmanta.dto.code import InmantaModule
+from inmanta.dto.compile import CompileData, CompileDetails, CompileReport
+from inmanta.dto.desiredstate import DesiredStateVersion, PromoteTriggerMethod
+from inmanta.dto.diff import ResourceComplianceDiff, ResourceDiff
+from inmanta.dto.discovery import DiscoveredResourceInput, DiscoveredResourceOutput
+from inmanta.dto.dryrun import DryRun, DryRunReport
+from inmanta.dto.environment import (
+    Environment,
+    EnvironmentMetricsResult,
+    EnvironmentSettingsReponse,
+    EnvSettingType,
+    Project,
+    ProtectedBy,
+)
+from inmanta.dto.log import ResourceLog
+from inmanta.dto.notification import Notification
+from inmanta.dto.parameter import Fact, Parameter
+from inmanta.dto.pip import PipConfig
+from inmanta.dto.resource import (
+    LatestReleasedResource,
+    ReleasedResourceDetails,
+    ResourceAction,
+    ResourceHistory,
+    VersionedResource,
+    VersionedResourceDetails,
+)
+from inmanta.dto.scheduler import DataBaseReport, SchedulerStatusReport
 from inmanta.graphql.rest_filter import ResourceFilterArg
 from inmanta.graphql.result import GraphQLResult
 from inmanta.protocol import methods
@@ -51,7 +78,7 @@ from inmanta.types import PrimitiveTypes, ResourceIdStr
 )
 def put_partial(
     tid: uuid.UUID,
-    module_version_info: Mapping[str, model.InmantaModule],
+    module_version_info: Mapping[str, InmantaModule],
     resource_state: Optional[Mapping[ResourceIdStr, Literal[ResourceState.available, ResourceState.undefined]]] = None,
     unknowns: Optional[Sequence[Mapping[str, PrimitiveTypes]]] = None,
     resource_sets: Optional[Mapping[ResourceIdStr, Optional[str]]] = None,
@@ -94,7 +121,7 @@ def put_partial(
 # Method for working with projects
 @auth(auth_label=const.CoreAuthorizationLabel.PROJECT_CREATE, read_only=False)
 @typedmethod(path="/project", operation="PUT", client_types=[ClientType.api], api_version=2)
-def project_create(name: str, project_id: Optional[uuid.UUID] = None) -> model.Project:
+def project_create(name: str, project_id: Optional[uuid.UUID] = None) -> Project:
     """
     Create a new project
 
@@ -105,7 +132,7 @@ def project_create(name: str, project_id: Optional[uuid.UUID] = None) -> model.P
 
 @auth(auth_label=const.CoreAuthorizationLabel.PROJECT_MODIFY, read_only=False)
 @typedmethod(path="/project/<id>", operation="POST", client_types=[ClientType.api], api_version=2)
-def project_modify(id: uuid.UUID, name: str) -> model.Project:
+def project_modify(id: uuid.UUID, name: str) -> Project:
     """
     Rename the given project
 
@@ -126,7 +153,7 @@ def project_delete(id: uuid.UUID) -> None:
 
 @auth(auth_label=const.CoreAuthorizationLabel.PROJECT_READ, read_only=True)
 @typedmethod(path="/project", operation="GET", client_types=[ClientType.api], api_version=2)
-def project_list(environment_details: bool = False) -> list[model.Project]:
+def project_list(environment_details: bool = False) -> list[Project]:
     """
     Returns a list of projects ordered alphabetically by name. The environments within each project are also sorted by name.
 
@@ -136,7 +163,7 @@ def project_list(environment_details: bool = False) -> list[model.Project]:
 
 @auth(auth_label=const.CoreAuthorizationLabel.PROJECT_READ, read_only=True)
 @typedmethod(path="/project/<id>", operation="GET", client_types=[ClientType.api], api_version=2)
-def project_get(id: uuid.UUID, environment_details: bool = False) -> model.Project:
+def project_get(id: uuid.UUID, environment_details: bool = False) -> Project:
     """
     Get a project and a list of the environments under this project
 
@@ -156,7 +183,7 @@ def environment_create(
     environment_id: Optional[uuid.UUID] = None,
     description: str = "",
     icon: str = "",
-) -> model.Environment:
+) -> Environment:
     """
     Create a new environment
 
@@ -185,7 +212,7 @@ def environment_modify(
     project_id: Optional[uuid.UUID] = None,
     description: Optional[str] = None,
     icon: Optional[str] = None,
-) -> model.Environment:
+) -> Environment:
     """
     Modify the given environment
     The optional parameters that are unspecified will be left unchanged by the update.
@@ -222,7 +249,7 @@ def environment_delete(id: uuid.UUID) -> None:
 
 @auth(auth_label=const.CoreAuthorizationLabel.ENVIRONMENT_READ, read_only=True)
 @typedmethod(path="/environment", operation="GET", client_types=[ClientType.api], api_version=2)
-def environment_list(details: bool = False) -> list[model.Environment]:
+def environment_list(details: bool = False) -> list[Environment]:
     """
     Returns a list of environments
 
@@ -238,7 +265,7 @@ def environment_list(details: bool = False) -> list[model.Environment]:
     arg_options={"id": methods.ArgOption(getter=methods.add_env)},
     api_version=2,
 )
-def environment_get(id: uuid.UUID, details: bool = False) -> model.Environment:
+def environment_get(id: uuid.UUID, details: bool = False) -> Environment:
     """
     Get an environment and all versions associated
 
@@ -339,7 +366,7 @@ def environment_create_token(
     client_types=[ClientType.api],
     api_version=2,
 )
-def environment_token_list(tid: uuid.UUID) -> list[model.Token]:
+def environment_token_list(tid: uuid.UUID) -> list[Token]:
     """
     List the registered, revocable tokens for an environment. Only non-idempotent tokens are tracked in
     the registry; idempotent (reproducible) tokens are not listed. Expired and revoked tokens remain
@@ -380,7 +407,7 @@ def environment_token_revoke(tid: uuid.UUID, jti: uuid.UUID) -> None:
     client_types=[ClientType.api, ClientType.agent, ClientType.compiler],
     api_version=2,
 )
-def environment_settings_list(tid: uuid.UUID) -> model.EnvironmentSettingsReponse:
+def environment_settings_list(tid: uuid.UUID) -> EnvironmentSettingsReponse:
     """
     List the settings in the current environment ordered by name alphabetically.
 
@@ -398,7 +425,7 @@ def environment_settings_list(tid: uuid.UUID) -> model.EnvironmentSettingsRepons
     client_types=[ClientType.api, ClientType.agent, ClientType.compiler],
     api_version=2,
 )
-def environment_settings_set(tid: uuid.UUID, id: str, value: model.EnvSettingType) -> ReturnValue[None]:
+def environment_settings_set(tid: uuid.UUID, id: str, value: EnvSettingType) -> ReturnValue[None]:
     """
     Set a specific setting in an environment's configuration.
 
@@ -419,7 +446,7 @@ def environment_settings_set(tid: uuid.UUID, id: str, value: model.EnvSettingTyp
     client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
-def environment_setting_get(tid: uuid.UUID, id: str) -> model.EnvironmentSettingsReponse:
+def environment_setting_get(tid: uuid.UUID, id: str) -> EnvironmentSettingsReponse:
     """
     Retrieve a specific setting from an environment's configuration.
 
@@ -457,7 +484,7 @@ def environment_setting_delete(tid: uuid.UUID, id: str) -> ReturnValue[None]:
     api_version=2,
 )
 def protected_environment_settings_set_batch(
-    tid: uuid.UUID, settings: dict[str, model.EnvSettingType], protected_by: model.ProtectedBy
+    tid: uuid.UUID, settings: dict[str, EnvSettingType], protected_by: ProtectedBy
 ) -> None:
     """
     Set the values for the given environment settings and mark them as protected.
@@ -512,7 +539,7 @@ def get_api_docs(
     client_types=[ClientType.api],
     api_version=2,
 )
-def get_scheduler_status(tid: uuid.UUID) -> model.SchedulerStatusReport:
+def get_scheduler_status(tid: uuid.UUID) -> SchedulerStatusReport:
     """
     Inspect the scheduler state from the given environment.
 
@@ -530,7 +557,7 @@ def get_scheduler_status(tid: uuid.UUID) -> model.SchedulerStatusReport:
     client_types=[],
     api_version=2,
 )
-def trigger_get_status(tid: uuid.UUID) -> model.SchedulerStatusReport:
+def trigger_get_status(tid: uuid.UUID) -> SchedulerStatusReport:
     """
     Get a snapshot of the scheduler state
 
@@ -635,7 +662,7 @@ def get_agents(
     last_id: Optional[str] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "name.asc",
-) -> list[model.Agent]:
+) -> list[Agent]:
     """
     Get all of the agents in the given environment
 
@@ -664,7 +691,7 @@ def get_agents(
 @typedmethod(
     path="/agents/process/<id>", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
 )
-def get_agent_process_details(tid: uuid.UUID, id: uuid.UUID, report: bool = False) -> model.AgentProcess:
+def get_agent_process_details(tid: uuid.UUID, id: uuid.UUID, report: bool = False) -> AgentProcess:
     """
     Get the details of an agent process
 
@@ -693,7 +720,7 @@ def get_db_status() -> DataBaseReport:
     client_types=[ClientType.api],
     api_version=2,
 )
-def get_compile_data(id: uuid.UUID) -> Optional[model.CompileData]:
+def get_compile_data(id: uuid.UUID) -> Optional[CompileData]:
     """
     Get the compile data for the given compile request.
 
@@ -717,7 +744,7 @@ def get_resource_actions(
     first_timestamp: Optional[datetime.datetime] = None,
     last_timestamp: Optional[datetime.datetime] = None,
     exclude_changes: Optional[Sequence[Change]] = None,
-) -> ReturnValue[list[model.ResourceAction]]:
+) -> ReturnValue[list[ResourceAction]]:
     """
     Return resource actions matching the search criteria.
 
@@ -761,7 +788,7 @@ def get_resource_events(
     tid: uuid.UUID,
     rvid: inmanta.types.ResourceVersionIdStr,
     exclude_change: Optional[Change] = None,
-) -> dict[inmanta.types.ResourceIdStr, list[model.ResourceAction]]:
+) -> dict[inmanta.types.ResourceIdStr, list[ResourceAction]]:
     """
     Return relevant events for a resource, i.e. all deploy actions for each of its dependencies since this resources' last
     successful deploy or all deploy actions if this resources hasn't been deployed before. The resource actions are sorted in
@@ -816,7 +843,7 @@ def resource_list(
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "resource_type.desc",
     deploy_summary: bool = False,
-) -> list[model.LatestReleasedResource]:
+) -> list[LatestReleasedResource]:
     """
     :param tid: The id of the environment this resource belongs to
     :param limit: Limit the number of instances that are returned
@@ -869,7 +896,7 @@ def resource_list(
 @typedmethod(
     path="/resource/<rid>", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
 )
-def resource_details(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> model.ReleasedResourceDetails:
+def resource_details(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> ReleasedResourceDetails:
     """
     :param tid: The id of the environment from which the resource's details are being requested.
     :param rid: The unique identifier (ResourceIdStr) of the resource. This value specifies the particular resource
@@ -893,7 +920,7 @@ def resource_history(
     start: Optional[datetime.datetime] = None,
     end: Optional[datetime.datetime] = None,
     sort: str = "date.desc",
-) -> list[model.ResourceHistory]:
+) -> list[ResourceHistory]:
     """
     :param tid: The id of the environment this resource belongs to
     :param rid: The id of the resource
@@ -929,7 +956,7 @@ def resource_logs(
     end: Optional[datetime.datetime] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "timestamp.desc",
-) -> list[model.ResourceLog]:
+) -> list[ResourceLog]:
     """
     Get the logs of a specific resource.
 
@@ -987,7 +1014,7 @@ def resource_logs(
     client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
-def get_facts(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> list[model.Fact]:
+def get_facts(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> list[Fact]:
     """
     Get the facts related to a specific resource. The results are sorted alphabetically by name.
     :param tid: The id of the environment
@@ -1005,7 +1032,7 @@ def get_facts(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr) -> list[model.Fa
     client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
-def get_fact(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr, id: uuid.UUID) -> model.Fact:
+def get_fact(tid: uuid.UUID, rid: inmanta.types.ResourceIdStr, id: uuid.UUID) -> Fact:
     """
     Get one specific fact
     :param tid: The id of the environment
@@ -1027,7 +1054,7 @@ def get_compile_reports(
     end: Optional[datetime.datetime] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "requested.desc",
-) -> list[model.CompileReport]:
+) -> list[CompileReport]:
     """
     Get the compile reports from an environment.
 
@@ -1080,7 +1107,7 @@ def get_compile_reports(
 @typedmethod(
     path="/compilereport/<id>", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
 )
-def compile_details(tid: uuid.UUID, id: uuid.UUID) -> model.CompileDetails:
+def compile_details(tid: uuid.UUID, id: uuid.UUID) -> CompileDetails:
     """
     The returned compile details object may carry links to other objects, e.g. a service instance.
     The full list of supported links can be found :ref:`here <api_self_referencing_links>`.
@@ -1102,7 +1129,7 @@ def list_desired_state_versions(
     end: Optional[int] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "version.desc",
-) -> list[model.DesiredStateVersion]:
+) -> list[DesiredStateVersion]:
     """
     Get the desired state versions from an environment.
 
@@ -1131,9 +1158,7 @@ def list_desired_state_versions(
     client_types=[ClientType.api],
     api_version=2,
 )
-def promote_desired_state_version(
-    tid: uuid.UUID, version: int, trigger_method: Optional[model.PromoteTriggerMethod] = None
-) -> None:
+def promote_desired_state_version(tid: uuid.UUID, version: int, trigger_method: Optional[PromoteTriggerMethod] = None) -> None:
     """
     Promote a desired state version, making it the active version in the environment.
 
@@ -1161,7 +1186,7 @@ def get_resources_in_version(
     end: Optional[str] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "resource_type.desc",
-) -> list[model.VersionedResource]:
+) -> list[VersionedResource]:
     """
     Get the resources that belong to a specific version.
 
@@ -1202,7 +1227,7 @@ def get_diff_of_versions(
     tid: uuid.UUID,
     from_version: int,
     to_version: int,
-) -> list[model.ResourceDiff]:
+) -> list[ResourceDiff]:
     """
     Compare two versions of desired states, and provide the difference between them,
     with regard to their resources and the attributes of these resources.
@@ -1230,9 +1255,7 @@ def get_diff_of_versions(
     client_types=[ClientType.api],
     api_version=2,
 )
-def versioned_resource_details(
-    tid: uuid.UUID, version: int, rid: inmanta.types.ResourceIdStr
-) -> model.VersionedResourceDetails:
+def versioned_resource_details(tid: uuid.UUID, version: int, rid: inmanta.types.ResourceIdStr) -> VersionedResourceDetails:
     """
     :param tid: The id of the environment
     :param version: The version number of the resource
@@ -1259,7 +1282,7 @@ def get_parameters(
     end: Optional[Union[datetime.datetime, str]] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "name.asc",
-) -> list[model.Parameter]:
+) -> list[Parameter]:
     """
     List the parameters in an environment
 
@@ -1303,7 +1326,7 @@ def set_parameter(
     value: str,
     metadata: Optional[Mapping[str, str]] = None,
     recompile: bool = False,
-) -> ReturnValue[model.Parameter]:
+) -> ReturnValue[Parameter]:
     """
     Set a parameter on the server. If the parameter is an tracked unknown, it will trigger a recompile on the server.
     Otherwise, if the value is changed and recompile is true, a recompile is also triggered.
@@ -1334,7 +1357,7 @@ def get_all_facts(
     end: Optional[str] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "name.asc",
-) -> list[model.Fact]:
+) -> list[Fact]:
     """
     List the facts in an environment.
 
@@ -1379,7 +1402,7 @@ def set_fact(
     metadata: Optional[Mapping[str, str]] = None,
     recompile: bool = False,
     expires: Optional[bool] = True,
-) -> ReturnValue[model.Fact]:
+) -> ReturnValue[Fact]:
     """
     Set a fact on the server. If the fact is a tracked unknown, it will trigger a recompile on the server.
     Otherwise, if the value is changed and recompile is true, a recompile is also triggered.
@@ -1442,7 +1465,7 @@ def dryrun_trigger(tid: uuid.UUID, version: int) -> uuid.UUID:
 @typedmethod(
     path="/dryrun/<version>", operation="GET", arg_options=methods.ENV_OPTS, client_types=[ClientType.api], api_version=2
 )
-def list_dryruns(tid: uuid.UUID, version: int) -> list[model.DryRun]:
+def list_dryruns(tid: uuid.UUID, version: int) -> list[DryRun]:
     """
     Query a list of dry runs for a specific version
 
@@ -1461,7 +1484,7 @@ def list_dryruns(tid: uuid.UUID, version: int) -> list[model.DryRun]:
     client_types=[ClientType.api],
     api_version=2,
 )
-def get_dryrun_diff(tid: uuid.UUID, version: int, report_id: uuid.UUID) -> model.DryRunReport:
+def get_dryrun_diff(tid: uuid.UUID, version: int, report_id: uuid.UUID) -> DryRunReport:
     """
     Get the report of a dryrun, describing the changes a deployment would make,
     with the difference between the current and target states provided in a form similar to the desired state diff endpoint.
@@ -1491,7 +1514,7 @@ def list_notifications(
     end: Optional[datetime.datetime] = None,
     filter: Optional[Mapping[str, Sequence[str]]] = None,
     sort: str = "created.desc",
-) -> list[model.Notification]:
+) -> list[Notification]:
     """
     List the notifications in an environment.
 
@@ -1535,7 +1558,7 @@ def list_notifications(
 def get_notification(
     tid: uuid.UUID,
     notification_id: uuid.UUID,
-) -> model.Notification:
+) -> Notification:
     """
     Get a single notification
 
@@ -1559,7 +1582,7 @@ def update_notification(
     notification_id: uuid.UUID,
     read: Optional[bool] = None,
     cleared: Optional[bool] = None,
-) -> model.Notification:
+) -> Notification:
     """
     Update a notification by setting its flags
 
@@ -1582,7 +1605,7 @@ def update_notification(
     client_types=[ClientType.agent, ClientType.api],
     api_version=2,
 )
-def get_pip_config(tid: uuid.UUID, version: int) -> Optional[model.PipConfig]:
+def get_pip_config(tid: uuid.UUID, version: int) -> Optional[PipConfig]:
     """
     Get the pip config for the given version
 
@@ -1607,7 +1630,7 @@ def get_environment_metrics(
     end_interval: datetime.datetime,
     nb_datapoints: int,
     round_timestamps: bool = False,
-) -> model.EnvironmentMetricsResult:
+) -> EnvironmentMetricsResult:
     """
     Obtain metrics about the given environment for the given time interval.
 
@@ -1635,7 +1658,7 @@ def get_environment_metrics(
 
 
 @typedmethod(path="/login", operation="POST", client_types=[ClientType.api], enforce_auth=False, api_version=2)
-def login(username: str, password: SecretStr) -> ReturnValue[model.LoginReturn]:
+def login(username: str, password: SecretStr) -> ReturnValue[LoginReturn]:
     """Login a user.
 
      When the login succeeds an authentication header is returned with the Bearer token set.
@@ -1648,7 +1671,7 @@ def login(username: str, password: SecretStr) -> ReturnValue[model.LoginReturn]:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_READ, read_only=True)
 @typedmethod(path="/login/renew", operation="POST", client_types=[ClientType.api], api_version=2)
-def login_renew() -> ReturnValue[model.LoginReturn]:
+def login_renew() -> ReturnValue[LoginReturn]:
     """Renew the current login session.
 
     The caller authenticates with their current, still-valid session token; no password is required. A fresh
@@ -1665,7 +1688,7 @@ def login_renew() -> ReturnValue[model.LoginReturn]:
 
 @auth(auth_label=const.CoreAuthorizationLabel.ROLE_ASSIGNMENT_READ, read_only=True)
 @typedmethod(path="/user", operation="GET", client_types=[ClientType.api], api_version=2)
-def list_users() -> list[model.UserWithRoles]:
+def list_users() -> list[UserWithRoles]:
     """List all users
 
     :return: A list of all users"""
@@ -1673,7 +1696,7 @@ def list_users() -> list[model.UserWithRoles]:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_READ, read_only=True)
 @typedmethod(path="/current_user", operation="GET", client_types=[ClientType.api], api_version=2)
-def get_current_user() -> model.CurrentUser:
+def get_current_user() -> CurrentUser:
     """Get the current logged in user (based on the provided JWT) and server auth settings
 
     :raises NotFound: Raised when server authentication is not enabled
@@ -1693,7 +1716,7 @@ def delete_user(username: str) -> None:
 
 @auth(auth_label=const.CoreAuthorizationLabel.USER_WRITE, read_only=False)
 @typedmethod(path="/user", operation="POST", client_types=[ClientType.api], api_version=2)
-def add_user(username: str, password: SecretStr) -> model.User:
+def add_user(username: str, password: SecretStr) -> User:
     """Add a new user to the system
 
     :param username: The username of the new user. The username cannot be an empty string.
@@ -1764,7 +1787,7 @@ def delete_role(name: str) -> None:
 
 @auth(auth_label=const.CoreAuthorizationLabel.ROLE_ASSIGNMENT_READ, read_only=True)
 @typedmethod(path="/role_assignment/<username>", operation="GET", client_types=[ClientType.api], api_version=2)
-def list_roles_for_user(username: str) -> model.RoleAssignmentsPerEnvironment:
+def list_roles_for_user(username: str) -> RoleAssignmentsPerEnvironment:
     """
     Returns the roles assigned to the given user.
 
@@ -1833,7 +1856,7 @@ def discovered_resource_create(
     client_types=[ClientType.agent],
     api_version=2,
 )
-def discovered_resource_create_batch(tid: uuid.UUID, discovered_resources: Sequence[model.DiscoveredResourceInput]) -> None:
+def discovered_resource_create_batch(tid: uuid.UUID, discovered_resources: Sequence[DiscoveredResourceInput]) -> None:
     """
     create multiple discovered resources.
     :param tid: The id of the environment this resource belongs to
@@ -1849,7 +1872,7 @@ def discovered_resource_create_batch(tid: uuid.UUID, discovered_resources: Seque
     client_types=[ClientType.api, ClientType.agent],
     api_version=2,
 )
-def discovered_resources_get(tid: uuid.UUID, discovered_resource_id: ResourceIdStr) -> model.DiscoveredResourceOutput:
+def discovered_resources_get(tid: uuid.UUID, discovered_resource_id: ResourceIdStr) -> DiscoveredResourceOutput:
     """
     Get a single discovered resource.
 
@@ -1873,7 +1896,7 @@ def discovered_resources_get_batch(
     end: Optional[str] = None,
     sort: str = "discovered_resource_id.asc",
     filter: Optional[Mapping[str, Sequence[str]]] = None,
-) -> list[model.DiscoveredResourceOutput]:
+) -> list[DiscoveredResourceOutput]:
     """
     Get a list of discovered resources.
 

--- a/src/inmanta/protocol/openapi/converter.py
+++ b/src/inmanta/protocol/openapi/converter.py
@@ -26,7 +26,6 @@ from pydantic import ConfigDict
 from typing_inspect import get_args, get_origin, is_generic_type
 
 from inmanta import util
-from inmanta.data.model import BaseModel
 from inmanta.protocol.common import ArgOption, MethodProperties, ReturnValue, UrlMethod
 from inmanta.protocol.openapi.model import (
     Components,
@@ -50,7 +49,7 @@ from inmanta.protocol.openapi.model import (
 )
 from inmanta.server import config
 from inmanta.server.extensions import FeatureManager
-from inmanta.types import ReturnTypes
+from inmanta.types import BaseModel, ReturnTypes
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/inmanta/protocol/openapi/model.py
+++ b/src/inmanta/protocol/openapi/model.py
@@ -29,7 +29,7 @@ from typing import Any, Optional, Self, Union
 import pydantic
 from pydantic import AnyUrl, ConfigDict, Field
 
-from inmanta.data.model import BaseModel
+from inmanta.types import BaseModel
 
 
 class License(BaseModel):

--- a/src/inmanta/protocol/rest/__init__.py
+++ b/src/inmanta/protocol/rest/__init__.py
@@ -31,13 +31,12 @@ import typing_inspect
 from tornado import escape
 
 from inmanta import const, tracing, util
-from inmanta.data.model import BaseModel
 from inmanta.protocol import common, exceptions
 from inmanta.protocol.auth import auth, providers
 from inmanta.protocol.common import ReturnValue
 from inmanta.server import config as server_config
 from inmanta.stable_api import stable_api
-from inmanta.types import Apireturn, JsonType
+from inmanta.types import Apireturn, BaseModel, JsonType
 
 LOGGER: logging.Logger = logging.getLogger(__name__)
 

--- a/src/inmanta/protocol/websocket.py
+++ b/src/inmanta/protocol/websocket.py
@@ -30,10 +30,10 @@ from tornado import httpclient, websocket
 
 from inmanta import config as inmanta_config
 from inmanta import const, tracing, types, util
-from inmanta.data import model
 from inmanta.protocol import common, endpoints, rest
 from inmanta.protocol.auth import auth as auth_module
 from inmanta.protocol.auth import providers
+from inmanta.types import BaseModel
 
 LOGGER = logging.getLogger(__name__)
 
@@ -230,7 +230,7 @@ class SessionListener:
         pass
 
 
-class WSMessage(model.BaseModel):
+class WSMessage(BaseModel):
     """Base class for all websocket protocol messages.
 
     Each subclass represents a distinct message type in the websocket protocol. Messages are

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -862,7 +862,7 @@ class Id:
             - attribute: The key attribute that uniquely identifies this resource on the agent
             - value: The corresponding value for this key attribute.
 
-        :return: Returns a :py:class:`inmanta.data.model.ResourceIdStr`
+        :return: Returns a :py:class:`inmanta.types.ResourceIdStr`
         """
         return cast(
             ResourceIdStr,

--- a/src/inmanta/server/agentmanager.py
+++ b/src/inmanta/server/agentmanager.py
@@ -44,8 +44,10 @@ from inmanta import tracing
 from inmanta.agent import config as agent_cfg
 from inmanta.config import Config, scheduler_log_config
 from inmanta.const import AgentAction, AgentStatus, AllAgentAction
-from inmanta.data import APILIMIT, Environment, InvalidSort, model
-from inmanta.data.model import DataBaseReport
+from inmanta.data import APILIMIT, Environment, InvalidSort
+from inmanta.dto import agent as dto_agent
+from inmanta.dto import environment as dto_environment
+from inmanta.dto.scheduler import DataBaseReport
 from inmanta.protocol import common, encode_token, endpoints, handle, methods, methods_v2, websocket
 from inmanta.protocol.exceptions import BadRequest, Conflict, Forbidden, NotFound, ShutdownInProgress
 from inmanta.server import (
@@ -632,7 +634,7 @@ class AgentManager(ServerSlice, websocket.SessionListener):
             return 404, {"message": "The given environment id does not exist!"}
         new_agent_endpoint = await self.get_agents(env, limit, start, end, start, end)
 
-        def mangle_format(agent: model.Agent) -> dict[str, object]:
+        def mangle_format(agent: dto_agent.Agent) -> dict[str, object]:
             native = agent.model_dump()
             native["state"] = agent.status
             return native
@@ -710,7 +712,7 @@ class AgentManager(ServerSlice, websocket.SessionListener):
         last_id: Optional[str] = None,
         filter: Optional[dict[str, list[str]]] = None,
         sort: str = "name.asc",
-    ) -> common.ReturnValue[Sequence[model.Agent]]:
+    ) -> common.ReturnValue[Sequence[dto_agent.Agent]]:
         try:
             handler = AgentView(
                 environment=env,
@@ -728,7 +730,9 @@ class AgentManager(ServerSlice, websocket.SessionListener):
             raise BadRequest(e.message) from e
 
     @handle(methods_v2.get_agent_process_details, env="tid")
-    async def get_agent_process_details(self, env: data.Environment, id: uuid.UUID, report: bool = False) -> model.AgentProcess:
+    async def get_agent_process_details(
+        self, env: data.Environment, id: uuid.UUID, report: bool = False
+    ) -> dto_agent.AgentProcess:
         agent_process = await data.SchedulerSession.get_one(environment=env.id, sid=id)
         if not agent_process:
             raise NotFound(f"Agent process with id {id} not found")
@@ -1214,7 +1218,7 @@ class AutostartedAgentManager(ServerSlice, inmanta.server.services.environmentli
         except asyncio.TimeoutError:
             LOGGER.warning("Agent processes did not close in time (%s)", [p.process for p in proc_details])
 
-    async def environment_action_created(self, env: model.Environment) -> None:
+    async def environment_action_created(self, env: dto_environment.Environment) -> None:
         """
         Will be called when a new environment is created to create a scheduler agent
 

--- a/src/inmanta/server/diff.py
+++ b/src/inmanta/server/diff.py
@@ -20,7 +20,7 @@ import json
 from typing import Optional
 
 from inmanta import resources
-from inmanta.data.model import AttributeDiff, ResourceDiff, ResourceDiffStatus
+from inmanta.dto.diff import AttributeDiff, ResourceDiff, ResourceDiffStatus
 from inmanta.types import ResourceIdStr
 
 

--- a/src/inmanta/server/extensions.py
+++ b/src/inmanta/server/extensions.py
@@ -27,7 +27,7 @@ import yaml
 import inmanta.logging
 from inmanta import data
 from inmanta.config import feature_file_config
-from inmanta.data.model import ExtensionStatus
+from inmanta.dto.status import ExtensionStatus
 from inmanta.server.protocol import ServerSlice
 from inmanta.stable_api import stable_api
 

--- a/src/inmanta/server/protocol.py
+++ b/src/inmanta/server/protocol.py
@@ -30,7 +30,7 @@ from tornado import routing, web
 
 import inmanta.protocol.endpoints  # noqa: F401
 from inmanta import tracing, types  # noqa: F401
-from inmanta.data.model import ExtensionStatus, ReportedStatus, SliceStatus
+from inmanta.dto.status import ExtensionStatus, ReportedStatus, SliceStatus
 from inmanta.protocol import Client, Result, TypedClient, common, endpoints, handle, methods, methods_v2, rest  # noqa: F401
 from inmanta.protocol.auth import providers
 from inmanta.protocol.exceptions import ShutdownInProgress  # noqa: F401

--- a/src/inmanta/server/server.py
+++ b/src/inmanta/server/server.py
@@ -29,7 +29,7 @@ from tornado import routing, web
 
 from inmanta import config, const, data
 from inmanta.const import ApiDocsFormat
-from inmanta.data.model import FeatureStatus, ReportedStatus, StatusResponse
+from inmanta.dto.status import FeatureStatus, ReportedStatus, StatusResponse
 from inmanta.protocol import exceptions, handle, methods, methods_v2
 from inmanta.protocol.common import HTML_CONTENT_WITH_UTF8_CHARSET, ReturnValue, attach_warnings
 from inmanta.protocol.openapi.converter import OpenApiConverter

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -43,12 +43,13 @@ import dateutil.parser
 import pydantic
 from asyncpg import Connection
 
-import inmanta.data.model as model
 import inmanta.server.services.environmentlistener
 from inmanta import config, const, data, protocol, server, tracing
 from inmanta.config import Config
 from inmanta.data import APILIMIT, InvalidSort
 from inmanta.data.dataview import CompileReportView
+from inmanta.dto import compile as dto_compile
+from inmanta.dto import environment as dto_environment
 from inmanta.env import PipCommandBuilder, PythonEnvironment, VenvActivationFailedError, VirtualEnv
 from inmanta.protocol import encode_token, methods, methods_v2
 from inmanta.protocol.common import ReturnValue
@@ -334,7 +335,7 @@ class CompileRun:
         await ensure_venv()
         await link()
 
-    async def run(self, force_update: Optional[bool] = False) -> tuple[bool, Optional[model.CompileData]]:
+    async def run(self, force_update: Optional[bool] = False) -> tuple[bool, Optional[dto_compile.CompileData]]:
         """
         Runs this compile run.
 
@@ -615,7 +616,7 @@ class CompileRun:
                 compile_data_json: str = file.read().decode()
                 if compile_data_json:
                     try:
-                        return success, model.CompileData.model_validate_json(compile_data_json)
+                        return success, dto_compile.CompileData.model_validate_json(compile_data_json)
                     except json.JSONDecodeError:
                         await warn(
                             "Failed to load compile data json for compile %s. Invalid json: '%s'"
@@ -1191,7 +1192,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             self._queue_count_cache -= 1
 
         # set force_update == True iff any compile request has force_update == True
-        compile_data: Optional[model.CompileData]
+        compile_data: Optional[dto_compile.CompileData]
         success, compile_data = await runner.run(force_update=any(c.force_update for c in chain([compile], merge_candidates)))
 
         version = runner.version
@@ -1269,14 +1270,14 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         return 200, {"report": report}
 
     @protocol.handle(methods_v2.get_compile_data, compile_id="id")
-    async def get_compile_data(self, compile_id: uuid.UUID) -> Optional[model.CompileData]:
+    async def get_compile_data(self, compile_id: uuid.UUID) -> Optional[dto_compile.CompileData]:
         compile: Optional[data.Compile] = await data.Compile.get_by_id(compile_id)
         if compile is None:
             raise NotFound("The given compile id does not exist")
         return compile.to_dto().compile_data
 
     @protocol.handle(methods.get_compile_queue, env="tid")
-    async def get_compile_queue(self, env: data.Environment) -> list[model.CompileRun]:
+    async def get_compile_queue(self, env: data.Environment) -> list[dto_compile.CompileRun]:
         """
         Get the current compiler queue on the server
         """
@@ -1294,7 +1295,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         end: Optional[datetime.datetime] = None,
         filter: Optional[dict[str, list[str]]] = None,
         sort: str = "requested.desc",
-    ) -> ReturnValue[Sequence[model.CompileReport]]:
+    ) -> ReturnValue[Sequence[dto_compile.CompileReport]]:
         try:
             handler = CompileReportView(env, limit, filter, sort, first_id, last_id, start, end)
             return await handler.execute()
@@ -1302,13 +1303,13 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
             raise BadRequest(e.message) from e
 
     @protocol.handle(methods_v2.compile_details, env="tid")
-    async def compile_details(self, env: data.Environment, id: uuid.UUID) -> model.CompileDetails:
+    async def compile_details(self, env: data.Environment, id: uuid.UUID) -> dto_compile.CompileDetails:
         details = await data.Compile.get_compile_details(env.id, id)
         if not details:
             raise NotFound("The compile with the given id does not exist.")
         return details
 
-    async def environment_action_cleared(self, env: model.Environment) -> None:
+    async def environment_action_cleared(self, env: dto_environment.Environment) -> None:
         """
         Will be called when the environment is cleared
 
@@ -1316,7 +1317,7 @@ class CompilerService(ServerSlice, inmanta.server.services.environmentlistener.E
         """
         await self.recalculate_queue_count_cache()
 
-    async def environment_action_deleted(self, env: model.Environment) -> None:
+    async def environment_action_deleted(self, env: dto_environment.Environment) -> None:
         """
         Will be called when the environment is deleted
 

--- a/src/inmanta/server/services/databaseservice.py
+++ b/src/inmanta/server/services/databaseservice.py
@@ -27,7 +27,8 @@ from typing import Callable, Mapping, Optional
 import asyncpg
 
 from inmanta.data import start_engine, stop_engine
-from inmanta.data.model import DataBaseReport, ReportedStatus
+from inmanta.dto.scheduler import DataBaseReport
+from inmanta.dto.status import ReportedStatus
 from inmanta.server import SLICE_DATABASE
 from inmanta.server import config as opt
 from inmanta.server import protocol

--- a/src/inmanta/server/services/dryrunservice.py
+++ b/src/inmanta/server/services/dryrunservice.py
@@ -22,7 +22,8 @@ import uuid
 from typing import Optional, cast
 
 from inmanta import const, data
-from inmanta.data.model import DryRun, DryRunReport, ResourceDiff, ResourceDiffStatus
+from inmanta.dto.diff import ResourceDiff, ResourceDiffStatus
+from inmanta.dto.dryrun import DryRun, DryRunReport
 from inmanta.protocol import handle, methods, methods_v2
 from inmanta.protocol.exceptions import Conflict, NotFound
 from inmanta.resources import Id

--- a/src/inmanta/server/services/environment_metrics_service.py
+++ b/src/inmanta/server/services/environment_metrics_service.py
@@ -38,7 +38,7 @@ from inmanta.data import (
     EnvironmentMetricsTimer,
     SchedulerSession,
 )
-from inmanta.data.model import EnvironmentMetricsResult, EnvSettingType
+from inmanta.dto.environment import EnvironmentMetricsResult, EnvSettingType
 from inmanta.protocol import methods_v2
 from inmanta.protocol.decorators import handle
 from inmanta.protocol.exceptions import BadRequest

--- a/src/inmanta/server/services/environmentlistener.py
+++ b/src/inmanta/server/services/environmentlistener.py
@@ -18,7 +18,7 @@ Contact: code@inmanta.com
 
 from enum import Enum
 
-from inmanta.data import model
+from inmanta.dto.environment import Environment
 
 
 class EnvironmentListener:
@@ -27,25 +27,25 @@ class EnvironmentListener:
     Exceptions from the listeners are dropped, the listeners are responsible for handling them
     """
 
-    async def environment_action_created(self, env: model.Environment) -> None:
+    async def environment_action_created(self, env: Environment) -> None:
         """
         Will be called when a new environment is created
         :param env: The new environment
         """
 
-    async def environment_action_cleared(self, env: model.Environment) -> None:
+    async def environment_action_cleared(self, env: Environment) -> None:
         """
         Will be called when the environment is cleared
         :param env: The environment that is cleared
         """
 
-    async def environment_action_deleted(self, env: model.Environment) -> None:
+    async def environment_action_deleted(self, env: Environment) -> None:
         """
         Will be called when the environment is deleted
         :param env: The environment that is deleted
         """
 
-    async def environment_action_updated(self, updated_env: model.Environment, original_env: model.Environment) -> None:
+    async def environment_action_updated(self, updated_env: Environment, original_env: Environment) -> None:
         """
         Will be called when an environment is updated
         :param updated_env: The updated environment

--- a/src/inmanta/server/services/notificationservice.py
+++ b/src/inmanta/server/services/notificationservice.py
@@ -27,7 +27,7 @@ from asyncpg import Connection
 from inmanta import const, data
 from inmanta.data import InvalidSort
 from inmanta.data.dataview import NotificationsView
-from inmanta.data.model import Notification
+from inmanta.dto.notification import Notification
 from inmanta.protocol import handle, methods_v2
 from inmanta.protocol.common import ReturnValue
 from inmanta.protocol.exceptions import BadRequest, NotFound

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -34,12 +34,16 @@ from inmanta import const, data
 from inmanta.const import ResourceState
 from inmanta.data import APILIMIT, AVAILABLE_VERSIONS_TO_KEEP, InvalidSort, ResourcePersistentState, RowLockMode
 from inmanta.data.dataview import DesiredStateVersionView
-from inmanta.data.model import AgentName, DesiredStateVersion
-from inmanta.data.model import InmantaModule as InmantaModuleDTO
-from inmanta.data.model import InmantaModuleName, InmantaModuleVersion, PipConfig, PromoteTriggerMethod
-from inmanta.data.model import Resource as ResourceDTO
-from inmanta.data.model import ResourceDiff, ResourceMinimal, SchedulerStatusReport
 from inmanta.data.sqlalchemy import AgentModules, InmantaModule
+from inmanta.dto.agent import AgentName
+from inmanta.dto.code import InmantaModule as InmantaModuleDTO
+from inmanta.dto.code import InmantaModuleName, InmantaModuleVersion
+from inmanta.dto.desiredstate import DesiredStateVersion, PromoteTriggerMethod
+from inmanta.dto.diff import ResourceDiff
+from inmanta.dto.pip import PipConfig
+from inmanta.dto.resource import Resource as ResourceDTO
+from inmanta.dto.resource import ResourceMinimal
+from inmanta.dto.scheduler import SchedulerStatusReport
 from inmanta.protocol import handle, methods, methods_v2
 from inmanta.protocol.common import ReturnValue, attach_warnings
 from inmanta.protocol.exceptions import BadRequest, BaseHttpException, Conflict, NotFound, ServerError

--- a/src/inmanta/server/services/paramservice.py
+++ b/src/inmanta/server/services/paramservice.py
@@ -26,7 +26,7 @@ from inmanta import data
 from inmanta.const import ParameterSource
 from inmanta.data import InvalidSort
 from inmanta.data.dataview import FactsView, ParameterView
-from inmanta.data.model import Fact, Parameter
+from inmanta.dto.parameter import Fact, Parameter
 from inmanta.protocol import handle, methods, methods_v2
 from inmanta.protocol.common import ReturnValue, attach_warnings
 from inmanta.protocol.exceptions import BadRequest, NotFound

--- a/src/inmanta/server/services/projectservice.py
+++ b/src/inmanta/server/services/projectservice.py
@@ -23,7 +23,7 @@ from typing import Optional, cast
 import asyncpg
 
 from inmanta import data
-from inmanta.data import model
+from inmanta.dto.environment import Project
 from inmanta.protocol import handle, methods, methods_v2
 from inmanta.protocol.exceptions import Conflict, NotFound, ServerError
 from inmanta.server import (
@@ -90,7 +90,7 @@ class ProjectService(protocol.ServerSlice):
 
     # v2 handlers
     @handle(methods_v2.project_create)
-    async def project_create(self, name: str, project_id: Optional[uuid.UUID]) -> model.Project:
+    async def project_create(self, name: str, project_id: Optional[uuid.UUID]) -> Project:
         if project_id is None:
             project_id = uuid.uuid4()
 
@@ -118,7 +118,7 @@ class ProjectService(protocol.ServerSlice):
         await project.delete()
 
     @handle(methods_v2.project_modify, project_id="id")
-    async def project_modify(self, project_id: uuid.UUID, name: str) -> model.Project:
+    async def project_modify(self, project_id: uuid.UUID, name: str) -> Project:
         try:
             project = await data.Project.get_by_id(project_id)
             if project is None:
@@ -132,7 +132,7 @@ class ProjectService(protocol.ServerSlice):
             raise ServerError(f"A project with name {name} already exists.")
 
     @handle(methods_v2.project_list)
-    async def project_list(self, environment_details: bool = False) -> list[model.Project]:
+    async def project_list(self, environment_details: bool = False) -> list[Project]:
         project_list = []
 
         for project in await data.Project.get_list(order_by_column="name", order="ASC"):
@@ -149,7 +149,7 @@ class ProjectService(protocol.ServerSlice):
         return project_list
 
     @handle(methods_v2.project_get, project_id="id")
-    async def project_get(self, project_id: uuid.UUID, environment_details: bool = False) -> model.Project:
+    async def project_get(self, project_id: uuid.UUID, environment_details: bool = False) -> Project:
         project = await data.Project.get_by_id(project_id)
 
         if project is None:

--- a/src/inmanta/server/services/resourceservice.py
+++ b/src/inmanta/server/services/resourceservice.py
@@ -28,7 +28,7 @@ from pydantic import ValidationError
 from tornado.httputil import url_concat
 
 from inmanta import const, data, util
-from inmanta.data import APILIMIT, InvalidSort, model
+from inmanta.data import APILIMIT, InvalidSort
 from inmanta.data.dataview import (
     DiscoveredResourceView,
     ResourceHistoryView,
@@ -36,14 +36,15 @@ from inmanta.data.dataview import (
     ResourcesInVersionView,
     ResourceView,
 )
-from inmanta.data.model import (
+from inmanta.dto.diff import ResourceComplianceDiff
+from inmanta.dto.discovery import DiscoveredResourceInput, DiscoveredResourceOutput
+from inmanta.dto.log import ResourceLog
+from inmanta.dto.resource import (
     LatestReleasedResource,
     ReleasedResourceDetails,
     Resource,
     ResourceAction,
-    ResourceComplianceDiff,
     ResourceHistory,
-    ResourceLog,
     VersionedResource,
     VersionedResourceDetails,
 )
@@ -440,7 +441,7 @@ class ResourceService(protocol.ServerSlice):
         discovery_resource_id: ResourceIdStr,
     ) -> None:
         try:
-            discovered_resource = model.DiscoveredResourceInput(
+            discovered_resource = DiscoveredResourceInput(
                 discovered_resource_id=discovered_resource_id, values=values, discovery_resource_id=discovery_resource_id
             )
         except ValidationError as e:
@@ -454,7 +455,7 @@ class ResourceService(protocol.ServerSlice):
 
     @handle(methods_v2.discovered_resource_create_batch, env="tid")
     async def discovered_resources_create_batch(
-        self, env: data.Environment, discovered_resources: list[model.DiscoveredResourceInput]
+        self, env: data.Environment, discovered_resources: list[DiscoveredResourceInput]
     ) -> None:
         dao_list = [data.DiscoveredResource.from_dto(res, env.id) for res in discovered_resources]
         await data.DiscoveredResource.insert_many_with_overwrite(dao_list)
@@ -462,7 +463,7 @@ class ResourceService(protocol.ServerSlice):
     @handle(methods_v2.discovered_resources_get, env="tid")
     async def discovered_resources_get(
         self, env: data.Environment, discovered_resource_id: ResourceIdStr
-    ) -> model.DiscoveredResourceOutput:
+    ) -> DiscoveredResourceOutput:
         if not self.feature_manager.enabled(resource_discovery):
             raise Forbidden(message="The resource discovery feature is not enabled.")
 
@@ -481,7 +482,7 @@ class ResourceService(protocol.ServerSlice):
         end: Optional[str] = None,
         sort: str = "discovered_resource_id.asc",
         filter: Optional[dict[str, list[str]]] = None,
-    ) -> ReturnValue[Sequence[model.DiscoveredResourceOutput]]:
+    ) -> ReturnValue[Sequence[DiscoveredResourceOutput]]:
         if not self.feature_manager.enabled(resource_discovery):
             raise Forbidden(message="The resource discovery feature is not enabled.")
 

--- a/src/inmanta/server/validate_filter.py
+++ b/src/inmanta/server/validate_filter.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, ValidationError, field_validator
 
 from inmanta import const
 from inmanta.data import DateRangeConstraint, QueryFilter, QueryType, RangeConstraint, RangeOperator
-from inmanta.data.model import ReleasedResourceState
+from inmanta.dto.resource import ReleasedResourceState
 
 
 class InvalidFilter(Exception):

--- a/src/inmanta/user_setup.py
+++ b/src/inmanta/user_setup.py
@@ -26,7 +26,7 @@ from asyncpg import PostgresError
 import nacl.pwhash
 from inmanta import config, data
 from inmanta.data import start_engine, stop_engine
-from inmanta.data.model import AuthMethod
+from inmanta.dto.auth import AuthMethod
 from inmanta.protocol.auth import auth
 from inmanta.server import config as server_config
 from inmanta.util import password_policy_violation

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -62,7 +62,7 @@ from inmanta.types import JsonType, PrimitiveTypes, ReturnTypes
 from packaging.utils import NormalizedName
 
 if TYPE_CHECKING:
-    from inmanta.data.model import ResourceId
+    from inmanta.dto.discovery import ResourceId
 
 LOGGER = logging.getLogger(__name__)
 SALT_SIZE = 16
@@ -603,7 +603,7 @@ def _custom_json_encoder(o: object) -> Union[ReturnTypes, "JSONSerializable"]:
         # Logs can push exceptions through RPC. Return a string representation.
         return str(o)
 
-    from inmanta.data.model import BaseModel
+    from inmanta.types import BaseModel
 
     if isinstance(o, (BaseModel, pydantic.BaseModel)):
         return o.model_dump(by_alias=True)


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

**Stacked on #10703, which is stacked on #10702. Review those first.** Base branch is `dto-package`, so the diff here is only this step.

Third car of the import cleanup train. #10703 created the thematic `inmanta.dto` modules but changed no call sites, so everything in inmanta-core still reached the DTOs through the `inmanta.data.model` re-export, which loads all of them and executes the database access layer. This PR points each import at the module that actually defines what it needs.

43 files, 96 name imports. `BaseModel`, `ResourceIdStr`, `ResourceType` and `ResourceVersionIdStr` now come from `inmanta.types`, where they are defined rather than re-exported.

After this, the only file in `src/inmanta` that imports `inmanta.data.model` is `inmanta/data/__init__.py`.

## Where a qualified reference is kept instead

Six files define or import something with the same name as the DTO they use, so flattening the name into their namespace would shadow it. These keep a qualified reference to the thematic module, as `dto_<theme>`:

| file | clashes on | because |
| ---- | ---------- | ------- |
| `data/__init__.py` | 29 names | the access layer defines its own `Environment`, `Project`, `Resource`, … — keeps `from inmanta.data import model as m` |
| `data/dataview.py` | `Agent`, `Notification`, `Parameter` | imports the same-named access layer classes |
| `server/agentmanager.py` | `Environment` | imports the access layer `Environment` |
| `compiler/data.py` | `CompileData` | defines its own `CompileData(ast_export.Exportable)` |
| `server/services/compilerservice.py` | `CompileRun` | defines its own `CompileRun` |
| `graphql/schema.py` | `ComposedResourceSummary` | defines its own strawberry type of that name |

`data/__init__.py` keeping the re-export is deliberate: it is the database layer, it is never on the compiler's import path, and it legitimately needs most of the DTOs. Retiring the re-export entirely means giving that file a qualified form too, which is a later step along with the test suite.

## This changes nothing measurable, and that is expected

Importing `inmanta.module` still loads `inmanta.data`, `sqlalchemy` and `asyncpg`, through two module level imports this PR does not touch:

```
inmanta/module.py:60  ->  inmanta/env.py:52  ->  from inmanta.server.bootloader import InmantaBootloader
                                              ->  inmanta/protocol/methods.py:26 -> from inmanta import const, data, resources
```

Deferring those two is the next car, and only then does the loaded module count move. This PR is what makes that car possible: until every consumer named a thematic module, deferring anything simply moved the same load elsewhere.

## Notes for review

The mechanical part was scripted, and two things are worth knowing because they shaped the diff:

- The script refused to flatten a name already bound in the file, which is how the six qualified cases above were found rather than silently shadowed.
- `graphql/schema.py` has a function parameter also called `model`, so `model.__name__` appears there with nothing to do with the DTOs. Substitution is therefore restricted to names that really are DTOs, and that line is untouched.

`inmanta/module.py` gains an explicit `import inmanta.util`. It uses `inmanta.util.*` in 19 places but had no `import inmanta.*` statement of its own; the bare `inmanta` name was bound as a side effect of `import inmanta.data.model`. `inmanta/agent/forking_executor.py` gains an explicit `import inmanta.dto.code` for the same reason: its annotations name that module, which previously resolved only because something else in the process had imported it.

## Verification

- CI mypy and the fast test suite. Locally, `mypy-baseline filter` with a cold cache reports `new: 9`, the identical set master produces.
- black, isort and flake8 clean.
- 157 tests pass across `tests/test_data.py`, `tests/test_data_model.py`, `tests/deploy/e2e/test_discovered_resources.py`, `tests/forking_agent/`, `tests/test_resource.py`, `tests/test_graphql.py` and `tests/server/test_databaseservice.py`.
- `inmanta.agent.forking_executor` and `inmanta.module` both import standalone in a bare interpreter.
