### PR TITLE
Take the database off the compile path in the CLI entry point

### DIFF
--- a/changelogs/unreleased/defer-app-server-imports.yml
+++ b/changelogs/unreleased/defer-app-server-imports.yml
@@ -1,0 +1,5 @@
+description: A compile no longer loads the database access layer. The CLI entry point imports the server packages only in the subcommands that need them, and inmanta.agent stops re-exporting Agent.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/agent/__init__.py
+++ b/src/inmanta/agent/__init__.py
@@ -16,8 +16,6 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-from inmanta.agent.agent_new import Agent
-
 # flake8: noqa: F401
 # Backward compatibility
 from inmanta.agent.reporting import collect_report

--- a/src/inmanta/app.py
+++ b/src/inmanta/app.py
@@ -66,10 +66,6 @@ from inmanta.const import ALL_LOG_CONTEXT_VARS, EXIT_START_FAILED, LOG_CONTEXT_V
 from inmanta.export import cfg_env
 from inmanta.logging import InmantaLoggerConfig, _is_on_tty
 from inmanta.protocol import common
-from inmanta.server import config as opt
-from inmanta.server.bootloader import InmantaBootloader
-from inmanta.server.services.databaseservice import initialize_database_connection_pool
-from inmanta.server.services.metricservice import MetricsService
 from inmanta.signals import safe_shutdown, setup_signal_handlers
 from inmanta.warnings import WarningsManager
 
@@ -108,6 +104,10 @@ def start_server(options: argparse.Namespace) -> None:
 
     if options.compatibility_file is not None:
         Config.set("server", "compatibility_file", str(options.compatibility_file))
+
+    # The server packages are imported here rather than at module scope: this module is the entry point for every
+    # subcommand, including compile, and importing them reaches the database access layer.
+    from inmanta.server.bootloader import InmantaBootloader
 
     tracing.configure_logfire("server")
     util.ensure_event_loop()
@@ -153,6 +153,12 @@ def start_scheduler(options: argparse.Namespace) -> None:
 
     if max_clients:
         AsyncHTTPClient.configure(None, max_clients=max_clients)
+
+    # The server packages are imported here rather than at module scope: this module is the entry point for every
+    # subcommand, including compile, and importing them reaches the database access layer.
+    from inmanta.server import config as opt
+    from inmanta.server.services.databaseservice import initialize_database_connection_pool
+    from inmanta.server.services.metricservice import MetricsService
 
     tracing.configure_logfire("scheduler")
 
@@ -985,6 +991,8 @@ def default_logging_config(options: argparse.Namespace) -> None:
 
         if options.config_for_component == "server":
             # Upgrade with extensions
+            from inmanta.server.bootloader import InmantaBootloader
+
             ibl = InmantaBootloader()
             ibl.start_loggers_for_extensions(component_config)
 
@@ -1028,6 +1036,8 @@ def policy_engine(options: argparse.Namespace) -> None:
 def print_versions_installed_components_and_exit() -> None:
     # coroutine to make sure event loop is running for server slices
     async def print_status() -> None:
+        from inmanta.server.bootloader import InmantaBootloader
+
         bootloader = InmantaBootloader()
         app_context = bootloader.load_slices()
         product_metadata = app_context.get_product_metadata()

--- a/tests/deploy/scheduler_mocks.py
+++ b/tests/deploy/scheduler_mocks.py
@@ -29,7 +29,8 @@ import asyncpg
 from asyncpg import Connection
 
 from inmanta import const
-from inmanta.agent import Agent, executor
+from inmanta.agent import executor
+from inmanta.agent.agent_new import Agent
 from inmanta.agent.executor import DeployReport, DryrunReport, GetFactReport, ModuleInstallSpec, ResourceDetails
 from inmanta.const import Change
 from inmanta.data.model import AttributeStateChange


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

**Stacked on #10709 → #10708 → #10707 → #10706 → #10705 → #10703 → #10702. Review those first.** Base is `defer-compiler-handler-import`.

**Merge inmanta/inmanta-lsm#2483 and inmanta/lsm#1005 before this.** They point three lsm test files at `inmanta.agent.agent_new` for `Agent`.

**A real `inmanta compile` no longer loads the database.** Measured on a project whose model is `import std`, with the import watcher counting `sys.modules` at interpreter exit:

| | modules | `inmanta.data` | `sqlalchemy` |
| --- | ------: | -------------- | ------------ |
| `inmanta compile`, before | 1397 | loaded | loaded |
| `inmanta compile`, after | **1189** | **absent** | **absent** |
| `import inmanta.app`, before | 1757 | loaded | loaded |
| `import inmanta.app`, after | **1548** | **absent** | **absent** |

## Two changes, and neither works without the other

**`app.py` defers four server imports.** It is the entry point for every subcommand, compile included, and imported the server bootloader, the server config, the database connection pool and the metrics service at module scope. All four are used only inside the `server` and `scheduler` subcommands, so they move there.

**`inmanta/agent/__init__.py` stops re-exporting `Agent`.** Deferring the app.py imports alone moved almost nothing, because two things reach the agent package on a plain compile regardless: `app()` reads the agent config on every invocation to build the log context, and `inmanta.export` imports the handler API. Both execute the package `__init__`, which re-exports `Agent` from `agent_new`, which reaches the scheduler and the database.

I tried deferring those two instead. Neither helps: the log-context read is on the unconditional path of every command, so deferring it just moves the same work from import time to run time, and I measured that as no change. Dropping the re-export is what closes it.

## On the blast radius of that re-export

It is smaller than it looks. Across every checkout in my workspace, roughly 180 sites do `from inmanta.agent import ...`, but they import a **submodule** — `handler`, `config`, `executor`, `cache`, `reporting`. Those are unaffected; they currently pay for the `Agent` import without using it, so they get cheaper.

Exactly four sites use the `Agent` name, all tests: `tests/deploy/scheduler_mocks.py` here, updated in this PR, and three in lsm, handled by the two PRs above. The `collect_report` re-export beside it is used nowhere and is left alone.

## Deliberately not included

The `export.py` and agent-config deferrals I built while working this out are **not** in the diff. Once the re-export is gone, `inmanta.agent.handler` and `inmanta.agent.config` are cheap to import, so those deferrals bought nothing and would only have added noise.

## Verification

- A real `inmanta compile` succeeds and loads neither `inmanta.data` nor `sqlalchemy`.
- 219 tests pass across `tests/test_app.py`, `tests/test_app_cli.py`, `tests/deploy/` and `tests/test_agent.py`.
- mypy over CI's three packages: adds nothing master does not already produce. `agent/__init__.py` has no baseline entries, so nothing there becomes resolved.
- black, isort and flake8 clean.
