### PR TITLE
Fix incorrect changelog entry

### DIFF
--- a/changelogs/unreleased/fix-incorrect-changelog-entry.yml
+++ b/changelogs/unreleased/fix-incorrect-changelog-entry.yml
@@ -1,4 +1,4 @@
 ---
 description: "Fix incorrect changelog entry updated attribute resolution algorithm."
 change-type: patch
-destination-branches: [master, iso9, iso8]
+destination-branches: [iso8]

--- a/changelogs/unreleased/fix-incorrect-changelog-entry.yml
+++ b/changelogs/unreleased/fix-incorrect-changelog-entry.yml
@@ -1,0 +1,4 @@
+---
+description: "Fix incorrect changelog entry updated attribute resolution algorithm."
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
+++ b/changelogs/unreleased/fix-traversal-algorithm-attributes-and-defaults.yml
@@ -5,5 +5,5 @@ destination-branches: [iso8]
 sections:
   bugfix: >-
     Fixed the resolution of attributes and default values for an entity that inherits the same attribute via multiple parents.
-    The definition made by the most derived entity in the inheritance hierarchy is now always used. Between unrelated parents,
-    the attribute of the left-most parent is used.
+    The inheritance hierarchy is now traversed depth-first and from left to right, and the first definition found for the
+    attribute is used.

--- a/src/inmanta/ast/entity.py
+++ b/src/inmanta/ast/entity.py
@@ -554,7 +554,9 @@ class Entity(NamedType, WithComment):
 
     def get_default_values(self) -> "Dict[str,ExpressionStatement]":
         """
-        Return the dictionary with default values
+        Return the dictionary with default values. In case a default value is defined more than
+        once in the inheritance hierarchy, the hierarchy is traversed depth-first and from left to
+        right and the first definition found for that attribute is used.
         """
         values: dict[str, Optional["ExpressionStatement"]] = {}
         for parent in self.get_all_parent_entities_sorted():


### PR DESCRIPTION
# Description

**Same PR as https://github.com/inmanta/inmanta-core/pull/10789, but on the iso8 branch because of a merge conflict.**

This PR updates the incorrect changelog entry/docstring put in place by https://github.com/inmanta/inmanta-core/commit/23ce7715dd2e7f63751a80f0b296007ac059f811