### PR TITLE
Fix resolution attributes and defaults (iso8)

### DIFF
--- a/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
+++ b/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
@@ -1,0 +1,9 @@
+---
+description: "Fix resolution algorithm for attributes and default values."
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: >-
+    Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents.
+    The definition made by the most derived entity in the inheritance hierarchy is now always used. Between unrelated parents,
+    the attribute of the left-most parent is used.

--- a/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
+++ b/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
@@ -1,7 +1,7 @@
 ---
 description: "Fix resolution algorithm for attributes and default values."
 change-type: patch
-destination-branches: [master, iso9, iso8]
+destination-branches: [iso8]
 sections:
   bugfix: >-
     Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents.

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -277,7 +277,7 @@ class Entity(NamedType, WithComment):
         """
         name_to_attribute: dict[str, "Attribute"] = {}
         for parent in self.get_all_parent_entities_sorted():
-            name_to_attribute.update(parent.get_attributes())
+            name_to_attribute.update(parent._attributes)
         name_to_attribute.update(self._attributes)
         return list(name_to_attribute)
 

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -294,18 +294,21 @@ class Entity(NamedType, WithComment):
                 "attribute '%s' already exists on entity '%s'" % (attribute.name, self.name),
             )
 
+    def get_all_attributes(self) -> Mapping[str, "Attribute"]:
+        """
+        Return a mapping of attribute name to Attribute for this entity and all parents.
+        """
+        result: dict[str, "Attribute"] = {}
+        for parent in self.get_all_parent_entities_sorted():
+            result.update(parent.get_attributes())
+        result.update(self._attributes)
+        return result
+
     def get_attribute(self, name: str) -> Optional["Attribute"]:
         """
         Get the attribute with the given name
         """
-        if name in self._attributes:
-            return self._attributes[name]
-        else:
-            for parent in self.parent_entities:
-                attr = parent.get_attribute(name)
-                if attr is not None:
-                    return attr
-        return None
+        return self.get_all_attributes().get(name)
 
     def has_attribute(self, attribute: str) -> bool:
         """

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -273,14 +273,13 @@ class Entity(NamedType, WithComment):
 
     def get_all_attribute_names(self) -> "List[str]":
         """
-        Return a list of all attribute names, including parents
+        Return a list of all attribute names, including attributes from parent entities.
         """
-        names = list(self._attributes.keys())
-
-        for parent in self.parent_entities:
-            names.extend(parent.get_all_attribute_names())
-
-        return names
+        name_to_attribute: dict[str, "Attribute"] = {}
+        for parent in self.get_all_parent_entities_sorted():
+            name_to_attribute.update(parent.get_attributes())
+        name_to_attribute.update(self._attributes)
+        return list(name_to_attribute)
 
     def add_attribute(self, attribute: "Attribute") -> None:
         """
@@ -554,18 +553,12 @@ class Entity(NamedType, WithComment):
         """
         Return the dictionary with default values
         """
-        values = []  # type: List[Tuple[str,Optional[ExpressionStatement]]]
-
-        # left most parent takes precedence
-        for parent in reversed(self.parent_entities):
-            values.extend(parent.get_default_values().items())
-
-        # self takes precedence
-        values.extend(self._get_own_defaults().items())
-        # make dict, remove doubles
-        dvalues = dict(values)
-        # remove erased defaults
-        return {k: v for k, v in dvalues.items() if v is not None}
+        values: dict[str, Optional["ExpressionStatement"]] = {}
+        for parent in self.get_all_parent_entities_sorted():
+            values.update(parent._get_own_defaults())
+        values.update(self._get_own_defaults())
+        # A None value indicates that the default value was explicitly removed.
+        return {k: v for k, v in values.items() if v is not None}
 
     def get_default(self, name: str) -> "ExpressionStatement":
         """

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -254,3 +254,56 @@ end
         "__config__::Left",
     ]
     assert leaf.get_all_parent_entities() == set(leaf.get_all_parent_entities_sorted())
