### PR TITLE
Let a GraphQL contribution resolve its page columns, and expose version selection

### DIFF
--- a/changelogs/unreleased/graphql-resolve-page-columns.yml
+++ b/changelogs/unreleased/graphql-resolve-page-columns.yml
@@ -2,7 +2,8 @@ description: >
   A GraphQL contribution now fills in the data it adds to each row with `resolve_page_columns`, over the fetched page,
   instead of contributing SQLAlchemy columns the database had to compute for every row the query could return. This
   removes `GraphQLContribution.get_sqlalchemy_columns` and `populate_sqlalchemy_columns`. A component whose filter
-  depends on the model version a resource is taken at can now express it with `ResourceFilterABC.latest_available_version`
-  and so keep the optimized `totalCount`.
-change-type: major
+  depends on the model version a resource is taken at can read core's `isOrphan` off `ResourceFilterABC` and express
+  that version with its `latest_scheduled_version` or `latest_available_version`, and so keep the optimized
+  `totalCount`.
+change-type: minor
 destination-branches: [master, iso9]

--- a/changelogs/unreleased/graphql-resolve-page-columns.yml
+++ b/changelogs/unreleased/graphql-resolve-page-columns.yml
@@ -1,9 +1,8 @@
 description: >
-  Replaced the `GraphQLContribution.get_sqlalchemy_columns` / `populate_sqlalchemy_columns` pair with
-  `resolve_page_columns`, which lets an extension fill in the extra data it adds to each row of a fetched page with a
-  query of its own. The pair it replaces added that data to the paginated statement, so the database computed it for
-  every row the query could return before the page limit applied, and again for `totalCount`; the new hook runs once,
-  over at most a page worth of rows. Every row the `resources` query returns now also carries the model version it was
-  resolved at, so a contribution can resolve version-dependent data at the version that decided the page.
+  A GraphQL contribution now fills in the data it adds to each row with `resolve_page_columns`, over the fetched page,
+  instead of contributing SQLAlchemy columns the database had to compute for every row the query could return. This
+  removes `GraphQLContribution.get_sqlalchemy_columns` and `populate_sqlalchemy_columns`. A component whose filter
+  depends on the model version a resource is taken at can now express it with `ResourceFilterABC.latest_available_version`
+  and so keep the optimized `totalCount`.
 change-type: major
 destination-branches: [master, iso9]

--- a/changelogs/unreleased/graphql-resolve-page-columns.yml
+++ b/changelogs/unreleased/graphql-resolve-page-columns.yml
@@ -1,0 +1,9 @@
+description: >
+  Replaced the `GraphQLContribution.get_sqlalchemy_columns` / `populate_sqlalchemy_columns` pair with
+  `resolve_page_columns`, which lets an extension fill in the extra data it adds to each row of a fetched page with a
+  query of its own. The pair it replaces added that data to the paginated statement, so the database computed it for
+  every row the query could return before the page limit applied, and again for `totalCount`; the new hook runs once,
+  over at most a page worth of rows. Every row the `resources` query returns now also carries the model version it was
+  resolved at, so a contribution can resolve version-dependent data at the version that decided the page.
+change-type: major
+destination-branches: [master, iso9]

--- a/changelogs/unreleased/graphql-resource-filter-version-expression.yml
+++ b/changelogs/unreleased/graphql-resource-filter-version-expression.yml
@@ -1,0 +1,7 @@
+description: >
+  Added `ResourceFilterABC.latest_available_version`, the model version a resource is taken at when no filter component
+  takes over version selection, expressed on `resource_persistent_state` alone. A component whose filter depends on that
+  version can now express it in `apply_filter_fast_count` too, and so keep the optimized `totalCount` instead of falling
+  back to counting the whole statement. `latest_scheduled_version`, which it is built on, is public for the same reason.
+change-type: minor
+destination-branches: [master, iso9]

--- a/changelogs/unreleased/graphql-resource-filter-version-expression.yml
+++ b/changelogs/unreleased/graphql-resource-filter-version-expression.yml
@@ -1,7 +1,0 @@
-description: >
-  Added `ResourceFilterABC.latest_available_version`, the model version a resource is taken at when no filter component
-  takes over version selection, expressed on `resource_persistent_state` alone. A component whose filter depends on that
-  version can now express it in `apply_filter_fast_count` too, and so keep the optimized `totalCount` instead of falling
-  back to counting the whole statement. `latest_scheduled_version`, which it is built on, is public for the same reason.
-change-type: minor
-destination-branches: [master, iso9]

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1067,6 +1067,36 @@ def decode_cursor(cursor: str) -> str:
     return decoded_cursor.split(prefix)[1]
 
 
+def bookmark_cursor(bookmark: str) -> str:
+    """
+    The position a sqlakeyset bookmark addresses, without the direction it was produced for. A bookmark carries that
+    direction as a leading '<' or '>', and it is the server's to choose when it pages -- `get_connection` puts one
+    back depending on whether it was given `after` or `before` -- so it is not part of the position.
+
+    The result is not yet a cursor a client can be handed: `encode_cursor`, or `Edge.resolve_edge` for an edge,
+    base64-encodes it first.
+
+    :param bookmark: a bookmark as sqlakeyset serialises it, e.g. from `Page.bookmark_items` or `Page.bookmark_next`.
+    """
+    return bookmark[1:]
+
+
+@dataclasses.dataclass(frozen=True)
+class PageItem:
+    """
+    One item of a fetched page: the object the statement selected, and the cursor addressing it.
+
+    Every statement `get_connection` pages selects a single entity, so `entity` is that entity itself rather than the
+    result row wrapping it.
+    """
+
+    cursor: str
+    """This item's position, as `bookmark_cursor` returns it: not yet base64-encoded, which `Edge.resolve_edge` does."""
+
+    entity: models.Base
+    """The ORM object the statement selected for this item."""
+
+
 def describe_modified_attributes(session: AsyncSession) -> str:
     """
     The mapped attributes that were modified on the objects the session tracks, as `<model>.<attribute>` entries, for
@@ -1101,7 +1131,18 @@ async def get_connection[*Ts](
     We do not call `ListConnection.resolve_connection` because:
      1) We already got the PageInfo arguments from sqlakeyset
      2) It calls `Edge.resolve_edge` with a cursor that is not useful to us
+
+    :param stmt: the statement to page. It must select exactly one ORM entity, which is then what each `PageItem`
+        carries and what the connection's nodes are resolved from. Rejected below if it does not.
     """
+    # Checked on the statement rather than on the fetched rows: how wide a row is is a property of the query, so this
+    # is one check instead of one per row, it runs before anything is executed, and it names the statement that is
+    # wrong rather than a row that looks odd. Without it, a statement selecting two entities would quietly serve
+    # nodes built from whichever one comes first.
+    selected = [description["name"] for description in stmt.column_descriptions]
+    if len(selected) != 1:
+        raise Exception(f"A paged statement must select exactly one entity, got {len(selected)}: {selected}.")
+
     async with get_session() as session:
         per_page: int
         # Get results per page and sanitation of input arguments
