### PR TITLE
Import the handler API in the compiler only where it is used

### DIFF
--- a/changelogs/unreleased/defer-compiler-handler-import.yml
+++ b/changelogs/unreleased/defer-compiler-handler-import.yml
@@ -1,0 +1,5 @@
+description: The compiler no longer imports the handler API at module scope, so importing inmanta.module no longer loads the database access layer.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/compiler/__init__.py
+++ b/src/inmanta/compiler/__init__.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Optional, Type
 import inmanta.ast.type as inmanta_type
 import inmanta.execute.dataflow as dataflow
 from inmanta import const, module, references, resources
-from inmanta.agent import handler
 from inmanta.ast import (
     AnchorTarget,
     AttributeException,
@@ -56,6 +55,10 @@ from inmanta.stable_api import stable_api
 LOGGER: logging.Logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    # Only imported for typing here, and inside the three methods below at runtime. Importing it at module scope would
+    # execute the agent package, which reaches the scheduler and the database, on every compile. Handlers register
+    # themselves when the module plugins import this same module, so the Commander registry is populated regardless.
+    from inmanta.agent import handler
     from inmanta.ast import BasicBlock, Statement  # noqa: F401
 
 # gen1/gen2 thresholds applied for the duration of a compile, see relaxed_gc_thresholds().
@@ -198,7 +201,7 @@ class ProjectLoader:
 
     _registered_plugins: ClassVar[dict[str, Type[Plugin]]] = {}
     _registered_resources: ClassVar[dict[str, tuple[type["resources.Resource"], dict[str, str]]]] = {}
-    _registered_providers: ClassVar[dict[str, type[handler.ResourceHandler[Any]]]] = {}
+    _registered_providers: ClassVar[dict[str, "type[handler.ResourceHandler[Any]]"]] = {}
     _registered_references: ClassVar[dict[str, type[references.Reference[references.RefValue]]]] = {}
     _registered_mutators: ClassVar[dict[str, type[references.Mutator]]] = {}
     _dynamic_modules: ClassVar[set[str]] = set()
@@ -238,6 +241,8 @@ class ProjectLoader:
 
     @classmethod
     def _save_compiler_state(cls) -> None:
+        from inmanta.agent import handler
+
         cls._registered_plugins.update(PluginMeta.get_functions())
         cls._registered_resources.update(dict(resources.resource._resources))
         cls._registered_providers.update(dict(handler.Commander.get_handlers()))
@@ -246,6 +251,8 @@ class ProjectLoader:
 
     @classmethod
     def _reset_compiler_state(cls) -> None:
+        from inmanta.agent import handler
+
         PluginMeta.clear()
         resources.resource.reset()
         handler.Commander.reset()
@@ -257,6 +264,8 @@ class ProjectLoader:
         """
         Re-register all compiler state objects.
         """
+        from inmanta.agent import handler
+
         for state_type_name, saved_registered, currently_registered_names, register_fnc in [
             (
                 "plugin",


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

**Stacked on #10708 → #10707 → #10706 → #10705 → #10703 → #10702. Review those first.** Base is `unify-logline`, so the diff here is only this step.

**This is the one where the number moves.** `import inmanta.module` goes from 1692 to **1465 loaded modules, with `inmanta.data` and `sqlalchemy` absent.**

`inmanta/compiler/__init__.py` imported `inmanta.agent.handler` at module scope. That single line executes the agent package, whose `__init__` re-exports `Agent` from `agent_new`, which reaches the scheduler and through it the database. It was the last route from a compile to the database access layer.

The compiler does not need the handler API to import; it only reads the `Commander` registry, in three classmethods, plus one annotation. So the import moves into those three methods, and under `TYPE_CHECKING` for the annotation, which the line above it already does for `resources.Resource`.

## Why deferring is safe

Handlers register themselves when a module's plugin code runs `from inmanta.agent import handler` and subclasses `ResourceHandler`. That is what populates `Commander`. The compiler importing the module never populated anything, it only read the registry. By the time `_save_compiler_state`, `_reset_compiler_state` or `_restore_compiler_state` run, the module plugins have already imported the same module object, so the registry is intact.

## Why this rather than emptying the agent package `__init__`

Both close the same route and measure identically. Dropping the `Agent` re-export would touch four test files, three of them in lsm, and needs coordination. This touches one file and nothing outside it.

Dropping that re-export is still worth doing as hygiene at some point: roughly 180 `from inmanta.agent import ...` sites across our repositories import a submodule and pay for the `Agent` import without using it, and the `collect_report` re-export beside it is used nowhere at all. It just does not have to happen now.

## What is left after this

`inmanta.app` is unchanged at 1757 with the database loaded, because it imports server pieces for its other subcommands. `inmanta compile` runs through it, so that is the step the end to end figure needs, and all five uses of `agent_config` there are in function bodies.

## Verification

- 914 tests pass: `tests/compiler/`, `tests/test_compiler_entrypoints.py`, `tests/test_loader.py`, `tests/deploy/e2e/`, `tests/test_export.py`, `tests/test_app_cli.py`. The export and code-loading suites are the ones that would catch a registry-ordering mistake.
- A real `inmanta compile` of a project importing `lsm` succeeds.
- mypy: `mypy-baseline filter` with a cold cache reports the same set of pre-existing violations master produces.
- black, isort and flake8 clean.
