### PR TITLE
Get all parent entities in consistent order (#10768)

### DIFF
--- a/changelogs/unreleased/add-method-get-all-parent-entities.yml
+++ b/changelogs/unreleased/add-method-get-all-parent-entities.yml
@@ -1,0 +1,4 @@
+---
+description: "Added a method to get all the parents of a certain entity in a sorted/stable order."
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -106,6 +106,7 @@ class Entity(NamedType, WithComment):
         # Lazy caches to avoid repeated parent-chain walks. Built on first access.
         self._all_attributes_cache: Optional[Mapping[str, "Attribute"]] = None
         self._default_values_cache: Optional[Mapping[str, "ExpressionStatement"]] = None
+        self._all_parent_entities_cache: Optional[Mapping["Entity", None]] = None
 
         self._paired_dataclass: type[DataclassProtocol] | None = None
         self._paired_dataclass_field_types: dict[str, Type] = {}
@@ -237,11 +238,38 @@ class Entity(NamedType, WithComment):
 
         return parents
 
+    def _get_all_parent_entities_sorted(self) -> Mapping["Entity", None]:
+        """
+        Helper method to return the parent entities of this entity as the keys
+        of a dictionary. This method uses a dictionary to remove duplicates and
+        to keep track of order, since iterating over a dictionary respects
+        insertion order. Iterating over the returned dictionary sorts
+        the parent entities in parent-to-child and right-to-left order, so that
+        left overrides right and subclass overrides parent.
+
+        The returned mapping is cached and must not be modified by the caller.
+        """
+        if self._all_parent_entities_cache is None:
+            result: dict["Entity", None] = {}
+            for entity in reversed(self.parent_entities):
+                result.update(entity._get_all_parent_entities_sorted())
+                result[entity] = None
+            self._all_parent_entities_cache = result
+        return self._all_parent_entities_cache
+
     def get_all_parent_entities(self) -> "Set[Entity]":
-        parents = [x for x in self.parent_entities]
-        for entity in self.parent_entities:
-            parents.extend(entity.get_all_parent_entities())
-        return set(parents)
+        return set(self._get_all_parent_entities_sorted())
+
+    def get_all_parent_entities_sorted(self) -> "List[Entity]":
+        """
+        Return all the parent entities of this entity in parent-to-child
+        and right-to-left order. Each parent appears exactly once in the
+        returned list, even when it is reachable via multiple paths in the
+        inheritance hierarchy. Such a parent is positioned at its first
+        occurrence in the walk over the hierarchy. As such, every entity
+        in the returned list is preceded by all of its own parent entities.
+        """
+        return list(self._get_all_parent_entities_sorted())
 
     def get_all_child_entities(self) -> "Set[Entity]":
         children = [x for x in self.child_entities]

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -178,3 +178,79 @@ import st-d
         compiler.do_compile()
 
     assert "st-d is not a valid module name: hyphens are not allowed, please use underscores instead." == e.value.msg
+
+
+def test_get_all_parent_entities_sorted(snippetcompiler) -> None:
+    """
+    Verify that Entity.get_all_parent_entities_sorted() returns each parent entity exactly once,
+    in parent-to-child and right-to-left order.
+    """
+    snippetcompiler.setup_for_snippet("""
+entity Root:
+end
+
+entity Left extends Root:
+end
+
+entity Right extends Root:
+end
+
+entity Standalone:
+end
+
+entity Leaf extends Left, Standalone, Right:
+end
+
+entity SubLeaf extends Leaf:
+end
+
+entity DirectAndIndirectParent extends Left, Root:
+end
+    """)
+    types, _ = compiler.do_compile()
+
+    def get_sorted_parent_names(entity_name: str) -> list[str]:
+        entity = types[f"__config__::{entity_name}"]
+        return [str(parent) for parent in entity.get_all_parent_entities_sorted()]
+
+    # Every entity implicitly extends std::Entity.
+    assert get_sorted_parent_names("Root") == ["std::Entity"]
+    assert get_sorted_parent_names("Standalone") == ["std::Entity"]
+    assert get_sorted_parent_names("Left") == ["std::Entity", "__config__::Root"]
+    assert get_sorted_parent_names("Right") == ["std::Entity", "__config__::Root"]
+    assert get_sorted_parent_names("Leaf") == [
+        "std::Entity",
+        "__config__::Root",
+        "__config__::Right",
+        "__config__::Standalone",
+        "__config__::Left",
+    ]
+    assert get_sorted_parent_names("SubLeaf") == [
+        "std::Entity",
+        "__config__::Root",
+        "__config__::Right",
+        "__config__::Standalone",
+        "__config__::Left",
+        "__config__::Leaf",
+    ]
+    # Root is both a direct parent and a parent of the direct parent Left. It must still be
+    # reported only once and before Left.
+    assert get_sorted_parent_names("DirectAndIndirectParent") == [
+        "std::Entity",
+        "__config__::Root",
+        "__config__::Left",
+    ]
+
+    # The result is cached. Verify that a second invocation returns the same result and that
+    # the caller cannot alter the cache by mutating the returned list.
+    leaf = types["__config__::Leaf"]
+    first_result = leaf.get_all_parent_entities_sorted()
+    first_result.clear()
+    assert get_sorted_parent_names("Leaf") == [
+        "std::Entity",
+        "__config__::Root",
+        "__config__::Right",
+        "__config__::Standalone",
+        "__config__::Left",
+    ]
+    assert leaf.get_all_parent_entities() == set(leaf.get_all_parent_entities_sorted())


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #10768