### PR TITLE
Disable redeploy_failed_on_export environment setting by default

### DIFF
--- a/changelogs/unreleased/flip-default-redeploy-failed-on-export.yml
+++ b/changelogs/unreleased/flip-default-redeploy-failed-on-export.yml
@@ -1,0 +1,8 @@
+description: >-
+  Flipped the default value of the `redeploy_failed_on_export` environment setting from true to false.
+issue-nr: 10591
+change-type: major
+destination-branches: [master]
+sections:
+  upgrade-note: >-
+    The `redeploy_failed_on_export` environment setting now defaults to false.

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2690,13 +2690,13 @@ class Environment(BaseDocument):
         REDEPLOY_FAILED_ON_EXPORT: Setting(
             name=REDEPLOY_FAILED_ON_EXPORT,
             typ="bool",
-            default=True,
+            default=False,
             doc=(
-                "When a new model version is exported, the orchestrator deploys everything that is not in a known good"
-                " state, including resources for which a previous deployment failed. When this option is disabled, only"
-                " resources that are new, that have an updated desired state or that became unblocked by the new model"
-                " version are deployed. Failed resources are still picked up by repair runs and by an explicit deploy"
-                " trigger."
+                "When a new model version is exported, the orchestrator only deploys resources that are new, that have an"
+                " updated desired state or that became unblocked by the new model version. Resources for which a previous"
+                " deployment failed are not redeployed, but they are still picked up by repair runs and by an explicit"
+                " deploy trigger. When this option is enabled, the orchestrator deploys everything that is not in a known"
+                " good state, including resources for which a previous deployment failed."
             ),
             validator=convert_boolean,
             section="scheduler",

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -1203,7 +1203,7 @@ async def test_resource_status(resource_container, server, client, clienthelper,
             {
                 "key": "key2",
                 "value": f"value-{version}",  # Make sure the attribute_hash changes on each version.
-                                              # Like this the failed resource will redeploy on export.
+                # Like this the failed resource will redeploy on export.
                 "id": f"test::Resource[agent1,key=key2],v={version}",
                 "requires": [],
                 "purged": False,

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -131,7 +131,7 @@ async def test_basics(agent, resource_container, clienthelper, client, environme
     resource_container.Provider.set("agent1", "key", "value")
     resource_container.Provider.set("agent2", "key", "value")
     resource_container.Provider.set("agent3", "key", "value")
-    resource_container.Provider.set_fail("agent1", "key3", 2)
+    resource_container.Provider.set_fail("agent1", "key3", 1)
 
     async def make_version(is_different=False):
         """
@@ -1202,7 +1202,8 @@ async def test_resource_status(resource_container, server, client, clienthelper,
             },
             {
                 "key": "key2",
-                "value": "value",
+                "value": f"value-{version}",  # Make sure the attribute_hash changes on each version.
+                                              # Like this the failed resource will redeploy on export.
                 "id": f"test::Resource[agent1,key=key2],v={version}",
                 "requires": [],
                 "purged": False,

--- a/tests/deploy/e2e/test_deploy.py
+++ b/tests/deploy/e2e/test_deploy.py
@@ -1202,8 +1202,9 @@ async def test_resource_status(resource_container, server, client, clienthelper,
             },
             {
                 "key": "key2",
-                "value": f"value-{version}",  # Make sure the attribute_hash changes on each version.
+                # Make sure the attribute_hash changes on each version.
                 # Like this the failed resource will redeploy on export.
+                "value": f"value-{version}",
                 "id": f"test::Resource[agent1,key=key2],v={version}",
                 "requires": [],
                 "purged": False,

--- a/tests/deploy/scheduler_mocks.py
+++ b/tests/deploy/scheduler_mocks.py
@@ -332,7 +332,7 @@ class TestScheduler(ResourceScheduler):
         self.state_update_manager = DummyStateManager()
         self._timer_manager = DummyTimerManager(self)
         # Stand-in for the redeploy_failed_on_export environment setting, which is not backed by a database here.
-        self.redeploy_failed_on_export = True
+        self.redeploy_failed_on_export = False
 
     async def read_version(
         self,


### PR DESCRIPTION
# Description

This PR makes sure that the redeploy_failed_on_export environment setting is now disabled by default.

Closes #10591

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~