### PR TITLE
Clean up module code when a model version is deleted

### DIFF
--- a/changelogs/unreleased/10778-cleanup-module-code-on-version-delete.yml
+++ b/changelogs/unreleased/10778-cleanup-module-code-on-version-delete.yml
@@ -1,0 +1,8 @@
+description: >
+  Fixed a leak in the cleanup of the code of the inmanta modules. Deleting a model version, either explicitly or through
+  the automatic cleanup of old versions, left the code of the modules it used behind in the database. That code is now
+  deleted along with the last model version that uses it. Rows that leaked before this fix are cleaned up as well, the
+  next time a model version of their environment is deleted.
+issue-nr: 10778
+change-type: patch
+destination-branches: [master, iso9]

--- a/changelogs/unreleased/10778-cleanup-module-code-on-version-delete.yml
+++ b/changelogs/unreleased/10778-cleanup-module-code-on-version-delete.yml
@@ -1,14 +1,12 @@
 description: >
-  Fixed a leak in the cleanup of the code of the inmanta modules. Deleting a model version, either explicitly or through
-  the automatic cleanup of old versions, left the code of the modules it used behind in the database. That code is now
-  deleted along with the last model version that uses it. Rows that leaked before this fix are cleaned up as well, the
-  next time a model version of their environment is deleted.
+  Fixed a leak in the cleanup of the inmanta modules of a model version. Deleting a model version, either explicitly or
+  through the automatic cleanup of old versions, kept the record of the modules it used indefinitely, so those records
+  accumulated over time. They are now discarded along with the last model version that uses them, and the ones left
+  behind before this fix are cleaned up as well, the next time a model version of their environment is deleted.
 issue-nr: 10778
 change-type: patch
 destination-branches: [master, iso9]
 sections:
   bugfix: >
-    Deleting a model version, or letting the orchestrator clean up old versions, now also removes the python
-    code of the inmanta modules that no remaining version uses. That code used to be kept indefinitely, so the
-    database grew with every module version ever exported. Code left behind by earlier releases is reclaimed
-    automatically, the next time a model version of that environment is deleted.
+    Fixed a bug in the cleanup of a deleted model version, where the information the orchestrator kept about the
+    inmanta modules it used was left behind.

--- a/changelogs/unreleased/10778-cleanup-module-code-on-version-delete.yml
+++ b/changelogs/unreleased/10778-cleanup-module-code-on-version-delete.yml
@@ -6,3 +6,9 @@ description: >
 issue-nr: 10778
 change-type: patch
 destination-branches: [master, iso9]
+sections:
+  bugfix: >
+    Deleting a model version, or letting the orchestrator clean up old versions, now also removes the python
+    code of the inmanta modules that no remaining version uses. That code used to be kept indefinitely, so the
+    database grew with every module version ever exported. Code left behind by earlier releases is reclaimed
+    automatically, the next time a model version of that environment is deleted.

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -2939,9 +2939,12 @@ class Environment(BaseDocument):
             await Parameter.delete_all(environment=self.id, connection=con)
             await Notification.delete_all(environment=self.id, connection=con)
 
+            # The registrations of a module first, then its files and only then the module itself: agent_modules
+            # references a module with ON DELETE RESTRICT, and its files are deleted here rather than through the
+            # cascade on the module.
             await AgentModules.delete_all(environment=self.id, connection=con)
-            await InmantaModule.delete_all(environment=self.id, connection=con)
             await ModuleFiles.delete_all(environment=self.id, connection=con)
+            await InmantaModule.delete_all(environment=self.id, connection=con)
 
             await DiscoveredResource.delete_all(environment=self.id, connection=con)
             await EnvironmentMetricsGauge.delete_all(environment=self.id, connection=con)
@@ -6762,9 +6765,12 @@ class ConfigurationModel(BaseDocument):
             await Compile.delete_all(environment=self.environment, version=self.version, connection=con)
             await DryRun.delete_all(environment=self.environment, model=self.version, connection=con)
 
+            # Drop the module registrations of this version, then the code of the modules that this leaves unused. A
+            # module version is shared by every model version that uses it, so it outlives this one unless it was the
+            # last to use it.
             await AgentModules.delete_version(environment=self.environment, model_version=self.version, connection=con)
