### PR TITLE
Report every attribute change of a deploy, not only the last one (iso8 backport of #10769)

### DIFF
--- a/changelogs/unreleased/compliance-report-single-change.yml
+++ b/changelogs/unreleased/compliance-report-single-change.yml
@@ -1,0 +1,5 @@
+description: >
+  Fix bug where only one attribute change per resource was stored on a deploy's resource action, hiding every other
+  change from the compliance report.
+change-type: patch
+destination-branches: [iso8]

--- a/src/inmanta/deploy/persistence.py
+++ b/src/inmanta/deploy/persistence.py
@@ -207,9 +207,12 @@ class ToDbUpdateManager(StateUpdateManager):
         change = result.change
 
         # TODO: clean up this particular dict
-        changes_with_rvid: dict[ResourceVersionIdStr, dict[str, object]] = {
-            resource_id_str: {attr_name: attr_change.model_dump()} for attr_name, attr_change in result.changes.items()
-        }
+        # An unchanged resource reports no rvid at all, rather than its rvid with nothing under it.
+        changes_with_rvid: dict[ResourceVersionIdStr, dict[str, object]] = (
+            {resource_id_str: {attr_name: attr_change.model_dump() for attr_name, attr_change in result.changes.items()}}
+            if result.changes
+            else {}
+        )
 
         if status not in VALID_STATES_ON_STATE_UPDATE:
             error_and_log(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1362,7 +1362,10 @@ async def test_send_deploy_done(server, client, environment, null_agent, caplog,
                     action_id=action_id,
                     resource_state=const.HandlerResourceState.deployed,
                     messages=messages,
-                    changes={"attr1": AttributeStateChange(current=None, desired="test")},
+                    changes={
+                        "attr1": AttributeStateChange(current=None, desired="test"),
+                        "attr2": AttributeStateChange(current="old", desired="new"),
+                    },
                     change=const.Change.purged,
                 ),
                 state=state.ResourceState(
@@ -1384,7 +1387,12 @@ async def test_send_deploy_done(server, client, environment, null_agent, caplog,
                 finished=now,
                 status=const.ResourceState.deployed,
                 messages=messages,
-                changes={rvid_r1_v1: {"attr1": AttributeStateChange(current=None, desired="test")}},
+                changes={
+                    rvid_r1_v1: {
+                        "attr1": AttributeStateChange(current=None, desired="test"),
+                        "attr2": AttributeStateChange(current="old", desired="new"),
+                    }
+                },
                 change=const.Change.purged,
                 send_events=True,
             )
@@ -1427,7 +1435,12 @@ async def test_send_deploy_done(server, client, environment, null_agent, caplog,
     ]
     assert resource_action["messages"] == expected_resource_action_messages
     assert resource_action["status"] == const.ResourceState.deployed
-    assert resource_action["changes"] == {rvid_r1_v1: {"attr1": AttributeStateChange(current=None, desired="test").dict()}}
+    assert resource_action["changes"] == {
+        rvid_r1_v1: {
+            "attr1": AttributeStateChange(current=None, desired="test").dict(),
+            "attr2": AttributeStateChange(current="old", desired="new").dict(),
+        }
+    }
     assert resource_action["change"] == const.Change.purged.value
 
     result = await client.resource_details(tid=env_id, rid=rid_r1)


### PR DESCRIPTION
# Description

iso8 backport of #10769 (merged to master as 9982aaff8, to iso9 as c41241a6f). The merge tool could not backport it automatically:

> Failed to merge changes into iso8 due to merge conflict. Please open a pull request for these branches separately by cherry-picking the commit that was made on the branch master.

`ToDbUpdateManager.send_deploy_done` built the resource action's `changes` dict with a comprehension that rebinds the same key on every iteration, so only the last entry of `result.changes` survived and every other change was silently dropped before reaching `resource_action.changes`.

The source fix is byte-identical to the master commit. Only the test needed adapting, which is what the auto-backport conflicted on: on iso8 `test_send_deploy_done` is parametrised over `send_deploy_done` and `resource_action_update`, so both paths now report two changes and assert both are stored. That also pins the fact that `resource_action_update` was never affected - it takes the changes already keyed by rvid.

The changelog entry targets `[iso8]` only, since master and iso9 already carry the fix.

## Why this matters on iso8 specifically

On iso8 the service compliance report is built from the resource action: `future::std::ResourceCompliance` reads `action.changes[rvid]` and stores it as a fact, which the report renders. So on iso8 the truncation is directly visible to operators, where on iso9 the report reads `resource_diff` and was never affected.

Measured on a production support archive, across the whole orchestrator:

```
distinct compliance facts: 5048
   status=deployed        diff_entries=0   count=4818
   status=non_compliant   diff_entries=1   count=184
   status=failed          diff_entries=0   count=45
   status=failed          diff_entries=1   count=1
facts with more than one changed object: 0
```

185 services reporting drift, every one showing exactly one changed object. One of them was promoted to an enforcing state on that basis; the deploy then applied all seven of its differences, two of which were VPLS mesh SDP bindings that closed a bridging loop on a live service.

Existing facts self-heal: the `ResourceCompliance` resource rewrites them on its next deploy.

# Self Check:

- [x] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation~~
- [x] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s)~~

Verified on this branch: `test_send_deploy_done[send_deploy_done]` fails without the fix and passes with it; `test_send_deploy_done[resource_action_update]` passes either way. Full `tests/test_server.py`: 54 passed, 1 failed - `test_resource_action_log[True]`, which fails identically on clean `origin/iso8` and is unrelated. `make pep8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
