### PR TITLE
Report every attribute change of a deploy, not only the last one

### DIFF
--- a/changelogs/unreleased/compliance-report-single-change.yml
+++ b/changelogs/unreleased/compliance-report-single-change.yml
@@ -1,0 +1,5 @@
+description: >
+  Fix bug where only one attribute change per resource was stored on a deploy's resource action, hiding every other
+  change from the compliance report.
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/deploy/persistence.py
+++ b/src/inmanta/deploy/persistence.py
@@ -199,9 +199,12 @@ class ToDbUpdateManager(StateUpdateManager):
         change = result.change
 
         # TODO: clean up this particular dict
-        changes_with_rvid: dict[ResourceVersionIdStr, dict[str, object]] = {
-            resource_id_str: {attr_name: attr_change.model_dump()} for attr_name, attr_change in result.changes.items()
-        }
+        # An unchanged resource reports no rvid at all, rather than its rvid with nothing under it.
+        changes_with_rvid: dict[ResourceVersionIdStr, dict[str, object]] = (
+            {resource_id_str: {attr_name: attr_change.model_dump() for attr_name, attr_change in result.changes.items()}}
+            if result.changes
+            else {}
+        )
 
         if status not in VALID_STATES_ON_STATE_UPDATE:
             error_and_log(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1227,7 +1227,10 @@ async def test_send_deploy_done(server, client, environment, null_agent, caplog,
                 action_id=action_id,
                 resource_state=const.HandlerResourceState.deployed,
                 messages=messages,
-                changes={"attr1": AttributeStateChange(current=None, desired="test")},
+                changes={
+                    "attr1": AttributeStateChange(current=None, desired="test"),
+                    "attr2": AttributeStateChange(current="old", desired="new"),
+                },
                 change=const.Change.purged,
             ),
             state=state.ResourceState(
@@ -1278,7 +1281,12 @@ async def test_send_deploy_done(server, client, environment, null_agent, caplog,
     ]
     assert resource_action["messages"] == expected_resource_action_messages
     assert resource_action["status"] == const.ResourceState.deployed
-    assert resource_action["changes"] == {rvid_r1_v1: {"attr1": AttributeStateChange(current=None, desired="test").dict()}}
+    assert resource_action["changes"] == {
+        rvid_r1_v1: {
+            "attr1": AttributeStateChange(current=None, desired="test").dict(),
+            "attr2": AttributeStateChange(current="old", desired="new").dict(),
+        }
+    }
     assert resource_action["change"] == const.Change.purged.value
 
     result = await client.resource_details(tid=env_id, rid=rid_r1)


### PR DESCRIPTION
# Description

`ToDbUpdateManager.send_deploy_done` built the resource action's `changes` dict with a comprehension that rebinds the same key on every iteration:

```python
changes_with_rvid = {
    resource_id_str: {attr_name: attr_change.model_dump()} for attr_name, attr_change in result.changes.items()
}
```

Only the last entry of `result.changes` survives; every other change is silently dropped before it reaches `resource_action.changes`. Present since the field was introduced, on master, iso9 and iso8.

Handlers that report one change per sub-object are hit hardest. A customer onboarding a service with an aggregate handler had seven drifted objects reported by the handler, of which exactly one was stored, picked by dict iteration order. On iso8 the service compliance report is built from the resource action (`future::std::ResourceCompliance` reads `action.changes[rvid]`), so the operator saw a single drifted object, promoted the service to an enforcing state on that basis, and the six hidden changes were applied. Two of them were VPLS mesh SDP bindings, which closed a bridging loop on a live service.

The dryrun path is unaffected: it passes `dryrun_result.changes` straight through. On iso9 the compliance report reads the `resource_diff` table, which is written from the complete change set, so only consumers of the resource action are affected there.

# Self Check:

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

`test_send_deploy_done` reported a single attribute change, which is exactly why this was never caught. It now reports two and asserts both are stored; it fails on master with only `attr2` present.

A resource with no change keeps reporting no rvid at all, rather than its rvid with nothing under it. `ResourceAction.add_changes` iterates the inner dict, so both forms leave the column null, but the explicit form says what is intended.

`make mypy` reports 14 new violations against the baseline, all pre-existing on master in unrelated files. Verified identical counts (fixed 13 / new 14 / unresolved 1043) with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
