### PR TITLE
Add a ResourceSetListener extension point on the resource write path

### DIFF
--- a/changelogs/unreleased/10780-resource-set-listener.yml
+++ b/changelogs/unreleased/10780-resource-set-listener.yml
@@ -1,0 +1,7 @@
+description: >
+  Added the `ResourceSetListener` extension point. A listener registered on the orchestration service is notified, in
+  the transaction that writes them, of the resource sets a model version was written with. Unlike the compile and
+  environment listeners it takes part in that transaction, so an extension can maintain data derived from the
+  resources without it ever being committed out of step with them.
+change-type: minor
+destination-branches: [master]

--- a/src/inmanta/data/__init__.py
+++ b/src/inmanta/data/__init__.py
@@ -5105,7 +5105,7 @@ class ResourceSet(BaseDocument):
         deleted_resource_sets: Optional[abc.Set[str]] = None,
         *,
         connection: asyncpg.connection.Connection,
-    ) -> None:
+    ) -> abc.Set[uuid.UUID]:
         """
         Inserts resources and resource sets and links resource sets to the target version.
 
@@ -5127,6 +5127,8 @@ class ResourceSet(BaseDocument):
         :param deleted_resource_sets: These are the resource set names from the base version which were removed
             in this partial compile. Not applicable for a full compile.
         :param connection: The connection to use. Must be in a transaction context.
+        :return: The ids the updated resource sets were inserted under. Resource sets that were linked to the target
+            version unchanged are not included.
         """
 
         is_partial_update = base_version is not None
@@ -5192,7 +5194,7 @@ class ResourceSet(BaseDocument):
         # insert the updated resource sets and resources into the database and link everything together
         # (resource -> set and set -> model)
         with pyformance.timer("sql.insert_sets_and_resources.insert").time():
