### PR TITLE
Fix resolution attributes and defaults

### DIFF
--- a/changelogs/unreleased/add-method-get-all-parent-entities.yml
+++ b/changelogs/unreleased/add-method-get-all-parent-entities.yml
@@ -1,4 +1,12 @@
 ---
-description: "Added a method to get all the parents of a certain entity in a sorted/stable order."
+description: >-
+  Added a method to get all the parents of a certain entity in a sorted/stable order and used it to consistently traverse the
+  entity hierarchy when resolving the attributes and the default values of an entity.
 change-type: patch
 destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: >-
+    Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents.
+    The definition made by the most derived entity in the inheritance hierarchy is now always used, also when that entity is
+    reached via a parent other than the left-most one. In the same way, an attribute for which a parent removed the default
+    value (`attr = undef`) no longer regains a default value via another parent.

--- a/changelogs/unreleased/add-method-get-all-parent-entities.yml
+++ b/changelogs/unreleased/add-method-get-all-parent-entities.yml
@@ -1,12 +1,4 @@
 ---
-description: >-
-  Added a method to get all the parents of a certain entity in a sorted/stable order and used it to consistently traverse the
-  entity hierarchy when resolving the attributes and the default values of an entity.
+description: "Added a method to get all the parents of a certain entity in a sorted/stable order."
 change-type: patch
 destination-branches: [master, iso9, iso8]
-sections:
-  bugfix: >-
-    Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents.
-    The definition made by the most derived entity in the inheritance hierarchy is now always used, also when that entity is
-    reached via a parent other than the left-most one. In the same way, an attribute for which a parent removed the default
-    value (`attr = undef`) no longer regains a default value via another parent.

--- a/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
+++ b/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
@@ -1,0 +1,10 @@
+---
+description: "Fix resolution algorithm for attributes and default values."
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: >-
+    Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents.
+    The definition made by the most derived entity in the inheritance hierarchy is now always used, also when that entity is
+    reached via a parent other than the left-most one. In the same way, an attribute for which a parent removed the default
+    value (`attr = undef`) no longer regains a default value via another parent.

--- a/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
+++ b/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
@@ -5,6 +5,5 @@ destination-branches: [master, iso9, iso8]
 sections:
   bugfix: >-
     Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents.
-    The definition made by the most derived entity in the inheritance hierarchy is now always used, also when that entity is
-    reached via a parent other than the left-most one. In the same way, an attribute for which a parent removed the default
-    value (`attr = undef`) no longer regains a default value via another parent.
+    The definition made by the most derived entity in the inheritance hierarchy is now always used. Between unrelated parents,
+    the attribute of the left-most parent is used.

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -280,13 +280,14 @@ class Entity(NamedType, WithComment):
     def get_all_attributes(self) -> Mapping[str, "Attribute"]:
         """
         Return a cached mapping of attribute name to Attribute for this entity and all parents.
-        The cache is built lazily on first access.
+        In case of shadowing, the attribute of the most derived entity is used and, between
+        unrelated parents, the attribute of the left-most parent is used. The cache is built
+        lazily on first access.
         """
         if self._all_attributes_cache is None:
             cache: dict[str, "Attribute"] = {}
-            # make sure to include left-most parent's attribute in case of shadowing to be consistent with get_default_values()
-            for parent in reversed(self.parent_entities):
-                cache.update(parent.get_all_attributes())
+            for parent in self.get_all_parent_entities_sorted():
+                cache.update(parent.get_attributes())
             cache.update(self._attributes)
             self._all_attributes_cache = cache
         return self._all_attributes_cache
@@ -565,16 +566,17 @@ class Entity(NamedType, WithComment):
 
     def get_default_values(self) -> Mapping[str, "ExpressionStatement"]:
         """
-        Return the dictionary with default values. Uses a lazy cache to avoid
-        repeated parent-chain walks.
+        Return the dictionary with default values. In case a default value is defined more than
+        once, the one of the most derived entity is used and, between unrelated parents, the one
+        of the left-most parent is used. Uses a lazy cache to avoid repeated parent-chain walks.
         """
         if self._default_values_cache is None:
-            values: list[tuple[str, Optional["ExpressionStatement"]]] = []
-            for parent in reversed(self.parent_entities):
-                values.extend(parent.get_default_values().items())
-            values.extend(self._get_own_defaults().items())
-            dvalues = dict(values)
-            self._default_values_cache = {k: v for k, v in dvalues.items() if v is not None}
+            values: dict[str, Optional["ExpressionStatement"]] = {}
+            for parent in self.get_all_parent_entities_sorted():
+                values.update(parent._get_own_defaults())
+            values.update(self._get_own_defaults())
+            # A None value indicates that the default value was explicitly removed.
+            self._default_values_cache = {k: v for k, v in values.items() if v is not None}
         return self._default_values_cache
 
     def get_default(self, name: str) -> "ExpressionStatement":

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -254,3 +254,56 @@ end
         "__config__::Left",
     ]
     assert leaf.get_all_parent_entities() == set(leaf.get_all_parent_entities_sorted())
+
+
+def test_attribute_shadowing_in_diamond_hierarchy(snippetcompiler) -> None:
+    """
+    Verify that, when an attribute is defined more than once in the inheritance hierarchy,
+    Entity.get_all_attributes() reports the attribute of the most derived entity that defines it
+    and Entity.get_default_values() reports the default value set by that entity. This also holds
+    when the most derived definition is reached via the right-most parent and the definition it
+    shadows via the left-most parent. A default value removed by such a definition is absent from
+    Entity.get_default_values().
+    """
+    snippetcompiler.setup_for_snippet("""
+entity Base:
+    int shadowed = 1
+    int removed = 1
+end
+
+entity Redefines extends Base:
+    int shadowed = 3
+    int removed = undef
+end
+
+entity Inherits extends Base:
+end
+
+entity Leaf extends Inherits, Redefines:
+end
+    """)
+    types, _ = compiler.do_compile()
+
+    def get_defining_entity(entity_name: str, attribute_name: str) -> str:
+        entity = types[f"__config__::{entity_name}"]
+        return entity.get_all_attributes()[attribute_name].entity.get_full_name()
+
+    def get_default(entity_name: str, attribute_name: str) -> object:
+        entity = types[f"__config__::{entity_name}"]
+        default = entity.get_default_values().get(attribute_name)
+        return None if default is None else default.as_constant()
+
+    assert get_defining_entity("Base", "shadowed") == "__config__::Base"
+    assert get_defining_entity("Redefines", "shadowed") == "__config__::Redefines"
+    assert get_defining_entity("Inherits", "shadowed") == "__config__::Base"
+    assert get_defining_entity("Leaf", "shadowed") == "__config__::Redefines"
+
+    assert get_default("Base", "shadowed") == 1
+    assert get_default("Redefines", "shadowed") == 3
+    assert get_default("Inherits", "shadowed") == 1
+    assert get_default("Leaf", "shadowed") == 3
+
+    assert get_default("Base", "removed") == 1
+    assert get_default("Redefines", "removed") is None
+    assert get_default("Inherits", "removed") == 1
+    assert get_default("Leaf", "removed") is None


### PR DESCRIPTION
# Description

Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents. The definition made by the most derived entity in the inheritance hierarchy is now always used. Between unrelated parents, the attribute of the left-most parent is used.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x]  Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
