### PR TITLE
Ensure stability of resource hash

### DIFF
--- a/changelogs/unreleased/10622-stable-fields-order.yml
+++ b/changelogs/unreleased/10622-stable-fields-order.yml
@@ -1,0 +1,7 @@
+description: >
+  Fix bug where a resource can be considered as updated across model versions although its attribute set has not changed.
+issue-nr: 10622
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -381,8 +381,8 @@ src/inmanta/data/__init__.py:0: note: def _generate_next_value_(name, start: int
 src/inmanta/data/__init__.py:0: note: def _generate_next_value_(name: str, start: int, count: int, last_values: list[Any]) -> Any
 src/inmanta/data/__init__.py:0: note: def get_list(cls, *, order_by_column: str | None = ..., order: str | None = ..., limit: int | None = ..., offset: int | None = ..., no_obj: bool | None = ..., lock: RowLockMode | None = ..., connection: Connection | None = ..., **query: object) -> Coroutine[Any, Any, list[Environment]]
 src/inmanta/data/__init__.py:0: note: def get_list(cls, *, order_by_column: str | None = ..., order: str | None = ..., limit: int | None = ..., offset: int | None = ..., no_obj: bool | None = ..., lock: RowLockMode | None = ..., connection: Connection | None = ..., details: bool = ..., **query: object) -> Coroutine[Any, Any, list[Environment]]
-src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
-src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
+src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
+src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
 src/inmanta/data/__init__.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/data/__init__.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/data/dataview.py:0: error: "object" has no attribute "get"  [attr-defined]
@@ -697,7 +697,7 @@ src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "LocatableString" ha
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "Reference" has incompatible type "str"; expected "LocatableString"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "float" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsFloat | SupportsIndex"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "get" of "dict" has incompatible type "str | LocatableString"; expected "str"  [arg-type]
-src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "int" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc"  [arg-type]
+src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "int" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsInt | SupportsIndex"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "len" has incompatible type "str | LocatableString"; expected "Sized"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Incompatible types in assignment (expression has type "Regex", variable has type "str | LocatableString")  [assignment]
 src/inmanta/parser/plyInmantaLex.py:0: error: Incompatible types in assignment (expression has type "float", variable has type "str | LocatableString")  [assignment]
@@ -998,7 +998,7 @@ src/inmanta/server/protocol.py:0: error: Item "None" of "HTTPServer | None" has 
 src/inmanta/server/protocol.py:0: error: Item "None" of "HTTPServer | None" has no attribute "_sockets"  [union-attr]
 src/inmanta/server/services/databaseservice.py:0: error: No overload variant of "int" matches argument type "object"  [call-overload]
 src/inmanta/server/services/databaseservice.py:0: note: Possible overload variants:
-src/inmanta/server/services/databaseservice.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
+src/inmanta/server/services/databaseservice.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
 src/inmanta/server/services/databaseservice.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/server/services/environment_metrics_service.py:0: error: "Sequence[EnvironmentMetricsGauge]" has no attribute "append"  [attr-defined]
 src/inmanta/server/services/environment_metrics_service.py:0: error: "Sequence[EnvironmentMetricsTimer]" has no attribute "append"  [attr-defined]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -381,8 +381,8 @@ src/inmanta/data/__init__.py:0: note: def _generate_next_value_(name, start: int
 src/inmanta/data/__init__.py:0: note: def _generate_next_value_(name: str, start: int, count: int, last_values: list[Any]) -> Any
 src/inmanta/data/__init__.py:0: note: def get_list(cls, *, order_by_column: str | None = ..., order: str | None = ..., limit: int | None = ..., offset: int | None = ..., no_obj: bool | None = ..., lock: RowLockMode | None = ..., connection: Connection | None = ..., **query: object) -> Coroutine[Any, Any, list[Environment]]
 src/inmanta/data/__init__.py:0: note: def get_list(cls, *, order_by_column: str | None = ..., order: str | None = ..., limit: int | None = ..., offset: int | None = ..., no_obj: bool | None = ..., lock: RowLockMode | None = ..., connection: Connection | None = ..., details: bool = ..., **query: object) -> Coroutine[Any, Any, list[Environment]]
-src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
-src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
+src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
+src/inmanta/data/__init__.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
 src/inmanta/data/__init__.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/data/__init__.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/data/dataview.py:0: error: "object" has no attribute "get"  [attr-defined]
@@ -697,7 +697,7 @@ src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "LocatableString" ha
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "Reference" has incompatible type "str"; expected "LocatableString"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "float" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsFloat | SupportsIndex"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "get" of "dict" has incompatible type "str | LocatableString"; expected "str"  [arg-type]
-src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "int" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsInt | SupportsIndex"  [arg-type]
+src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "int" has incompatible type "str | LocatableString"; expected "str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Argument 1 to "len" has incompatible type "str | LocatableString"; expected "Sized"  [arg-type]
 src/inmanta/parser/plyInmantaLex.py:0: error: Incompatible types in assignment (expression has type "Regex", variable has type "str | LocatableString")  [assignment]
 src/inmanta/parser/plyInmantaLex.py:0: error: Incompatible types in assignment (expression has type "float", variable has type "str | LocatableString")  [assignment]
@@ -998,7 +998,7 @@ src/inmanta/server/protocol.py:0: error: Item "None" of "HTTPServer | None" has 
 src/inmanta/server/protocol.py:0: error: Item "None" of "HTTPServer | None" has no attribute "_sockets"  [union-attr]
 src/inmanta/server/services/databaseservice.py:0: error: No overload variant of "int" matches argument type "object"  [call-overload]
 src/inmanta/server/services/databaseservice.py:0: note: Possible overload variants:
-src/inmanta/server/services/databaseservice.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex = ..., /) -> int
+src/inmanta/server/services/databaseservice.py:0: note: def int(str | Buffer | SupportsInt | SupportsIndex | SupportsTrunc = ..., /) -> int
 src/inmanta/server/services/databaseservice.py:0: note: def int(str | bytes | bytearray, /, base: SupportsIndex) -> int
 src/inmanta/server/services/environment_metrics_service.py:0: error: "Sequence[EnvironmentMetricsGauge]" has no attribute "append"  [attr-defined]
 src/inmanta/server/services/environment_metrics_service.py:0: error: "Sequence[EnvironmentMetricsTimer]" has no attribute "append"  [attr-defined]

--- a/src/inmanta/references.py
+++ b/src/inmanta/references.py
@@ -262,11 +262,12 @@ ArgumentTypes = typing.Annotated[
 """ A list of all specific types of arguments. Pydantic uses this to instantiate the correct argument class
 """
 
+
 def get_id_reference_or_mutator(
     type: ReferenceType,
     args: list[ArgumentTypes],
 ) -> uuid.UUID:
-    data = json.dumps({"type": self.type, "args": args}, default=util.api_boundary_json_encoder, sort_keys=True)
+    data = json.dumps({"type": type, "args": args}, default=util.api_boundary_json_encoder, sort_keys=True)
     hasher = hashlib.md5()
     hasher.update(data.encode())
     return uuid.uuid3(uuid.NAMESPACE_OID, hasher.digest())

--- a/src/inmanta/references.py
+++ b/src/inmanta/references.py
@@ -291,8 +291,12 @@ class ReferenceModel(SerializedReferenceLike):
 class MutatorModel(SerializedReferenceLike):
     """A mutator"""
 
+    _id: uuid.UUID | None = pydantic.PrivateAttr(default=None)
+
     def get_id(self) -> uuid.UUID:
-        return compute_reference_or_mutator_id(reference_type=self.type, args=self.args)
+        if self._id is None:
+            self._id = compute_reference_or_mutator_id(reference_type=self.type, args=self.args)
+        return self._id
 
 
 C = typing.TypeVar("C", bound="ReferenceLike")
@@ -423,7 +427,9 @@ class Mutator(ReferenceLike):
         """Emit the correct pydantic objects to serialize the reference in the exporter."""
         if not self._model:
             arg_id, arguments = self.serialize_arguments()
-            self._model = MutatorModel(type=self.type, args=arguments)
+            model = MutatorModel(type=self.type, args=arguments)
+            model._id = arg_id
+            self._model = model
 
         assert isinstance(self._model, MutatorModel)
         return self._model

--- a/src/inmanta/references.py
+++ b/src/inmanta/references.py
@@ -263,11 +263,11 @@ ArgumentTypes = typing.Annotated[
 """
 
 
-def get_id_reference_or_mutator(
-    type: ReferenceType,
+def compute_reference_or_mutator_id(
+    reference_type: ReferenceType,
     args: list[ArgumentTypes],
 ) -> uuid.UUID:
-    data = json.dumps({"type": type, "args": args}, default=util.api_boundary_json_encoder, sort_keys=True)
+    data = json.dumps({"type": reference_type, "args": args}, default=util.api_boundary_json_encoder, sort_keys=True)
     hasher = hashlib.md5()
     hasher.update(data.encode())
     return uuid.uuid3(uuid.NAMESPACE_OID, hasher.digest())
@@ -292,7 +292,7 @@ class MutatorModel(SerializedReferenceLike):
     """A mutator"""
 
     def get_id(self) -> uuid.UUID:
-        return get_id_reference_or_mutator(type=self.type, args=self.args)
+        return compute_reference_or_mutator_id(reference_type=self.type, args=self.args)
 
 
 C = typing.TypeVar("C", bound="ReferenceLike")
@@ -396,7 +396,7 @@ class ReferenceLike:
                 case _:
                     raise TypeError(f"Unable to serialize argument `{name}` of `{self!r}` with value {value}")
 
-        arg_id = get_id_reference_or_mutator(type=self.type, args=arguments)
+        arg_id = compute_reference_or_mutator_id(reference_type=self.type, args=arguments)
         return arg_id, arguments
 
     @property

--- a/src/inmanta/references.py
+++ b/src/inmanta/references.py
@@ -262,6 +262,15 @@ ArgumentTypes = typing.Annotated[
 """ A list of all specific types of arguments. Pydantic uses this to instantiate the correct argument class
 """
 
+def get_id_reference_or_mutator(
+    type: ReferenceType,
+    args: list[ArgumentTypes],
+) -> uuid.UUID:
+    data = json.dumps({"type": self.type, "args": args}, default=util.api_boundary_json_encoder, sort_keys=True)
+    hasher = hashlib.md5()
+    hasher.update(data.encode())
+    return uuid.uuid3(uuid.NAMESPACE_OID, hasher.digest())
+
 
 class SerializedReferenceLike(pydantic.BaseModel):
     """
@@ -280,6 +289,9 @@ class ReferenceModel(SerializedReferenceLike):
 
 class MutatorModel(SerializedReferenceLike):
     """A mutator"""
+
+    def get_id(self) -> uuid.UUID:
+        return get_id_reference_or_mutator(type=self.type, args=self.args)
 
 
 C = typing.TypeVar("C", bound="ReferenceLike")
@@ -383,10 +395,8 @@ class ReferenceLike:
                 case _:
                     raise TypeError(f"Unable to serialize argument `{name}` of `{self!r}` with value {value}")
 
-        data = json.dumps({"type": self.type, "args": arguments}, default=util.api_boundary_json_encoder, sort_keys=True)
-        hasher = hashlib.md5()
-        hasher.update(data.encode())
-        return uuid.uuid3(uuid.NAMESPACE_OID, hasher.digest()), arguments
+        arg_id = get_id_reference_or_mutator(type=self.type, args=arguments)
+        return arg_id, arguments
 
     @property
     def arguments(self) -> collections.abc.Mapping[str, object]:

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -209,6 +209,13 @@ class ReferenceSubCollector:
         self.references: dict[uuid.UUID, references.ReferenceModel] = {}
         self.replacements: dict[str, references.ReferenceModel] = {}
 
+    def get_references_sorted(self) -> list[references.ReferenceModel]:
+        """
+        Return the references in a list sorted by their uuid.
+        """
+        sorted_reference_ids = sorted(self.references.keys())
+        return [self.references[ref_id] for ref_id in sorted_reference_ids]
+
     def collect_reference(self, value: object) -> None:
         """Add a value reference and recursively add any other references."""
         match value:
@@ -519,7 +526,7 @@ class Resource(metaclass=ResourceMeta):
                 for field in resource_cls.fields
             }
 
-        fields[const.RESOURCE_ATTRIBUTE_REFERENCES] = list(reference_collector.references.values())
+        fields[const.RESOURCE_ATTRIBUTE_REFERENCES] = reference_collector.get_references_sorted()
         fields[const.RESOURCE_ATTRIBUTE_MUTATORS] = reference_collector.mutators
 
         obj.populate(fields)

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -187,7 +187,10 @@ class ResourceMeta(type):
 
             fields.extend(dct["fields"])
 
-        dct["fields"] = tuple(set(fields))
+        # Deduplicate while preserving first-occurrence order. Using a set here would make the order depend on the
+        # per-process string hash seed (PYTHONHASHSEED),  producing a new desired state version even when nothing
+        # changed (see issue #10622).
+        dct["fields"] = tuple(dict.fromkeys(fields))
         return type.__new__(cls, class_name, bases, dct)
 
 

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -294,6 +294,11 @@ class ReferenceCollector(ReferenceSubCollector):
         self.mutators: list[references.MutatorModel] = []
         self.resource = resource
 
+    def get_mutators_sorted(self) -> list[references.MutatorModel]:
+        mutator_by_id = {m.get_id(): m for m in self.mutators}
+        mutator_ids = sorted(mutator_by_id.keys())
+        return [mutator_by_id[m_id] for m_id in mutator_ids]
+
     def add_reference(self, path: str, reference: "references.Reference[references.PrimitiveTypes]") -> None:
         """Add a new attribute map to a value reference that we found at the given path.
 
@@ -527,7 +532,7 @@ class Resource(metaclass=ResourceMeta):
             }
 
         fields[const.RESOURCE_ATTRIBUTE_REFERENCES] = reference_collector.get_references_sorted()
-        fields[const.RESOURCE_ATTRIBUTE_MUTATORS] = reference_collector.mutators
+        fields[const.RESOURCE_ATTRIBUTE_MUTATORS] = reference_collector.get_mutators_sorted()
 
         obj.populate(fields)
         obj.model = model_object

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -291,13 +291,15 @@ class ReferenceCollector(ReferenceSubCollector):
 
     def __init__(self, resource: "Resource") -> None:
         super().__init__()
-        self.mutators: list[references.MutatorModel] = []
+        self.mutators: dict[uuid.UUID, references.MutatorModel] = {}
         self.resource = resource
 
     def get_mutators_sorted(self) -> list[references.MutatorModel]:
-        mutator_by_id = {m.get_id(): m for m in self.mutators}
-        mutator_ids = sorted(mutator_by_id.keys())
-        return [mutator_by_id[m_id] for m_id in mutator_ids]
+        """
+        Return the mutators in a list sorted by their uuid.
+        """
+        mutator_ids = sorted(self.mutators.keys())
+        return [self.mutators[m_id] for m_id in mutator_ids]
 
     def add_reference(self, path: str, reference: "references.Reference[references.PrimitiveTypes]") -> None:
         """Add a new attribute map to a value reference that we found at the given path.
@@ -306,13 +308,13 @@ class ReferenceCollector(ReferenceSubCollector):
         :param reference: The attribute reference
         """
         super().add_reference(path, reference)
-        self.mutators.append(
-            references.ReplaceValue(
-                resource=self.resource,
-                value=reference,
-                destination=path,
-            ).serialize()
+        mutator: references.Mutator = references.ReplaceValue(
+            resource=self.resource,
+            value=reference,
+            destination=path,
         )
+        mutator_model: references.MutatorModel = mutator.serialize()
+        self.mutators[mutator_model.get_id()] = mutator_model
 
 
 @stable_api

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -209,7 +209,7 @@ class ReferenceSubCollector:
         self.references: dict[uuid.UUID, references.ReferenceModel] = {}
         self.replacements: dict[str, references.ReferenceModel] = {}
 
-    def get_references_sorted(self) -> list[references.ReferenceModel]:
+    def get_references_sorted(self) -> list["references.ReferenceModel"]:
         """
         Return the references in a list sorted by their uuid.
         """
@@ -294,7 +294,7 @@ class ReferenceCollector(ReferenceSubCollector):
         self.mutators: dict[uuid.UUID, references.MutatorModel] = {}
         self.resource = resource
 
-    def get_mutators_sorted(self) -> list[references.MutatorModel]:
+    def get_mutators_sorted(self) -> list["references.MutatorModel"]:
         """
         Return the mutators in a list sorted by their uuid.
         """

--- a/src/inmanta/resources.py
+++ b/src/inmanta/resources.py
@@ -533,6 +533,7 @@ class Resource(metaclass=ResourceMeta):
                 for field in resource_cls.fields
             }
 
+        # Sort these lists to ensure the stability of the attribute hash
         fields[const.RESOURCE_ATTRIBUTE_REFERENCES] = reference_collector.get_references_sorted()
         fields[const.RESOURCE_ATTRIBUTE_MUTATORS] = reference_collector.get_mutators_sorted()
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -28,7 +28,7 @@ from uuid import UUID
 
 import pytest
 
-from inmanta import compiler, env, references, resources, util
+from inmanta import compiler, data, env, references, resources, util
 from inmanta.agent.handler import PythonLogger
 from inmanta.ast import (
     ExternalException,
@@ -297,6 +297,66 @@ async def test_deploy_end_to_end(
     result = await client.resource_logs(environment, "refs::DeepResource[test,name=test4]")
     assert result.code == 200
     assert [msg for msg in result.result["data"] if "Observed value: {'inner.something': ['TESTX']}" in msg["msg"]]
+
+
+async def test_attribute_hash_stable_across_reference_and_mutator_order(
+    snippetcompiler: "SnippetCompilationTest",
+    modules_v2_dir: str,
+    client,
+    environment,
+) -> None:
+    """
+    Export the same resource to the server in two different model versions. Both versions produce the same desired state,
+    but the references and mutators are collected in a different order. The attribute hash must be identical for both
+    versions, because a different ordering of the references and mutators does not represent an observable change in
+    desired state (see issue #10622).
+    """
+    refs_module = os.path.join(modules_v2_dir, "refs")
+
+    def snippet(reversed_order: bool) -> str:
+        # A dict of references. Both versions declare the same set of references, but in a different order in the dict
+        # literal. A dict is order-independent, so both versions have the same desired state, but the references and the
+        # mutators are collected by the exporter in the order in which they appear in the dict literal.
+        references_in_order = [
+            ("key1", "one"),
+            ("key2", "two"),
+            ("key3", "three"),
+        ]
+        entries = reversed(references_in_order) if reversed_order else references_in_order
+        dict_body = ", ".join(f'"{key}": refs::create_string_reference(name="{name}")' for key, name in entries)
+        return f"""
+            import refs
+            refs::DictResource(
+                name="test",
+                agentname="test",
+                value={{{dict_body}}},
+            )
+        """
+
+    resource_version_id = "refs::DictResource[test,name=test]"
+
+    snippetcompiler.setup_for_snippet(
+        snippet=snippet(reversed_order=False),
+        install_v2_modules=[env.LocalPackagePath(path=refs_module)],
+        autostd=True,
+    )
+    version_1, _ = await snippetcompiler.do_export_and_deploy()
+
+    snippetcompiler.setup_for_snippet(
+        snippet=snippet(reversed_order=True),
+        install_v2_modules=[env.LocalPackagePath(path=refs_module)],
+        autostd=True,
+    )
+    version_2, _ = await snippetcompiler.do_export_and_deploy()
+
+    assert version_1 != version_2
+
+    resource_version_1, resource_version_2 = await data.Resource.get_resources(
+        UUID(environment),
+        [f"{resource_version_id},v={version_1}", f"{resource_version_id},v={version_2}"],
+    )
+    assert resource_version_1.attribute_hash is not None
+    assert resource_version_1.attribute_hash == resource_version_2.attribute_hash
 
 
 def test_decoding_legacy_resources(snippetcompiler, modules_v2_dir):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -46,16 +46,10 @@ def test_fields_order_stable_across_processes():
     """
     Reproduces https://github.com/inmanta/inmanta-core/issues/10622
 
-    ``Resource.fields`` is deduplicated through ``tuple(set(fields))`` in
-    ``ResourceMeta.__new__``. Since Python randomizes string hashing per process
-    (``PYTHONHASHSEED``), the resulting field order differs between compiler
-    processes. This reorders the serialized ``references``/``mutators`` lists that
-    ``Resource.create_from_model`` builds in field-visit order, producing a new
-    desired state version on every export even when the model is unchanged.
-
-    This test defines a resource with several fields and checks that the resulting
-    ``fields`` tuple is identical across processes started with different hash
-    seeds.
+    Verify that ``Resource.fields`` produces a consistent order that
+    independent from the PYTHONHASHSEED that is used. This is important
+    to make sure that the same attribute set also produces the same
+    attribute hash.
     """
     script = textwrap.dedent(
         """
@@ -68,14 +62,19 @@ def test_fields_order_stable_across_processes():
         """
     )
 
-    def field_order(seed: str) -> str:
+    def field_order(seed: int) -> str:
         return subprocess.check_output(
             [sys.executable, "-c", script],
-            env={"PYTHONHASHSEED": seed},
+            env={"PYTHONHASHSEED": str(seed)},
             text=True,
         ).strip()
 
-    orders = {field_order(seed) for seed in ("1", "2", "3", "4", "5")}
+    orders = set()
+    for seed in range(1, 6):
+        orders.add(field_order(seed))
+        # Stop as soon as we detect an inconsistent order
+        if len(orders) > 1:
+            break
     assert len(orders) == 1, f"Resource.fields order is not stable across processes: {orders}"
 
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -51,8 +51,6 @@ def test_fields_order_stable_across_processes():
     to make sure that the same attribute set also produces the same
     attribute hash.
     """
-    # TODO: Shouldn't we make the make_attribute_hash method responsible
-    #       for producing a consistent hash?
     script = textwrap.dedent(
         """
         from inmanta.resources import Resource

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -51,6 +51,8 @@ def test_fields_order_stable_across_processes():
     to make sure that the same attribute set also produces the same
     attribute hash.
     """
+    # TODO: Shouldn't we make the make_attribute_hash method responsible
+    #       for producing a consistent hash?
     script = textwrap.dedent(
         """
         from inmanta.resources import Resource

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -16,6 +16,9 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import subprocess
+import sys
+import textwrap
 from collections.abc import Mapping
 
 import pytest
@@ -37,6 +40,43 @@ class Base(resources.Resource):
 class Resource(Base):
     fields = ("c", "d")
     map = {"d": lambda _, x: x.d}
+
+
+def test_fields_order_stable_across_processes():
+    """
+    Reproduces https://github.com/inmanta/inmanta-core/issues/10622
+
+    ``Resource.fields`` is deduplicated through ``tuple(set(fields))`` in
+    ``ResourceMeta.__new__``. Since Python randomizes string hashing per process
+    (``PYTHONHASHSEED``), the resulting field order differs between compiler
+    processes. This reorders the serialized ``references``/``mutators`` lists that
+    ``Resource.create_from_model`` builds in field-visit order, producing a new
+    desired state version on every export even when the model is unchanged.
+
+    This test defines a resource with several fields and checks that the resulting
+    ``fields`` tuple is identical across processes started with different hash
+    seeds.
+    """
+    script = textwrap.dedent(
+        """
+        from inmanta.resources import Resource
+
+        class A(Resource):
+            fields = ("account_id", "tunnel_id", "uri", "config_items", "api_token")
+
+        print(",".join(A.fields))
+        """
+    )
+
+    def field_order(seed: str) -> str:
+        return subprocess.check_output(
+            [sys.executable, "-c", script],
+            env={"PYTHONHASHSEED": seed},
+            text=True,
+        ).strip()
+
+    orders = {field_order(seed) for seed in ("1", "2", "3", "4", "5")}
+    assert len(orders) == 1, f"Resource.fields order is not stable across processes: {orders}"
 
 
 def test_fields_type():

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -16,6 +16,7 @@ limitations under the License.
 Contact: code@inmanta.com
 """
 
+import os
 import subprocess
 import sys
 import textwrap
@@ -63,7 +64,7 @@ def test_fields_order_stable_across_processes():
     def field_order(seed: int) -> str:
         return subprocess.check_output(
             [sys.executable, "-c", script],
-            env={"PYTHONHASHSEED": str(seed)},
+            env={**os.environ, "PYTHONHASHSEED": str(seed)},
             text=True,
         ).strip()
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -51,16 +51,14 @@ def test_fields_order_stable_across_processes():
     to make sure that the same attribute set also produces the same
     attribute hash.
     """
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         from inmanta.resources import Resource
 
         class A(Resource):
             fields = ("account_id", "tunnel_id", "uri", "config_items", "api_token")
 
         print(",".join(A.fields))
-        """
-    )
+        """)
 
     def field_order(seed: int) -> str:
         return subprocess.check_output(


### PR DESCRIPTION
# Description

Fix bug where a resource can be considered as updated across model versions although its attribute set has not changed.

closes #10622

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