-            await cls._execute_query(
+            inserted_resource_sets = await cls._fetch_query(
                 """\
                 -- insert resource sets and keep track of name-id mapping
                 WITH inserted_resource_sets AS (
@@ -5224,36 +5226,42 @@ class ResourceSet(BaseDocument):
                         UNNEST($9::text[]) AS attribute_hash,
                         UNNEST($10::boolean[]) AS is_undefined,
                         UNNEST($11::text[]) AS resource_set
+                ), inserted_resources AS (
+                    -- insert resources
+                    INSERT INTO public.resource(
+                        environment,
+                        resource_id,
+                        resource_type,
+                        resource_id_value,
+                        agent,
+                        attributes,
+                        attribute_hash,
+                        is_undefined,
+                        resource_set
+                    )
+                    SELECT
+                        $1,
+                        r.resource_id,
+                        r.resource_type,
+                        r.resource_id_value,
+                        r.agent,
+                        r.attributes,
+                        r.attribute_hash,
+                        r.is_undefined,
+                        rs.id
+                    FROM resource_data AS r
+                    -- this join has been tested to be up to four times faster than joining with
+                    -- resource_configuration_model, even if the latter would have the name column directly
+                    -- (for 5k models, 5k sets, updating 1-1000 sets, with 100-10k resources per set).
+                    -- Order of magnitude for reference: 0.5s when updating 10 sets with 1k resources per set.
+                    INNER JOIN inserted_resource_sets AS rs
+                        ON r.resource_set IS NOT DISTINCT FROM rs.name
                 )
-                -- insert resources
-                INSERT INTO public.resource(
-                    environment,
-                    resource_id,
-                    resource_type,
-                    resource_id_value,
-                    agent,
-                    attributes,
-                    attribute_hash,
-                    is_undefined,
-                    resource_set
-                )
-                SELECT
-                    $1,
-                    r.resource_id,
-                    r.resource_type,
-                    r.resource_id_value,
-                    r.agent,
-                    r.attributes,
-                    r.attribute_hash,
-                    r.is_undefined,
-                    rs.id
-                FROM resource_data AS r
-                -- this join has been tested to be up to four times faster than joining with
-                -- resource_configuration_model, even if the latter would have the name column directly
-                -- (for 5k models, 5k sets, updating 1-1000 sets, with 100-10k resources per set).
-                -- Order of magnitude for reference: 0.5s when updating 10 sets with 1k resources per set.
-                INNER JOIN inserted_resource_sets AS rs
-                    ON r.resource_set IS NOT DISTINCT FROM rs.name
+                -- The ids the sets were inserted under. gen_random_uuid() produces them inside this statement, so
+                -- returning them here is what spares the caller a second query to find them. A data-modifying CTE
+                -- runs to completion whether or not the primary query reads it, so wrapping the resource insert in
+                -- one does not make it conditional.
+                SELECT irs.id FROM inserted_resource_sets AS irs
                 """,
                 *common_values,
                 cls._get_value(updated_resource_sets),
@@ -5277,6 +5285,8 @@ class ResourceSet(BaseDocument):
                     updated_resource_sets=updated_resource_sets,
                     connection=connection,
                 )
+
+        return {cast(uuid.UUID, record["id"]) for record in inserted_resource_sets}
 
     @classmethod
     async def clear_resource_sets_in_version(

--- a/src/inmanta/server/services/orchestrationservice.py
+++ b/src/inmanta/server/services/orchestrationservice.py
@@ -56,6 +56,7 @@ from inmanta.server import (
 from inmanta.server import config as opt
 from inmanta.server import diff, protocol
 from inmanta.server.services import resourceservice
+from inmanta.server.services.resourcesetlistener import ResourceSetListener
 from inmanta.server.validate_filter import InvalidFilter
 from inmanta.types import Apireturn, JsonType, PrimitiveTypes, ResourceIdStr, ResourceVersionIdStr, ReturnTupple
 
@@ -381,6 +382,14 @@ class OrchestrationService(protocol.ServerSlice):
 
     def __init__(self) -> None:
         super().__init__(SLICE_ORCHESTRATION)
+        self.resource_set_listeners: list[ResourceSetListener] = []
+
+    def add_resource_set_listener(self, listener: ResourceSetListener) -> None:
+        """
+        Register a listener to be notified, in the transaction that writes them, of the resource sets a model version
+        was written with. Listeners are registered while the server starts, before the API becomes available.
+        """
+        self.resource_set_listeners.append(listener)
 
     def get_dependencies(self) -> list[str]:
         return [SLICE_RESOURCE, SLICE_AGENT_MANAGER, SLICE_DATABASE]
@@ -892,7 +901,7 @@ class OrchestrationService(protocol.ServerSlice):
 
             all_ids: set[Id] = {Id.parse_id(rid, version) for rid in rid_to_resource.keys()}
             try:
-                await data.ResourceSet.insert_sets_and_resources(
+                written_resource_sets = await data.ResourceSet.insert_sets_and_resources(
                     environment=env.id,
                     updated_resources=list(rid_to_resource.values()),
                     target_version=version,
@@ -902,6 +911,10 @@ class OrchestrationService(protocol.ServerSlice):
                 )
             except data.InvalidResourceSetMigration as e:
                 raise BadRequest(e.message)
+            # Deliberately not guarded against failure: a listener maintains data derived from these resources, so it
+            # has to be committed with them or not at all.
+            for listener in self.resource_set_listeners:
+                await listener.resource_sets_written(env.id, version, written_resource_sets, connection=connection)
             await cm.recalculate_total(connection=connection)
             await data.UnknownParameter.insert_many(unknowns, connection=connection)
 

--- a/src/inmanta/server/services/resourcesetlistener.py
+++ b/src/inmanta/server/services/resourcesetlistener.py
@@ -1,0 +1,54 @@
+"""
+Copyright 2026 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+import abc
+import uuid
+from collections import abc as collections_abc
+
+import asyncpg
+
+
+class ResourceSetListener(abc.ABC):
+    """
+    Base class for listeners on the resources of a model version being written.
+
+    Unlike the compile and environment listeners, this one takes part in the transaction that writes the resources: it
+    is handed that transaction's connection, and an exception it raises aborts the export. A listener that cannot
+    offer that guarantee does not belong here, because whatever it maintains would then be committed out of step with
+    the resources it is derived from.
+    """
+
+    @abc.abstractmethod
+    async def resource_sets_written(
+        self,
+        environment: uuid.UUID,
+        model_version: int,
+        resource_sets: collections_abc.Set[uuid.UUID],
+        *,
+        connection: asyncpg.connection.Connection,
+    ) -> None:
+        """
+        Called when the resources of a model version have been written, before the transaction commits.
+
+        :param environment: The environment the resources were written for.
+        :param model_version: The model version the resource sets were linked to.
+        :param resource_sets: The ids of the resource sets that were newly inserted for this version. A resource set
+            that was carried over from the base version unchanged is not included: its resources did not change.
+        :param connection: The connection of the transaction that wrote the resources. The listener must use it, and
+            must not commit or roll it back.
+        """

--- a/tests/server/test_resource_set_listener.py
+++ b/tests/server/test_resource_set_listener.py
@@ -1,0 +1,177 @@
+"""
+Copyright 2026 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: code@inmanta.com
+"""
+
+import contextlib
+import uuid
+from collections import abc
+
+import asyncpg
+
+from inmanta.server import SLICE_ORCHESTRATION
+from inmanta.server.services.orchestrationservice import OrchestrationService
+from inmanta.server.services.resourcesetlistener import ResourceSetListener
+
+
+class RecordingListener(ResourceSetListener):
+    """
+    Records every notification, and asserts on the way in that it is handed a usable connection.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[uuid.UUID, int, abc.Set[uuid.UUID]]] = []
+
+    async def resource_sets_written(
+        self,
+        environment: uuid.UUID,
+        model_version: int,
+        resource_sets: abc.Set[uuid.UUID],
+        *,
+        connection: asyncpg.connection.Connection,
+    ) -> None:
+        assert connection.is_in_transaction()
+        self.calls.append((environment, model_version, set(resource_sets)))
+
+
+class FailingListener(ResourceSetListener):
+    async def resource_sets_written(
+        self,
+        environment: uuid.UUID,
+        model_version: int,
+        resource_sets: abc.Set[uuid.UUID],
+        *,
+        connection: asyncpg.connection.Connection,
+    ) -> None:
+        raise Exception("this listener cannot do its work")
+
+
+@contextlib.contextmanager
+def registered(orchestration_service: OrchestrationService, listener: ResourceSetListener) -> abc.Iterator[None]:
+    """
+    Register a listener for the duration of the test. Production code registers during server startup and never
+    unregisters, so there is no API for this.
+    """
+    orchestration_service.resource_set_listeners.append(listener)
+    try:
+        yield
+    finally:
+        orchestration_service.resource_set_listeners.remove(listener)
+
+
+def resource(key: str, version: int) -> dict[str, object]:
+    return {
+        "id": f"test::Resource[agent1,key={key}],v={version}",
+        "att": "val",
+        "send_event": False,
+        "purged": False,
+        "requires": [],
+    }
+
+
+async def sets_in_version(postgresql_client: asyncpg.Connection, environment: str, version: int) -> dict[str | None, uuid.UUID]:
+    records = await postgresql_client.fetch(
+        """
+        SELECT rs.name, rs.id
+        FROM public.resource_set_configuration_model AS rscm
+        INNER JOIN public.resource_set AS rs
+            ON rs.environment = rscm.environment AND rs.id = rscm.resource_set
+        WHERE rscm.environment = $1 AND rscm.model = $2
+        """,
+        uuid.UUID(environment),
+        version,
+    )
+    return {record["name"]: record["id"] for record in records}
+
+
+async def test_listener_is_told_which_resource_sets_were_written(
+    server, client, environment, clienthelper, postgresql_client: asyncpg.Connection
+) -> None:
+    """
+    A listener is notified of the ids the resource sets were inserted under, and on a partial export only of the sets
+    that were actually written: a set that is linked to the new version unchanged keeps its id and its resources.
+    """
+    orchestration_service: OrchestrationService = server.get_slice(SLICE_ORCHESTRATION)
+    listener = RecordingListener()
+
+    with registered(orchestration_service, listener):
+        version = await clienthelper.get_version()
+        result = await client.put_version(
+            tid=environment,
+            version=version,
+            resources=[resource("in_a", version), resource("in_b", version)],
+            resource_sets={
+                "test::Resource[agent1,key=in_a]": "set_a",
+                "test::Resource[agent1,key=in_b]": "set_b",
+            },
+            unknowns=[],
+            version_info={},
+            module_version_info={},
+        )
+        assert result.code == 200
+
+        full_sets = await sets_in_version(postgresql_client, environment, version)
+        assert listener.calls == [(uuid.UUID(environment), version, set(full_sets.values()))]
+
+        result = await client.put_partial(
+            tid=environment,
+            resources=[resource("in_a", 0)],
+            resource_sets={"test::Resource[agent1,key=in_a]": "set_a"},
+            unknowns=[],
+            version_info={},
+            module_version_info={},
+        )
+        assert result.code == 200
+        partial_version = result.result["data"]
+
+        partial_sets = await sets_in_version(postgresql_client, environment, partial_version)
+        # set_b was linked to the new version unchanged, so it keeps its id and is not reported.
+        assert partial_sets["set_b"] == full_sets["set_b"]
+        assert partial_sets["set_a"] != full_sets["set_a"]
+        assert listener.calls[-1] == (uuid.UUID(environment), partial_version, {partial_sets["set_a"]})
+
+
+async def test_a_failing_listener_aborts_the_export(
+    server, client, environment, clienthelper, postgresql_client: asyncpg.Connection
+) -> None:
+    """
+    A listener maintains data derived from the resources, so it is committed with them or not at all: a listener that
+    raises takes the export down and leaves no version behind.
+    """
+    orchestration_service: OrchestrationService = server.get_slice(SLICE_ORCHESTRATION)
+
+    with registered(orchestration_service, FailingListener()):
+        version = await clienthelper.get_version()
+        result = await client.put_version(
+            tid=environment,
+            version=version,
+            resources=[resource("in_a", version)],
+            resource_sets={"test::Resource[agent1,key=in_a]": "set_a"},
+            unknowns=[],
+            version_info={},
+            module_version_info={},
+        )
+        assert result.code == 500, result.result
+
+    assert await sets_in_version(postgresql_client, environment, version) == {}
+    assert (
+        await postgresql_client.fetchval(
+            "SELECT count(*) FROM public.configurationmodel WHERE environment = $1 AND version = $2",
+            uuid.UUID(environment),
+            version,
+        )
+        == 0
+    )


### PR DESCRIPTION
_Opened by Claude on behalf of @jptrindade._

An extension that maintains data derived from the resources of a model version has no way of being told they were
written. The two existing listeners core offers are notifications after the (i.e. a compile completing (`CompileStateListener`)an environment changing (`EnvironmentListener`) ).

With the `ResourceSetListener` we wanted to guarantee that the information derived from the resource sets was written in the same transaction, and if the listener somehow failed, that we are able to rollback the export.

To let a listener scope its work to what actually changed, `ResourceSet.insert_sets_and_resources` now returns the ids of the updated resource sets.

Nothing registers a listener in core, so there is no behaviour change without an extension.
The extension side is inmanta/inmanta-lsm#2499.
