### PR TITLE
Move extension discovery from the server bootloader into inmanta.util

### DIFF
--- a/changelogs/unreleased/extension-discovery-in-util.yml
+++ b/changelogs/unreleased/extension-discovery-in-util.yml
@@ -1,0 +1,5 @@
+description: Moved extension discovery from InmantaBootloader to inmanta.util, so managing a virtual environment no longer imports the server.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -979,7 +979,6 @@ src/inmanta/resources.py:0: error: Returning Any from function declared to retur
 src/inmanta/server/agentmanager.py:0: error: Call to untyped function "get_status" in typed context  [no-untyped-call]
 src/inmanta/server/agentmanager.py:0: error: Item "None" of "Sequence[Agent] | None" has no attribute "__iter__" (not iterable)  [union-attr]
 src/inmanta/server/agentmanager.py:0: error: Value of type "dict[str, Any] | None" is not indexable  [index]
-src/inmanta/server/bootloader.py:0: error: Incompatible return value type (got "Iterator[ModuleInfo]", expected "Generator[ModuleInfo, None, None]")  [return-value]
 src/inmanta/server/config.py:0: error: Cannot infer value of type parameter "T" of "Option"  [misc]
 src/inmanta/server/config.py:0: error: Cannot infer value of type parameter "T" of "Option"  [misc]
 src/inmanta/server/config.py:0: error: Cannot infer value of type parameter "T" of "Option"  [misc]

--- a/src/inmanta/env.py
+++ b/src/inmanta/env.py
@@ -49,7 +49,6 @@ import packaging.version
 from inmanta import const
 from inmanta.ast import CompilerException
 from inmanta.dto.pip import LEGACY_PIP_DEFAULT, PipConfig
-from inmanta.server.bootloader import InmantaBootloader
 from inmanta.stable_api import stable_api
 from inmanta.util import parse_requirement, strtobool
 from packaging.utils import NormalizedName, canonicalize_name
@@ -1089,7 +1088,7 @@ import sys
             # Protect all server extensions
             *(
                 packaging.utils.canonicalize_name(f"inmanta-{ext_name}")
-                for ext_name in InmantaBootloader.get_available_extensions().keys()
+                for ext_name in inmanta.util.get_available_extensions().keys()
             ),
         ]
 

--- a/src/inmanta/server/bootloader.py
+++ b/src/inmanta/server/bootloader.py
@@ -19,13 +19,11 @@ Contact: code@inmanta.com
 import asyncio
 import importlib
 import logging
-import pkgutil
-from collections.abc import Generator
-from pkgutil import ModuleInfo
 from types import ModuleType
 from typing import Optional
 
 from inmanta import logging as inmanta_logging
+from inmanta import util
 from inmanta.const import EXTENSION_MODULE, EXTENSION_NAMESPACE
 from inmanta.logging import FullLoggingConfig, InmantaLoggerConfig
 from inmanta.server import config
@@ -34,15 +32,6 @@ from inmanta.server.protocol import Server, ServerSlice
 from inmanta.stable_api import stable_api
 
 LOGGER = logging.getLogger(__name__)
-
-
-def iter_namespace(ns_pkg: ModuleType) -> Generator[ModuleInfo, None, None]:
-    """From python docs https://packaging.python.org/guides/creating-and-discovering-plugins/"""
-    # Specifying the second argument (prefix) to iter_modules makes the
-    # returned name an absolute name instead of a relative one. This allows
-    # import_module to work without having to do additional modification to
-    # the name.
-    return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
 
 
 class PluginLoadFailed(Exception):
@@ -76,9 +65,6 @@ class InmantaBootloader:
     - loading core and extension slices
     - starting the server and its slices in the correct order
     """
-
-    # Cache field for available extensions
-    AVAILABLE_EXTENSIONS: Optional[dict[str, str]] = None
 
     def __init__(self, configure_logging: bool = False) -> None:
         """
