### PR TITLE
Ensure compatibility with python3.14

### DIFF
--- a/.ci-performance.yml
+++ b/.ci-performance.yml
@@ -1,1 +1,0 @@
-pipeline_template: ci/inmanta-core/jenkinsfile-performance

--- a/changelogs/unreleased/restrict-inmanta-core-to-python3.14-and-above.yml
+++ b/changelogs/unreleased/restrict-inmanta-core-to-python3.14-and-above.yml
@@ -1,4 +1,4 @@
 ---
-description: "Drop support for Python 3.13, Python 3.14 is now the minimum required version."
+description: "Ensure compatibility with Python 3.14"
 change-type: minor
 destination-branches: [master]

--- a/changelogs/unreleased/restrict-inmanta-core-to-python3.14-and-above.yml
+++ b/changelogs/unreleased/restrict-inmanta-core-to-python3.14-and-above.yml
@@ -1,0 +1,4 @@
+---
+description: "Drop support for Python 3.13, Python 3.14 is now the minimum required version."
+change-type: minor
+destination-branches: [master]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -381,8 +381,8 @@ src/inmanta/data/__init__.py:0: note: def _generate_next_value_(name, start: int
 src/inmanta/data/__init__.py:0: note: def _generate_next_value_(name: str, start: int, count: int, last_values: list[Any]) -> Any
 src/inmanta/data/__init__.py:0: note: def get_list(cls, *, order_by_column: str | None = ..., order: str | None = ..., limit: int | None = ..., offset: int | None = ..., no_obj: bool | None = ..., lock: RowLockMode | None = ..., connection: Connection | None = ..., **query: object) -> Coroutine[Any, Any, list[Environment]]
 src/inmanta/data/__init__.py:0: note: def get_list(cls, *, order_by_column: str | None = ..., order: str | None = ..., limit: int | None = ..., offset: int | None = ..., no_obj: bool | None = ..., lock: RowLockMode | None = ..., connection: Connection | None = ..., details: bool = ..., **query: object) -> Coroutine[Any, Any, list[Environment]]
-src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
-src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
+src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
+src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
 src/inmanta/data/__init__.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/data/__init__.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/data/dataview.py:0: error: "object" has no attribute "get"  [attr-defined]
@@ -697,7 +697,7 @@ src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "LocatableString" ha
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "Reference" has incompatible type "str"; expected "LocatableString"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "float" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsFloat | SupportsIndex"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "get" of "dict" has incompatible type "str | LocatableString"; expected "str"  [arg-type]
-src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "int" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc"  [arg-type]
+src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "int" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsInt | SupportsIndex"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "len" has incompatible type "str | LocatableString"; expected "Sized"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Incompatible types in assignment (expression has type "Regex", variable has type "str | LocatableString")  [assignment]
 src/inmanta/parser/plyInmantaLex.py:0: error: Incompatible types in assignment (expression has type "float", variable has type "str | LocatableString")  [assignment]
@@ -998,7 +998,7 @@ src/inmanta/server/protocol.py:0: error: Item "None" of "HTTPServer | None" has 
 src/inmanta/server/protocol.py:0: error: Item "None" of "HTTPServer | None" has no attribute "_sockets"  [union-attr]
 src/inmanta/server/services/databaseservice.py:0: error: No overload variant of "int" matches argument type "object"  [call-overload]
 src/inmanta/server/services/databaseservice.py:0: note: Possible overload variants:
-src/inmanta/server/services/databaseservice.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
+src/inmanta/server/services/databaseservice.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
 src/inmanta/server/services/databaseservice.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/server/services/environment_metrics_service.py:0: error: "Sequence[EnvironmentMetricsGauge]" has no attribute "append"  [attr-defined]
 src/inmanta/server/services/environment_metrics_service.py:0: error: "Sequence[EnvironmentMetricsTimer]" has no attribute "append"  [attr-defined]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ version = "19.1.0"
 
 setup(
     version=version,
-    python_requires=">=3.14",  # also update classifiers
+    python_requires=">=3.13",  # also update classifiers
     # Meta data
     name="inmanta-core",
     description="Inmanta deployment tool",
@@ -75,7 +75,7 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",
-        "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: 3.13",
     ],
     keywords="orchestrator orchestration configurationmanagement",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ version = "19.1.0"
 
 setup(
     version=version,
-    python_requires=">=3.13",  # also update classifiers
+    python_requires=">=3.14",  # also update classifiers
     # Meta data
     name="inmanta-core",
     description="Inmanta deployment tool",
@@ -75,7 +75,7 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",
-        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     keywords="orchestrator orchestration configurationmanagement",
     project_urls={

--- a/src/inmanta/ast/__init__.py
+++ b/src/inmanta/ast/__init__.py
@@ -21,6 +21,9 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from inmanta import warnings
+
+# The classes below define an export method, which shadows this name in their annotation scopes. Annotations that
+# refer to this module are quoted so that they resolve against the module scope instead.
 from inmanta.ast import export
 from inmanta.execute.util import Unknown
 from inmanta.stable_api import stable_api
@@ -66,7 +69,7 @@ class Location(export.Exportable):
 
         return Location(self.file, min(self.lnr, other.lnr))
 
-    def export(self) -> export.Location:
+    def export(self) -> "export.Location":
         # Location is 1-based, export.Position spec is 0-based
         # whole line: range from line:0 to line+1:0
         range_start: export.Position = export.Position(line=self.lnr - 1, character=0)
@@ -122,7 +125,7 @@ class Range(Location):
                 end_char = self.end_char
             return Range(self.file, lnr, start_char, end_lnr, end_char)
 
-    def export(self) -> export.Location:
+    def export(self) -> "export.Location":
         range_start: export.Position = export.Position(line=self.lnr - 1, character=self.start_char - 1)
         range_end: export.Position = export.Position(line=self.end_lnr - 1, character=self.end_char - 1)
         result: export.Location = super().export()
@@ -611,7 +614,7 @@ class CompilerException(Exception, export.Exportable):
     def attach_compile_info(self, compiler: "Compiler") -> None:
         self.root_ns = compiler.get_ns()
 
-    def export(self) -> export.Error:
+    def export(self) -> "export.Error":
         location: Optional[Location] = self.get_location()
         module: Optional[str] = self.__class__.__module__
         name: str = self.__class__.__qualname__
@@ -782,7 +785,7 @@ class ExplicitPluginException(ExternalException):
         ExternalException.__init__(self, stmt, msg, cause)
         self.__cause__: PluginException
 
-    def export(self) -> export.Error:
+    def export(self) -> "export.Error":
         location: Optional[Location] = self.get_location()
         module: Optional[str] = self.__cause__.__class__.__module__
         name: str = self.__cause__.__class__.__qualname__

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -748,6 +748,7 @@ When a development release is done using the \--dev option, this command:
             raise ModuleVersionException(f"Expected a v1 module, but found v{mod.GENERATION.value} module")
         ModuleConverter(mod).convert_in_place()
 
+    # The return annotation is quoted because the list method below shadows the builtin in this class' annotation scope.
     def build(
         self,
         path: Optional[str] = None,
@@ -756,7 +757,7 @@ When a development release is done using the \--dev option, this command:
         byte_code: bool = False,
         wheel: bool = False,
         sdist: bool = False,
-    ) -> list[str]:
+    ) -> "list[str]":
         """
         Build a v2 module and return the path to the build artifact(s).
 
@@ -831,7 +832,8 @@ When a development release is done using the \--dev option, this command:
             project = self.get_project(load=True)
             return project.get_module(module, allow_v1=True)
 
-    def get_modules(self, module: Optional[str] = None) -> list[Module]:
+    # The return annotation is quoted because the list method below shadows the builtin in this class' annotation scope.
+    def get_modules(self, module: Optional[str] = None) -> "list[Module]":
         if module is not None:
             return [self.get_module(module)]
         else:

--- a/src/inmanta/moduletool.py
+++ b/src/inmanta/moduletool.py
@@ -748,7 +748,7 @@ When a development release is done using the \--dev option, this command:
             raise ModuleVersionException(f"Expected a v1 module, but found v{mod.GENERATION.value} module")
         ModuleConverter(mod).convert_in_place()
 
-    # The return annotation is quoted because the list method below shadows the builtin in this class' annotation scope.
+    # The return annotation is quoted because the list method below shadows builtins.list in this class' annotation scope.
     def build(
         self,
         path: Optional[str] = None,
@@ -832,7 +832,7 @@ When a development release is done using the \--dev option, this command:
             project = self.get_project(load=True)
             return project.get_module(module, allow_v1=True)
 
-    # The return annotation is quoted because the list method below shadows the builtin in this class' annotation scope.
+    # The return annotation is quoted because the list method below shadows builtins.list in this class' annotation scope.
     def get_modules(self, module: Optional[str] = None) -> "list[Module]":
         if module is not None:
             return [self.get_module(module)]

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -16,7 +16,6 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
-import re
 import typing
 import warnings
 from re import error as RegexError

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -282,10 +282,8 @@ def safe_decode(token: lex.LexToken, warning_message: str, start: int = 1, end: 
     Check for the presence of an invalid escape sequence (e.g. "\.") in the value attribute of a given token.
     This function assumes to be called from within a t_STRING or a t_MLS rule.
 
-    - Python < 3.12 raises a DeprecationWarning when encountering an invalid escape sequence
-    - Python 3.12 will raise a SyntaxWarning
-    - Future versions will eventually raise a SyntaxError
-    (see https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes )
+    Decoding an invalid escape sequence raises a DeprecationWarning. Future Python versions will eventually raise a
+    SyntaxError (see https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes ).
 
     :param token: The token whose value we want to decode.
     :param warning_message: The warning message to display.
@@ -298,7 +296,8 @@ def safe_decode(token: lex.LexToken, warning_message: str, start: int = 1, end: 
     try:
         # This first block will try to decode the value and turn any deprecation warning into an actual Exception.
         with warnings.catch_warnings():
-            warnings.filterwarnings("error", message="invalid escape sequence", category=DeprecationWarning)
+            # Match on the category alone: the wording of the message differs between Python versions.
+            warnings.filterwarnings("error", category=DeprecationWarning)
             value: str = bytes(typing.cast(str, token.value)[start:end], "utf_8").decode("unicode_escape")
     except DeprecationWarning:
         # If the first block did actually encounter an invalid escape sequence, we have to decode the value again, this time

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -297,9 +297,7 @@ def safe_decode(token: lex.LexToken, warning_message: str, start: int = 1, end: 
     try:
         # This first block will try to decode the value and turn any deprecation warning into an actual Exception.
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "error", message=re.escape(r'"\." is an invalid escape sequence.'), category=DeprecationWarning
-            )
+            warnings.filterwarnings("error", message=".*invalid escape sequence\\.", category=DeprecationWarning)
             value: str = bytes(typing.cast(str, token.value)[start:end], "utf_8").decode("unicode_escape")
     except DeprecationWarning:
         # If the first block did actually encounter an invalid escape sequence, we have to decode the value again, this time

--- a/src/inmanta/parser/plyInmantaLex.py
+++ b/src/inmanta/parser/plyInmantaLex.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import re
 import typing
 import warnings
 from re import error as RegexError
@@ -296,8 +297,9 @@ def safe_decode(token: lex.LexToken, warning_message: str, start: int = 1, end: 
     try:
         # This first block will try to decode the value and turn any deprecation warning into an actual Exception.
         with warnings.catch_warnings():
-            # Match on the category alone: the wording of the message differs between Python versions.
-            warnings.filterwarnings("error", category=DeprecationWarning)
+            warnings.filterwarnings(
+                "error", message=re.escape(r'"\." is an invalid escape sequence.'), category=DeprecationWarning
+            )
             value: str = bytes(typing.cast(str, token.value)[start:end], "utf_8").decode("unicode_escape")
     except DeprecationWarning:
         # If the first block did actually encounter an invalid escape sequence, we have to decode the value again, this time

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -565,7 +565,8 @@ class PluginValue:
         plugin_line: Range = Range(plugin.location.file, plugin.location.lnr, 1, plugin.location.lnr + 1, 1)
         if not isinstance(self.type_expression, str):
             if typing_inspect.is_union_type(self.type_expression) and not typing.get_args(self.type_expression):
-                # If typing.Union is not subscripted, isinstance(self.type_expression, type) evaluates to False.
+                # An unsubscripted Union carries no type information. It is reported here so that it doesn't end up
+                # in the branches below, which would describe it as a bad annotation instead.
                 raise InvalidTypeAnnotation(stmt=None, msg=f"Union type must be subscripted, got {self.type_expression}")
             if (
                 isinstance(self.type_expression, (type, typing.TypeAliasType))

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -381,7 +381,7 @@ class AuthJWTConfig:
         else:
             cls._config_successfully_loaded = True
 
-    # The return annotation is quoted because this method shadows the builtin in the class' annotation scope.
+    # The return annotation is quoted because this method shadows the builtins.list in the class' annotation scope.
     @classmethod
     def list(cls) -> "list[str]":
         """

--- a/src/inmanta/protocol/auth/auth.py
+++ b/src/inmanta/protocol/auth/auth.py
@@ -381,8 +381,9 @@ class AuthJWTConfig:
         else:
             cls._config_successfully_loaded = True
 
+    # The return annotation is quoted because this method shadows the builtin in the class' annotation scope.
     @classmethod
-    def list(cls) -> list[str]:
+    def list(cls) -> "list[str]":
         """
         Return a list of all defined auth jwt configurations. This method will load new sections if they were added
         since the last invocation.

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -701,4 +701,4 @@ end
     )
     with pytest.raises(InvalidTypeAnnotation) as exc_info:
         compiler.do_compile()
-    assert "Union type must be subscripted, got typing.Union" in str(exc_info.value)
+    assert "Union type must be subscripted, got <class 'typing.Union'>" in str(exc_info.value)


### PR DESCRIPTION
# Description

Drop support for python 3.13. 
3.14 is now the supported version for iso10

related to: https://github.com/inmanta/inmanta-core/issues/10590

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
