### PR TITLE
Improve performance of validating large nested dict and list values (Issue #10733)

### DIFF
--- a/changelogs/unreleased/10733-literal-validation-performance.yml
+++ b/changelogs/unreleased/10733-literal-validation-performance.yml
@@ -1,0 +1,7 @@
+description: >
+  Improve the performance of validating large nested dict and list values, both at the plugin boundary and for entity attributes.
+issue-nr: 10733
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -21,6 +21,7 @@ import copy
 import dataclasses
 import functools
 import numbers
+import reprlib
 import typing
 from collections import defaultdict, deque
 from collections.abc import Callable, Sequence
@@ -51,6 +52,21 @@ if TYPE_CHECKING:
 # Exact types for which we can skip unwrap_reference() in TypeReferenceUnion.validate().
 # These Python builtins can never be or contain a Reference.
 _VALIDATE_FAST_PATH_TYPES: frozenset[type] = frozenset({str, int, float, bool})
+
+# Bounded repr for dicts and lists embedded in error messages: reprlib truncates while building,
+# so the cost stays constant even for huge nested structures.
+_error_value_repr = reprlib.Repr()
+_error_value_repr.maxstring = 80
+_error_value_repr.maxother = 80
+
+
+def shorten_value_str(value: object, max_len: int = 200) -> str:
+    """
+    Bounded string representation of a value, for use in error messages. Keeps message construction
+    cheap and messages readable when the value is a large nested structure.
+    """
+    result: str = _error_value_repr.repr(value) if isinstance(value, (dict, list)) else str(value)
+    return result if len(result) <= max_len else result[:max_len] + "..."
 
 
 @stable_api
@@ -262,7 +278,7 @@ class ReferenceType(Type):
             if ref._model_type.issubtype(self.element_type):
                 return True
 
-        raise TypingException(None, f"Invalid value: {value} is not a subtype of {self}")
+        raise TypingException(None, f"Invalid value: {shorten_value_str(value)} is not a subtype of {self}")
 
     def has_custom_to_python(self) -> bool:
         return self.is_dataclass
@@ -423,7 +439,7 @@ class Null(Type):
         if isinstance(value, NoneValue):
             return True
 
-        raise RuntimeException(None, f"Invalid value '{value}', expected {self.type_string()}")
+        raise RuntimeException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
 
     def type_string(self) -> str:
         return "null"
@@ -656,7 +672,7 @@ class Number(Primitive):
             return True
 
         if not isinstance(value, numbers.Number):
-            raise RuntimeException(None, f"Invalid value '{value}', expected {self.type_string()}")
+            raise RuntimeException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
 
         return True  # allow this function to be called from a lambda function
 
@@ -706,7 +722,7 @@ class Float(Primitive):
             return True
 
         if not isinstance(value, float):
-            raise RuntimeException(None, f"Invalid value '{value}', expected {self.type_string()}")
+            raise RuntimeException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
         return True  # allow this function to be called from a lambda function
 
     def get_location(self) -> None:
@@ -746,7 +762,7 @@ class Integer(Primitive):
             return True
 
         if not isinstance(value, numbers.Integral):
-            raise RuntimeException(None, f"Invalid value '{value}', expected {self.type_string()}")
+            raise RuntimeException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
         return True  # allow this function to be called from a lambda function
 
     def type_string(self) -> str:
@@ -780,7 +796,7 @@ class Bool(Primitive):
         super().validate(value)
         if isinstance(value, AnyType):
             return True
-        raise RuntimeException(None, f"Invalid value '{value}', expected {self.type_string()}")
+        raise RuntimeException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
 
     def cast(self, value: Optional[object]) -> object:
         # this is a bit odd, in that is accepts None, but it has always been so
@@ -821,7 +837,7 @@ class String(Primitive):
         if isinstance(value, AnyType):
             return True
         if not isinstance(value, str):
-            raise RuntimeException(None, f"Invalid value '{value}', expected {self.type_string()}")
+            raise RuntimeException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
 
         return True
 
@@ -863,7 +879,7 @@ class List(Type):
             return True
 
         if not isinstance(value, list):
-            raise TypingException(None, f"Invalid value '{value}', expected {self.type_string()}")
+            raise TypingException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
 
         return True
 
@@ -1033,7 +1049,7 @@ class Dict(Type):
             return True
 
         if not isinstance(value, dict):
-            raise RuntimeException(None, f"Invalid value '{value}', expected {self.type_string()}")
+            raise RuntimeException(None, f"Invalid value '{shorten_value_str(value)}', expected {self.type_string()}")
 
         return True
 
@@ -1235,7 +1251,7 @@ class Union(Type):
                     return True
             except RuntimeException:
                 pass
-        raise TypingException(None, f"Invalid value '{value}', expected {self}")
+        raise TypingException(None, f"Invalid value '{shorten_value_str(value)}', expected {self}")
 
     def type_string_internal(self) -> str:
         return "Union[%s]" % ",".join(t.type_string_internal() for t in self.types)

--- a/src/inmanta/ast/type.py
+++ b/src/inmanta/ast/type.py
@@ -1337,6 +1337,25 @@ class Literal(Union):
             self, [NullableType(Float()), Number(), Bool(), String(), TypedList(self), TypedDict(self), ReferenceType(self)]
         )
 