+
+
+def test_attribute_shadowing_in_diamond_hierarchy(snippetcompiler) -> None:
+    """
+    Verify that, when an attribute is defined more than once in the inheritance hierarchy,
+    Entity.get_all_attributes() reports the attribute of the most derived entity that defines it
+    and Entity.get_default_values() reports the default value set by that entity. This also holds
+    when the most derived definition is reached via the right-most parent and the definition it
+    shadows via the left-most parent. A default value removed by such a definition is absent from
+    Entity.get_default_values().
+    """
+    snippetcompiler.setup_for_snippet("""
+entity Base:
+    int shadowed = 1
+    int removed = 1
+end
+
+entity Redefines extends Base:
+    int shadowed = 3
+    int removed = undef
+end
+
+entity Inherits extends Base:
+end
+
+entity Leaf extends Inherits, Redefines:
+end
+    """)
+    types, _ = compiler.do_compile()
+
+    def get_defining_entity(entity_name: str, attribute_name: str) -> str:
+        entity = types[f"__config__::{entity_name}"]
+        return entity.get_all_attributes()[attribute_name].entity.get_full_name()
+
+    def get_default(entity_name: str, attribute_name: str) -> object:
+        entity = types[f"__config__::{entity_name}"]
+        default = entity.get_default_values().get(attribute_name)
+        return None if default is None else default.as_constant()
+
+    assert get_defining_entity("Base", "shadowed") == "__config__::Base"
+    assert get_defining_entity("Redefines", "shadowed") == "__config__::Redefines"
+    assert get_defining_entity("Inherits", "shadowed") == "__config__::Base"
+    assert get_defining_entity("Leaf", "shadowed") == "__config__::Redefines"
+
+    assert get_default("Base", "shadowed") == 1
+    assert get_default("Redefines", "shadowed") == 3
+    assert get_default("Inherits", "shadowed") == 1
+    assert get_default("Leaf", "shadowed") == 3
+
+    assert get_default("Base", "removed") == 1
+    assert get_default("Redefines", "removed") is None
+    assert get_default("Inherits", "removed") == 1
+    assert get_default("Leaf", "removed") is None

--- a/tests/compiler/test_define.py
+++ b/tests/compiler/test_define.py
@@ -263,7 +263,8 @@ def test_attribute_shadowing_in_diamond_hierarchy(snippetcompiler) -> None:
     and Entity.get_default_values() reports the default value set by that entity. This also holds
     when the most derived definition is reached via the right-most parent and the definition it
     shadows via the left-most parent. A default value removed by such a definition is absent from
-    Entity.get_default_values().
+    Entity.get_default_values(). Entity.get_all_attribute_names() reports such an attribute exactly
+    once and reports the attributes of the parent entities before the ones defined by the entity itself.
     """
     snippetcompiler.setup_for_snippet("""
 entity Base:
@@ -307,3 +308,14 @@ end
     assert get_default("Redefines", "removed") is None
     assert get_default("Inherits", "removed") == 1
     assert get_default("Leaf", "removed") is None
+
+    def get_all_attribute_names(entity_name: str) -> list[str]:
+        return types[f"__config__::{entity_name}"].get_all_attribute_names()
+
+    # Every entity implicitly extends std::Entity, so the attributes of std::Entity are reported first.
+    std_entity_attribute_names: list[str] = types["std::Entity"].get_all_attribute_names()
+    expected_attribute_names: list[str] = [*std_entity_attribute_names, "shadowed", "removed"]
+    assert get_all_attribute_names("Base") == expected_attribute_names
+    assert get_all_attribute_names("Redefines") == expected_attribute_names
+    assert get_all_attribute_names("Inherits") == expected_attribute_names
+    assert get_all_attribute_names("Leaf") == expected_attribute_names


### PR DESCRIPTION
# Description

**Applies https://github.com/inmanta/inmanta-core/pull/10777 on the iso8 branch. There was a merge conflict in `src/inmanta/ast/entity.py`.**

Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents. The definition made by the most derived entity in the inheritance hierarchy is now always used. Between unrelated parents, the attribute of the left-most parent is used.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Type annotations are present
- [x]  Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
