### PR TITLE
Fix race condition in test_executor_server test

### DIFF
--- a/changelogs/unreleased/fix-test-executor-server-test.yml
+++ b/changelogs/unreleased/fix-test-executor-server-test.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix race condition in test_executor_server test"
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -104,6 +104,9 @@ async def test_executor_server(set_custom_executor_policy, mpmanager: MPManager,
     # check config copying from parent to child
     result = await simplest.call(GetConfig("test", "aaa"))
     assert "bbbb" == result
+    # Fetch the name now, while the executor is guaranteed to be alive. Asserting on it later would
+    # require a live call that can fail with ConnectionLost if the executor got cleaned up for inactivity
+    # during the slow pip install of the full executor below.
     simplest_name = await simplest.call(GetName())
 
     # Make a more complete venv

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -104,7 +104,7 @@ async def test_executor_server(set_custom_executor_policy, mpmanager: MPManager,
     # check config copying from parent to child
     result = await simplest.call(GetConfig("test", "aaa"))
     assert "bbbb" == result
-    name_simplest = await simplest.call(GetName())
+    simplest_name = await simplest.call(GetName())
 
     # Make a more complete venv
     # Direct: source is sent over directly
@@ -168,7 +168,7 @@ def test():
     assert ["DIRECT", "server"] == result2
 
     # assert they are distinct
-    assert name_simplest == simplest_blueprint.blueprint_hash()
+    assert simplest_name == simplest_blueprint.blueprint_hash()
     assert await full_runner.call(GetName()) == full.blueprint_hash()
 
     # Request a third executor:

--- a/tests/forking_agent/test_executor.py
+++ b/tests/forking_agent/test_executor.py
@@ -104,6 +104,7 @@ async def test_executor_server(set_custom_executor_policy, mpmanager: MPManager,
     # check config copying from parent to child
     result = await simplest.call(GetConfig("test", "aaa"))
     assert "bbbb" == result
+    name_simplest = await simplest.call(GetName())
 
     # Make a more complete venv
     # Direct: source is sent over directly
@@ -167,7 +168,7 @@ def test():
     assert ["DIRECT", "server"] == result2
 
     # assert they are distinct
-    assert await simplest.call(GetName()) == simplest_blueprint.blueprint_hash()
+    assert name_simplest == simplest_blueprint.blueprint_hash()
     assert await full_runner.call(GetName()) == full.blueprint_hash()
 
     # Request a third executor:


### PR DESCRIPTION
# Description

Fixes a race condition in the `test_executor_server` test. The test asserted on the name of the `simplest` executor near the end, via a live `GetName()` call. By that point a slow pip install of the full executor had run, during which the `simplest` executor could be cleaned up for inactivity, causing the call to fail with `ConnectionLost`.

The name is now fetched earlier, while the `simplest` executor is guaranteed to be alive, and the later assertion uses the cached value.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)

---

This PR was generated by Claude Code on behalf of Arnaud Schoonjans.