### PR TITLE
Added support for scoped dryrun on agent-side

### DIFF
--- a/changelogs/unreleased/do-dryrun-resources-filter.yml
+++ b/changelogs/unreleased/do-dryrun-resources-filter.yml
@@ -1,0 +1,5 @@
+description: >-
+  Add an optional `resources` argument to the internal `do_dryrun` server-to-agent endpoint, which restricts the
+  dryrun to the given resources.
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/inmanta/agent/agent_new.py
+++ b/src/inmanta/agent/agent_new.py
@@ -307,17 +307,36 @@ class Agent(SessionEndpoint):
         return 200
 
     @protocol.handle(methods.do_dryrun, env="tid", dry_run_id="id")
-    async def run_dryrun(self, env: uuid.UUID, dry_run_id: uuid.UUID, agent: str, version: int) -> Apireturn:
+    async def run_dryrun(
+        self,
+        env: uuid.UUID,
+        dry_run_id: uuid.UUID,
+        agent: str,
+        version: int,
+        resources: Sequence[ResourceIdStr] | None = None,
+    ) -> Apireturn:
         """
-        Run a dryrun of the given version
+        Run a dryrun of the given version. When <resources> is given, only those resources are considered.
 
         Paused agents are silently ignored
         """
         assert env == self.environment
         assert agent == AGENT_SCHEDULER_ID
-        LOGGER.info("Agent %s got a trigger to run dryrun %s for version %s in environment %s", agent, dry_run_id, version, env)
 
-        await self.scheduler.dryrun(dry_run_id, version)
+        # slightly inaccurate in case the resources list contains resources that are not part of the given version,
+        # but we want to keep the log line concise.
+        nb_resources: str = str(len(resources)) if resources is not None else "all"
+
+        LOGGER.info(
+            "Agent %s got a trigger to run dryrun %s for %s resources in version %s in environment %s",
+            agent,
+            dry_run_id,
+            nb_resources,
+            version,
+            env,
+        )
+
+        await self.scheduler.dryrun(dry_run_id, version=version, resources=resources)
         return 200
 
     @protocol.handle(methods.get_parameter, env="tid")

--- a/src/inmanta/deploy/scheduler.py
+++ b/src/inmanta/deploy/scheduler.py
@@ -661,16 +661,28 @@ class ResourceScheduler(TaskManager):
             self._timer_manager.stop_timers(to_deploy)
             self._work.deploy_with_context(to_deploy, reason=reason, priority=priority, deploying=self._deploying_latest)
 
-    async def dryrun(self, dry_run_id: uuid.UUID, version: int) -> None:
+    async def dryrun(self, dry_run_id: uuid.UUID, version: int, resources: Optional[Collection[ResourceIdStr]] = None) -> None:
+        """
+        Trigger a dry-run
+
+        :param dry_run_id: The id of the dry-run to report the results on.
+        :param version: The version of the model to dry-run.
+        :param resources: If given, dry-run only the resources in this collection. Otherwise dry-run all resources of the
+            given model version. Resources in this collection that are not part of the given model version are ignored.
+        """
         if not self._running:
             LOGGER.debug("Ignoring dry-run request for halted resource scheduler")
             return
 
         paused_agents = await self.all_paused_agents()
+        in_scope: Optional[Set[ResourceIdStr]] = set(resources) if resources is not None else None
 
         LOGGER.debug("Triggering dry-run %s for version %d", str(dry_run_id), version)
         model: ModelVersion = await self._get_single_model_version_from_db(version=version)
         for resource, resource_intent in model.resources.items():
+            if in_scope is not None and resource not in in_scope:
+                continue
+
             if resource in model.undefined:
                 continue
 

--- a/src/inmanta/protocol/methods.py
+++ b/src/inmanta/protocol/methods.py
@@ -598,7 +598,7 @@ def dryrun_update(tid: uuid.UUID, id: uuid.UUID, resource: str, changes: dict):
     client_types=[],
     enforce_auth=False,
 )
-def do_dryrun(tid: uuid.UUID, id: uuid.UUID, agent: str, version: int):
+def do_dryrun(tid: uuid.UUID, id: uuid.UUID, agent: str, version: int, resources: Sequence[ResourceIdStr] | None = None):
     """
     Do a dryrun on an agent
 
@@ -606,6 +606,8 @@ def do_dryrun(tid: uuid.UUID, id: uuid.UUID, agent: str, version: int):
     :param id: The id of the dryrun
     :param agent: The agent to do the dryrun for
     :param version: The version of the model to dryrun
+    :param resources: Optional, the resources to execute the dryrun on. When omitted, all resources of the given
+        version are considered.
     """
 
 

