### PR TITLE
scheduler: only redeploy resources affected by new version

### DIFF
--- a/changelogs/unreleased/10591-redeploy-failed-on-export.yml
+++ b/changelogs/unreleased/10591-redeploy-failed-on-export.yml
@@ -1,0 +1,8 @@
+description: >
+  Added the temporary `scheduler.redeploy-failed-on-export` config option. When set to false, the scheduler only deploys
+  resources that are new, that have an updated desired state or that became unblocked when a new model version is
+  exported, rather than everything that is not in a known good state. It defaults to true, which retains the existing
+  behavior. This option is meant to be dropped again once the new behavior has been validated.
+issue-nr: 10591
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -96,7 +96,7 @@ scheduler_redeploy_failed_on_export: Option[bool] = Option(
     True,
     "If True, the scheduler will try to redeploy resources for which the deployment failed when"
     " a new model version is exported. Otherwise, it will only try to deploy new resources,"
-    " updated reources or resources that became unblocked by the new model version.",
+    " updated resources or resources that became unblocked by the new model version.",
     is_bool,
 )
 

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -90,6 +90,15 @@ scheduler_db_connection_timeout: Option[float] = Option(
     " (in seconds).",
     is_float,
 )
+scheduler_redeploy_failed_on_export: Option[bool] = Option(
+    "scheduler",
+    "redeploy-failed-on-export",
+    True,
+    "If True, the scheduler will try to redeploy resources for which the deployment failed when"
+    " a new model version is exported. Otherwise, it will only try to deploy new resources,",
+    " updated reources or resources that became unblocked by the new model version.",
+    is_bool,
+)
 
 agent_executor_cap = Option[int](
     "agent",

--- a/src/inmanta/agent/config.py
+++ b/src/inmanta/agent/config.py
@@ -95,7 +95,7 @@ scheduler_redeploy_failed_on_export: Option[bool] = Option(
     "redeploy-failed-on-export",
     True,
     "If True, the scheduler will try to redeploy resources for which the deployment failed when"
-    " a new model version is exported. Otherwise, it will only try to deploy new resources,",
+    " a new model version is exported. Otherwise, it will only try to deploy new resources,"
     " updated reources or resources that became unblocked by the new model version.",
     is_bool,
 )

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -34,7 +34,7 @@ from typing import ClassVar, Optional, Self
 import asyncpg
 
 from inmanta import const, data, types
-from inmanta.agent import executor
+from inmanta.agent import config, executor
 from inmanta.agent.code_manager import CodeManager
 from inmanta.const import HandlerResourceState
 from inmanta.data import Environment
@@ -1190,8 +1190,11 @@ class ResourceScheduler(TaskManager):
             # - new_intent may contain undefineds
             # - unskipped may be transitively_blocked
             # - transitive_unblocked may be up to date if it was only blocked for a short time
-            # TODO: make this configurable for backwards compatibility
-            deploy_triggers: Set[ResourceIdStr] = (new_intent | unskipped | transitive_unblocked) & self._state.dirty
+            deploy_triggers: Set[ResourceIdStr] = []
+            if config.scheduler_redeploy_failed_on_export:
+                deploy_triggers = self._state.dirty
+            else:
+                deploy_triggers = (new_intent | unskipped | transitive_unblocked) & self._state.dirty
 
             # Remove timers for resources that are:
             #    - about to be triggered for deploy

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -1110,6 +1110,7 @@ class ResourceScheduler(TaskManager):
         # assert invariants of the constructed sets
         assert len(intent_changes) == len(deleted.keys() | new | updated) == len(deleted) + len(new) + len(updated)
         assert len(became_defined | became_undefined) == (len(became_defined) + len(became_undefined))
+        new_intent: Set[ResourceIdStr] = new | updated  # subset of intent_changes that reflect *new* intent (incl undefined)
 
         # pass control to IO loop once more before we acquire the lock
         await asyncio.sleep(0)
@@ -1133,13 +1134,14 @@ class ResourceScheduler(TaskManager):
                             del self._state.resource_sets[resource_set]
             else:
                 self._state.resource_sets = {name: set(s) for name, s in model.resource_sets.items()}
+
             # update resource intent
             for resource in up_to_date_resources:
                 # Registers resource and removes from the dirty set
                 self._state.update_resource(
                     model.resources[resource], known_compliant=True, last_deployed=last_deploy_time.get(resource, None)
                 )
-            for resource in new | updated:
+            for resource in new_intent:
                 # update resource state and dirty set
                 self._state.update_resource(
                     model.resources[resource],
@@ -1147,16 +1149,13 @@ class ResourceScheduler(TaskManager):
                     undefined=resource in model.undefined,
                     last_deployed=last_deploy_time.get(resource, None),
                 )
+
+            unskipped: set[ResourceIdStr] = set()  # TEMPORARILY_BLOCKED -> NOT_BLOCKED
             # update requires
             for resource in added_requires.keys() | dropped_requires.keys():
-                self._state.update_requires(resource, model.requires[resource])
-
-            # update transitive state
-            transitive_unblocked, transitive_blocked = self._state.update_transitive_state(
-                new_undefined=became_undefined,
-                verify_blocked=added_requires.keys(),
-                verify_unblocked=became_defined | dropped_requires.keys(),
-            )
+                res_unskipped: bool = self._state.update_requires(resource, model.requires[resource])
+                if res_unskipped:
+                    unskipped.add(resource)
             # update TEMPORARILY_BLOCKED (skipped-for-dependencies) state
             # for resources with a dependency for which state was reset
             resources_with_reset_requires: Set[ResourceIdStr] = set(
@@ -1172,27 +1171,43 @@ class ResourceScheduler(TaskManager):
                     and not self._state.should_skip_for_dependencies(resource)
                 ):
                     self._state.resource_state[resource].blocked = Blocked.NOT_BLOCKED
+                    self._state.dirty.add(resource)
+                    unskipped.add(resource)
+
+            transitive_unblocked: Set[ResourceIdStr]  # BLOCKED -> NOT_BLOCKED
+            transitive_blocked: Set[ResourceIdStr]  # NOT_BLOCKED / TEMPORARILY_BLOCKED -> BLOCKED
+            # update transitive state
+            transitive_unblocked, transitive_blocked = self._state.update_transitive_state(
+                new_undefined=became_undefined,
+                verify_blocked=added_requires.keys(),
+                verify_unblocked=became_defined | dropped_requires.keys(),
+            )
 
             # Update set of in-progress deploys that became unmanaged
             self._deploying_unmanaged.update(self._deploying_latest & (new | deleted.keys()))
             # Update set of in-progress non-stale deploys by trimming resources with new state
             self._deploying_latest.difference_update(intent_changes.keys(), transitive_blocked)
 
-            # Remove timers for resources that are:
-            #    - in the dirty set (because they will be picked up by the scheduler eventually)
-            #    - blocked: must not be deployed
-            #    - deleted from the model
-            self._timer_manager.stop_timers(self._state.dirty | became_undefined | transitive_blocked)
-            self._timer_manager.remove_timers(deleted.keys())
-            # Install timers for initial up-to-date resources. They are up-to-date now,
-            # but we want to make sure we periodically repair them.
-            self._timer_manager.update_timers(
-                up_to_date_resources | ((transitive_unblocked | resources_with_reset_requires) - self._state.dirty)
-            )
+            # intersection with self._state dirty because
+            # - new_intent may contain undefineds
+            # - unskipped may be transitively_blocked
+            # - transitive_unblocked may be up to date if it was only blocked for a short time
+            # TODO: make this configurable for backwards compatibility
+            deploy_triggers: Set[ResourceIdStr] = (new_intent | unskipped | transitive_unblocked) & self._state.dirty
 
-            # ensure deploy for ALL dirty resources, not just the new ones
+            # Remove timers for resources that are:
+            #    - about to be triggered for deploy
+            #    - blocked: must not be deployed at all
+            #    - deleted from the model
+            self._timer_manager.stop_timers(deploy_triggers | became_undefined | transitive_blocked)
+            self._timer_manager.remove_timers(deleted.keys())
+            # Install timers for up-to-date resources without existing timers. They are up-to-date now,
+            # but we want to make sure we periodically repair them.
+            self._timer_manager.update_timers(up_to_date_resources | (transitive_unblocked - self._state.dirty))
+
+            # ensure deploy for all resources with intent changes
             self._work.deploy_with_context(
-                self._state.dirty,
+                deploy_triggers,
                 reason=reason,
                 priority=TaskPriority.NEW_VERSION_DEPLOY,
                 deploying=self._deploying_latest,

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -1191,7 +1191,7 @@ class ResourceScheduler(TaskManager):
             # - unskipped may be transitively_blocked
             # - transitive_unblocked may be up to date if it was only blocked for a short time
             deploy_triggers: Set[ResourceIdStr]
-            if config.scheduler_redeploy_failed_on_export:
+            if config.scheduler_redeploy_failed_on_export.get():
                 deploy_triggers = self._state.dirty
             else:
                 deploy_triggers = (new_intent | unskipped | transitive_unblocked) & self._state.dirty

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -558,20 +558,18 @@ class ResourceScheduler(TaskManager):
                     provides=self._state.requires.provides_view(),
                     new_agent_notify=self._create_agent,
                 )
-            initialized_version: int = self._state.version
             # Set running flag because we're ready to start accepting tasks.
             # Set before scheduling first tasks because many methods (e.g. read_version) skip silently when not running
             LOGGER.debug("Scheduler initialization: resuming deploy operations and reading latest model version")
             self._running = True
             await self.read_version(connection=con)
 
-            if self._state.version == initialized_version:
-                # no new version was present. Simply trigger a deploy for everything that's not in a known good state
-                LOGGER.debug("Scheduler initialization: triggering deploy")
-                await self.deploy(
-                    reason="the resource scheduler was started",
-                    priority=TaskPriority.INTERVAL_DEPLOY,
-                )
+            # Trigger a deploy for everything that's not in a known good state in addition to those triggered by read_version()
+            LOGGER.debug("Scheduler initialization: triggering deploy")
+            await self.deploy(
+                reason="the resource scheduler was started",
+                priority=TaskPriority.INTERVAL_DEPLOY,
+            )
             LOGGER.debug("Scheduler initialization: setting up initial deploy timers")
             # Now that the scheduler state is initialized, we can set the timers:
             #  * Configuring per-resource timers requires the scheduler to be initialized
@@ -816,9 +814,9 @@ class ResourceScheduler(TaskManager):
     ) -> None:
         """
         Update model state and scheduled work based on the latest released version in the database,
-        e.g. when a new version is released. Triggers a deploy after updating internal state:
+        e.g. when a new version is released. Triggers a deploy for affected resources after updating internal state:
         - schedules new or updated resources to be deployed
-        - schedules any resources that are not in a known good state.
+        - schedules any resources that became unblocked as a result
         - rearranges deploy tasks by requires if required
 
         :param connection: Connection to use for db operations. Should not be in a transaction context.
@@ -1205,7 +1203,7 @@ class ResourceScheduler(TaskManager):
             # but we want to make sure we periodically repair them.
             self._timer_manager.update_timers(up_to_date_resources | (transitive_unblocked - self._state.dirty))
 
-            # ensure deploy for all resources with intent changes
+            # trigger deploys for affected resources
             self._work.deploy_with_context(
                 deploy_triggers,
                 reason=reason,

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -1190,7 +1190,7 @@ class ResourceScheduler(TaskManager):
             # - new_intent may contain undefineds
             # - unskipped may be transitively_blocked
             # - transitive_unblocked may be up to date if it was only blocked for a short time
-            deploy_triggers: Set[ResourceIdStr] = []
+            deploy_triggers: Set[ResourceIdStr]
             if config.scheduler_redeploy_failed_on_export:
                 deploy_triggers = self._state.dirty
             else:

--- a/src/inmanta/deploy/state.py
+++ b/src/inmanta/deploy/state.py
@@ -483,11 +483,15 @@ class ModelState:
         else:
             self.dirty.discard(resource)
 
-    def update_requires(self, resource: "ResourceIdStr", requires: Set["ResourceIdStr"]) -> None:
+    def update_requires(self, resource: "ResourceIdStr", requires: Set["ResourceIdStr"]) -> bool:
         """