-            await InmantaModule.delete_version(environment=self.environment, model_version=self.version, connection=con)
-            await ModuleFiles.delete_version(environment=self.environment, model_version=self.version, connection=con)
+            await ModuleFiles.delete_unused(environment=self.environment, connection=con)
+            await InmantaModule.delete_unused(environment=self.environment, connection=con)
 
             await UnknownParameter.delete_all(environment=self.environment, version=self.version, connection=con)
             await self._execute_query(

--- a/src/inmanta/data/sqlalchemy.py
+++ b/src/inmanta/data/sqlalchemy.py
@@ -118,6 +118,23 @@ class SetValidatedMixin:
             )
 
 
+# Subquery selecting the inmanta modules of one environment ($1) that no model version uses any more. A module version
+# is shared by every model version that uses it, so it can only be deleted along with the last one. agent_modules is the
+# only table that references inmanta_module with ON DELETE RESTRICT, which makes deleting what this returns safe.
+_UNUSED_INMANTA_MODULES = """
+    SELECT unused_module.environment, unused_module.name, unused_module.version
+    FROM public.inmanta_module AS unused_module
+    WHERE unused_module.environment=$1
+    AND NOT EXISTS (
+        SELECT 1
+        FROM public.agent_modules AS agent_module
+        WHERE agent_module.environment=unused_module.environment
+        AND agent_module.inmanta_module_name=unused_module.name
+        AND agent_module.inmanta_module_version=unused_module.version
+    )
+"""
+
+
 class InmantaModule(Base):
     __tablename__ = "inmanta_module"
 
@@ -225,21 +242,18 @@ class InmantaModule(Base):
             )
 
     @classmethod
-    async def delete_version(
-        cls, environment: uuid.UUID, model_version: int, connection: asyncpg.connection.Connection
-    ) -> None:
+    async def delete_unused(cls, environment: uuid.UUID, connection: asyncpg.connection.Connection) -> None:
+        """
+        Delete the inmanta modules of the given environment that no model version uses any more. Expected to be called
+        once the registrations of a deleted model version are gone, as the last step of its cleanup: the files of these
+        modules have to be deleted first (see ModuleFiles.delete_unused).
+        """
         await connection.execute(
             f"""
-            DELETE FROM {InmantaModule.__tablename__}
-            WHERE (environment, name, version) IN (
-                SELECT environment, inmanta_module_name, inmanta_module_version
-                FROM public.agent_modules
-                WHERE environment=$1
-                AND cm_version=$2
-            )
+            DELETE FROM {cls.__tablename__}
+            WHERE (environment, name, version) IN ({_UNUSED_INMANTA_MODULES})
             """,
             environment,
-            model_version,
         )
 
 
@@ -275,21 +289,18 @@ class ModuleFiles(Base):
     file: Mapped["File"] = relationship("File", back_populates="module_files")
 
     @classmethod
