### PR TITLE
Build the pydantic TypeAdapters in inmanta.data once instead of per call

### DIFF
--- a/changelogs/unreleased/build-type-adapters-once.yml
+++ b/changelogs/unreleased/build-type-adapters-once.yml
@@ -1,0 +1,4 @@
+description: >
+  Improve the performance of loading resource action logs from the database.
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -108,6 +108,10 @@ default_unset = object()
 
 PRIMITIVE_SQL_TYPES = Union[str, int, bool, datetime.datetime, UUID]
 
+# Building a TypeAdapter compiles a validator, so build the ones used per value once.
+BOOL_ADAPTER: pydantic.TypeAdapter[bool] = pydantic.TypeAdapter(bool)
+DATETIME_ADAPTER: pydantic.TypeAdapter[datetime.datetime] = pydantic.TypeAdapter(datetime.datetime)
+
 """
 Locking order rules:
 In general, locks should be acquired consistently with delete cascade lock order, which is top down. Additional lock orderings
@@ -340,8 +344,7 @@ class ColumnType:
             # It is as expected
             return value
         if self.base_type == bool:
-            ta = pydantic.TypeAdapter(bool)
-            return ta.validate_python(value)
+            return BOOL_ADAPTER.validate_python(value)
         if self.base_type == datetime.datetime and isinstance(value, str):
             return api_boundary_datetime_normalizer(dateutil.parser.isoparse(value))
         if issubclass(self.base_type, (str, int)) and isinstance(value, (str, int, bool)):
@@ -4149,9 +4152,8 @@ class ResourceAction(BaseDocument):
             new_messages = []
             for message in self.messages:
                 if "timestamp" in message:
-                    ta = pydantic.TypeAdapter(datetime.datetime)
                     # use pydantic instead of datetime.strptime because strptime has trouble parsing isoformat timezone offset
-                    timestamp = ta.validate_python(message["timestamp"])
+                    timestamp = DATETIME_ADAPTER.validate_python(message["timestamp"])
                     if timestamp.tzinfo is None:
                         raise Exception("Found naive timestamp in the database, this should not be possible")
                     message["timestamp"] = timestamp


### PR DESCRIPTION
> Posted by Claude on behalf of @bartv.

Found while comparing how we cache pydantic `TypeAdapter`s across repos (inmanta-lsm#2485 fixes the same shape in the LSM DAO layer).

## The problem

Two places in `inmanta.data` construct a `TypeAdapter` on every call rather than once:

- `ResourceAction.__init__` builds `TypeAdapter(datetime.datetime)` **inside its per-message loop** when loading rows from postgres, so a page of resource action logs rebuilds the same validator once per log line.
- `ColumnType.get_value` builds `TypeAdapter(bool)` on every bool filter value.

Building an adapter compiles a validator, which costs far more than using it:

| Operation                                       | Cost     |
| ----------------------------------------------- | -------- |
| `TypeAdapter(datetime.datetime)` construction   | 11.8 us  |
| `validate_python` on an isoformat timestamp     | 0.29 us  |
| ratio                                            | 40x      |

## The change

Hoist both adapters to module constants. No behaviour change: a `TypeAdapter` is stateless for validation, so the same object validates identically on every call.

## Measured

Constructing 100 `ResourceAction` rows of 50 log messages each (5000 timestamps):

| | Time |
| --- | --- |
| adapter built per message | 75.3 ms |
| adapter built once        | 10.7 ms |
| **saved**                 | **64.5 ms (7x)** |

That works out to 12.9 ms saved per 1000 log messages.

## Verification

- `tests/server/test_resource_action_logs.py` (20 passed), `tests/test_data.py` (68 passed), `tests/server/test_agents_api.py` (12 passed, covers the bool filter path via the agent `status` filter), `tests/server/test_resourceservice.py -k log` (1 passed).
- black, isort and flake8 clean.
- mypy output is byte-identical to master apart from line-number shifts, so no baseline change is needed.

## Not changed

`export.py`, `orchestrationservice.py` and `protocol/websocket.py` also build adapters per call, but once per export, per `put_version` and per connection respectively, which is not worth the churn. The `AnyHttpUrl` branch in `Field._from_db_single` is dead in core (no core document field uses that type), so I left it alone.