+    def validate(self, value: Optional[object]) -> bool:
+        # Fast path: dispatch on the exact type instead of trying each union member in turn, which
+        # constructs and discards an exception per non-matching member, per node of the value.
+        # Exact type checks can not match Reference values or proxy objects, so those still take the
+        # union path below, as do subclasses of the types checked here.
+        value_type = type(value)
+        if value_type is str or value_type is int or value_type is float or value_type is bool or value_type is NoneValue:
+            return True
+        # spelled as type(value) inline because mypy only narrows on that form
+        if type(value) is dict:
+            for element in value.values():
+                self.validate(element)
+            return True
+        if type(value) is list:
+            for element in value:
+                self.validate(element)
+            return True
+        return Union.validate(self, value)
+
     def type_string_internal(self) -> str:
         return "Literal"
 

--- a/src/inmanta/plugins.py
+++ b/src/inmanta/plugins.py
@@ -1158,7 +1158,8 @@ class Plugin(NamedType, WithComment, metaclass=PluginMeta):
             raise PluginTypeException(
                 stmt=None,
                 msg=(
-                    f"Return value {value} of plugin {self.get_full_name()} has incompatible type."
+                    f"Return value {inmanta_type.shorten_value_str(value)} of plugin {self.get_full_name()}"
+                    f" has incompatible type."
                     f" Expected type: {self.return_type.resolved_type.type_string_internal()}"
                 ),
                 cause=e,
@@ -1206,7 +1207,8 @@ class Plugin(NamedType, WithComment, metaclass=PluginMeta):
             raise PluginTypeException(
                 stmt=None,
                 msg=(
-                    f"Return value {value} of plugin {self.get_full_name()} has incompatible type."
+                    f"Return value {inmanta_type.shorten_value_str(value)} of plugin {self.get_full_name()}"
+                    f" has incompatible type."
                     f" Expected type: {self.return_type.resolved_type.type_string_internal()}"
                 ),
                 cause=e,

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -702,3 +702,16 @@ end
     with pytest.raises(InvalidTypeAnnotation) as exc_info:
         compiler.do_compile()
     assert "Union type must be subscripted, got typing.Union" in str(exc_info.value)
+
+
+def test_10733_returned_dict_list_validation(snippetcompiler: "SnippetCompilationTest") -> None:
+    """
+    Verify that a nested literal structure returned by a plugin annotated dict[] validates (issue #10733).
+    """
+    snippetcompiler.setup_for_snippet("""
+import plugin_returned_type_validation
+
+plugin_returned_type_validation::as_dict_list([{"str": "a", "int": 1, "float": 1.5, "bool": true, "null": null,
+    "list": ["a", 1, [2, 3]], "dict": {"nested": {"deep": ["x"]}}}])
+        """)
+    compiler.do_compile()

--- a/tests/compiler/test_plugins.py
+++ b/tests/compiler/test_plugins.py
@@ -715,3 +715,20 @@ plugin_returned_type_validation::as_dict_list([{"str": "a", "int": 1, "float": 1
     "list": ["a", 1, [2, 3]], "dict": {"nested": {"deep": ["x"]}}}])
         """)
     compiler.do_compile()
+
+
+def test_10733_returned_dict_list_validation_error(snippetcompiler: "SnippetCompilationTest") -> None:
+    """
+    An invalid leaf in a nested plugin return value fails validation with a bounded error message.
+    """
+    snippetcompiler.setup_for_snippet("""
+import plugin_returned_type_validation
+
+plugin_returned_type_validation::as_invalid_dict_list()
+        """)
+    with pytest.raises(WrappingRuntimeException) as exc_info:
+        compiler.do_compile()
+    message = str(exc_info.value)
+    assert "has incompatible type" in message
+    # the message must not embed the full return value
+    assert len(message) < 1500

--- a/tests/data/modules/plugin_returned_type_validation/plugins/__init__.py
+++ b/tests/data/modules/plugin_returned_type_validation/plugins/__init__.py
@@ -42,3 +42,8 @@ def as_null(value: "any") -> "null":
 @plugin
 def as_string(value: "any") -> "string":
     return value
+
+
+@plugin
+def as_dict_list(value: "any") -> "dict[]":
+    return value

--- a/tests/data/modules/plugin_returned_type_validation/plugins/__init__.py
+++ b/tests/data/modules/plugin_returned_type_validation/plugins/__init__.py
@@ -47,3 +47,8 @@ def as_string(value: "any") -> "string":
 @plugin
 def as_dict_list(value: "any") -> "dict[]":
     return value
+
+
+@plugin
+def as_invalid_dict_list() -> "dict[]":
+    return [{"key": [{"nested": object()}], "sibling": "0" * 10000}]

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -37,6 +37,7 @@ from inmanta.ast.type import (
     String,
     Type,
     TypedList,
+    shorten_value_str,
 )
 from inmanta.execute.util import NoneValue, Unknown
 from inmanta.references import Reference, reference
@@ -170,3 +171,13 @@ def test_literal_validate_failure() -> None:
         lit.validate([{"sibling": big_sibling, "bad": object()}])
     assert "expected Literal" in str(e.value)
     assert len(str(e.value)) < 500
+
+
+def test_shorten_value_str() -> None:
+    assert shorten_value_str("short") == "short"
+    assert shorten_value_str(42) == "42"
+    long_string = "x" * 500
+    assert len(shorten_value_str(long_string)) < 250
+    big_dict = {f"key{i}": "value" * 20 for i in range(1000)}
+    assert len(shorten_value_str(big_dict)) < 250
+    assert len(shorten_value_str([big_dict] * 100)) < 250

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -25,8 +25,21 @@ from more_itertools import pairwise
 from inmanta.ast import Location, Namespace, RuntimeException
 from inmanta.ast.attribute import Attribute
 from inmanta.ast.entity import Entity
-from inmanta.ast.type import TYPES, Bool, Integer, LiteralDict, LiteralList, NullableType, Number, String, Type, TypedList
-from inmanta.execute.util import NoneValue
+from inmanta.ast.type import (
+    TYPES,
+    Bool,
+    Integer,
+    Literal,
+    LiteralDict,
+    LiteralList,
+    NullableType,
+    Number,
+    String,
+    Type,
+    TypedList,
+)
+from inmanta.execute.util import NoneValue, Unknown
+from inmanta.references import Reference, reference
 
 
 @pytest.mark.parametrize("base_type_string", TYPES.keys())
@@ -94,3 +107,66 @@ def test_type_equals_transformations() -> None:
     for t1, t2 in pairwise(l1):
         assert t1 != t2
         assert t2 != t1
+
+
+def test_literal_validate_nested() -> None:
+    """
+    Validate nested literal structures, covering the exact-type fast path in Literal.validate.
+    """
+    nested = {
+        "string": "value",
+        "int": 42,
+        "float": 1.5,
+        "bool": True,
+        "none": NoneValue(),
+        "list": ["a", 1, [2.5, False], {"k": "v"}],
+        "dict": {"deep": {"deeper": [{"leaf": "x"}]}},
+    }
+    for tp in [Literal(), LiteralDict(), TypedList(LiteralDict())]:
+        value = nested if not isinstance(tp, TypedList) else [nested, nested]
+        assert tp.validate(value)
+    assert LiteralList().validate(["a", {"b": 1}])
+
+
+def test_literal_validate_slow_path() -> None:
+    """
+    Values that are not plain Python data must still be validated through the union members.
+    """
+
+    class MyStr(str):
+        pass
+
+    class MyDict(dict):
+        pass
+
+    lit = Literal()
+    # subclasses of the fast-path types fall through to the union and remain valid
+    assert lit.validate(MyStr("sub"))
+    assert lit.validate(MyDict({"a": 1}))
+    # unknowns are accepted anywhere in the structure
+    assert lit.validate({"a": [Unknown(source=None)]})
+
+    @reference("test::TestLiteralRef")
+    class TestReference(Reference[str]):
+        def __init__(self, name: str) -> None:
+            super().__init__()
+            self.name = name
+
+    ref = TestReference("name")
+    # set by DynamicProxy.unwrap at the plugin boundary
+    ref._model_type = String()
+    assert lit.validate({"a": ref})
+    assert lit.validate([ref, "x", 1])
+
+
+def test_literal_validate_failure() -> None:
+    """
+    An invalid leaf deep inside a large structure raises an error about the leaf itself,
+    without embedding the full structure in the message.
+    """
+    lit = Literal()
+    big_sibling = {f"key{i}": "value" * 10 for i in range(1000)}
+    with pytest.raises(RuntimeException) as e:
+        lit.validate([{"sibling": big_sibling, "bad": object()}])
+    assert "expected Literal" in str(e.value)
+    assert len(str(e.value)) < 500


### PR DESCRIPTION
# Description

Validating a plugin return value annotated `dict[]` cost 64.5s of a 113.9s customer LSM compile with 4147 service instances.

`dict[]` resolves to `TypedList(LiteralDict())`, so every value is validated by `Literal`, a `Union` of seven member types whose `validate` try/excepts each member in turn. Every non-matching member constructed and immediately discarded an exception, and each exception message eagerly formatted the full repr of the subtree being validated. A string leaf cost three discarded exceptions, a dict node five, and the repr made the cost grow with structure size times depth. That accounts for the 4.8M exception constructions and 25.9M `isinstance` calls in the profile, all for a value that validates cleanly.

The same code path validates every `dict` and `list` entity attribute in the DSL (`Attribute.validate`), so this is not specific to plugin boundaries.

Two commits:

1. **Exact-type fast path in `Literal.validate`** - dispatch on the exact Python type for `str`/`int`/`float`/`bool`/`NoneValue`/`dict`/`list` instead of walking the union. Anything that is not plain Python data (references, unknowns, proxies, subclasses of the checked types) still takes the union path, so behaviour is unchanged. A side benefit is that a bad leaf now raises an error naming the leaf, rather than one embedding the whole structure.

2. **Bound the value reprs in validation error messages** - the failure path had the same pathology: `PluginTypeException` embeds the entire plugin return value, and the union slow path still formats a full subtree repr per swallowed exception. `shorten_value_str` uses `reprlib` to truncate while building rather than after, so message construction stays cheap regardless of value size. Separable from commit 1 and reviewable on its own.

Measured on a synthetic structure of 4147 instances and roughly one million leaves, chosen to match the reported compile:

| Case                                       | Time  |
| ------------------------------------------ | ----: |
| `TypedList(LiteralDict()).validate` before | 3.96s |
| `TypedList(LiteralDict()).validate` after  | 0.09s |

The customer's 64s is worse than the synthetic 3.96s at comparable leaf count because their subtree reprs are larger, which is consistent with the repr formatting being the dominant multiplier.

Not addressed here, and worth a separate discussion: memoizing validation by `id()` (unsound under mutation, and unnecessary now), and a way to mark data arriving from a `protocol/` API call as pre-validated.

closes #10733

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: n/a, internal performance fix)
- ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~
