### PR TITLE
Guard the compile path against heavy module scope imports

### DIFF
--- a/changelogs/unreleased/guard-compile-path-imports.yml
+++ b/changelogs/unreleased/guard-compile-path-imports.yml
@@ -1,0 +1,5 @@
+description: Added a test that fails if the database access layer, the server, the scheduler, strawberry or cookiecutter end up back on the compile path.
+change-type: patch
+destination-branches:
+  - master
+  - iso9

--- a/tests/test_compile_path_imports.py
+++ b/tests/test_compile_path_imports.py
@@ -1,0 +1,70 @@
+"""
+Copyright 2026 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+import subprocess
+import sys
+
+# Packages a compile must not load. Each one was taken off the import path deliberately, and each is cheap to put back by
+# accident, because a single module scope import anywhere in the reachable graph is enough.
+#
+# inmanta.data                the database access layer, which drags sqlalchemy and the DAO with it
+# sqlalchemy                  only reachable through inmanta.data
+# inmanta.agent.agent_new     the scheduler entry point, which reaches inmanta.data
+# inmanta.server.bootloader   the server, which reaches inmanta.data through server.extensions
+# strawberry                  a graphql annotation in inmanta/graphql/result.py used to pull this in
+# cookiecutter                only used by the project and module scaffolding commands
+FORBIDDEN_ON_COMPILE_PATH = (
+    "inmanta.data",
+    "sqlalchemy",
+    "inmanta.agent.agent_new",
+    "inmanta.server.bootloader",
+    "strawberry",
+    "cookiecutter",
+)
+
+DUMP_LOADED_MODULES = "import sys; import inmanta.app; print('\\n'.join(sys.modules))"
+
+
+def test_compile_path_does_not_load_the_database_or_the_server() -> None:
+    """
+    Importing the CLI entry point must not load the database access layer, the server or the scheduler.
+
+    A compile needs none of them, but they sit one module scope import away: the compiler imports the protocol layer for
+    Context.get_client(), and the handler API for the Commander registry. Both used to reach inmanta.data.
+
+    Run in a subprocess, because by the time this test executes the pytest process has imported most of the code base.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", DUMP_LOADED_MODULES],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    loaded: set[str] = set(result.stdout.split())
+    assert "inmanta.app" in loaded, f"the subprocess did not import inmanta.app: {result.stderr}"
+
+    found = [
+        package
+        for package in FORBIDDEN_ON_COMPILE_PATH
+        if any(module == package or module.startswith(f"{package}.") for module in loaded)
+    ]
+    assert not found, (
+        f"{', '.join(found)} is loaded by importing inmanta.app."
+        " Something gained a module scope import of it; move that import into the function that needs it,"
+        f" or under TYPE_CHECKING if it is only an annotation. See {__file__} for why each entry is listed."
+    )


### PR DESCRIPTION
_This PR was opened by Claude on behalf of @bartv._

**Stacked on #10712.** Base is `keep-strawberry-and-cookiecutter-off-compile-path`, the last of the ten PRs this guards.

Everything below this took something off the import path of a compile. All of it comes back through a single module scope import anywhere in the reachable graph, which is precisely how it got there in the first place: one line in `inmanta/env.py`, one annotation in `graphql/result.py`, one re-export in `inmanta/agent/__init__.py`.

The test imports `inmanta.app` in a subprocess and asserts that none of these is in `sys.modules`:

| package | why it is listed |
| ------- | ---------------- |
| `inmanta.data` | the database access layer, which drags the DAO and sqlalchemy with it |
| `sqlalchemy` | only reachable through `inmanta.data` |
| `inmanta.agent.agent_new` | the scheduler entry point, which reaches `inmanta.data` |
| `inmanta.server.bootloader` | the server, which reaches `inmanta.data` through `server.extensions` |
| `strawberry` | one graphql annotation used to pull this in, and the graphql package with it |
| `cookiecutter` | only used by the project and module scaffolding commands |

The subprocess matters: by the time this test runs, the pytest process has imported most of the code base, so an in-process check would assert nothing.

## Verified to fail

A guard that cannot fail is worthless, so I reintroduced each class of regression and confirmed the test catches it and names the culprit:

- a module scope `strawberry` import in `graphql/result.py` → `strawberry is loaded by importing inmanta.app`
- a module scope `cookiecutter` import in `moduletool.py` → `cookiecutter is loaded by importing inmanta.app`
- the `Agent` re-export back in `inmanta/agent/__init__.py` → `inmanta.data, sqlalchemy, inmanta.agent.agent_new is loaded by importing inmanta.app`

The third is worth noting: one re-export trips three entries, which is a fair picture of how these things cascade.

## Deliberately not in the list

`graphql` and `asyncpg` are **still on the path**, 127 and 22 modules, so listing them would fail today. Both are tracked as follow-ups: graphql through `methods_v2` needing `ResourceFilterArg` for an API annotation that `typedmethod` resolves at decoration time, and asyncpg through a module scope import in `util/__init__.py:51` that exists for an annotation.

`requests` and `rich` are absent from a production-like environment but **present in the dev environment**, pulled in by the dev dependencies. Asserting them would fail in CI rather than guard anything, so they are out. That difference is also why the module counts quoted in the earlier PRs come in two families: figures for `inmanta compile` were taken in a venv without dev extras, figures for `import inmanta.<module>` in the development venv. Each family is internally consistent; they are not comparable to each other.