@@ -1139,16 +1180,18 @@ async def get_connection[*Ts](
 
         # Fetch the page using sqlakeyset
         result = await select_page(session, stmt, per_page=per_page, page=page)
-        page_rows = [(str(cursor)[1:], next(iter(value._mapping.values()))) for cursor, value in result.paging.bookmark_items()]
-        if contributions and page_rows:
+        page_items = [
+            PageItem(cursor=bookmark_cursor(bookmark), entity=row[0]) for bookmark, row in result.paging.bookmark_items()
+        ]
+        if contributions and page_items:
             # Let the contributions fill in the columns they resolve per page, before the rows go to Strawberry. They
             # do that by setting attributes on the rows, which are loaded and therefore tracked, so autoflush is
             # suspended: a name colliding with a mapped attribute stays a wrong answer instead of becoming a write.
             requested_fields = {to_snake_case(name) for name in get_selected_field_names(info)}
-            rows = [row for _, row in page_rows]
+            entities = [item.entity for item in page_items]
             with session.no_autoflush:
                 for contribution in contributions:
-                    await contribution.resolve_page_columns(session, rows, requested_fields)
+                    await contribution.resolve_page_columns(session, entities, requested_fields)
                     # Checked per contribution rather than once at the end, so the error names the one that did it.
                     # Not an assertion: this is the only thing standing between a contribution naming a mapped
                     # attribute and a read-only query issuing an UPDATE, and it has to hold when run with -O.
@@ -1164,18 +1207,18 @@ async def get_connection[*Ts](
         # it is fine to call them repeatedly
         connection = cast(type[CustomListConnection[Node]], mapper._connection_type_for(model))
 
-        for formatted_cursor, sqla_obj in page_rows:
+        for item in page_items:
             edge = cast(relay.Edge, mapper._edge_type_for(model))
-            node = connection.resolve_node(sqla_obj, info=info)
-            edges.append(edge.resolve_edge(cursor=formatted_cursor, node=node))
+            node = connection.resolve_node(item.entity, info=info)
+            edges.append(edge.resolve_edge(cursor=item.cursor, node=node))
 
         return connection(
             edges=edges,
             page_info=strawberry.relay.PageInfo(
                 has_next_page=result.paging.has_next,
                 has_previous_page=result.paging.has_previous,
-                start_cursor=encode_cursor(result.paging.bookmark_previous[1:]),
-                end_cursor=encode_cursor(result.paging.bookmark_next[1:]),
+                start_cursor=encode_cursor(bookmark_cursor(result.paging.bookmark_previous)),
+                end_cursor=encode_cursor(bookmark_cursor(result.paging.bookmark_next)),
             ),
             total_count=total_count,
         )

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -380,8 +380,9 @@ def walk_selected_fields(selection: Selection) -> typing.Iterator[SelectedField]
 
 def get_selected_field_names(info: Info) -> set[str]:
     """
-    Return the (camelCase) names of every field selected anywhere in the query, recursing through nested
-    selections and fragments. This includes the names of the top-level resolved fields themselves (e.g. `resources`);
+    Return the (camelCase) names of every field selected anywhere in the selection the current field is resolved for,
+    recursing through nested selections and fragments. This includes the names of the top-level resolved fields
+    themselves (e.g. `resources`);
 
     :param info: the Strawberry resolver info holding the selected fields of the current query.
     """
@@ -799,7 +800,7 @@ class ResourceFilterABC(StrawberryFilter):
         """
         The model version a resource is taken at when no component takes over version selection: the currently
         scheduled version if the resource is still managed, or otherwise the last version it appeared in. Expressed on
-        ResourcePersistentState alone, so a component whose filter depends on the version can also express it in
+        ResourcePersistentState's own columns, so a component whose filter depends on the version can also express it in
         `apply_filter_fast_count`. A component that needs it on a second, aliased reference to that table can build it
         from `latest_scheduled_version`.
         """
@@ -807,10 +808,16 @@ class ResourceFilterABC(StrawberryFilter):
 
     def apply_filter_fast_count[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]] | None:
         """
-        Apply this component's filter to the optimized total count query. Concretely, any filters added here must only
-        access ResourcePersistentState and version pinning to any version other than the latest for each resource is not
-        allowed. Returns None if this component has one or more filters that are not compatible with the optimized
-        mode.
+        Apply this component's filter to the optimized total count query, a count over ResourcePersistentState, which
+        holds exactly one row per resource. Returns None if this component has one or more filters that are not
+        compatible with the optimized mode, which falls the caller back to counting the whole statement.
+
+        Two things make an implementation correct. The statement has to stay one row per ResourcePersistentState row,
+        so narrow it with predicates and reach any other table through a subquery: a join both fans the count out and
+        risks colliding with the joins another component adds to the same statement. And it has to select the same
+        resources as `apply_filter` does, at the version each resource is taken at, which here can only be
+        `latest_available_version` -- ResourcePersistentState is not versioned, so a component pinning any other
+        version has to return None.
 
         The default implementation should suffice for most components. It disables the optimized query when at least one
         filter is present.
@@ -1176,11 +1183,15 @@ class GraphQLContribution(ABC):
         statement instead would have the database compute it for every row the query could return before the page
         limit applies, and again for `totalCount`.
 
+        The attribute an implementation sets must be one the target model does not map, and distinct from the names
+        other contributions and `RESOLVED_MODEL_VERSION_FIELD` use: setting a mapped attribute changes the output of
+        the query it is set on, and setting one another contribution reads overwrites what that one reported.
+
         :param session: the session the page was fetched with. Use it rather than opening another one.
         :param rows: the objects of the fetched page, in page order. Empty for an empty page (this is not called then).
-        :param requested_fields: the (snake_case) names of every field selected anywhere in the GraphQL query, so a
-            field counts as requested when its name appears in the set. An implementation should do nothing when none
-            of the fields it fills in appear.
+        :param requested_fields: the (snake_case) names of every field selected in the query this page was fetched for,
+            so a field counts as requested when its name appears in the set. An implementation should do nothing when
+            none of the fields it fills in appear.
         """
         return None
 
@@ -1488,8 +1499,12 @@ def get_schema(
         requested_fields = {to_snake_case(name) for name in get_selected_field_names(info)}
 
         async def resolve(session: AsyncSession, rows: Sequence[models.Base]) -> None:
-            for contribution in contributions:
-                await contribution.resolve_page_columns(session, rows, requested_fields)
+            # A contribution fills its data in by setting it on the row objects, which are loaded and therefore
+            # tracked. Suspend autoflush so that a name collision with a mapped attribute stays a wrong answer instead
+            # of becoming a write, issued by the next query anything runs on this session.
+            with session.no_autoflush:
+                for contribution in contributions:
+                    await contribution.resolve_page_columns(session, rows, requested_fields)
 
         return resolve
 

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -42,7 +42,6 @@ from sqlalchemy import not_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapper, query_expression, with_expression
-from sqlalchemy.orm.util import AliasedClass
 from strawberry import relay, scalars
 from strawberry.relay import Node, NodeType
 from strawberry.scalars import JSON
@@ -801,22 +800,17 @@ class ResourceFilterABC(StrawberryFilter):
 
     @classmethod
     def latest_available_version(
-        cls,
-        *,
-        environment: uuid.UUID,
-        resource_state: "type[models.ResourcePersistentState] | AliasedClass[models.ResourcePersistentState] | None" = None,
+        cls, orphaned_after: SQLColumnExpression[int | None], *, environment: uuid.UUID
     ) -> SQLColumnExpression[int | None]:
         """
-        The model version a resource is taken at when no component takes over version selection: the currently
-        scheduled version if the resource is still managed, or otherwise the last version it appeared in. Expressed on
-        ResourcePersistentState's own columns, so a component whose filter depends on the version can also express it
-        in `apply_filter_fast_count`.
+        The model version a resource is taken at when no component pins one: the scheduled version while the resource
+        is still managed, and otherwise the last version it appeared in.
 
-        :param resource_state: the reference to ResourcePersistentState to read it from, for a component that needs it
-            on a second, aliased one next to the table the count is built from.
+        :param orphaned_after: the resource's `orphaned_after`, off whichever ResourcePersistentState reference the
+            caller builds on -- the table itself, or an alias of it where a second, independent reference is needed.
+        :param environment: the environment the resources belong to.
         """
-        state = models.ResourcePersistentState if resource_state is None else resource_state
-        return func.coalesce(state.orphaned_after, cls.latest_scheduled_version(environment))
+        return func.coalesce(orphaned_after, cls.latest_scheduled_version(environment))
 
     def apply_filter_fast_count[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]] | None:
         """
@@ -825,11 +819,7 @@ class ResourceFilterABC(StrawberryFilter):
         compatible with the optimized mode, which falls the caller back to counting the whole statement.
 
         Two things make an implementation correct. The statement has to stay one row per ResourcePersistentState row,
-        so narrow it with predicates and reach any other table through a subquery: a join both fans the count out and
-        risks colliding with the joins another component adds to the same statement. And it has to select the same
-        resources as `apply_filter` does, at the version each resource is taken at, which here can only be
-        `latest_available_version` -- ResourcePersistentState is not versioned, so a component pinning any other
-        version has to return None.
+        and it has to select the same resources as `apply_filter` does.
 
         The default implementation should suffice for most components. It disables the optimized query when at least one
         filter is present.
@@ -961,7 +951,10 @@ class CoreResourceFilter(ResourceFilterABC):
 
         Should be called iff no single version filter is added, i.e. iff all filters return False for `handles_version()`.
         """
-        return stmt.where(models.Configurationmodel.version == cls.latest_available_version(environment=environment))
+        return stmt.where(
+            models.Configurationmodel.version
+            == cls.latest_available_version(models.ResourcePersistentState.orphaned_after, environment=environment)
+        )
 
 
 class ResourceOrder(StrawberryOrder):
@@ -1156,12 +1149,12 @@ async def get_connection[*Ts](
         # Fetch the page using sqlakeyset
         result = await select_page(session, stmt, per_page=per_page, page=page)
         page_items = [
-            PageItem(bookmark=remove_direction_from_bookmark(bookmark), entity=row[0]) for bookmark, row in result.paging.bookmark_items()
+            PageItem(bookmark=remove_direction_from_bookmark(bookmark), entity=row[0])
+            for bookmark, row in result.paging.bookmark_items()
         ]
         if contributions and page_items:
             # Let the contributions fill in the columns they resolve per page, before the rows go to Strawberry. They
-            # do that by setting attributes on the rows, which are loaded and therefore tracked, so autoflush is
-            # suspended: a name colliding with a mapped attribute stays a wrong answer instead of becoming a write.
+            # do that by setting attributes on the rows, which are loaded and therefore tracked, so autoflush is suspended.
             requested_fields = {to_snake_case(name) for name in get_selected_field_names(info)}
             entities = [item.entity for item in page_items]
             with session.no_autoflush:
@@ -1251,9 +1244,7 @@ class GraphQLContribution(ABC):
         limit applies, and again for `totalCount`.
 
         The attribute an implementation sets must be one the target model does not map, and distinct from the names
-        other contributions and `RESOLVED_MODEL_VERSION_FIELD` use: setting a mapped attribute changes the output of
-        the query it is set on, and setting one another contribution reads overwrites what that one reported. Setting
-        a mapped attribute is rejected: the caller raises rather than let a read-only query write.
+        other contributions and `RESOLVED_MODEL_VERSION_FIELD` use. Setting a mapped attribute is rejected.
 
         :param session: the session the page was fetched with. Use it rather than opening another one.
         :param rows: the objects of the fetched page, in page order. Never empty: this is not called for an empty page.
@@ -1284,10 +1275,10 @@ def build_composed_sqlalchemy_model(
     """
     Build the SQLAlchemy model backing an output type.
 
-    An object type can declare SQLAlchemy columns of its own (`ContributableGraphQLType.core_columns`) that do not
-    live on its table. When it does we build a subclass of `base_model` carrying them (single-table inheritance: same
-    table, extra mapped columns), so each row the query selects is a single ORM object that carries them; otherwise
-    `base_model` is used directly. get_schema is called once per process, so a fixed class name is fine.
+    An object type can declare SQLAlchemy columns of its own that do not live on its table.
+    When it does, we build a subclass of `base_model` carrying them,
+    so each row the query selects is a single ORM object that carries them; otherwise `base_model` is used directly.
+    get_schema is called once per process, so a fixed class name is fine.
 
     The returned model is what the query selects, and what `build_strawberry_output_type` maps the Strawberry output
     type from.
@@ -1672,8 +1663,7 @@ def get_schema(
             if version_handler is None:
                 stmt = CoreResourceFilter.filter_latest_available_version(stmt, environment=filter.environment)
 
-            # Carry the version each row is taken at, which version selection above has just constrained
-            # `Configurationmodel.version` to, so a contribution resolving version-dependent data for the fetched page
+            # Carry the version each row is taken at, so a contribution resolving version-dependent data for the fetched page
             # resolves it at the same version the row was selected at.
             stmt = stmt.options(
                 with_expression(getattr(resource_model, RESOLVED_MODEL_VERSION_FIELD), models.Configurationmodel.version)

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -36,7 +36,9 @@ from inmanta.server.services.compilerservice import CompilerService
 from inmanta.types import ResourceIdStr
 from sqlakeyset import Marker, unserialize_bookmark
 from sqlakeyset.asyncio import select_page
-from sqlalchemy import Boolean, Select, SQLColumnExpression, UnaryExpression, and_, asc, desc, func, not_, select
+from sqlalchemy import Boolean, Select, SQLColumnExpression, UnaryExpression, and_, asc, desc, func
+from sqlalchemy import inspect as sqlalchemy_inspect
+from sqlalchemy import not_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapper, query_expression, with_expression
@@ -1065,6 +1067,24 @@ def decode_cursor(cursor: str) -> str:
     return decoded_cursor.split(prefix)[1]
 
 
+def describe_modified_attributes(session: AsyncSession) -> str:
+    """
+    The mapped attributes that were modified on the objects the session tracks, as `<model>.<attribute>` entries, for
+    the error reporting that a page column contribution wrote one. Reads the session's pre-flush change history, so it
+    names the attributes that were actually set rather than every attribute the model maps. It emits no loads.
+    """
+    return ", ".join(
+        sorted(
+            {
+                f"{type(row).__name__}.{attribute.key}"
+                for row in session.dirty
+                for attribute in sqlalchemy_inspect(row).attrs
+                if attribute.history.has_changes()
+            }
+        )
+    )
+
+
 async def get_connection[*Ts](
     stmt: Select[tuple[*Ts]],
     model: str,
@@ -1120,7 +1140,7 @@ async def get_connection[*Ts](
         # Fetch the page using sqlakeyset
         result = await select_page(session, stmt, per_page=per_page, page=page)
         page_rows = [(str(cursor)[1:], next(iter(value._mapping.values()))) for cursor, value in result.paging.bookmark_items()]
-        if contributions:
+        if contributions and page_rows:
             # Let the contributions fill in the columns they resolve per page, before the rows go to Strawberry. They
             # do that by setting attributes on the rows, which are loaded and therefore tracked, so autoflush is
             # suspended: a name colliding with a mapped attribute stays a wrong answer instead of becoming a write.
@@ -1129,7 +1149,14 @@ async def get_connection[*Ts](
             with session.no_autoflush:
                 for contribution in contributions:
                     await contribution.resolve_page_columns(session, rows, requested_fields)
-            assert not session.dirty, "a page column contribution set a mapped attribute on a row it was given"
+                    # Checked per contribution rather than once at the end, so the error names the one that did it.
+                    # Not an assertion: this is the only thing standing between a contribution naming a mapped
+                    # attribute and a read-only query issuing an UPDATE, and it has to hold when run with -O.
+                    if session.dirty:
+                        raise Exception(
+                            f"GraphQL contribution {contribution.__name__} set mapped attributes on the rows it was"
+                            f" given, which a page column may never do: {describe_modified_attributes(session)}."
+                        )
 
         edges = []
         # We use the private methods for the mapper because their respective public attributes like `mapper.connection_types`
@@ -1199,10 +1226,11 @@ class GraphQLContribution(ABC):
 
         The attribute an implementation sets must be one the target model does not map, and distinct from the names
         other contributions and `RESOLVED_MODEL_VERSION_FIELD` use: setting a mapped attribute changes the output of
-        the query it is set on, and setting one another contribution reads overwrites what that one reported.
+        the query it is set on, and setting one another contribution reads overwrites what that one reported. Setting
+        a mapped attribute is rejected: the caller raises rather than let a read-only query write.
 
         :param session: the session the page was fetched with. Use it rather than opening another one.
-        :param rows: the objects of the fetched page, in page order. Empty for an empty page (this is not called then).
+        :param rows: the objects of the fetched page, in page order. Never empty: this is not called for an empty page.
         :param requested_fields: the (snake_case) names of every field selected in the query this page was fetched for,
             so a field counts as requested when its name appears in the set. An implementation should do nothing when
             none of the fields it fills in appear.

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -1067,16 +1067,12 @@ def decode_cursor(cursor: str) -> str:
     return decoded_cursor.split(prefix)[1]
 
 
-def bookmark_cursor(bookmark: str) -> str:
+def remove_direction_from_bookmark(bookmark: str) -> str:
     """
     The position a sqlakeyset bookmark addresses, without the direction it was produced for. A bookmark carries that
-    direction as a leading '<' or '>', and it is the server's to choose when it pages -- `get_connection` puts one
-    back depending on whether it was given `after` or `before` -- so it is not part of the position.
+    direction as a leading '<' or '>', which determines the direction to fetch the results.
 
-    The result is not yet a cursor a client can be handed: `encode_cursor`, or `Edge.resolve_edge` for an edge,
-    base64-encodes it first.
-
-    :param bookmark: a bookmark as sqlakeyset serialises it, e.g. from `Page.bookmark_items` or `Page.bookmark_next`.
+    :param bookmark: a bookmark as sqlakeyset serialises it.
     """
     return bookmark[1:]
 
@@ -1084,35 +1080,17 @@ def bookmark_cursor(bookmark: str) -> str:
 @dataclasses.dataclass(frozen=True)
 class PageItem:
     """
-    One item of a fetched page: the object the statement selected, and the cursor addressing it.
+    One item of a fetched page: the object the statement selected, and the bookmark addressing it.
 
     Every statement `get_connection` pages selects a single entity, so `entity` is that entity itself rather than the
     result row wrapping it.
     """
 
-    cursor: str
-    """This item's position, as `bookmark_cursor` returns it: not yet base64-encoded, which `Edge.resolve_edge` does."""
+    bookmark: str
+    """This item's position, as a directionless bookmark."""
 
     entity: models.Base
     """The ORM object the statement selected for this item."""
-
-
-def describe_modified_attributes(session: AsyncSession) -> str:
-    """
-    The mapped attributes that were modified on the objects the session tracks, as `<model>.<attribute>` entries, for
-    the error reporting that a page column contribution wrote one. Reads the session's pre-flush change history, so it
-    names the attributes that were actually set rather than every attribute the model maps. It emits no loads.
-    """
-    return ", ".join(
-        sorted(
-            {
-                f"{type(row).__name__}.{attribute.key}"
-                for row in session.dirty
-                for attribute in sqlalchemy_inspect(row).attrs
-                if attribute.history.has_changes()
-            }
-        )
-    )
 
 
 async def get_connection[*Ts](
@@ -1135,10 +1113,8 @@ async def get_connection[*Ts](
     :param stmt: the statement to page. It must select exactly one ORM entity, which is then what each `PageItem`
         carries and what the connection's nodes are resolved from. Rejected below if it does not.
     """
-    # Checked on the statement rather than on the fetched rows: how wide a row is is a property of the query, so this
-    # is one check instead of one per row, it runs before anything is executed, and it names the statement that is
-    # wrong rather than a row that looks odd. Without it, a statement selecting two entities would quietly serve
-    # nodes built from whichever one comes first.
+    # Checked on the statement rather than on every single fetched row.
+    # Without this, a statement selecting two entities would quietly serve nodes built from whichever one comes first.
     selected = [description["name"] for description in stmt.column_descriptions]
     if len(selected) != 1:
         raise Exception(f"A paged statement must select exactly one entity, got {len(selected)}: {selected}.")
@@ -1156,8 +1132,7 @@ async def get_connection[*Ts](
             per_page = last
         else:
             per_page = DEFAULT_PER_PAGE
-        # The same ceiling every paginated endpoint in the API applies. It also bounds what a contribution resolving
-        # columns for the page has to do in one go.
+
         if per_page > APILIMIT:
             raise BadRequest(f"`first`/`last` can not exceed {APILIMIT}, got {per_page}.")
 
@@ -1181,7 +1156,7 @@ async def get_connection[*Ts](
         # Fetch the page using sqlakeyset
         result = await select_page(session, stmt, per_page=per_page, page=page)
         page_items = [
-            PageItem(cursor=bookmark_cursor(bookmark), entity=row[0]) for bookmark, row in result.paging.bookmark_items()
+            PageItem(bookmark=remove_direction_from_bookmark(bookmark), entity=row[0]) for bookmark, row in result.paging.bookmark_items()
         ]
         if contributions and page_items:
             # Let the contributions fill in the columns they resolve per page, before the rows go to Strawberry. They
@@ -1193,12 +1168,20 @@ async def get_connection[*Ts](
                 for contribution in contributions:
                     await contribution.resolve_page_columns(session, entities, requested_fields)
                     # Checked per contribution rather than once at the end, so the error names the one that did it.
-                    # Not an assertion: this is the only thing standing between a contribution naming a mapped
-                    # attribute and a read-only query issuing an UPDATE, and it has to hold when run with -O.
                     if session.dirty:
+                        # Read off the session's pre-flush change history, so the error names the attributes that
+                        # were actually set rather than every attribute the model maps. This emits no loads.
+                        modified = sorted(
+                            {
+                                f"{type(row).__name__}.{attribute.key}"
+                                for row in session.dirty
+                                for attribute in sqlalchemy_inspect(row).attrs
+                                if attribute.history.has_changes()
+                            }
+                        )
                         raise Exception(
                             f"GraphQL contribution {contribution.__name__} set mapped attributes on the rows it was"
-                            f" given, which a page column may never do: {describe_modified_attributes(session)}."
+                            f" given, which a page column may never do: {', '.join(modified)}."
                         )
 
         edges = []
@@ -1210,15 +1193,15 @@ async def get_connection[*Ts](
         for item in page_items:
             edge = cast(relay.Edge, mapper._edge_type_for(model))
             node = connection.resolve_node(item.entity, info=info)
-            edges.append(edge.resolve_edge(cursor=item.cursor, node=node))
+            edges.append(edge.resolve_edge(cursor=item.bookmark, node=node))
 
         return connection(
             edges=edges,
             page_info=strawberry.relay.PageInfo(
                 has_next_page=result.paging.has_next,
                 has_previous_page=result.paging.has_previous,
-                start_cursor=encode_cursor(bookmark_cursor(result.paging.bookmark_previous)),
-                end_cursor=encode_cursor(bookmark_cursor(result.paging.bookmark_next)),
+                start_cursor=encode_cursor(remove_direction_from_bookmark(result.paging.bookmark_previous)),
+                end_cursor=encode_cursor(remove_direction_from_bookmark(result.paging.bookmark_next)),
             ),
             total_count=total_count,
         )

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -368,38 +368,21 @@ def is_provided[T](value: T | None) -> typing.TypeGuard[T]:
     return value is not None and value is not strawberry.UNSET
 
 
-def walk_selected_fields(selection: Selection) -> typing.Iterator[SelectedField]:
-    """
-    Yield every SelectedField in a selection subtree: the selection itself if it is a field, plus all nested
-    selections, recursing through inline (`... on Type`) and named (`...Fragment`) fragments.
-
-    :param selection: the root of the selection subtree to walk.
-    """
-    if isinstance(selection, SelectedField):
-        yield selection
-    for sub_selection in selection.selections or []:
-        yield from walk_selected_fields(sub_selection)
-
-
 def get_selected_field_names(info: Info) -> set[str]:
     """
-    Return the (camelCase) names of every field selected anywhere in the selection the current field is resolved for,
-    recursing through nested selections and fragments. This includes the names of the top-level resolved fields
-    themselves (e.g. `resources`);
+    The (camelCase) names of every field the query selects under the one being resolved, at any depth and through
+    inline (`... on Type`) and named (`...Fragment`) fragments -- the resolved field itself included, e.g. `resources`.
 
     :param info: the Strawberry resolver info holding the selected fields of the current query.
     """
-    return {field.name for selected_field in info.selected_fields for field in walk_selected_fields(selected_field)}
-
-
-def is_field_selected(info: Info, field_name: str) -> bool:
-    """
-    Check whether the user requested `field_name` anywhere in the query, including nested fields and fragments.
-
-    :param info: the Strawberry resolver info holding the selected fields of the current query.
-    :param field_name: the (camelCase) name of the field to look for.
-    """
-    return field_name in get_selected_field_names(info)
+    names: set[str] = set()
+    todo: list[Selection] = list(info.selected_fields)
+    while todo:
+        selection = todo.pop()
+        if isinstance(selection, SelectedField):
+            names.add(selection.name)
+        todo.extend(selection.selections or [])
+    return names
 
 
 def to_snake_case(name: str) -> str:
@@ -799,18 +782,14 @@ class ResourceFilterABC(StrawberryFilter):
         )
 
     @classmethod
-    def latest_available_version(
-        cls, orphaned_after: SQLColumnExpression[int | None], *, environment: uuid.UUID
-    ) -> SQLColumnExpression[int | None]:
+    def latest_available_version(cls, *, environment: uuid.UUID) -> SQLColumnExpression[int | None]:
         """
         The model version a resource is taken at when no component pins one: the scheduled version while the resource
         is still managed, and otherwise the last version it appeared in.
 
-        :param orphaned_after: the resource's `orphaned_after`, off whichever ResourcePersistentState reference the
-            caller builds on -- the table itself, or an alias of it where a second, independent reference is needed.
         :param environment: the environment the resources belong to.
         """
-        return func.coalesce(orphaned_after, cls.latest_scheduled_version(environment))
+        return func.coalesce(models.ResourcePersistentState.orphaned_after, cls.latest_scheduled_version(environment))
 
     def apply_filter_fast_count[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]] | None:
         """
@@ -951,10 +930,7 @@ class CoreResourceFilter(ResourceFilterABC):
 
         Should be called iff no single version filter is added, i.e. iff all filters return False for `handles_version()`.
         """
-        return stmt.where(
-            models.Configurationmodel.version
-            == cls.latest_available_version(models.ResourcePersistentState.orphaned_after, environment=environment)
-        )
+        return stmt.where(models.Configurationmodel.version == cls.latest_available_version(environment=environment))
 
 
 class ResourceOrder(StrawberryOrder):
@@ -1129,9 +1105,11 @@ async def get_connection[*Ts](
         if per_page > APILIMIT:
             raise BadRequest(f"`first`/`last` can not exceed {APILIMIT}, got {per_page}.")
 
+        selected_fields = get_selected_field_names(info)
+
         # Check if we requested total_count
         total_count: int | None = None
-        if is_field_selected(info, "totalCount"):
+        if "totalCount" in selected_fields:
             if count_stmt is None:
                 count_stmt = select(func.count()).select_from(stmt.subquery())
             count_result = await session.execute(count_stmt)
@@ -1155,7 +1133,7 @@ async def get_connection[*Ts](
         if contributions and page_items:
             # Let the contributions fill in the columns they resolve per page, before the rows go to Strawberry. They
             # do that by setting attributes on the rows, which are loaded and therefore tracked, so autoflush is suspended.
-            requested_fields = {to_snake_case(name) for name in get_selected_field_names(info)}
+            requested_fields = {to_snake_case(name) for name in selected_fields}
             entities = [item.entity for item in page_items]
             with session.no_autoflush:
                 for contribution in contributions:

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -28,9 +28,10 @@ import inmanta.data.sqlalchemy as models
 import strawberry
 from graphql import GraphQLInputObjectType
 from inmanta import data
-from inmanta.data import get_session, get_session_factory, model
+from inmanta.data import APILIMIT, get_session, get_session_factory, model
 from inmanta.deploy import state
 from inmanta.graphql.rest_filter import ResolvedFilter, strip_input_field
+from inmanta.protocol.exceptions import BadRequest
 from inmanta.server.services.compilerservice import CompilerService
 from inmanta.types import ResourceIdStr
 from sqlakeyset import Marker, unserialize_bookmark
@@ -39,6 +40,7 @@ from sqlalchemy import Boolean, Select, SQLColumnExpression, UnaryExpression, an
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapper, query_expression, with_expression
+from sqlalchemy.orm.util import AliasedClass
 from strawberry import relay, scalars
 from strawberry.relay import Node, NodeType
 from strawberry.scalars import JSON
@@ -796,15 +798,23 @@ class ResourceFilterABC(StrawberryFilter):
         )
 
     @classmethod
-    def latest_available_version(cls, *, environment: uuid.UUID) -> SQLColumnExpression[int | None]:
+    def latest_available_version(
+        cls,
+        *,
+        environment: uuid.UUID,
+        resource_state: "type[models.ResourcePersistentState] | AliasedClass[models.ResourcePersistentState] | None" = None,
+    ) -> SQLColumnExpression[int | None]:
         """
         The model version a resource is taken at when no component takes over version selection: the currently
         scheduled version if the resource is still managed, or otherwise the last version it appeared in. Expressed on
-        ResourcePersistentState's own columns, so a component whose filter depends on the version can also express it in
-        `apply_filter_fast_count`. A component that needs it on a second, aliased reference to that table can build it
-        from `latest_scheduled_version`.
+        ResourcePersistentState's own columns, so a component whose filter depends on the version can also express it
+        in `apply_filter_fast_count`.
+
+        :param resource_state: the reference to ResourcePersistentState to read it from, for a component that needs it
+            on a second, aliased one next to the table the count is built from.
         """
-        return func.coalesce(models.ResourcePersistentState.orphaned_after, cls.latest_scheduled_version(environment))
+        state = models.ResourcePersistentState if resource_state is None else resource_state
+        return func.coalesce(state.orphaned_after, cls.latest_scheduled_version(environment))
 
     def apply_filter_fast_count[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]] | None:
         """
@@ -1055,11 +1065,6 @@ def decode_cursor(cursor: str) -> str:
     return decoded_cursor.split(prefix)[1]
 
 
-# What `get_connection` runs on a fetched page: hands the page's rows to every contribution that resolves columns per
-# page (see `GraphQLContribution.resolve_page_columns`), on the session the page was fetched with.
-type ResolvePage = typing.Callable[[AsyncSession, Sequence[models.Base]], typing.Awaitable[None]]
-
-
 async def get_connection[*Ts](
     stmt: Select[tuple[*Ts]],
     model: str,
@@ -1069,7 +1074,7 @@ async def get_connection[*Ts](
     last: typing.Optional[int] = strawberry.UNSET,
     before: typing.Optional[str] = strawberry.UNSET,
     count_stmt: Select[tuple[int]] | None = None,
-    resolve_page: "ResolvePage | None" = None,
+    contributions: "Sequence[type[GraphQLContribution]]" = (),
 ) -> CustomListConnection[Node]:
     """
     Build the connection object. Here we do all the pagination and fetching of results (edges) to return to the user.
@@ -1090,6 +1095,10 @@ async def get_connection[*Ts](
             per_page = last
         else:
             per_page = DEFAULT_PER_PAGE
+        # The same ceiling every paginated endpoint in the API applies. It also bounds what a contribution resolving
+        # columns for the page has to do in one go.
+        if per_page > APILIMIT:
+            raise BadRequest(f"`first`/`last` can not exceed {APILIMIT}, got {per_page}.")
 
         # Check if we requested total_count
         total_count: int | None = None
@@ -1111,9 +1120,16 @@ async def get_connection[*Ts](
         # Fetch the page using sqlakeyset
         result = await select_page(session, stmt, per_page=per_page, page=page)
         page_rows = [(str(cursor)[1:], next(iter(value._mapping.values()))) for cursor, value in result.paging.bookmark_items()]
-        # Let the extensions fill in the columns they resolve per page, before the rows are handed to Strawberry.
-        if resolve_page is not None and page_rows:
-            await resolve_page(session, [sqla_obj for _, sqla_obj in page_rows])
+        if contributions:
+            # Let the contributions fill in the columns they resolve per page, before the rows go to Strawberry. They
+            # do that by setting attributes on the rows, which are loaded and therefore tracked, so autoflush is
+            # suspended: a name colliding with a mapped attribute stays a wrong answer instead of becoming a write.
+            requested_fields = {to_snake_case(name) for name in get_selected_field_names(info)}
+            rows = [row for _, row in page_rows]
+            with session.no_autoflush:
+                for contribution in contributions:
+                    await contribution.resolve_page_columns(session, rows, requested_fields)
+            assert not session.dirty, "a page column contribution set a mapped attribute on a row it was given"
 
         edges = []
         # We use the private methods for the mapper because their respective public attributes like `mapper.connection_types`
@@ -1138,8 +1154,6 @@ async def get_connection[*Ts](
         )
 
 
-# TODO: once everything is in (including the lsm side), do a critical final pass about how everything fits together,
-# and whether the are redundancies, verbosities, complexties, ... that we can clean up by tweaking the interface.
 class GraphQLContribution(ABC):
     """
     Extension hook that lets extensions (e.g. LSM) contribute extra information to a single GraphQL output type
@@ -1438,7 +1452,7 @@ class ContributableGraphQLType:
     core_filter: type[StrawberryFilter]
     base_filter: type = StrawberryFilter
     core_columns: "Mapping[str, object]" = dataclasses.field(default_factory=dict)
-    """SQLAlchemy columns this object type carries for its own use, next to the ones extensions contribute."""
+    """SQLAlchemy columns this object type needs that do not live on its table."""
 
 
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
@@ -1468,53 +1482,18 @@ def get_schema(
         type they target (see `graphql_type_name`). Extension names are not relevant here, so they are dropped by the
         caller (`GraphQLSlice`).
     """
-
-    def build_output_type(base_model: type[models.Base], specs: ContributableGraphQLType) -> tuple[type[models.Base], type]:
-        """
-        Build the (possibly extension-composed) SQLAlchemy model and Strawberry output type for one object type.
-        Returns the SQLAlchemy model to select in the query (a subclass carrying the type's own and the extensions'
-        extra columns when there are any, `base_model` otherwise) and the Strawberry output type to return.
-
-        :param base_model: the SQLAlchemy model of the object type being built (e.g. `models.Resource`).
-        :param specs: the core building blocks of this object type (see `CONTRIBUTABLE_MODELS`).
-        """
-        type_name = graphql_type_name(base_model)
-        contributions = extension_contributions.get(type_name, [])
-        composed_model = build_composed_sqlalchemy_model(base_model, specs.core_columns)
-        output_type = build_strawberry_output_type(type_name, composed_model, specs.core_mixin, contributions)
-        return composed_model, output_type
-
-    def resolve_page_columns(base_model: type[models.Base], info: Info) -> ResolvePage | None:
-        """
-        The callback `get_connection` runs on a fetched page, letting every contribution for `base_model` resolve the
-        columns it fills in per page (see `GraphQLContribution.resolve_page_columns`). None when no extension
-        contributes to this type, so the common path adds nothing to the request.
-
-        :param base_model: the original SQLAlchemy model of the object type (e.g. `models.Resource`).
-        :param info: the Strawberry resolver info, used to determine which fields were selected in the query.
-        """
-        contributions = extension_contributions.get(graphql_type_name(base_model), [])
-        if not contributions:
-            return None
-        requested_fields = {to_snake_case(name) for name in get_selected_field_names(info)}
-
-        async def resolve(session: AsyncSession, rows: Sequence[models.Base]) -> None:
-            # A contribution fills its data in by setting it on the row objects, which are loaded and therefore
-            # tracked. Suspend autoflush so that a name collision with a mapped attribute stays a wrong answer instead
-            # of becoming a write, issued by the next query anything runs on this session.
-            with session.no_autoflush:
-                for contribution in contributions:
-                    await contribution.resolve_page_columns(session, rows, requested_fields)
-
-        return resolve
-
     # Build each registrable object type's output type and filter input.
     built_output_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
     built_filters: dict[GraphQLTypeName, tuple[tuple[type[StrawberryFilter], ...], type]] = {}
     for base_model, model_specs in CONTRIBUTABLE_MODELS.items():
         type_name = graphql_type_name(base_model)
         contributions = extension_contributions.get(type_name, [])
-        built_output_types[type_name] = build_output_type(base_model, model_specs)
+        # A subclass carrying the type's own extra columns when it declares any, `base_model` itself otherwise.
+        composed_model = build_composed_sqlalchemy_model(base_model, model_specs.core_columns)
+        built_output_types[type_name] = (
+            composed_model,
+            build_strawberry_output_type(type_name, composed_model, model_specs.core_mixin, contributions),
+        )
         built_filters[type_name] = build_composed_filter_input(
             type_name, model_specs.core_filter, model_specs.base_filter, contributions
         )
@@ -1552,7 +1531,7 @@ def get_schema(
                 after=after,
                 last=last,
                 before=before,
-                resolve_page=resolve_page_columns(models.Environment, info),
+                contributions=extension_contributions.get(graphql_type_name(models.Environment), []),
             )
 
         @strawberry.field(description="Fetches a paginated list of notifications")
@@ -1577,7 +1556,7 @@ def get_schema(
                 after=after,
                 last=last,
                 before=before,
-                resolve_page=resolve_page_columns(models.Notification, info),
+                contributions=extension_contributions.get(graphql_type_name(models.Notification), []),
             )
 
         @strawberry.field(description="Fetches a paginated list of resources")
@@ -1666,7 +1645,7 @@ def get_schema(
                 last=last,
                 before=before,
                 count_stmt=count_stmt,
-                resolve_page=resolve_page_columns(models.Resource, info),
+                contributions=extension_contributions.get(graphql_type_name(models.Resource), []),
             )
 
         @strawberry.field(description="Fetches a summary of the state of all resources in a specific environment")

--- a/src/inmanta/graphql/schema.py
+++ b/src/inmanta/graphql/schema.py
@@ -36,8 +36,9 @@ from inmanta.types import ResourceIdStr
 from sqlakeyset import Marker, unserialize_bookmark
 from sqlakeyset.asyncio import select_page
 from sqlalchemy import Boolean, Select, SQLColumnExpression, UnaryExpression, and_, asc, desc, func, not_, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapper
+from sqlalchemy.orm import Mapper, query_expression, with_expression
 from strawberry import relay, scalars
 from strawberry.relay import Node, NodeType
 from strawberry.scalars import JSON
@@ -733,13 +734,20 @@ def get_purged(root: "CoreResourceMixin") -> bool:
     return bool(root.attributes.get("purged"))
 
 
+# The column core populates on every row the `resources` query returns, with the model version that row was resolved at.
+# Not a GraphQL field (it is excluded from the output type below): it is there so that a contribution resolving
+# version-dependent data for a fetched page (see `GraphQLContribution.resolve_page_columns`) knows, per row, which
+# version to resolve it at -- the same version selection that decided which rows the query returned in the first place.
+RESOLVED_MODEL_VERSION_FIELD = "resolved_model_version"
+
+
 class CoreResourceMixin:
     """
     Mixin carrying the core Resource output fields. It is merged with the extensions' output mixins (and mapped onto
     the SQLAlchemy Resource model) by `build_strawberry_output_type` to build the `Resource` GraphQL output type.
     """
 
-    __exclude__ = ["resource_set_"]
+    __exclude__ = ["resource_set_", RESOLVED_MODEL_VERSION_FIELD]
     requires_length: int = strawberry.field(
         resolver=get_requires_length, description="The length of the requires of this resource."
     )
@@ -773,6 +781,29 @@ class ResourceFilterABC(StrawberryFilter):
         join boilerplate.
         """
         return False
+
+    @classmethod
+    def latest_scheduled_version(cls, environment: uuid.UUID) -> SQLColumnExpression[int | None]:
+        """
+        The latest model version the scheduler has processed for `environment`, as a scalar expression to be used inside
+        a larger statement. It is NULL if the scheduler has not processed any version yet.
+        """
+        return (
+            select(models.Scheduler.last_processed_model_version)
+            .where(models.Scheduler.environment == environment)
+            .scalar_subquery()
+        )
+
+    @classmethod
+    def latest_available_version(cls, *, environment: uuid.UUID) -> SQLColumnExpression[int | None]:
+        """
+        The model version a resource is taken at when no component takes over version selection: the currently
+        scheduled version if the resource is still managed, or otherwise the last version it appeared in. Expressed on
+        ResourcePersistentState alone, so a component whose filter depends on the version can also express it in
+        `apply_filter_fast_count`. A component that needs it on a second, aliased reference to that table can build it
+        from `latest_scheduled_version`.
+        """
+        return func.coalesce(models.ResourcePersistentState.orphaned_after, cls.latest_scheduled_version(environment))
 
     def apply_filter_fast_count[*Ts](self, stmt: Select[tuple[*Ts]]) -> Select[tuple[*Ts]] | None:
         """
@@ -839,18 +870,6 @@ class CoreResourceFilter(ResourceFilterABC):
         # and consider is_orphan=True to always select the latest version for each resource.
         return is_provided(self.is_orphan) or is_provided(self.model_version)
 
-    @classmethod
-    def _latest_scheduled_version_subquery(cls, environment: uuid.UUID) -> SQLColumnExpression[int | None]:
-        """
-        The latest model version the scheduler has processed for `environment`, as a scalar expression to be used inside
-        a larger statement. It is NULL if the scheduler has not processed any version yet.
-        """
-        return (
-            select(models.Scheduler.last_processed_model_version)
-            .where(models.Scheduler.environment == environment)
-            .scalar_subquery()
-        )
-
     def _apply_filter_rps[*Ts](
         self, stmt: Select[tuple[*Ts]]
     ) -> Select[tuple[*Ts]]:  # Every filter we apply to the resource is custom, so we don't use `get_filter_dict`
@@ -897,7 +916,7 @@ class CoreResourceFilter(ResourceFilterABC):
                 model_version = models.ResourcePersistentState.orphaned_after
             elif self.is_orphan is False:
                 # 1 version: latest scheduled version
-                model_version = self._latest_scheduled_version_subquery(self.environment)
+                model_version = self.latest_scheduled_version(self.environment)
             else:
                 assert is_provided(self.is_orphan), "mismatch between handles_version() and apply_filter() implementation"
                 typing.assert_never(self.is_orphan)
@@ -923,10 +942,7 @@ class CoreResourceFilter(ResourceFilterABC):
 
         Should be called iff no single version filter is added, i.e. iff all filters return False for `handles_version()`.
         """
-        return stmt.where(
-            models.Configurationmodel.version
-            == func.coalesce(models.ResourcePersistentState.orphaned_after, cls._latest_scheduled_version_subquery(environment))
-        )
+        return stmt.where(models.Configurationmodel.version == cls.latest_available_version(environment=environment))
 
 
 class ResourceOrder(StrawberryOrder):
@@ -1032,6 +1048,11 @@ def decode_cursor(cursor: str) -> str:
     return decoded_cursor.split(prefix)[1]
 
 
+# What `get_connection` runs on a fetched page: hands the page's rows to every contribution that resolves columns per
+# page (see `GraphQLContribution.resolve_page_columns`), on the session the page was fetched with.
+type ResolvePage = typing.Callable[[AsyncSession, Sequence[models.Base]], typing.Awaitable[None]]
+
+
 async def get_connection[*Ts](
     stmt: Select[tuple[*Ts]],
     model: str,
@@ -1041,6 +1062,7 @@ async def get_connection[*Ts](
     last: typing.Optional[int] = strawberry.UNSET,
     before: typing.Optional[str] = strawberry.UNSET,
     count_stmt: Select[tuple[int]] | None = None,
+    resolve_page: "ResolvePage | None" = None,
 ) -> CustomListConnection[Node]:
     """
     Build the connection object. Here we do all the pagination and fetching of results (edges) to return to the user.
@@ -1081,15 +1103,18 @@ async def get_connection[*Ts](
 
         # Fetch the page using sqlakeyset
         result = await select_page(session, stmt, per_page=per_page, page=page)
+        page_rows = [(str(cursor)[1:], next(iter(value._mapping.values()))) for cursor, value in result.paging.bookmark_items()]
+        # Let the extensions fill in the columns they resolve per page, before the rows are handed to Strawberry.
+        if resolve_page is not None and page_rows:
+            await resolve_page(session, [sqla_obj for _, sqla_obj in page_rows])
+
         edges = []
         # We use the private methods for the mapper because their respective public attributes like `mapper.connection_types`
         # Are only filled when the private methods are called first. The private methods use the public attributes as cache so
         # it is fine to call them repeatedly
         connection = cast(type[CustomListConnection[Node]], mapper._connection_type_for(model))
 
-        for cursor, value in result.paging.bookmark_items():
-            formatted_cursor = str(cursor)[1:]
-            sqla_obj = next(iter(value._mapping.values()))
+        for formatted_cursor, sqla_obj in page_rows:
             edge = cast(relay.Edge, mapper._edge_type_for(model))
             node = connection.resolve_node(sqla_obj, info=info)
             edges.append(edge.resolve_edge(cursor=formatted_cursor, node=node))
@@ -1133,45 +1158,31 @@ class GraphQLContribution(ABC):
     def get_graphql_output_type_mixin(cls) -> type | None:
         """
         Return a plain class (no decorator) whose `strawberry.field` declarations are merged into the target
-        output type. These output fields can be sqlalchemy columns that are later populated with `populate_sqlalchemy_columns`
-        or simple resolvers (e.g. `purged` on `CoreResourceMixin`).
+        output type. These output fields can be resolvers over the target's own columns (e.g. `purged` on
+        `CoreResourceMixin`), or over what `resolve_page_columns` sets on each row.
         Return None if this contribution adds no output fields.
         """
         return None
 
     @classmethod
-    def get_sqlalchemy_columns(cls) -> "typing.Mapping[str, object]":
+    async def resolve_page_columns(
+        cls, session: AsyncSession, rows: "Sequence[models.Base]", requested_fields: typing.AbstractSet[str]
+    ) -> None:
         """
-        Return SQLAlchemy column descriptors (e.g. `query_expression()`) keyed by attribute name. These are
-        merged onto a dynamically built subclass of the target model, so the query can select a single ORM object
-        that carries extra, SQL-backed columns (joins/subqueries) that don't live on the target's table. The value
-        of each column is populated per query by `populate_sqlalchemy_columns`.
+        Fill in the extra data this contribution adds to each row of one fetched page, with a query of its own, by
+        setting it on the row object (which is what a `get_graphql_output_type_mixin` resolver reads back).
 
-        For each column declared here, the matching output field should also be declared with a concrete type on
-        the mixin returned by `get_graphql_output_type_mixin` (otherwise the mapper would try to
-        auto-map the untyped column).
-        """
-        return {}
+        Runs after the page is fetched, so the work is bounded by the page. Adding the same data to the paginated
+        statement instead would have the database compute it for every row the query could return before the page
+        limit applies, and again for `totalCount`.
 
-    @classmethod
-    def populate_sqlalchemy_columns[*Ts](
-        cls, stmt: "Select[tuple[*Ts]]", model: type[models.Base], requested_fields: typing.AbstractSet[str]
-    ) -> "Select[tuple[*Ts]]":
+        :param session: the session the page was fetched with. Use it rather than opening another one.
+        :param rows: the objects of the fetched page, in page order. Empty for an empty page (this is not called then).
+        :param requested_fields: the (snake_case) names of every field selected anywhere in the GraphQL query, so a
+            field counts as requested when its name appears in the set. An implementation should do nothing when none
+            of the fields it fills in appear.
         """
-        Populate the columns declared in `get_sqlalchemy_columns` onto the query, typically via sqlalchemy's
-        `with_expression`.
-        Populating a column is usually expensive (extra joins/subqueries), so an implementation should only
-        populate the columns whose name is in `requested_fields` and leave the rest as their (null)
-        `query_expression` default. Name columns distinctly to avoid colliding with unrelated fields in the set.
-
-        :param stmt: the query the columns are populated onto. Implementations should return it with their columns
-            added (e.g. via `with_expression`).
-        :param model: the dynamically built subclass of the target model that carries the `query_expression()`
-            placeholders (so its core columns keep their type, while the extra columns are read with `getattr`).
-        :param requested_fields: the (snake_case) names of every field selected anywhere in the GraphQL query
-            (not only the target's output fields), so a column counts as requested when its name appears in the set.
-        """
-        return stmt
+        return None
 
     @classmethod
     def get_filter_input_class(cls) -> "type[StrawberryFilter] | None":
@@ -1189,33 +1200,27 @@ class GraphQLContribution(ABC):
 
 def build_composed_sqlalchemy_model(
     base_model: type[models.Base],
-    contributions: Sequence[type[GraphQLContribution]],
+    core_columns: "Mapping[str, object]",
 ) -> type[models.Base]:
     """
     Build the SQLAlchemy model backing an output type.
 
-    Extensions can contribute SQLAlchemy columns (`get_sqlalchemy_columns`). When any are contributed we build a
-    subclass of `base_model` that carries them (single-table inheritance: same table, extra mapped columns), so each
-    row the query selects is a single ORM object that can carry the extra columns; otherwise `base_model` is used
-    directly. get_schema is called once per process, so a fixed class name is fine.
+    An object type can declare SQLAlchemy columns of its own (`ContributableGraphQLType.core_columns`) that do not
+    live on its table. When it does we build a subclass of `base_model` carrying them (single-table inheritance: same
+    table, extra mapped columns), so each row the query selects is a single ORM object that carries them; otherwise
+    `base_model` is used directly. get_schema is called once per process, so a fixed class name is fine.
 
-    The returned model is needed by the query to select the right entity and let extensions populate their columns,
-    and by `build_strawberry_output_type` to map the Strawberry output type from it.
+    The returned model is what the query selects, and what `build_strawberry_output_type` maps the Strawberry output
+    type from.
 
     :param base_model: the SQLAlchemy model of the object type being built (e.g. `models.Resource`)
-    :param contributions: the extension contributions that target `base_model`
+    :param core_columns: the columns this object type declares itself
     """
-    sqlalchemy_columns: dict[str, object] = {}
-    for c in contributions:
-        for name, column in c.get_sqlalchemy_columns().items():
-            if name in sqlalchemy_columns:
-                raise Exception(f"Column {name} defined more than once in {graphql_type_name(base_model)} contributions.")
-            sqlalchemy_columns[name] = column
-    if not sqlalchemy_columns:
+    if not core_columns:
         return base_model
     return cast(
         type[models.Base],
-        type(f"Composed{base_model.__name__}", (base_model,), sqlalchemy_columns),
+        type(f"Composed{base_model.__name__}", (base_model,), dict(core_columns)),
     )
 
 
@@ -1421,6 +1426,8 @@ class ContributableGraphQLType:
     core_mixin: type
     core_filter: type[StrawberryFilter]
     base_filter: type = StrawberryFilter
+    core_columns: "Mapping[str, object]" = dataclasses.field(default_factory=dict)
+    """SQLAlchemy columns this object type carries for its own use, next to the ones extensions contribute."""
 
 
 # The object types extensions can register GraphQL contributions for (see GraphQLContribution), mapping each SQLAlchemy
@@ -1428,7 +1435,10 @@ class ContributableGraphQLType:
 # registered contributions; registrations for any other model are rejected.
 CONTRIBUTABLE_MODELS: "Mapping[type[models.Base], ContributableGraphQLType]" = {
     models.Resource: ContributableGraphQLType(
-        core_mixin=CoreResourceMixin, base_filter=ResourceFilterABC, core_filter=CoreResourceFilter
+        core_mixin=CoreResourceMixin,
+        base_filter=ResourceFilterABC,
+        core_filter=CoreResourceFilter,
+        core_columns={RESOLVED_MODEL_VERSION_FIELD: query_expression()},
     ),
     models.Environment: ContributableGraphQLType(core_mixin=CoreEnvironmentMixin, core_filter=CoreEnvironmentFilter),
     models.Notification: ContributableGraphQLType(core_mixin=CoreNotificationMixin, core_filter=CoreNotificationFilter),
@@ -1448,42 +1458,40 @@ def get_schema(
         caller (`GraphQLSlice`).
     """
 
-    def build_output_type(base_model: type[models.Base], core_mixin: type) -> tuple[type[models.Base], type]:
+    def build_output_type(base_model: type[models.Base], specs: ContributableGraphQLType) -> tuple[type[models.Base], type]:
         """
         Build the (possibly extension-composed) SQLAlchemy model and Strawberry output type for one object type.
-        Returns the SQLAlchemy model to select in the query (a subclass carrying the extensions' extra columns when
-        there are any, `base_model` otherwise) and the Strawberry output type to return.
+        Returns the SQLAlchemy model to select in the query (a subclass carrying the type's own and the extensions'
+        extra columns when there are any, `base_model` otherwise) and the Strawberry output type to return.
 
         :param base_model: the SQLAlchemy model of the object type being built (e.g. `models.Resource`).
-        :param core_mixin: the mixin carrying the core output fields for this type (e.g. `CoreResourceMixin`).
+        :param specs: the core building blocks of this object type (see `CONTRIBUTABLE_MODELS`).
         """
         type_name = graphql_type_name(base_model)
         contributions = extension_contributions.get(type_name, [])
-        composed_model = build_composed_sqlalchemy_model(base_model, contributions)
-        output_type = build_strawberry_output_type(type_name, composed_model, core_mixin, contributions)
+        composed_model = build_composed_sqlalchemy_model(base_model, specs.core_columns)
+        output_type = build_strawberry_output_type(type_name, composed_model, specs.core_mixin, contributions)
         return composed_model, output_type
 
-    def populate_extension_columns[*Ts](
-        stmt: "Select[tuple[*Ts]]", base_model: type[models.Base], composed_model: type[models.Base], info: Info
-    ) -> "Select[tuple[*Ts]]":
+    def resolve_page_columns(base_model: type[models.Base], info: Info) -> ResolvePage | None:
         """
-        Let the extensions populate the extra SQL-backed columns they declared on `composed_model` (see
-        GraphQLContribution.populate_sqlalchemy_columns), passing the names of the fields selected in the query so they only
-        populate what was requested. Skipped entirely on the common path where no extension contributed columns.
+        The callback `get_connection` runs on a fetched page, letting every contribution for `base_model` resolve the
+        columns it fills in per page (see `GraphQLContribution.resolve_page_columns`). None when no extension
+        contributes to this type, so the common path adds nothing to the request.
 
-        :param stmt: the query the extension columns are populated onto.
         :param base_model: the original SQLAlchemy model of the object type (e.g. `models.Resource`).
-        :param composed_model: the model actually selected by the query: a subclass of `base_model` carrying the
-            extensions' extra columns, or `base_model` itself when no extension contributed columns (in which case
-            this is a no-op).
         :param info: the Strawberry resolver info, used to determine which fields were selected in the query.
         """
-        if composed_model is base_model:
-            return stmt
+        contributions = extension_contributions.get(graphql_type_name(base_model), [])
+        if not contributions:
+            return None
         requested_fields = {to_snake_case(name) for name in get_selected_field_names(info)}
-        for contribution in extension_contributions.get(graphql_type_name(base_model), []):
-            stmt = contribution.populate_sqlalchemy_columns(stmt, composed_model, requested_fields)
-        return stmt
+
+        async def resolve(session: AsyncSession, rows: Sequence[models.Base]) -> None:
+            for contribution in contributions:
+                await contribution.resolve_page_columns(session, rows, requested_fields)
+
+        return resolve
 
     # Build each registrable object type's output type and filter input.
     built_output_types: dict[GraphQLTypeName, tuple[type[models.Base], type]] = {}
@@ -1491,7 +1499,7 @@ def get_schema(
     for base_model, model_specs in CONTRIBUTABLE_MODELS.items():
         type_name = graphql_type_name(base_model)
         contributions = extension_contributions.get(type_name, [])
-        built_output_types[type_name] = build_output_type(base_model, model_specs.core_mixin)
+        built_output_types[type_name] = build_output_type(base_model, model_specs)
         built_filters[type_name] = build_composed_filter_input(
             type_name, model_specs.core_filter, model_specs.base_filter, contributions
         )
@@ -1519,11 +1527,17 @@ def get_schema(
             order_by: typing.Optional[Sequence[EnvironmentOrder]] = strawberry.UNSET,
         ) -> CustomListConnection[Environment]:
             stmt = select(environment_model)
-            stmt = populate_extension_columns(stmt, models.Environment, environment_model, info)
             filters = decompose_and_validate_filter(filter, environment_filter_components)
             stmt = add_filter_and_sort(stmt, EnvironmentOrder.default_order(), filters, order_by)
             return await get_connection(
-                stmt, info=info, model="Environment", first=first, after=after, last=last, before=before
+                stmt,
+                info=info,
+                model="Environment",
+                first=first,
+                after=after,
+                last=last,
+                before=before,
+                resolve_page=resolve_page_columns(models.Environment, info),
             )
 
         @strawberry.field(description="Fetches a paginated list of notifications")
@@ -1538,11 +1552,17 @@ def get_schema(
             order_by: typing.Optional[Sequence[NotificationOrder]] = strawberry.UNSET,
         ) -> CustomListConnection[Notification]:
             stmt = select(notification_model)
-            stmt = populate_extension_columns(stmt, models.Notification, notification_model, info)
             filters = decompose_and_validate_filter(filter, notification_filter_components)
             stmt = add_filter_and_sort(stmt, NotificationOrder.default_order(), filters, order_by)
             return await get_connection(
-                stmt, info=info, model="Notification", first=first, after=after, last=last, before=before
+                stmt,
+                info=info,
+                model="Notification",
+                first=first,
+                after=after,
+                last=last,
+                before=before,
+                resolve_page=resolve_page_columns(models.Notification, info),
             )
 
         @strawberry.field(description="Fetches a paginated list of resources")
@@ -1604,7 +1624,12 @@ def get_schema(
             if version_handler is None:
                 stmt = CoreResourceFilter.filter_latest_available_version(stmt, environment=filter.environment)
 
-            stmt = populate_extension_columns(stmt, models.Resource, resource_model, info)
+            # Carry the version each row is taken at, which version selection above has just constrained
+            # `Configurationmodel.version` to, so a contribution resolving version-dependent data for the fetched page
+            # resolves it at the same version the row was selected at.
+            stmt = stmt.options(
+                with_expression(getattr(resource_model, RESOLVED_MODEL_VERSION_FIELD), models.Configurationmodel.version)
+            )
             stmt = add_filter_and_sort(stmt, ResourceOrder.default_order(), resource_filter_instances, order_by)
 
             # Try to build the optimized count statement: ResourcePersistentState holds exactly one row per
@@ -1618,7 +1643,15 @@ def get_schema(
                 count_stmt = filter_instance.apply_filter_fast_count(count_stmt)
 
             return await get_connection(
-                stmt, info=info, model="Resource", first=first, after=after, last=last, before=before, count_stmt=count_stmt
+                stmt,
+                info=info,
+                model="Resource",
+                first=first,
+                after=after,
+                last=last,
+                before=before,
+                count_stmt=count_stmt,
+                resolve_page=resolve_page_columns(models.Resource, info),
             )
 
         @strawberry.field(description="Fetches a summary of the state of all resources in a specific environment")

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1458,6 +1458,52 @@ async def test_custom_extension_contributions(server, environment, client, caplo
         log_doesnt_contain(caplog, __name__, logging.INFO, "Populated joined_value column")
 
 
+async def test_page_column_contribution_may_not_write(server, environment, client, mixed_resource_generator):
+    """
+    A page column contribution setting a *mapped* attribute is rejected. The rows it is handed are loaded and
+    therefore tracked, so such a name would be flushed as an UPDATE by the next query on that session -- a read-only
+    query issuing a write. The error names the contribution and the attribute it wrote.
+    """
+
+    class WritingContribution(GraphQLContribution):
+        @classmethod
+        def get_target_model(cls) -> type:
+            return models.Resource
+
+        @classmethod
+        async def resolve_page_columns(
+            cls, session: AsyncSession, rows: Sequence[object], requested_fields: typing.AbstractSet[str]
+        ) -> None:
+            for row in rows:
+                # `attributes` is mapped on Resource, which is exactly what a contribution may not touch.
+                row.attributes = {"written": "by the contribution"}
+
+    graphql_slice = server.get_slice(SLICE_GRAPHQL)
+    assert isinstance(graphql_slice, GraphQLSlice)
+    # GraphQLSlice has already started, so we reset its schema to make registering possible again for this test.
+    graphql_slice.schema = None
+    graphql_slice.register_graphql_contribution_for_extension("writer", WritingContribution)
+    await graphql_slice.start()
+
+    await mixed_resource_generator(environment, 1, 6)
+
+    result = await client.graphql(query="""
+        {
+            resources (filter: {environment: "%s"}) {
+                edges {
+                    node {
+                        resourceId
+                    }
+                }
+            }
+        }
+        """ % environment)
+    assert result.code == 400, result.result
+    reported = str(result.result)
+    assert "WritingContribution" in reported, reported
+    assert "ComposedResource.attributes" in reported, reported
+
+
 async def test_resolved_model_version_available_to_contributions(server, environment, client, mixed_resource_generator):
     """
     Every row the `resources` query returns carries the model version it was taken at, so a contribution resolving

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -25,7 +25,7 @@ import inmanta.data.sqlalchemy as models
 import inmanta.graphql.schema as graphql_schema
 import strawberry
 from inmanta import const, data
-from inmanta.data import model
+from inmanta.data import APILIMIT, model
 from inmanta.deploy import state
 from inmanta.graphql.graphql import GraphQLSlice
 from inmanta.graphql.schema import (
@@ -422,6 +422,25 @@ async def test_query_environments_with_sorting(server, client, setup_database):
         check_correct_graphql_response(result)
         results = result.result["data"]["data"]["environments"]["edges"]
         assert [node["node"]["name"] for node in results] == test_case[1]
+
+
+async def test_page_size_is_capped(server, client, setup_database):
+    """
+    `first` and `last` are bounded by the same ceiling the rest of the API applies, so neither a page nor the work a
+    contribution does for one can be made arbitrarily large by the caller.
+    """
+    query = """
+    {
+        environments (%s) { edges { node { id } } }
+    }
+    """
+    for paging in (f"first: {APILIMIT + 1}", f'last: {APILIMIT + 1}, before: "abc"'):
+        result = await client.graphql(query=query % paging)
+        assert result.code == 400, result.result
+        assert f"can not exceed {APILIMIT}" in str(result.result["data"]["errors"]), result.result
+
+    result = await client.graphql(query=query % f"first: {APILIMIT}")
+    assert result.code == 200, result.result
 
 
 async def test_query_environments_with_paging(server, client, setup_database):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1498,6 +1498,8 @@ async def test_page_column_contribution_may_not_write(server, environment, clien
             }
         }
         """ % environment)
+    # 400 is what the endpoint reports for every failed GraphQL request (GraphQLResult.status_code), so the status
+    # says nothing about this case in particular. What the contribution did wrong is in the message.
     assert result.code == 400, result.result
     reported = str(result.result)
     assert "WritingContribution" in reported, reported

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -17,6 +17,7 @@ import inspect
 import logging
 import typing
 import uuid
+from collections.abc import Sequence
 
 import pytest
 
@@ -28,11 +29,11 @@ from inmanta.data import model
 from inmanta.deploy import state
 from inmanta.graphql.graphql import GraphQLSlice
 from inmanta.graphql.schema import (
+    RESOLVED_MODEL_VERSION_FIELD,
     GraphQLContribution,
     ResourceFilterABC,
     StrawberryFilter,
     _docstring_param_cache,
-    build_composed_sqlalchemy_model,
     is_provided,
     mapper,
     to_snake_case,
@@ -41,8 +42,8 @@ from inmanta.protocol import Result
 from inmanta.server import SLICE_COMPILER, SLICE_GRAPHQL
 from inmanta.server.services.compilerservice import CompilerService
 from inmanta.util import retry_limited
-from sqlalchemy import Select, func, literal, select, true
-from sqlalchemy.orm import query_expression, with_expression
+from sqlalchemy import Select, func
+from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyMapper
 from strawberry_sqlalchemy_mapper.mapper import _GENERATED_FIELD_KEYS_KEY
 from utils import (
@@ -1323,20 +1324,24 @@ async def test_missing_query_exception(server, environment, client):
 async def test_custom_extension_contributions(server, environment, client, caplog, mixed_resource_generator):
     """
     Test that an extension can contribute output fields to the `resources` query: both a plain resolver field
-    (`example`) and a query_expression-backed field (`joinedValue`) that the extension populates onto the query via
-    with_expression, only when the field is actually selected.
+    (`example`) and a field (`joinedValue`) the extension fills in for each row of the fetched page, only when the
+    field is actually selected.
     """
 
     def get_example(root: "ExampleResourceMixin") -> str:
         return "my-example"
 
+    def get_joined_value(root: object) -> int | None:
+        return getattr(root, "joined_value", None)
+
     class ExampleResourceMixin:
         """Mixin merged into the Resource output type."""
 
         example: str = strawberry.field(resolver=get_example, description="Checks if this mixin was loaded")
-        # Output field backed by a SQLAlchemy query_expression column that the extension populates per query
-        # (declared with a concrete type so the mapper exposes it instead of trying to auto-map the untyped column).
-        joined_value: int = strawberry.field(description="PoC field, joined in by the extension with a hardcoded value of 42.")
+        # Output field the extension fills in per page, read back off the row here.
+        joined_value: int | None = strawberry.field(
+            resolver=get_joined_value, description="PoC field, filled in by the extension with a hardcoded value of 42."
+        )
 
     class ExampleQueryContribution(GraphQLContribution):
         @classmethod
@@ -1348,22 +1353,15 @@ async def test_custom_extension_contributions(server, environment, client, caplo
             return ExampleResourceMixin
 
         @classmethod
-        def get_sqlalchemy_columns(cls) -> dict[str, object]:
-            return {"joined_value": query_expression()}
-
-        @classmethod
-        def populate_sqlalchemy_columns[*Ts](
-            cls, stmt: Select[tuple[*Ts]], model: type, requested_fields: typing.AbstractSet[str]
-        ) -> Select[tuple[*Ts]]:
-            # Only populate the (potentially expensive) column when it is actually requested.
+        async def resolve_page_columns(
+            cls, session: AsyncSession, rows: Sequence[object], requested_fields: typing.AbstractSet[str]
+        ) -> None:
+            # Only do the (potentially expensive) work when the field is actually requested.
             if "joined_value" not in requested_fields:
-                return stmt
+                return
             LOGGER.info("Populated joined_value column")
-            # Join in a hardcoded value of 42 and populate it onto each resource's `joined_value` attribute.
-            joined_value_subquery = select(literal(42).label("joined_value")).subquery()
-            return stmt.join(joined_value_subquery, true()).options(
-                with_expression(getattr(model, "joined_value"), joined_value_subquery.c.joined_value)
-            )
+            for row in rows:
+                row.joined_value = 42
 
     class UnsupportedModelContribution(GraphQLContribution):
         """Targets a model that extensions are not allowed to contribute to."""
@@ -1443,17 +1441,21 @@ async def test_custom_extension_contributions(server, environment, client, caplo
 
 async def test_resolved_model_version_available_to_contributions(server, environment, client, mixed_resource_generator):
     """
-    The `resources` resolver joins `configurationmodel`, and the component that owns version selection constrains its
-    `version` to the version each resource is taken at. A contribution can therefore read that version in
-    populate_sqlalchemy_columns to resolve version-dependent data at the same version, without any Python-side
-    recording of the selection. For a pinned
-    `modelVersion` every resource reports that version; for the default selection each resource reports the version it
-    was actually taken at (the latest scheduled version, or -- for orphans -- the last version they were present in).
+    Every row the `resources` query returns carries the model version it was taken at, so a contribution resolving
+    version-dependent data for a fetched page can resolve it at the version that decided the page, without any
+    Python-side recording of the selection. For a pinned `modelVersion` every resource reports that version; for the
+    default selection each resource reports the version it was actually taken at (the latest scheduled version, or --
+    for orphans -- the last version they were present in).
     """
+
+    def get_resolved_version(root: object) -> int | None:
+        return getattr(root, "resolved_version", None)
 
     class ResolvedVersionMixin:
         # Output field echoing the model version the query resolved each resource to.
-        resolved_version: int | None = strawberry.field(description="The model version this resource was taken at.")
+        resolved_version: int | None = strawberry.field(
+            resolver=get_resolved_version, description="The model version this resource was taken at."
+        )
 
     class ResolvedVersionContribution(GraphQLContribution):
         @classmethod
@@ -1465,18 +1467,13 @@ async def test_resolved_model_version_available_to_contributions(server, environ
             return ResolvedVersionMixin
 
         @classmethod
-        def get_sqlalchemy_columns(cls) -> dict[str, object]:
-            return {"resolved_version": query_expression()}
-
-        @classmethod
-        def populate_sqlalchemy_columns[*Ts](
-            cls, stmt: Select[tuple[*Ts]], model: type, requested_fields: typing.AbstractSet[str]
-        ) -> Select[tuple[*Ts]]:
+        async def resolve_page_columns(
+            cls, session: AsyncSession, rows: Sequence[object], requested_fields: typing.AbstractSet[str]
+        ) -> None:
             if "resolved_version" not in requested_fields:
-                return stmt
-            # The resolver already joined configurationmodel, and version selection constrained it to the version each
-            # resource resolves to, so we can read the resolved version straight off that table.
-            return stmt.options(with_expression(getattr(model, "resolved_version"), models.Configurationmodel.version))
+                return
+            for row in rows:
+                row.resolved_version = getattr(row, RESOLVED_MODEL_VERSION_FIELD)
 
     graphql_slice = server.get_slice(SLICE_GRAPHQL)
     assert isinstance(graphql_slice, GraphQLSlice)
@@ -1512,31 +1509,6 @@ async def test_resolved_model_version_available_to_contributions(server, environ
     # The default selection takes non-orphaned resources at the latest scheduled version (2) and orphaned resources
     # at the last version they were present in (1).
     assert await resolved_versions("") == {1, 2}
-
-
-def test_build_composed_sqlalchemy_model_rejects_duplicate_columns() -> None:
-    """Two contributions declaring the same SQLAlchemy column on the same model is rejected."""
-
-    class ContributionA(GraphQLContribution):
-        @classmethod
-        def get_target_model(cls) -> type:
-            return models.Resource
-
-        @classmethod
-        def get_sqlalchemy_columns(cls) -> dict[str, object]:
-            return {"joined_value": query_expression()}
-
-    class ContributionB(GraphQLContribution):
-        @classmethod
-        def get_target_model(cls) -> type:
-            return models.Resource
-
-        @classmethod
-        def get_sqlalchemy_columns(cls) -> dict[str, object]:
-            return {"joined_value": query_expression()}
-
-    with pytest.raises(Exception, match="Column joined_value defined more than once in Resource contributions."):
-        build_composed_sqlalchemy_model(models.Resource, [ContributionA, ContributionB])
 
 
 async def test_extension_registers_multiple_contributions(server, environment, client, mixed_resource_generator):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -42,8 +42,9 @@ from inmanta.protocol import Result
 from inmanta.server import SLICE_COMPILER, SLICE_GRAPHQL
 from inmanta.server.services.compilerservice import CompilerService
 from inmanta.util import retry_limited
-from sqlalchemy import Select, func
+from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
 from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyMapper
 from strawberry_sqlalchemy_mapper.mapper import _GENERATED_FIELD_KEYS_KEY
 from utils import (
@@ -1456,6 +1457,16 @@ async def test_custom_extension_contributions(server, environment, client, caplo
         check_correct_graphql_response(result)
         assert len(result.result["data"]["data"]["resources"]["edges"]) > 0
         log_doesnt_contain(caplog, __name__, logging.INFO, "Populated joined_value column")
+
+
+async def test_paged_statement_must_select_one_entity() -> None:
+    """
+    `get_connection` reads one entity off each row it fetches, so a statement selecting anything else is rejected
+    before it is executed, rather than serving nodes built from whichever element came first.
+    """
+    for stmt in (select(models.Resource, models.Notification), select()):
+        with pytest.raises(Exception, match="must select exactly one entity"):
+            await graphql_schema.get_connection(stmt, model="Resource", info=typing.cast(Info, None))
 
 
 async def test_page_column_contribution_may_not_write(server, environment, client, mixed_resource_generator):


### PR DESCRIPTION
Claude (Claude Code) opened this PR on behalf of @jptrindade.

## What

An extension contributing to the `resources` GraphQL query had one way to add data to each row: contribute SQLAlchemy columns, which the framework added to the paginated statement. The database therefore computed that data for **every row the query could return before the page limit applied**, and again for `totalCount`.

`GraphQLContribution.get_sqlalchemy_columns` / `populate_sqlalchemy_columns` are replaced by `resolve_page_columns(session, rows, requested_fields)`, an async hook that `get_connection` runs on the fetched page. The extension fills in its data with a query of its own, over at most a page worth of rows.

Two additions let a contribution resolve that data at the right model version:

| addition                                     | what it is                                                                              | why an extension needs it                                                                                                          |
| -------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
| `RESOLVED_MODEL_VERSION_FIELD`               | the version each returned row was resolved at, via `with_expression`                     | so page-resolved data is resolved at the same version selection that decided which rows came back                                      |
| `ResourceFilterABC.latest_available_version` | `coalesce(rps.orphaned_after, <latest scheduled>)`, on `resource_persistent_state` alone | so a component whose filter depends on the version can express it in `apply_filter_fast_count` and keep the optimized `totalCount` |

`filter_latest_available_version` is now that same expression with the `Configurationmodel.version ==` around it, so the two cannot drift. `latest_scheduled_version` (previously `_latest_scheduled_version_subquery`) is public for a component that has to build the coalesce on a second, aliased reference to the table.

With no extension able to contribute columns, `build_composed_sqlalchemy_model` loses its `contributions` parameter and its duplicate-column check.

## Why

This exists to serve inmanta-lsm, whose `serviceInstances` field and service-instance filters are the reason the nightly performance job reports seconds per page of `resources` at 200k resources. What this hook buys there is a **change of shape**: that extension's per-row data stops being O(environment size) and becomes O(page). The measured figures are in inmanta/inmanta-lsm#2490, along with an honest account of how stable they are.

## Safety of the new hook

`resolve_page_columns` hands a contribution the loaded, session-tracked row objects and lets it `setattr` its data onto them. That has one sharp edge, and the loop runs inside `session.no_autoflush` because of it: a name colliding with a **mapped** attribute would otherwise be flushed as an `UPDATE` by the next query on that session — a read-only GraphQL query issuing a write. With autoflush suspended a collision is a wrong answer rather than a write, and the hook documents the constraint that avoids it.

`apply_filter_fast_count` also documented a contract it does not have (*"any filters added here must only access ResourcePersistentState"*), which the first implementation of it already contradicts. It now states the invariant that actually makes the count correct: one row per `ResourcePersistentState` row, reaching other tables through a subquery rather than a join, and selecting the same resources as `apply_filter` at the version each is taken at.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