-        Update the requires relation for a resource. Updates the reverse relation accordingly.
+        Updates the requires relation for a resource, bidirectionally. In case of TEMPORARILY_BLOCKED resources, additionally
+        checks if the new requires are cause for unblocking. Returns True if the resource is unblocked in that manner.
 
-        When updating requires, also call update_transitive_state to ensure temporirly_blocked state is also updated
+        When updating requires in a model with undefined resources, make sure to also call update_transitive_state to ensure
+        BLOCKED state is also updated.
+
+        :return: True iff the resource becomes unblocked as a result of the new requires (TEMPORARILY_BLOCKED -> NOT_BLOCKED).
         """
         check_dependencies: bool = self.resource_state[resource].blocked is Blocked.TEMPORARILY_BLOCKED and bool(
             self.requires[resource] - requires
@@ -499,6 +503,8 @@ class ModelState:
         if check_dependencies and not self.should_skip_for_dependencies(resource):
             self.resource_state[resource].blocked = Blocked.NOT_BLOCKED
             self.dirty.add(resource)
+            return True
+        return False
 
     def drop(self, resource: "ResourceIdStr") -> None:
         """

--- a/src/inmanta/deploy/state.py
+++ b/src/inmanta/deploy/state.py
@@ -695,8 +695,6 @@ class ModelState:
                 if is_hard_block:
                     is_blocked.add(to_be_blocked)
                 my_state = self.resource_state[to_be_blocked]