--- a/tests/deploy/test_scheduler_agent.py
+++ b/tests/deploy/test_scheduler_agent.py
@@ -1794,10 +1794,57 @@ async def test_dryrun(agent: TestAgent, make_resource_minimal):
     agent.scheduler.mock_versions[5] = resources
 
     dryrun = uuid.uuid4()
-    await agent.scheduler.dryrun(dryrun, 5)
+    await agent.scheduler.dryrun(dryrun, version=5)
     await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
 
     assert agent.executor_manager.executors["agent1"].dry_run_count == 2
+
+
+async def test_dryrun_specific_resources(agent: TestAgent, make_resource_minimal):
+    """
+    Ensure that a dryrun can be restricted to a subset of the resources of a model version and that resources that are
+    not part of that model version are ignored.
+    """
+
+    version = 1
+    rid1 = ResourceIdStr("test::Resource[agent1,name=1]")
+    rid2 = ResourceIdStr("test::Resource[agent1,name=2]")
+    rid_not_in_version = ResourceIdStr("test::Resource[agent1,name=3]")
+    resources = {
+        rid1: make_resource_minimal(rid1, values={"value": "a"}, requires=[]),
+        rid2: make_resource_minimal(rid2, values={"value": "a"}, requires=[rid1]),
+    }
+
+    agent.scheduler.mock_versions[version] = resources
+
+    dryrun = uuid.uuid4()
+    await agent.scheduler.dryrun(dryrun, version=version, resources=[rid1, rid_not_in_version])
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+
+    assert agent.executor_manager.executors["agent1"].dry_run_count == 1
+
+
+async def test_dryrun_specific_resources_via_endpoint(agent: TestAgent, environment: uuid.UUID, make_resource_minimal):
+    """
+    Ensure that the resources passed to the do_dryrun endpoint are taken into account by the scheduler.
+    """
+
+    version = 1
+    rid1 = ResourceIdStr("test::Resource[agent1,name=1]")
+    rid2 = ResourceIdStr("test::Resource[agent1,name=2]")
+    resources = {
+        rid1: make_resource_minimal(rid1, values={"value": "a"}, requires=[]),
+        rid2: make_resource_minimal(rid2, values={"value": "a"}, requires=[rid1]),
+    }
+
+    agent.scheduler.mock_versions[version] = resources
+
+    dryrun = uuid.uuid4()
+    result = await agent.run_dryrun(environment, dryrun, const.AGENT_SCHEDULER_ID, version, resources=[rid1])
+    assert result == 200
+    await retry_limited(utils.is_agent_done, timeout=5, scheduler=agent.scheduler, agent_name="agent1")
+
+    assert agent.executor_manager.executors["agent1"].dry_run_count == 1
 
 
 async def test_get_facts(agent: TestAgent, make_resource_minimal):
@@ -2183,7 +2230,7 @@ async def test_scheduler_priority(agent: TestAgent, environment, make_resource_m
 
     # And then a dryrun
     dryrun = uuid.uuid4()
-    await agent.scheduler.dryrun(dryrun, 1)
+    await agent.scheduler.dryrun(dryrun, version=1)
 
     # The tasks are consumed in the priority order
     first_task = await agent.scheduler._work.agent_queues.queue_get("agent1")
@@ -2214,7 +2261,7 @@ async def test_scheduler_priority(agent: TestAgent, environment, make_resource_m
 
     # Add a dryrun to the queue (which has more priority)
     dryrun = uuid.uuid4()
-    await agent.scheduler.dryrun(dryrun, 1)
+    await agent.scheduler.dryrun(dryrun, version=1)
 
     # Assert that we have both tasks in the queue
     queue = agent.scheduler._work.agent_queues._get_queue("agent1")._queue
@@ -2245,7 +2292,7 @@ async def test_scheduler_priority(agent: TestAgent, environment, make_resource_m
 
     # Add a dryrun to the queue
     dryrun = uuid.uuid4()
-    await agent.scheduler.dryrun(dryrun, 1)
+    await agent.scheduler.dryrun(dryrun, version=1)
 
     # Add a user deploy
     await agent.trigger_update(environment, "$__scheduler", incremental_deploy=True)


### PR DESCRIPTION
# Description

Add an optional `resources` argument to the internal `do_dryrun` server-to-agent endpoint, which restricts the dryrun to the given resources.

Part of https://github.com/inmanta/inmanta-core/issues/10480

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Type annotations are present
- [x] Code is clear and sufficiently documented
- [x] No (preventable) type errors (check using make mypy or make mypy-diff)
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation
- [ ] ~~If this PR fixes a race condition in the test suite, also push the fix to the relevant stable branche(s) (see [test-fixes](https://internal.inmanta.com/development/core/tasks/build-master.html#test-fixes) for more info)~~