@@ -140,17 +126,7 @@ class InmantaBootloader:
         Returns a dictionary of all available inmanta extensions.
         The key contains the name of the extension and the value the fully qualified path to the python package.
         """
-        if cls.AVAILABLE_EXTENSIONS is None:
-            try:
-                inmanta_ext = importlib.import_module(EXTENSION_NAMESPACE)
-            except ModuleNotFoundError:
-                # This only happens when a test case creates and activates a new venv
-                return {}
-            else:
-                cls.AVAILABLE_EXTENSIONS = {
-                    name[len(EXTENSION_NAMESPACE) + 1 :]: name for finder, name, ispkg in iter_namespace(inmanta_ext)
-                }
-        return dict(cls.AVAILABLE_EXTENSIONS)
+        return util.get_available_extensions()
 
     # Extension loading Phase I: from start to setup functions collected
 

--- a/src/inmanta/util/__init__.py
+++ b/src/inmanta/util/__init__.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import pathlib
+import pkgutil
 import socket
 import threading
 import time
@@ -43,7 +44,8 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Coro
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from logging import Logger
-from types import TracebackType
+from pkgutil import ModuleInfo
+from types import ModuleType, TracebackType
 from typing import TYPE_CHECKING, BinaryIO, Generic, Optional, TypeVar, Union
 
 import asyncpg
@@ -116,6 +118,49 @@ def ensure_directory_exist(directory: str, *subdirs: str) -> str:
 
 def is_sub_dict(subdct: dict[PrimitiveTypes, PrimitiveTypes], dct: dict[PrimitiveTypes, PrimitiveTypes]) -> bool:
     return not any(True for k, v in subdct.items() if k not in dct or dct[k] != v)
+
+
+def iter_namespace(ns_pkg: ModuleType) -> Iterator[ModuleInfo]:
+    """From python docs https://packaging.python.org/guides/creating-and-discovering-plugins/"""
+    # Specifying the second argument (prefix) to iter_modules makes the
+    # returned name an absolute name instead of a relative one. This allows
+    # import_module to work without having to do additional modification to
+    # the name.
+    return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
+
+
+# Cache field for available extensions
+_available_extensions: Optional[dict[str, str]] = None
+
+
+def get_available_extensions() -> dict[str, str]:
+    """
+    Returns a dictionary of all available inmanta extensions.
+    The key contains the name of the extension and the value the fully qualified path to the python package.
+
+    This only inspects the inmanta_ext namespace package, so it lives here rather than on the server bootloader: the
+    compiler needs it to protect extension packages in a venv, and should not have to import the server to get it.
+    """
+    global _available_extensions
+    if _available_extensions is None:
+        try:
+            inmanta_ext = importlib.import_module(const.EXTENSION_NAMESPACE)
+        except ModuleNotFoundError:
+            # This only happens when a test case creates and activates a new venv
+            return {}
+        else:
+            _available_extensions = {
+                name[len(const.EXTENSION_NAMESPACE) + 1 :]: name for finder, name, ispkg in iter_namespace(inmanta_ext)
+            }
+    return dict(_available_extensions)
+
+
+def reset_available_extensions_cache() -> None:
+    """
+    Forget the discovered extensions, so that the next call inspects the current virtual environment again.
+    """
+    global _available_extensions
+    _available_extensions = None
 
 
 def strtobool(val: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -537,13 +537,11 @@ def get_type_of_column(postgresql_client) -> Callable[[], Awaitable[Optional[str
 @pytest.fixture(scope="function")
 def deactive_venv() -> ActiveEnv:
     snapshot = env.store_venv()
-    old_available_extensions = (
-        dict(InmantaBootloader.AVAILABLE_EXTENSIONS) if InmantaBootloader.AVAILABLE_EXTENSIONS is not None else None
-    )
     yield process_env
     snapshot.restore()
     loader.PluginModuleFinder.reset()
-    InmantaBootloader.AVAILABLE_EXTENSIONS = old_available_extensions
+    # The venv is back to what it was, so discovery will find the same extensions again.
+    inmanta.util.reset_available_extensions_cache()
 
 
 def reset_metrics():
@@ -583,7 +581,7 @@ def reset_all_objects():
     handler.Commander.reset()
     Project._project = None
     unknown_parameters.clear()
-    InmantaBootloader.AVAILABLE_EXTENSIONS = None
+    inmanta.util.reset_available_extensions_cache()
     V2ModuleBuilder.DISABLE_DEFAULT_ISOLATED_ENV_CACHED = False
     compiler.Finalizers.reset_finalizers()
     auth.AuthJWTConfig.reset()


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

**Stacked on #10705 → #10703 → #10702. Review those first.** Base branch is `migrate-dto-imports`, so the diff here is only this step.

`inmanta/env.py` manages virtual environments, which the compiler uses. It has to protect extension packages from being uninstalled, and asked the server for the list of them:

```python
from inmanta.server.bootloader import InmantaBootloader
...
for ext_name in InmantaBootloader.get_available_extensions().keys()
```

That one call put the server slice machinery and the database access layer on the compiler's import path.

`get_available_extensions` does not need the server. It walks the `inmanta_ext` namespace package with `pkgutil` and caches the result, so it moves to `inmanta.util` along with its `iter_namespace` helper and the cache. `InmantaBootloader.get_available_extensions` stays and proxies to it, so its callers and the `@stable_api` surface of the class are unaffected.

## Effect

| import | before | after |
| ------ | -----: | ----: |
| `inmanta.env` | 1580 modules, server + `inmanta.data` + `sqlalchemy` all loaded | **920 modules, none of them loaded** |
| `inmanta.module` | 1692 | 1692 |
| `inmanta.app` | 1757 | 1757 |

`inmanta.module` and `inmanta.app` do not move, because they still reach `inmanta.data` by a route this PR does not touch:

```
module.py:60 → plugins.py:39 → protocol/__init__.py:56 → methods.py:26 → from inmanta import const, data, resources
```

`plugins.py` importing the protocol layer is legitimate — that is `Context.get_client()`. What is not is `protocol/methods.py` importing the database at module scope for one server side getter, and `protocol/auth/policy_engine.py` doing the same for one line. Those two are the next step; deferring them takes `import inmanta.logging` from 1574 to 1395 modules with the database absent, which matters because nearly everything imports `inmanta.logging`.

## Also fixed

`iter_namespace` was annotated `-> Generator[ModuleInfo, None, None]` but returns `pkgutil.iter_modules(...)`, an `Iterator`. The mismatch was suppressed by a baseline entry rather than fixed. Since the function moves, the annotation is corrected to `Iterator[ModuleInfo]` and the baseline entry is deleted.

## Verification

- CI mypy and the fast test suite. Locally, `mypy-baseline filter` with a cold cache reports the same set of pre-existing violations master produces, one baseline entry lighter.
- black, isort and flake8 clean.
- `InmantaBootloader.get_available_extensions()` and `inmanta.util.get_available_extensions()` return equal results, and `import inmanta.env` no longer loads `inmanta.server.*` at all.
