### PR TITLE
Issue/fix request timeout options ignored

### DIFF
--- a/changelogs/unreleased/fix-request-timeout-ignored.yml
+++ b/changelogs/unreleased/fix-request-timeout-ignored.yml
@@ -1,0 +1,6 @@
+---
+description: "Fix bug that prevents the compiler_rest_transport.request-timeout config option from being incremented."
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/fix-request-timeout-ignored.yml
+++ b/changelogs/unreleased/fix-request-timeout-ignored.yml
@@ -1,5 +1,5 @@
 ---
-description: "Fix bug that prevents the compiler_rest_transport.request-timeout config option from being incremented."
+description: "Fix bug that prevented the request-timeout config option of a *_rest_transport section from being increased."
 change-type: patch
 destination-branches: [master, iso9, iso8]
 sections:

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -167,9 +167,10 @@ class SyncClient:
         Return the timeout for the entire API call.
         """
         request_timeout: int | None = self._client.get_request_timeout()
-        if request_timeout is None:
-            # The client doesn't have a request timeout set.
-            # Use the connection timeout as a fallback.
+        if request_timeout is None or request_timeout <= 0:
+            # The client doesn't enforce a positive request timeout, either because it has no
+            # REST transport or because the request timeout is disabled (a request_timeout of 0
+            # means no timeout in Tornado). Use the connection timeout as a fallback.
             # This value is used for backwards compatibility reasons.
             return self.connection_timeout
         else:

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -84,6 +84,14 @@ class Client(Endpoint):
         self._version_match = version_match
         self._exact_version = exact_version
 
+    def get_request_timeout(self) -> int | None:
+        """
+        Returns the request timeout of this client or None if this client doesn't have a request timeout.
+        """
+        if self._transport_instance is None:
+            return None
+        return self._transport_instance.request_timeout
+
     def close(self) -> None:
         """
         Closes the RESTclient instance manually. This is only needed when it is started with force_instance set to true
@@ -134,7 +142,7 @@ class SyncClient:
 
         :param name: name of the configuration to use for this endpoint. The config section used is "{name}_rest_transport"
         :param client: the client to use for this sync_client
-        :param timeout: http timeout on all requests
+        :param timeout: The connection timeout for all requests.
 
         :param ioloop: the specific (running) ioloop to schedule this request on. The loop should run on a different thread
             than the one the client methods are called on. If no ioloop is passed, we assume there is no running ioloop in the
@@ -144,19 +152,35 @@ class SyncClient:
             # Exactly one must be set
             raise Exception("Either name or client needs to be provided.")
 
-        self.timeout = timeout
+        self.connection_timeout = timeout
         self._ioloop: Optional[asyncio.AbstractEventLoop] = ioloop
         if client is None:
             assert name is not None  # Make mypy happy
             self.name = name
-            self._client = Client(name, self.timeout)
+            self._client = Client(name, self.connection_timeout)
         else:
             self.name = client.name
             self._client = client
 
+    def _get_call_timeout(self) -> int:
+        """
+        Return the timeout for the entire API call.
+        """
+        request_timeout: int | None = self._client.get_request_timeout()
+        if request_timeout is None:
+            # The client doesn't have a request timeout set.
+            # Use the connection timeout as a fallback.
+            # This value is used for backwards compatibility reasons.
+            return self.connection_timeout
+        else:
+            # The underlying client uses a request_timeout. Set the timeout here
+            # slightly higher as a fallback if the request timeout of the client
+            # doesn't trigger.
+            return request_timeout + 5
+
     def __getattr__(self, name: str) -> Callable[..., common.Result]:
         async_method = getattr(self._client, name)
-        return lambda *args, **kwargs: async_method(*args, **kwargs).sync(timeout=self.timeout, ioloop=self._ioloop)
+        return lambda *args, **kwargs: async_method(*args, **kwargs).sync(timeout=self._get_call_timeout(), ioloop=self._ioloop)
 
 
 class TypedClient(Client):

--- a/tests/protocol/test_protocol.py
+++ b/tests/protocol/test_protocol.py
@@ -347,6 +347,12 @@ def test_sync_client_call_timeout():
     sync_client_without_transport = protocol.SyncClient(client=client_without_transport, timeout=60)
     assert sync_client_without_transport._get_call_timeout() == 60
 
+    # A request_timeout of 0 disables the request timeout in Tornado. In that case the connection
+    # timeout is used as a fallback instead of a nonsensical 5 second timeout.
+    Config.set("client_rest_transport", "request_timeout", "0")
+    sync_client_without_request_timeout = protocol.SyncClient("client", timeout=60)
+    assert sync_client_without_request_timeout._get_call_timeout() == 60
+
 
 async def test_pydantic():
     """

--- a/tests/protocol/test_protocol.py
+++ b/tests/protocol/test_protocol.py
@@ -327,6 +327,27 @@ def test_create_client():
         protocol.Client("agent", "120")
 
 
+def test_sync_client_call_timeout():
+    """
+    Verify that the SyncClient waits for the entire duration of the request_timeout config option (plus a small
+    buffer) and not just for the connection timeout. This ensures that a request_timeout larger than the connection
+    timeout is honored instead of being prematurely aborted by the synchronous wrapper.
+    """
+    from inmanta.config import Config
+
+    Config.set("client_rest_transport", "request_timeout", "300")
+
+    sync_client = protocol.SyncClient("client", timeout=60)
+    # The request timeout (300) dominates the connection timeout (60), plus a 5 second buffer.
+    assert sync_client._get_call_timeout() == 305
+
+    # When the underlying client has no REST transport, there is no request timeout and the connection
+    # timeout is used as a fallback.
+    client_without_transport = protocol.Client("client", timeout=60, with_rest_client=False)
+    sync_client_without_transport = protocol.SyncClient(client=client_without_transport, timeout=60)
+    assert sync_client_without_transport._get_call_timeout() == 60
+
+
 async def test_pydantic():
     """
     Test validating pydantic objects


### PR DESCRIPTION
# Description

Fix bug that prevented the `request-timeout` config option of a `*_rest_transport` section from being increased.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