-                # TODO: Claude flagged a pre-existing bug here, stating that the "not" should be dropped.
-                #       Probably best deferred to another ticket. Priotity TBD depending on impact.
                 if my_state.blocked is not Blocked.BLOCKED:
                     continue
                 else:

--- a/src/inmanta/deploy/state.py
+++ b/src/inmanta/deploy/state.py
@@ -695,6 +695,8 @@ class ModelState:
                 if is_hard_block:
                     is_blocked.add(to_be_blocked)
                 my_state = self.resource_state[to_be_blocked]
+                # TODO: Claude flagged a pre-existing bug here, stating that the "not" should be dropped.
+                #       Probably best deferred to another ticket. Priotity TBD depending on impact.
                 if my_state.blocked is not Blocked.BLOCKED:
                     continue
                 else:

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -3667,3 +3667,95 @@ async def test_transient_deploy(agent: TestAgent, make_resource_minimal, caplog)
     assert scheduler._state.resource_state[rid2].blocked is Blocked.NOT_BLOCKED
     # verify that scheduler recognized that it is no longer blocked
     assert scheduler._state.resource_state[rid1].blocked is Blocked.NOT_BLOCKED
+
+
+@pytest.mark.parametrize("redeploy_failed_on_export", [True, False])
+async def test_redeploy_failed_on_export(agent: TestAgent, make_resource_minimal, redeploy_failed_on_export: bool) -> None:
+    """
+    Verify the behavior of the scheduler.redeploy-failed-on-export config option: when a new model version is released,
+    a resource that is in a failed state is only redeployed when the option is enabled. Resources that are new, updated
+    or unblocked by the new version are always deployed, regardless of the option.
+    """
+    Config.set("scheduler", "redeploy-failed-on-export", str(redeploy_failed_on_export))
+
+    rid_failed = ResourceIdStr("test::Resource[agent1,name=failed]")
+    rid_compliant = ResourceIdStr("test::Resource[agent1,name=compliant]")
+    rid_updated = ResourceIdStr("test::Resource[agent1,name=updated]")
+    rid_new = ResourceIdStr("test::Resource[agent1,name=new]")
+    # skipped-for-dependencies resource, on a separate agent so that its deploy result can be driven by the test case
+    rid_skipped = ResourceIdStr("test::Resource[agent2,name=skipped]")
+    executor2: ManagedExecutor = agent.executor_manager.register_managed_executor("agent2")
+
+    scheduler: ResourceScheduler = agent.scheduler
+
+    # release first version: rid_failed fails and rid_skipped skips for its dependency on rid_failed
+    await scheduler._new_version(
+        [
+            model_version(
+                version=1,
+                resources={
+                    rid_failed: make_resource_minimal(rid_failed, values={FAIL_DEPLOY: True}, requires=[]),
+                    rid_compliant: make_resource_minimal(rid_compliant, values={"value": 0}, requires=[]),
+                    rid_updated: make_resource_minimal(rid_updated, values={"value": 0}, requires=[]),
+                    rid_skipped: make_resource_minimal(rid_skipped, values={"value": 0}, requires=[rid_failed]),
+                },
+                requires={rid_skipped: {rid_failed}},
+            )
+        ]
+    )
+    await retry_limited_fast(lambda: rid_skipped in executor2.deploys)
+    executor2.deploys[rid_skipped].set_result(const.HandlerResourceState.skipped_for_dependency)
+    await wait_until_done(agent)
+
+    # assert expected start state
+    assert scheduler._state.resource_state[rid_failed].compliance is Compliance.NON_COMPLIANT
+    assert scheduler._state.resource_state[rid_failed].blocked is Blocked.NOT_BLOCKED
+    assert scheduler._state.resource_state[rid_compliant].compliance is Compliance.COMPLIANT
+    assert scheduler._state.resource_state[rid_updated].compliance is Compliance.COMPLIANT
+    assert scheduler._state.resource_state[rid_skipped].blocked is Blocked.TEMPORARILY_BLOCKED
+    assert scheduler._state.dirty == {rid_failed}
+
+    # release second version:
+    #  - rid_failed and rid_compliant are unchanged
+    #  - rid_updated has new intent
+    #  - rid_new is added to the model
+    #  - rid_skipped is unchanged but its requires on rid_failed is dropped, unblocking it
+    agent.executor_manager.reset_executor_counters()
+    before_new_version: datetime.datetime = datetime.datetime.now().astimezone()
+    await scheduler._new_version(
+        [
+            model_version(
+                version=2,
+                resources={
+                    rid_failed: make_resource_minimal(rid_failed, values={FAIL_DEPLOY: True}, requires=[]),
+                    rid_compliant: make_resource_minimal(rid_compliant, values={"value": 0}, requires=[]),
+                    rid_updated: make_resource_minimal(rid_updated, values={"value": 1}, requires=[]),
+                    rid_new: make_resource_minimal(rid_new, values={"value": 0}, requires=[]),
+                    rid_skipped: make_resource_minimal(rid_skipped, values={"value": 0}, requires=[]),
+                },
+                requires={},
+            )
+        ]
+    )
+    await retry_limited_fast(lambda: rid_skipped in executor2.deploys)
+    executor2.deploys[rid_skipped].set_result(const.HandlerResourceState.deployed)
+    await wait_until_done(agent)
+
+    # the new, the updated and the unblocked resource are always deployed, the compliant one never is
+    deployed_by_agent1: set[ResourceIdStr] = {details.rid for details in agent.executor_manager.executors["agent1"].seen}
+    expected_deployed: set[ResourceIdStr] = {rid_updated, rid_new}
+    if redeploy_failed_on_export:
+        expected_deployed.add(rid_failed)
+    assert deployed_by_agent1 == expected_deployed
+    assert agent.executor_manager.executors["agent1"].execute_count == len(expected_deployed)
+    assert agent.executor_manager.executors["agent2"].execute_count == 1
+    assert scheduler._state.resource_state[rid_skipped].blocked is Blocked.NOT_BLOCKED
+    assert scheduler._state.resource_state[rid_compliant].last_deployed < before_new_version
+    assert (scheduler._state.resource_state[rid_failed].last_deployed > before_new_version) is redeploy_failed_on_export
+
+    # regardless of the option, the failed resource remains dirty, so a deploy trigger still picks it up
+    assert rid_failed in scheduler._state.dirty
+    agent.executor_manager.reset_executor_counters()
+    await scheduler.deploy(reason="Test: triggering full deploy")
+    await wait_until_done(agent)
+    assert {details.rid for details in agent.executor_manager.executors["agent1"].seen} == {rid_failed}


### PR DESCRIPTION
# Description

On model export, only redeploy resources affected by the new version, i.e. resources with changes to their intent or to their blocked status.

This should be a huge improvement in resource starvation for environments with a lot of failed resources. See the ticket for more details.

Status:
- [x] Implement fix
- [x] Add config option
- [x] Fix broken tests
- [x] Add new tests
- [ ] Merge and ask solutions team to enable it on their pipelines to battle-test it.

closes #10591

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Type annotations are present
- [ ] Code is clear and sufficiently documented
- [ ] No (preventable) type errors (check using make mypy or make mypy-diff)
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
- [ ] If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)
