### PR TITLE
Fix bug compiler server doesn't install project

### DIFF
--- a/changelogs/unreleased/install-project-after-python-version-change.yml
+++ b/changelogs/unreleased/install-project-after-python-version-change.yml
@@ -1,6 +1,7 @@
 description: >
-  Fix bug where the Inmanta project was not installed into the compiler venv when the compiler service created a new
-  compiler venv because the Python version of the Inmanta server changed.
+  Fix bug where a server-side compile failed because the Inmanta project and its modules were missing from the compiler
+  venv whenever the compiler service created a new compiler venv, for example because the Python version of the Inmanta
+  server changed.
 change-type: patch
 destination-branches: [master, iso9, iso8]
 sections:

--- a/changelogs/unreleased/install-project-after-python-version-change.yml
+++ b/changelogs/unreleased/install-project-after-python-version-change.yml
@@ -1,0 +1,7 @@
+description: >
+  Fix bug where the Inmanta project was not installed into the compiler venv when the compiler service created a new
+  compiler venv because the Python version of the Inmanta server changed.
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/inmanta/server/services/compilerservice.py
+++ b/src/inmanta/server/services/compilerservice.py
@@ -263,7 +263,7 @@ class CompileRun:
                 # The process is still running, kill it
                 sub_process.kill()
 
-    async def ensure_compiler_venv(self) -> None:
+    async def ensure_compiler_venv(self) -> bool:
         """ "
         Ensure we have a compiler venv in the project
 
@@ -272,6 +272,9 @@ class CompileRun:
         It is built as
         1. a `.env` symlink to
         2. a `.env-py3.12` versioned directory
+
+        :return: True iff a new, empty venv was created. In that case the Inmanta project still has to be
+                 installed into the venv.
         """
         assert os.path.exists(self._project_dir)
         project_dir = self._project_dir
@@ -284,14 +287,16 @@ class CompileRun:
         versioned_venv_dir = ".env-py" + python_version
         versioned_venv_dir_full = os.path.join(project_dir, versioned_venv_dir)
 
-        async def ensure_venv() -> None:
+        async def ensure_venv() -> bool:
             """
             Ensures that a compatible venv exists at .env-py<version>
+
+            :return: True iff a new, empty venv was created.
             """
             if os.path.exists(versioned_venv_dir_full):
                 virtual_env = VirtualEnv(versioned_venv_dir_full)
                 virtual_env.update_venv_version()
-                return
+                return False
 
             # migration from old .env
             if os.path.exists(venv_dir) and not os.path.islink(venv_dir):
@@ -304,7 +309,7 @@ class CompileRun:
                         os.rename(venv_dir, versioned_venv_dir_full)
                         await self._info(f"Moving existing venv from {venv_dir} to {versioned_venv_dir_full}")
                         # All done
-                        return
+                        return False
                 # python version doesn't match
                 os.rename(venv_dir, venv_dir + "_old")
                 await self._info(f"Discarding existing venv from {venv_dir} to {venv_dir}_old, Creating new")
@@ -313,6 +318,7 @@ class CompileRun:
             await self._info(f"Creating new venv at {versioned_venv_dir_full}")
             virtual_env = VirtualEnv(versioned_venv_dir_full)
             virtual_env.init_env()
+            return True
 
         async def link() -> None:
             """
@@ -331,8 +337,9 @@ class CompileRun:
 
             os.symlink(versioned_venv_dir, venv_dir)
 
-        await ensure_venv()
+        created_new_venv: bool = await ensure_venv()
         await link()
+        return created_new_venv
 
     async def run(self, force_update: Optional[bool] = False) -> tuple[bool, Optional[model.CompileData]]:
         """
@@ -448,13 +455,18 @@ class CompileRun:
 
             cmd = app_cli_args + export_command
 
+            # True iff a new, empty compiler venv was created during this compile run. Such a venv doesn't
+            # contain the Inmanta project yet.
+            created_new_venv: bool = False
+
             async def ensure_venv() -> Optional[data.Report]:
                 """
                 Ensure a venv is present at `venv_dir`.
                 """
+                nonlocal created_new_venv
                 await self._start_stage("Venv check", command="")
                 try:
-                    await self.ensure_compiler_venv()
+                    created_new_venv = await self.ensure_compiler_venv()
                 except Exception as e:
                     await self._error(message=str(e))
                     return await self._end_stage(returncode=1)
