### PR TITLE
Keep strawberry and cookiecutter off the compile path

### DIFF
--- a/changelogs/unreleased/keep-strawberry-and-cookiecutter-off-compile-path.yml
+++ b/changelogs/unreleased/keep-strawberry-and-cookiecutter-off-compile-path.yml
@@ -1,0 +1,5 @@
+description: A compile no longer loads strawberry or cookiecutter, which together pulled in requests, rich and urllib3.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/src/inmanta/graphql/result.py
+++ b/src/inmanta/graphql/result.py
@@ -15,7 +15,11 @@ Contact: code@inmanta.com
 import typing
 
 from inmanta.types import BaseModel
-from strawberry.types.execution import ExecutionResult
+
+if typing.TYPE_CHECKING:
+    # Imported for typing only. inmanta.protocol.methods_v2 imports this module and the compiler imports the protocol
+    # layer, so importing strawberry here would put it and the whole graphql package on the import path of every compile.
+    from strawberry.types.execution import ExecutionResult
 
 
 class GraphQLResult(BaseModel):
@@ -35,7 +39,7 @@ class GraphQLResult(BaseModel):
         return 200 if self.data else 400
 
     @classmethod
-    def from_execution_result(cls, execution_result: ExecutionResult) -> "GraphQLResult":
+    def from_execution_result(cls, execution_result: "ExecutionResult") -> "GraphQLResult":
         """
         Creates a GraphQLResult object from the ExecutionResult returned by strawberry
         """

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -46,7 +46,6 @@ import click
 import more_itertools
 import texttable
 import yaml
-from cookiecutter.main import cookiecutter
 
 import build
 import inmanta
@@ -402,6 +401,10 @@ compatible with the dependencies specified by the updated modules.
         project_path = os.path.join(output_dir, name)
         if os.path.exists(project_path):
             raise Exception(f"Project directory {project_path} already exists")
+        # Imported here rather than at module scope: cookiecutter pulls in requests and rich, and this module is imported
+        # for every compile while the templates are only used by this scaffolding command.
+        from cookiecutter.main import cookiecutter
+
         cookiecutter(
             "https://github.com/inmanta/inmanta-project-template.git",
             output_dir=output_dir,
@@ -851,6 +854,10 @@ When a development release is done using the \--dev option, this command:
             module_dir: str = name
             if os.path.exists(module_dir):
                 raise Exception(f"Directory {module_dir} already exists")
+            # Imported here rather than at module scope: cookiecutter pulls in requests and rich, and this module is imported
+            # for every compile while the templates are only used by this scaffolding command.
+            from cookiecutter.main import cookiecutter
+
             cookiecutter(
                 "https://github.com/inmanta/inmanta-module-template.git",
                 no_input=no_input,


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

**Stacked on #10710.** Base is `defer-app-server-imports`.

Once the database came off the compile path, two module scope imports dominated what was left. Both are used in one place each.

**`graphql/result.py`** imported strawberry for a single annotation, on `GraphQLResult.from_execution_result`. `inmanta.protocol.methods_v2` imports that module and the compiler imports the protocol layer, so every compile loaded strawberry and, through it, the graphql package. It moves under `TYPE_CHECKING` and the annotation is quoted.

**`moduletool.py`** imported cookiecutter at module scope for the two scaffolding commands, `inmanta project init` and `inmanta module init`, which also brought in requests, rich, urllib3 and chardet. The import moves into those two methods.

## Effect

Real `inmanta compile` of a project whose model is `import std`, counting `sys.modules` at interpreter exit:

| | modules |
| --- | ------: |
| master | 1379 |
| the stack up to #10710 | 1189 |
| **this PR** | **810** |

`strawberry`, `cookiecutter`, `requests`, `rich`, `urllib3` and `chardet` are all absent from a compile afterwards. That is 379 modules, which is more than the eight PRs below this one removed between them, and worth saying plainly: the database work was structural, this is where the module count actually was.

## What is left, and why it is harder

`graphql-core` is still loaded, 127 modules, on this chain:

```
plugins.py:39 → protocol/__init__.py:56 → methods_v2.py:60 → graphql/rest_filter.py:23 → graphql
```

`methods_v2.py` imports `ResourceFilterArg` for one annotation on an API method, and `typedmethod` resolves type hints at decoration time, so that import cannot move under `TYPE_CHECKING` without breaking API schema generation. It could be fixed a level down instead: `rest_filter.py` uses the graphql names in three functions plus one frozen dataclass field annotation, and `dataclasses` does not resolve annotations, so quoting that one would work. That belongs in its own PR.

`asyncpg` also lingers at 22 modules, from a module scope `import asyncpg` in `util/__init__.py:51` that exists for an annotation in `ExhaustedPoolWatcher`.

## Verification

- 246 tests pass across `tests/test_graphql.py`, `tests/test_rest_filter.py`, `tests/moduletool/` and `tests/test_app_cli.py`. The graphql and rest-filter suites are what would catch a broken annotation, and the moduletool suite covers the scaffolding commands.
- A real `inmanta compile` succeeds.
- mypy over CI's three packages adds nothing master does not already produce, and neither file's baseline entries change.
- black, isort and flake8 clean.
