### PR TITLE
Fix backwards compatibility issue SynClient class

### DIFF
--- a/changelogs/unreleased/fix-backwards-compatibility-issue-client.yml
+++ b/changelogs/unreleased/fix-backwards-compatibility-issue-client.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix backwards compatibility issue where the timeout instance variable was removed from the SyncClient class."
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -153,6 +153,9 @@ class SyncClient:
             raise Exception("Either name or client needs to be provided.")
 
         self.connection_timeout = timeout
+        # The timeout instance variabel is kept for backwards compatibilty.
+        # pytest-inmanta-lsm relies on it.
+        self.timeout = timeout
         self._ioloop: Optional[asyncio.AbstractEventLoop] = ioloop
         if client is None:
             assert name is not None  # Make mypy happy

--- a/src/inmanta/protocol/endpoints.py
+++ b/src/inmanta/protocol/endpoints.py
@@ -153,7 +153,7 @@ class SyncClient:
             raise Exception("Either name or client needs to be provided.")
 
         self.connection_timeout = timeout
-        # The timeout instance variabel is kept for backwards compatibilty.
+        # The timeout instance variable is kept for backwards compatibility.
         # pytest-inmanta-lsm relies on it.
         self.timeout = timeout
         self._ioloop: Optional[asyncio.AbstractEventLoop] = ioloop


### PR DESCRIPTION
# Description

Fix backwards compatibility issue where the timeout instance variable was removed from the `SyncClient` class.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~