-    async def delete_version(
-        cls, environment: uuid.UUID, model_version: int, connection: asyncpg.connection.Connection
-    ) -> None:
+    async def delete_unused(cls, environment: uuid.UUID, connection: asyncpg.connection.Connection) -> None:
+        """
+        Delete the files of the inmanta modules of the given environment that no model version uses any more. Expected
+        to be called before those modules themselves are deleted (see InmantaModule.delete_unused): a module still has
+        to be there to be found unused.
+        """
         await connection.execute(
             f"""
-            DELETE FROM {ModuleFiles.__tablename__}
-            WHERE (environment, inmanta_module_name, inmanta_module_version) IN (
-                SELECT environment, inmanta_module_name, inmanta_module_version
-                FROM {AgentModules.__tablename__}
-                WHERE environment=$1
-                AND cm_version=$2
-            )
+            DELETE FROM {cls.__tablename__}
+            WHERE (environment, inmanta_module_name, inmanta_module_version) IN ({_UNUSED_INMANTA_MODULES})
             """,
             environment,
-            model_version,
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,13 +17,14 @@ Contact: code@inmanta.com
 """
 
 import asyncio
+import base64
 import functools
 import json
 import logging
 import os
 import sys
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping, Sequence
 from datetime import UTC, datetime, timedelta, timezone
 from functools import partial
 
@@ -36,6 +37,8 @@ from inmanta.agent import executor
 from inmanta.const import ParameterSource
 from inmanta.data import AUTO_DEPLOY, ResourcePersistentState
 from inmanta.data.model import AttributeStateChange
+from inmanta.data.model import InmantaModule as InmantaModuleDTO
+from inmanta.data.model import ModuleSourceMetadata
 from inmanta.deploy import persistence, state
 from inmanta.protocol import Client
 from inmanta.resources import Id
@@ -45,6 +48,7 @@ from inmanta.server.bootloader import InmantaBootloader
 from inmanta.server.protocol import ServerStartFailure
 from inmanta.server.services.databaseservice import PostgreSQLVersion
 from inmanta.types import ResourceIdStr, ResourceVersionIdStr
+from sqlalchemy import func, select
 from utils import insert_with_link_to_configuration_model, log_contains, log_doesnt_contain, retry_limited
 
 LOGGER = logging.getLogger(__name__)
@@ -386,19 +390,71 @@ async def test_get_resource_on_invalid_resource_id(server, client, environment) 
     assert f"{invalid_resource_version_id} is not a valid resource version id" in result.result["message"]
 
 
+async def register_inmanta_module(
+    client: Client, name: str, version: str, python_files: Mapping[str, str], for_agents: Sequence[str]
+) -> InmantaModuleDTO:
+    """
+    Upload the python files of one inmanta module version and return its export representation, to be passed to
+    put_version as part of its module_version_info.
+
+    :param python_files: The content of each of the module's python files, by fully qualified python module name.
+    :param for_agents: The agents that need this module. Each of them has to have a resource in the model versions this
+        module is registered for: an agent only exists in the database once a resource is assigned to it.
+    """
+    files_in_module = []
+    for python_module_name, content in python_files.items():
+        hash_value = util.hash_file(content.encode())
+        result = await client.upload_file(id=hash_value, content=base64.b64encode(content.encode()).decode("ascii"))
+        assert result.code == 200
+        files_in_module.append(ModuleSourceMetadata(name=python_module_name, hash_value=hash_value, is_byte_code=False))
+    return InmantaModuleDTO(
+        name=name, version=version, files_in_module=files_in_module, requirements=[], for_agents=list(for_agents)
+    )
+
+
+async def get_module_code_row_counts(environment: str) -> dict[str, int]:
+    """
+    The number of rows that each of the tables holding the code of the inmanta modules has for the given environment.
+    """
+    async with data.get_session() as session:
+        return {
+            table.__tablename__: (
+                await session.execute(
+                    select(func.count()).select_from(table).where(table.environment == uuid.UUID(environment))
+                )
+            ).scalar_one()
+            for table in (data.AgentModules, data.InmantaModule, data.ModuleFiles)
+        }
+
+
 @pytest.mark.parametrize("no_agent", [True])
 async def test_clear_environment(client, server, clienthelper, environment):
     """
     Test clearing out an environment
     """
+    module = await register_inmanta_module(
+        client,
+        name="test",
+        version="abc",
+        python_files={"inmanta_plugins.test.dummy_file": "file content"},
+        for_agents=["agent1"],
+    )
     version = await clienthelper.get_version()
     result = await client.put_version(
         tid=environment,
         version=version,
-        resources=[],
+        # A resource for the agent the module is registered for: an agent only exists once a resource is assigned to it.
+        resources=[
+            {
+                "id": f"test::Test[agent1,name=test],v={version}",
+                "purged": False,
+                "requires": [],
+                "name": "test",
+            }
+        ],
         unknowns=[],
         version_info={},
-        module_version_info={},
+        module_version_info={module.name: module},
     )
     assert result.code == 200
 
@@ -407,6 +463,12 @@ async def test_clear_environment(client, server, clienthelper, environment):
     versions = await client.list_versions(tid=environment)
     assert versions.code == 200
     assert versions.result["count"] == 1
+
+    assert await get_module_code_row_counts(environment) == {
+        "agent_modules": 1,
+        "inmanta_module": 1,
+        "module_files": 1,
+    }
 
     # trigger multiple compiles and wait for them to complete in order to test cascade deletion of collapsed compiles (#2350)
     result = await client.notify_change_get(id=environment)
@@ -439,6 +501,101 @@ async def test_clear_environment(client, server, clienthelper, environment):
     versions = await client.list_versions(tid=environment)
     assert versions.code == 200
     assert versions.result["count"] == 0
+
+    assert await get_module_code_row_counts(environment) == {
+        "agent_modules": 0,
+        "inmanta_module": 0,
+        "module_files": 0,
+    }
+
+
+@pytest.mark.parametrize("no_agent", [True])
+async def test_delete_version_cleans_up_module_code(client, server, clienthelper, environment) -> None:
+    """
+    Deleting a model version cleans up the code of the inmanta modules it used, except for the modules that are still
+    used by another model version. A module version is shared by every model version that uses it, so it can only be
+    deleted along with the last one.
+    """
+    # Keep every version unreleased: delete_version refuses to delete the active version.
+    result = await client.set_setting(tid=environment, id=AUTO_DEPLOY, value="false")
+    assert result.code == 200
+
+    shared_module = await register_inmanta_module(
+        client,
+        name="shared",
+        version="abc",
+        python_files={"inmanta_plugins.shared.dummy_file": "shared file content"},
+        for_agents=["agent1"],
+    )
+    dropped_module = await register_inmanta_module(
+        client,
+        name="dropped",
+        version="def",
+        python_files={"inmanta_plugins.dropped.dummy_file": "dropped file content"},
+        for_agents=["agent1"],
+    )
+
+    async def put_version(modules: Sequence[InmantaModuleDTO]) -> int:
+        version = await clienthelper.get_version()
+        result = await client.put_version(
+            tid=environment,
+            version=version,
+            resources=[
+                {
+                    "id": f"test::Test[agent1,name=test],v={version}",
+                    "purged": False,
+                    "requires": [],
+                    "name": "test",
+                }
+            ],
+            unknowns=[],
+            version_info={},
+            module_version_info={module.name: module for module in modules},
+            pip_config=data.PipConfig(),
+        )
+        assert result.code == 200, result.result
+        return version
+
+    version_1 = await put_version([shared_module])
+    version_2 = await put_version([shared_module, dropped_module])
+
+    # A module registered for no model version at all: the shape of the rows that leaked before this cleanup existed.
+    leaked_module = await register_inmanta_module(
+        client,
+        name="leaked",
+        version="ghi",
+        python_files={"inmanta_plugins.leaked.dummy_file": "leaked file content"},
+        for_agents=[],
+    )
+    async with data.Environment.get_connection() as connection:
+        await data.InmantaModule.register_modules(
+            environment=uuid.UUID(environment), modules={leaked_module.name: leaked_module}, connection=connection
+        )
+
+    assert await get_module_code_row_counts(environment) == {
+        "agent_modules": 3,
+        "inmanta_module": 3,
+        "module_files": 3,
+    }
+
+    # Version 1 still uses the shared module, so only the code of the dropped module is cleaned up. The cleanup is
+    # environment wide, so it reclaims the already unused module as well.
+    result = await client.delete_version(tid=environment, id=version_2)
+    assert result.code == 200
+    assert await get_module_code_row_counts(environment) == {
+        "agent_modules": 1,
+        "inmanta_module": 1,
+        "module_files": 1,
+    }
+
+    # The last version using the shared module: its code goes as well.
+    result = await client.delete_version(tid=environment, id=version_1)
+    assert result.code == 200
+    assert await get_module_code_row_counts(environment) == {
+        "agent_modules": 0,
+        "inmanta_module": 0,
+        "module_files": 0,
+    }
 
 
 async def test_tokens(server_multi, client_multi, environment_multi, request):


### PR DESCRIPTION
*Opened by Claude on behalf of @Hugo-Inmanta.*

Fixes #10778.

## Problem

Deleting a model version left the code of the inmanta modules it used behind in the database, permanently. This hit both the explicit `delete_version` endpoint and the automatic cleanup of old versions (`OrchestrationService._purge_versions`, which calls the same `ConfigurationModel.delete_cascade`), so it accumulated on its own on any running orchestrator.

`InmantaModule.delete_version` and `ModuleFiles.delete_version` both picked their targets with a subquery over `agent_modules` **for the version being deleted** — rows that `AgentModules.delete_version` had already deleted one line earlier in `delete_cascade`. The subquery returned nothing, so both statements were unconditional no-ops.

Impact is row growth in `inmanta_module` and `module_files`, proportional to the number of distinct module versions ever exported, unbounded in time. No functional breakage: re-registering the same module version is an `ON CONFLICT DO NOTHING` insert, so stale rows were simply reused.

## Fix

Reordering the existing calls does not work: a module version is shared by every model version that uses it (a module rarely changes between compiles), so it can only be deleted once the last of them is gone — and the `ON DELETE RESTRICT` foreign key from the *other* versions' `agent_modules` rows blocks the delete otherwise.

Instead, both methods become an unused-module sweep over one shared subquery (`_UNUSED_INMANTA_MODULES`): the modules of the environment that no `agent_modules` row references any more. `agent_modules` is the only table that references `inmanta_module` with `ON DELETE RESTRICT` (`module_files` references it with `CASCADE`), so deleting what the subquery returns is safe. `delete_cascade` drops the registrations of the deleted version first, then the files and then the modules that this leaves unused — the files explicitly rather than through the cascade, matching the "this method doesn't rely on DELETE CASCADE" convention of that method.

Because the sweep is environment wide, it also reclaims the rows that leaked before this fix, the next time any version of that environment is deleted. **No schema change and no data migration.** The anti-join is served by the existing `agent_modules_environment_module_name_module_version_index`.

`Environment.clear` was never affected — it deletes `agent_modules` before `inmanta_module`, so the environment-wide path did free everything. Its `ModuleFiles.delete_all` call ran *after* `InmantaModule.delete_all` though, so the cascade had already removed its rows and the call was dead; it now runs before, in the same order as `delete_cascade`.

## Test

`tests/test_server.py::test_delete_version_cleans_up_module_code`, next to `test_clear_environment`: two versions sharing one module version, a second module used only by version 2, and a third registered for no version at all (the shape of a pre-fix leaked row). Deleting version 2 must leave the shared module and reclaim the other two; deleting version 1 must leave nothing. It asserts row counts in `agent_modules`, `inmanta_module` and `module_files` and fails on all three steps before the fix. `test_clear_environment` now registers a module too, so it locks the environment-wide path.

Verified locally: `tests/test_server.py`, `tests/test_data.py`, `tests/test_data_concurrency.py`, `tests/deploy/e2e/test_code_loading.py` and `tests/deploy/e2e/test_facts.py` all pass; `black`/`isort`/`flake8` clean and `make mypy` exits 0.

## Notes for the reviewer

- `destination-branches: [master, iso9]`. The issue suggested leaving master out because a fix for it exists on the `issue/improve-agent-code-install-stage2-install-refinements` branch, but master's module tables and their `delete_version` code are byte-identical to iso9's today, so master is affected and unfixed until that branch lands. Once this is merged, the equivalent commit on that branch should be dropped, and its `configurationmodel_modules` table added as a second `NOT EXISTS` clause in `_UNUSED_INMANTA_MODULES` instead (that table is a second `ON DELETE RESTRICT` referrer of `inmanta_module`, so the sweep has to check it too). Its `cleanup-module-code-on-version-delete.yml` changelog entry should go as well, in favour of this one.
- iso8 predates the code-transport rework (`d59916f2c`, first released in core v16.0.0) and cleaned its `Code` table up correctly, so it is not affected.
- The two sweep statements run in separate transactions, so an export that re-registers the very module version being reclaimed, concurrently with a version delete on the same environment, can make the `inmanta_module` delete hit the `agent_modules` foreign key. That surfaces as an error on `delete_version` (or a logged error in `_purge_versions`, self-healing on the next run), not as data loss, and the pre-existing code had the same exposure — flagging it rather than growing the scope of a patch fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)