@@ -528,6 +540,8 @@ class CompileRun:
                     yield ensure_venv()
 
                     should_update: bool = force_update or self.request.force_update
+                    # A freshly created venv doesn't contain the Inmanta project yet, so it has to be installed.
+                    install_required: bool = created_new_venv
 
                     # switch branches
                     if repo_branch:
@@ -540,9 +554,7 @@ class CompileRun:
                                 ["git", "checkout", repo_branch],
                                 project_dir,
                             )
-                            if not should_update:
-                                # if we update, update procedure will install modules
-                                yield install_modules()
+                            install_required = True
 
                     # update project
                     if should_update:
@@ -550,7 +562,10 @@ class CompileRun:
                         if await self.get_upstream_branch():
                             yield self._run_compile_stage("Pulling updates", ["git", "pull"], project_dir)
                         yield uninstall_protected_inmanta_packages()
+                        # the update procedure installs the modules as well
                         yield update_modules()
+                    elif install_required:
+                        yield install_modules()
                 else:
                     if not repo_url:
                         await self._warning(f"Failed to compile: no project found in {project_dir} and no repository set.")

--- a/tests/server/test_compilerservice.py
+++ b/tests/server/test_compilerservice.py
@@ -2571,6 +2571,54 @@ async def test_venv_upgrade_managed_files(tmp_path, caplog, stale_version: bool)
     assert version_file.read_text().strip() == str(PythonEnvironment.VENV_VERSION)
 
 
+@pytest.mark.slowtest
+@pytest.mark.parametrize("no_agent", [True])
+async def test_install_project_after_python_version_change(
+    environment_factory: EnvironmentFactory, server, client, tmpdir
+) -> None:
+    """
+    When the Python version of the Inmanta server changes, the compiler service creates a new compiler venv.
+    Verify that the project is installed in that new venv.
+    """
+    main_cf = """
+import std::testing
+
+std::testing::NullResource(name="test")
+    """
+    env = await environment_factory.create_environment(main_cf)
+
+    project_work_dir = os.path.join(tmpdir, "work")
+    ensure_directory_exist(project_work_dir)
+
+    python_version = ".".join(platform.python_version_tuple()[0:2])
+    venv_dir = os.path.join(project_work_dir, ".env")
+    versioned_venv_dir = os.path.join(project_work_dir, f".env-py{python_version}")
+    # The venv directory that would exist if the server ran on another Python version
+    venv_dir_other_python_version = os.path.join(project_work_dir, ".env-py1.0")
+
+    # First compile: clone the project and create the compiler venv for the current Python version.
+    _, stages = await compile_and_assert(env=env, client=client, project_work_dir=project_work_dir, export=False)
+    assert stages["Venv check"]["returncode"] == 0
+    assert stages["Installing modules"]["returncode"] == 0
+    assert stages["Recompiling configuration model"]["returncode"] == 0
+    assert os.readlink(venv_dir) == os.path.basename(versioned_venv_dir)
+
+    # Simulate a change in the Python version of the Inmanta server by renaming the compiler venv
+    # to the name it would have when the server would run on another Python version.
+    os.rename(versioned_venv_dir, venv_dir_other_python_version)
+    os.unlink(venv_dir)
+    os.symlink(os.path.basename(venv_dir_other_python_version), venv_dir)
+
+    # Second compile: a new compiler venv is created for the current Python version.
+    _, stages = await compile_and_assert(env=env, client=client, project_work_dir=project_work_dir, export=False)
+    assert stages["Venv check"]["returncode"] == 0
+    assert f"Creating new venv at {versioned_venv_dir}" in stages["Venv check"]["outstream"]
+    assert os.readlink(venv_dir) == os.path.basename(versioned_venv_dir)
+    assert "Installing modules" in stages, "The project was not installed in the newly created compiler venv"
+    assert stages["Installing modules"]["returncode"] == 0
+    assert stages["Recompiling configuration model"]["returncode"] == 0
+
+
 @pytest.mark.parametrize("use_post_endpoint", [True, False])
 @pytest.mark.parametrize("no_agent", [True])
 async def test_reinstall_project_and_venv(


### PR DESCRIPTION
# Description

Fix bug where the Inmanta project was not installed into the compiler venv when the compiler service created a new compiler venv because the Python version of the Inmanta server changed.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
