### PR TITLE
Defer the inmanta.data import in the protocol layer

### DIFF
--- a/changelogs/unreleased/defer-protocol-data-import.yml
+++ b/changelogs/unreleased/defer-protocol-data-import.yml
@@ -1,0 +1,5 @@
+description: The protocol layer no longer imports the database access layer, so importing inmanta.logging or inmanta.protocol does not pull it in.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/protocol/auth/policy_engine.py
+++ b/src/inmanta/protocol/auth/policy_engine.py
@@ -28,7 +28,7 @@ from typing import Mapping
 from tornado import httpclient
 from tornado.httpclient import HTTPRequest
 
-from inmanta import config, const, data
+from inmanta import config, const
 from inmanta import tornado as inmanta_tornado
 from inmanta import util
 from inmanta.protocol import common
@@ -252,6 +252,10 @@ class PolicyEngine:
         """
         Make sure that the roles defined in the access policy are also present in the database.
         """
+        # Imported here rather than at module scope: this runs server side only, while inmanta.logging imports this module and
+        # is in turn imported by the compiler.
+        from inmanta import data
+
         roles = await self._get_roles()
         if not roles:
             return

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -20,10 +20,10 @@ Module defining the v1 rest api
 
 import uuid
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import inmanta.types
-from inmanta import const, data, resources
+from inmanta import const, resources
 from inmanta.const import ResourceState
 from inmanta.dto.code import InmantaModule
 from inmanta.dto.compile import CompileRun
@@ -35,12 +35,19 @@ from inmanta.protocol.common import ArgOption
 from inmanta.protocol.decorators import method, typedmethod
 from inmanta.types import JsonType, PrimitiveTypes, ResourceIdStr
 
+if TYPE_CHECKING:
+    from inmanta import data
+
 
 async def convert_environment(env: uuid.UUID, metadata: dict) -> "data.Environment":
     """
 
     :meta private:
     """
+    # Imported here rather than at module scope: this getter only ever runs server side, while these method definitions are
+    # also imported by every client, including the compiler.
+    from inmanta import data
+
     metadata[const.INMANTA_URN + "env"] = str(env)
     env = await data.Environment.get_by_id(env)
     if env is None:


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

**Stacked on #10706 → #10705 → #10703 → #10702. Review those first.** Base branch is `move-extension-discovery`, so the diff here is only this step.

Two modules in the protocol layer touch the database access layer in exactly one place each, and both only ever run server side:

- `protocol/methods.py`, in `convert_environment`, the `ArgOption` getter behind `tid`
- `protocol/auth/policy_engine.py`, in `_synchronize_roles_to_db`, for `data.Role.ensure_roles`

Importing `inmanta.data` at module scope for those put the database on the import path of every client. It reached further than it looks: `inmanta/logging.py` imports `policy_engine` for a single call, and `inmanta.logging` is imported by nearly everything, the compiler included.

Both imports move into the function that needs them. In `methods.py` the annotation was already quoted, so `data` just moves under `TYPE_CHECKING`.

## Effect

| import | before | after |
| ------ | -----: | ----: |
| `inmanta.logging` | 1574, database loaded | **1396, database absent** |
| `inmanta.protocol` | 1548, database loaded | **1370, database absent** |
| `inmanta.env` | 920, absent | 920, absent |
| `inmanta.module` | 1691 | 1692 |
| `inmanta.app` | 1757 | 1757 |

`inmanta.protocol` no longer loading the database is the interesting one: the compiler genuinely needs the protocol client, so this is the layer that could never be deferred away.

`inmanta.module` and `inmanta.app` do not move. Two routes remain, both traced with an import watcher:

```
compiler/__init__.py:31 → agent/__init__.py:19 → agent_new.py → data
compiler/__init__.py:31 → agent/handler.py:35 → data
```

The first is the `Agent` re-export in the agent package `__init__`. The second is `handler.py` needing the `DataDocument` based `LogLine` at `data/__init__.py:4032`, so it only goes away with the `LogLine` unification. Fixing the first two routes plus this one gets `inmanta.module` to 1644 with the database still loaded, so the count only really drops once all three land.

## On the deferred imports

A repeat import is a `sys.modules` hit, not a re-execution. Measured on this machine: `from inmanta import data` costs about 210 ns more than the module level form, against a function that awaits a database round trip. `convert_environment` runs once per API request carrying a `tid`, not in a loop.

Worth knowing about `policy_engine.py`: its `start` method has a local variable also called `data`, so the module level import was already invisible there. Only `_synchronize_roles_to_db` ever used it.

## Verification

- CI mypy and the fast test suite. Locally, `mypy-baseline filter` with a cold cache reports the same set of pre-existing violations master produces.
- black, isort and flake8 clean.
- Import measurements taken from separate worktrees, so before and after are really different code.
